### PR TITLE
fix: preview SVGs

### DIFF
--- a/src/layouts/EditImage.jsx
+++ b/src/layouts/EditImage.jsx
@@ -115,7 +115,8 @@ export default class EditImage extends Component {
         { sha
           ? (
             <>
-              <img alt="" src={`data:image/jpeg;base64,${content}`} />
+              <img alt="" src={`data:image/svg+xml;base64,${content}`} />
+              <img alt="" src={`data:image/png;base64,${content}`} />
             </>
           )
           : (


### PR DESCRIPTION
This fixes the SVG preview issue mentioned in #8.

SVGs can now be previewed with the additional `<img>` tag. The initial
tag is left there for previews regarding `png/jpg` image.
