### PR TITLE
fix: make image upload predictable

### DIFF
--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -59,6 +59,7 @@ export default class Images extends Component {
        */
 
       const imgData = imgReader.result.split(',')[1];
+
       const { imgName } = imgReader;
 
       this.setState({ newImageName: imgName, newImageContent: imgData });
@@ -119,7 +120,7 @@ export default class Images extends Component {
           }
         </div>
 
-        <button type="button" onClick={this.uploadImage(newImageName, newImageContent)}>Upload new image</button>
+        <button type="button" onClick={() => this.uploadImage(newImageName, newImageContent)}>Upload new image</button>
       </div>
     );
   }


### PR DESCRIPTION
Initially, the image upload function would get called immediately after the page loads even
when the button was not clicked. Here was why:

So the issue arises from the way the `uploadImage` function is passed in the
`onClick` prop of the upload button. How onClick basically works is that
it accepts a function definition and then carries out that function definition when the
the click event occurs. What we were passing initially was actually the
returned value from calling `uploadImage` and not it's function definition.
So when the button gets clicked, `onClick` would try to call that returned
value but since `uploadImage` does not return anything, nothing happens
and we just get a really buggy behaviour.