### PR TITLE
Use this.setState to set newFileName 

### DIFF
--- a/src/layouts/EditCollectionPage.jsx
+++ b/src/layouts/EditCollectionPage.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
 import LeftNavPage from '../templates/LeftNavPage';
-import { frontMatterParser, concatFrontMatterMdBody } from '../utils';
+import { frontMatterParser, concatFrontMatterMdBody, changeFileName } from '../utils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
 import styles from '../styles/App.module.scss';
@@ -19,6 +19,7 @@ export default class EditCollectionPage extends Component {
       sha: null,
       editorValue: '',
       frontMatter: '',
+      tempFileName: '',
     };
   }
 
@@ -112,8 +113,8 @@ export default class EditCollectionPage extends Component {
     try {
       const { match } = this.props;
       const { siteName, collectionName, fileName } = match.params;
-      const { content, sha } = this.state;
-      const newFileName = this.newFileName.value;
+      const { content, sha, tempFileName } = this.state;
+      const newFileName = tempFileName;
       const params = { content, sha };
       await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages/${fileName}/rename/${newFileName}`, params, {
         withCredentials: true,
@@ -155,7 +156,7 @@ export default class EditCollectionPage extends Component {
             <button type="button" onClick={this.deletePage}>Delete</button>
             <br />
             <br />
-            <input placeholder="New file name" ref={(node) => { this.newFileName = node; }} />
+            <input placeholder="New file name" onChange={(event) => changeFileName(event, this)} />
             <button type="button" onClick={this.renamePage}>Rename</button>
           </div>
           <div className={styles.rightPane}>

--- a/src/layouts/EditCollectionPage.jsx
+++ b/src/layouts/EditCollectionPage.jsx
@@ -184,10 +184,10 @@ EditCollectionPage.propTypes = {
   }).isRequired,
   location: PropTypes.shape({
     state: PropTypes.shape({
-      leftNavPages: PropTypes.shape({
+      leftNavPages: PropTypes.arrayOf(PropTypes.shape({
         path: PropTypes.string,
         fileName: PropTypes.string,
-      }),
+      })),
     }),
   }).isRequired,
 };

--- a/src/layouts/EditFile.jsx
+++ b/src/layouts/EditFile.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
+import { changeFileName } from '../utils';
 import styles from '../styles/App.module.scss';
 
 export default class EditFile extends Component {
@@ -11,6 +12,7 @@ export default class EditFile extends Component {
     this.state = {
       content: null,
       sha: null,
+      tempFileName: '',
     };
   }
 
@@ -88,11 +90,11 @@ export default class EditFile extends Component {
     try {
       const { match } = this.props;
       const { siteName, fileName } = match.params;
-      const { state } = this;
-      const newFileName = (this.newFileName).value;
+      const { content, sha, tempFileName } = this.state;
+      const newFileName = tempFileName;
       const params = {
-        content: state.content,
-        sha: state.sha,
+        content,
+        sha,
       };
       await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/documents/${fileName}/rename/${newFileName}`, params, {
         withCredentials: true,
@@ -134,7 +136,7 @@ export default class EditFile extends Component {
         <button type="button" onClick={this.deletePage}>Delete</button>
         <br />
         <br />
-        <input placeholder="New file name" ref={(node) => { this.newFileName = node; }} />
+        <input placeholder="New file name" onChange={(event) => changeFileName(event, this)} />
         <button type="button" onClick={this.renamePage}>Rename</button>
       </>
     );

--- a/src/layouts/EditImage.jsx
+++ b/src/layouts/EditImage.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
+import { changeFileName } from '../utils';
 // import styles from '../styles/App.module.scss';
 
 export default class EditImage extends Component {
@@ -11,6 +12,7 @@ export default class EditImage extends Component {
     this.state = {
       content: null,
       sha: null,
+      tempFileName: '',
     };
   }
 
@@ -88,11 +90,11 @@ export default class EditImage extends Component {
     try {
       const { match } = this.props;
       const { siteName, fileName } = match.params;
-      const { state } = this;
-      const newFileName = (this.newFileName).value;
+      const { content, sha, tempFileName } = this.state;
+      const newFileName = tempFileName;
       const params = {
-        content: state.content,
-        sha: state.sha,
+        content,
+        sha,
       };
       await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images/${fileName}/rename/${newFileName}`, params, {
         withCredentials: true,
@@ -129,7 +131,7 @@ export default class EditImage extends Component {
         <button type="button" onClick={this.deletePage}>Delete</button>
         <br />
         <br />
-        <input placeholder="New file name" ref={(node) => { this.newFileName = node; }} />
+        <input placeholder="New file name" onChange={(event) => changeFileName(event, this)} />
         <button type="button" onClick={this.renamePage}>Rename</button>
       </>
     );

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -6,7 +6,7 @@ import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
 import { Base64 } from 'js-base64';
 import SimplePage from '../templates/SimplePage';
-import { frontMatterParser, concatFrontMatterMdBody } from '../utils';
+import { frontMatterParser, concatFrontMatterMdBody, changeFileName } from '../utils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
 import styles from '../styles/App.module.scss';
@@ -19,6 +19,7 @@ export default class EditPage extends Component {
       sha: null,
       editorValue: '',
       frontMatter: '',
+      tempFileName: '',
     };
   }
 
@@ -113,8 +114,8 @@ export default class EditPage extends Component {
     try {
       const { match } = this.props;
       const { siteName, fileName } = match.params;
-      const { content, sha } = this.state;
-      const newFileName = (this.newFileName).value;
+      const { content, sha, tempFileName } = this.state;
+      const newFileName = tempFileName;
       const params = { content, sha };
       await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}/rename/${newFileName}`, params, {
         withCredentials: true,
@@ -155,7 +156,7 @@ export default class EditPage extends Component {
             <button type="button" onClick={this.deletePage}>Delete</button>
             <br />
             <br />
-            <input placeholder="New file name" ref={(node) => { this.newFileName = node; }} />
+            <input placeholder="New file name" onChange={(event) => changeFileName(event, this)} />
             <button type="button" onClick={this.renamePage}>Rename</button>
           </div>
           <div className={styles.rightPane}>

--- a/src/templates/LeftNavPage.jsx
+++ b/src/templates/LeftNavPage.jsx
@@ -21,10 +21,10 @@ const LeftNavPage = ({ chunk, leftNavPages, fileName }) => (
 
 LeftNavPage.propTypes = {
   chunk: PropTypes.string.isRequired,
-  leftNavPages: PropTypes.shape({
+  leftNavPages: PropTypes.arrayOf(PropTypes.shape({
     path: PropTypes.string,
     fileName: PropTypes.string,
-  }).isRequired,
+  })).isRequired,
   fileName: PropTypes.string.isRequired,
 };
 

--- a/src/templates/pageComponents/LeftNav.jsx
+++ b/src/templates/pageComponents/LeftNav.jsx
@@ -100,10 +100,10 @@ const LeftNav = ({ leftNavPages, fileName }) => (
 );
 
 LeftNav.propTypes = {
-  leftNavPages: PropTypes.shape({
+  leftNavPages: PropTypes.arrayOf(PropTypes.shape({
     path: PropTypes.string,
     fileName: PropTypes.string,
-  }).isRequired,
+  })).isRequired,
   fileName: PropTypes.string.isRequired,
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,3 +24,9 @@ export function deslugifyCollectionPage(collectionPageName) {
     .map((string) => string.charAt(0).toUpperCase() + string.slice(1)) // capitalize first letter
     .join(' '); // join it back together
 }
+
+export function changeFileName(event, context) {
+  context.setState({
+    tempFileName: event.target.value,
+  });
+}


### PR DESCRIPTION
**Overview**
When renaming files, we saved to state improperly (`this.newFileName = node`). This has been fixed so that we use `this.setState({ tempFileName: event.target.value })` 

**Bug fix**
The prop `leftNavPages` in `EditCollectionPage` was validated as an object even though it is returned as an array of objects. Proptype validation was corrected to reflect that.