### PR TITLE
Add basic resource room functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13184,6 +13184,11 @@
         }
       }
     },
+    "slugify": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+      "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",
     "react-simplemde-editor": "^4.1.0",
+    "slugify": "^1.3.6",
     "uuid": "^3.3.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",
+    "bluebird": "^3.7.1",
     "bootstrap": "^4.3.1",
     "cheerio": "^1.0.0-rc.3",
     "easymde": "^2.8.0",

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
-    <!-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"> -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <!-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import EditImage from './layouts/EditImage';
 import Files from './layouts/Files';
 import EditFile from './layouts/EditFile';
 import EditHomepage from './layouts/EditHomepage';
+import Resources from './layouts/Resources';
 // import Menus from './layouts/Menus';
 // import EditNav from './layouts/EditNav';
 // import EditFooter from './layouts/EditFooter';
@@ -43,6 +44,7 @@ function App() {
           <Route path="/sites/:siteName/pages/:fileName" component={EditPage} />
           <Route path="/sites/:siteName/pages" component={Pages} />
           <Route path="/sites/:siteName/homepage" component={EditHomepage} />
+          <Route path="/sites/:siteName/resources" component={Resources} />
           {/* <Route path="/sites/:siteName/menus/footer" component={EditFooter} />
           <Route path="/sites/:siteName/menus/navigation" component={EditNav} />
           <Route path="/sites/:siteName/menus" component={Menus} /> */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import Files from './layouts/Files';
 import EditFile from './layouts/EditFile';
 import EditHomepage from './layouts/EditHomepage';
 import Resources from './layouts/Resources';
+import EditResourcePage from './layouts/EditResourcePage';
 // import Menus from './layouts/Menus';
 // import EditNav from './layouts/EditNav';
 // import EditFooter from './layouts/EditFooter';
@@ -44,6 +45,7 @@ function App() {
           <Route path="/sites/:siteName/pages/:fileName" component={EditPage} />
           <Route path="/sites/:siteName/pages" component={Pages} />
           <Route path="/sites/:siteName/homepage" component={EditHomepage} />
+          <Route path="/sites/:siteName/resources/:resourceName/:fileName" component={EditResourcePage} />
           <Route path="/sites/:siteName/resources" component={Resources} />
           {/* <Route path="/sites/:siteName/menus/footer" component={EditFooter} />
           <Route path="/sites/:siteName/menus/navigation" component={EditNav} />

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -52,7 +52,7 @@ const ResourceCardModal = ({
   </div>
 )
 
-export default class TemplateResourceCard extends Component {
+export default class ResourceCard extends Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -239,7 +239,10 @@ export default class ResourceCard extends Component {
     return (
       <div>
         { isNewPost
-          ? <button type="button" onClick={this.settingsToggle}>Create New Post</button>
+          ? 
+          <>
+            <button type="button" onClick={this.settingsToggle}>Create New Post</button>
+          </>
           : (
             <>
               <p>
@@ -259,6 +262,7 @@ Type:
                 {type}
               </p>
               <button type="button" onClick={this.settingsToggle}>Settings</button>
+              <Link to={`/sites/${siteName}/resources/${category}/pages/${fileName}`}>Edit</Link>
             </>
           )}
         {settingsIsActive
@@ -278,7 +282,6 @@ Type:
             />
           )
           : null}
-        <Link to={`/sites/${siteName}/resources/${category}/pages/${fileName}`}>Edit</Link>
       </div>
     );
   }

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -262,7 +262,7 @@ Type:
                 {type}
               </p>
               <button type="button" onClick={this.settingsToggle}>Settings</button>
-              <Link to={`/sites/${siteName}/resources/${category}/pages/${fileName}`}>Edit</Link>
+              <Link to={`/sites/${siteName}/resources/${category}/${fileName}`}>Edit</Link>
             </>
           )}
         {settingsIsActive

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -1,202 +1,220 @@
-import React, { Component }from 'react';
+import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
-import { prettifyResourceCategory, slugifyResourceCategory } from '../utils';
-import { frontMatterParser, concatFrontMatterMdBody, enquoteString, dequoteString, generateResourceFileName } from '../utils';
 import { Base64 } from 'js-base64';
+import PropTypes from 'prop-types';
+import {
+  prettifyResourceCategory,
+  slugifyResourceCategory,
+  frontMatterParser,
+  concatFrontMatterMdBody,
+  enquoteString,
+  dequoteString,
+  generateResourceFileName,
+} from '../utils';
 
 const ResourceCardModal = ({
-  title, 
-  category, 
-  date, 
-  permalink, 
-  fileUrl, 
-  resourceCategories, 
-  changeHandler, 
-  saveHandler, 
-  deleteHandler, 
+  title,
+  category,
+  date,
+  permalink,
+  fileUrl,
+  resourceCategories,
+  changeHandler,
+  saveHandler,
+  deleteHandler,
   permalinkFileUrlToggle,
-  isNewPost
+  isNewPost,
 }) => (
   <div>
     <p>Category</p>
     <select id="category" defaultValue={slugifyResourceCategory(category)} onChange={changeHandler}>
       {
-        resourceCategories.map(resourceCategory => (
-          <option value={slugifyResourceCategory(resourceCategory.dirName)} label={prettifyResourceCategory(resourceCategory.dirName)}/>
+        resourceCategories.map((resourceCategory) => (
+          <option
+            value={slugifyResourceCategory(resourceCategory.dirName)}
+            label={prettifyResourceCategory(resourceCategory.dirName)}
+          />
         ))
       }
     </select>
     <p>Title</p>
-    <input value={dequoteString(title)} id="title" onChange={changeHandler}/>
+    <input value={dequoteString(title)} id="title" onChange={changeHandler} />
     <p>Date</p>
-    <input value={date} id="date" onChange={changeHandler}/>
+    <input value={date} id="date" onChange={changeHandler} />
     <button type="button" onClick={permalinkFileUrlToggle}>{permalink ? 'Switch to download' : 'Switch to post'}</button>
-    {permalink ?
-      <>
-        <p>Permalink</p>
-        <input value={permalink} id="permalink" onChange={changeHandler}/>
-      </>
-    :
-      <>
-        <p>File URL</p>
-        <input value={fileUrl} id="fileUrl" onChange={changeHandler}/>
-      </>
-    }
+    {permalink
+      ? (
+        <>
+          <p>Permalink</p>
+          <input value={permalink} id="permalink" onChange={changeHandler} />
+        </>
+      )
+      : (
+        <>
+          <p>File URL</p>
+          <input value={fileUrl} id="fileUrl" onChange={changeHandler} />
+        </>
+      )}
     <button type="button" onClick={saveHandler}>Save</button>
-    { !isNewPost ?
-      <button type="button" onClick={deleteHandler}>Delete</button>
-    :
-      null
-    }
+    { !isNewPost
+      ? <button type="button" onClick={deleteHandler}>Delete</button>
+      : null}
   </div>
-)
+);
 
 export default class ResourceCard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      title: '', 
+      title: '',
       permalink: null,
       fileUrl: null,
       date: '',
       settingsIsActive: false,
       mdBody: null,
       category: null,
-      sha: ''
+      sha: '',
     };
   }
 
   async componentDidMount() {
     try {
-      const { category, siteName, fileName, isNewPost } = this.props;
+      const {
+        category, siteName, fileName, isNewPost,
+      } = this.props;
       if (isNewPost) {
         const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
           withCredentials: true,
         });
-        const { resources: resourceCategories } = resourcesResp.data
+        const { resources: resourceCategories } = resourcesResp.data;
 
-        this.setState({ 
-          title: "TITLE", 
-          permalink: "PERMALINK", 
-          date: "DATE", 
-          mdBody: "",
-          category: resourceCategories[0].dirName
-         })
+        this.setState({
+          title: 'TITLE',
+          permalink: 'PERMALINK',
+          date: 'DATE',
+          mdBody: '',
+          category: resourceCategories[0].dirName,
+        });
       } else {
         const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
           withCredentials: true,
-        })
-  
-        const { content, sha } = resp.data
+        });
+
+        const { content, sha } = resp.data;
         const base64DecodedContent = Base64.decode(content);
         const { frontMatter, mdBody } = frontMatterParser(base64DecodedContent);
-        const { title, permalink, file_url, date } = frontMatter
-  
-        this.setState({ title, permalink, fileUrl: file_url, date, sha, mdBody, category })
+        const {
+          title, permalink, file_url: fileUrl, date,
+        } = frontMatter;
+
+        this.setState({
+          title, permalink, fileUrl, date, sha, mdBody, category,
+        });
       }
     } catch (err) {
-      console.log(err)
+      console.log(err);
     }
   }
 
   settingsToggle = () => {
     this.setState((currState) => ({
-      settingsIsActive: !currState.settingsIsActive
-    }))
+      settingsIsActive: !currState.settingsIsActive,
+    }));
   }
 
   permalinkFileUrlToggle = () => {
-    const { permalink } = this.state
+    const { permalink } = this.state;
     if (permalink) {
-      this.setState({ permalink: null, fileUrl: "FILE_URL"})
+      this.setState({ permalink: null, fileUrl: 'FILE_URL' });
     } else {
-      this.setState({ permalink: "PERMALINK", fileUrl: null})
+      this.setState({ permalink: 'PERMALINK', fileUrl: null });
     }
-
   }
 
-  deleteHandler = async() => {
+  deleteHandler = async () => {
     try {
-      const { sha } = this.state
-      const { category, fileName, siteName } = this.props
+      const { sha } = this.state;
+      const { category, fileName, siteName } = this.props;
       const params = { sha };
       await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
         data: params,
         withCredentials: true,
-      })
+      });
 
       // Refresh page
       window.location.reload();
     } catch (err) {
-      console.log(err)
+      console.log(err);
     }
   }
 
-  saveHandler = async() => {
+  saveHandler = async () => {
     try {
-      const { title, permalink, fileUrl, date, mdBody, sha, category } = this.state
-      const { fileName, siteName, isNewPost} = this.props
+      const {
+        title, permalink, fileUrl, date, mdBody, sha, category,
+      } = this.state;
+      const { fileName, siteName, isNewPost } = this.props;
 
-      const frontMatter = { title: enquoteString(title), date }
-      let type = ''
+      const frontMatter = { title: enquoteString(title), date };
+      let type = '';
       if (permalink) {
-        frontMatter.permalink = permalink
-        type = 'post'
+        frontMatter.permalink = permalink;
+        type = 'post';
       }
       if (fileUrl) {
-        frontMatter.file_url = fileUrl
-        type = 'download'
+        frontMatter.file_url = fileUrl;
+        type = 'download';
       }
 
-      const content = concatFrontMatterMdBody(frontMatter, mdBody)
+      const content = concatFrontMatterMdBody(frontMatter, mdBody);
       const base64EncodedContent = Base64.encode(content);
 
-      let newFileName = generateResourceFileName(dequoteString(title), type, date)
-      let params = {}
+      const newFileName = generateResourceFileName(dequoteString(title), type, date);
+      let params = {};
 
       if (newFileName !== fileName) {
         // We'll need to create a new .md file with a new filename
         params = {
           content: base64EncodedContent,
-          pageName: newFileName
+          pageName: newFileName,
         };
 
         // If it is an existing post, delete the existing page
         if (!isNewPost) {
           await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
             data: {
-              sha
+              sha,
             },
             withCredentials: true,
-          })
+          });
         }
 
         await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages`, params, {
           withCredentials: true,
-        })
+        });
       } else {
         // Save to existing .md file
         params = {
           content: base64EncodedContent,
           sha,
         };
-  
+
         await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, params, {
           withCredentials: true,
-        })
+        });
       }
 
       // Refresh page
       window.location.reload();
     } catch (err) {
-      console.log(err)
+      console.log(err);
     }
   }
 
   changeHandler = (event) => {
-    const { id, value } = event.target
-    this.setState({[id]: value})
+    const { id, value } = event.target;
+    this.setState({ [id]: value });
   }
 
   render() {
@@ -208,41 +226,85 @@ export default class ResourceCard extends Component {
       siteName,
       fileName,
       resourceCategories,
-      isNewPost
-    } = this.props
-    const { settingsIsActive } = this.state
+      isNewPost,
+    } = this.props;
+    const {
+      settingsIsActive,
+      title: stateTitle,
+      category: stateCategory,
+      date: stateDate,
+      permalink: statePermalink,
+      fileUrl: stateFileUrl,
+    } = this.state;
     return (
       <div>
-        { isNewPost ?
-          <button type="button" onClick={this.settingsToggle}>Create New Post</button>
-        :
-          <>
-            <p>Category: {prettifyResourceCategory(category)}</p>
-            <p>Title: {title}</p>
-            <p>Date: {date}</p>
-            <p>Type: {type}</p>
-            <button type="button" onClick={this.settingsToggle}>Settings</button>
-          </>
-        }
-        {settingsIsActive ?
-          <ResourceCardModal 
-            title={this.state.title}
-            category={this.state.category}
-            date={this.state.date}
-            permalink={this.state.permalink}
-            fileUrl={this.state.fileUrl}
-            resourceCategories={resourceCategories}
-            changeHandler={this.changeHandler}
-            saveHandler={this.saveHandler}
-            deleteHandler={this.deleteHandler}
-            permalinkFileUrlToggle={this.permalinkFileUrlToggle}
-            isNewPost={isNewPost}
-          />
-        :
-          null
-        }
+        { isNewPost
+          ? <button type="button" onClick={this.settingsToggle}>Create New Post</button>
+          : (
+            <>
+              <p>
+Category:
+                {prettifyResourceCategory(category)}
+              </p>
+              <p>
+Title:
+                {title}
+              </p>
+              <p>
+Date:
+                {date}
+              </p>
+              <p>
+Type:
+                {type}
+              </p>
+              <button type="button" onClick={this.settingsToggle}>Settings</button>
+            </>
+          )}
+        {settingsIsActive
+          ? (
+            <ResourceCardModal
+              title={stateTitle}
+              category={stateCategory}
+              date={stateDate}
+              permalink={statePermalink}
+              fileUrl={stateFileUrl}
+              resourceCategories={resourceCategories}
+              changeHandler={this.changeHandler}
+              saveHandler={this.saveHandler}
+              deleteHandler={this.deleteHandler}
+              permalinkFileUrlToggle={this.permalinkFileUrlToggle}
+              isNewPost={isNewPost}
+            />
+          )
+          : null}
         <Link to={`/sites/${siteName}/resources/${category}/pages/${fileName}`}>Edit</Link>
       </div>
-    )
+    );
   }
 }
+
+ResourceCardModal.propTypes = {
+  title: PropTypes.string.isRequired,
+  category: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  permalink: PropTypes.string.isRequired,
+  fileUrl: PropTypes.string.isRequired,
+  resourceCategories: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  saveHandler: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  permalinkFileUrlToggle: PropTypes.func.isRequired,
+  isNewPost: PropTypes.bool.isRequired,
+};
+
+ResourceCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  category: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  fileName: PropTypes.string.isRequired,
+  siteName: PropTypes.string.isRequired,
+  resourceCategories: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  isNewPost: PropTypes.bool.isRequired,
+};

--- a/src/components/ResourceCategoryModal.jsx
+++ b/src/components/ResourceCategoryModal.jsx
@@ -1,0 +1,149 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import update from 'immutability-helper';
+import { prettifyResourceCategory, slugifyResourceCategory } from '../utils';
+
+// Constants
+const RADIX_PARSE_INT = 10;
+const NEW_CATEGORY_STR = 'newcategory';
+
+export default class ResourceCategoryModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      resourceCategories: [],
+    };
+    this.currInputValues = {};
+  }
+
+  async componentDidMount() {
+    try {
+      const { siteName } = this.props;
+      const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
+        withCredentials: true,
+      });
+      const { resources } = resourcesResp.data;
+      const resourceCategories = resources.map((resource) => resource.dirName);
+
+      this.setState({ resourceCategories });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  // Create new category
+  createHandler = () => {
+    this.setState((currState) => ({
+      resourceCategories: update(currState.resourceCategories, {
+        $push: [NEW_CATEGORY_STR],
+      }),
+    }));
+  }
+
+  // Save changes to the resource category
+  saveHandler = async (event) => {
+    try {
+      const { siteName } = this.props;
+      const { resourceCategories } = this.state;
+      const { id } = event.target;
+      const idArray = id.split('-');
+      const categoryIndex = parseInt(idArray[1], RADIX_PARSE_INT);
+      const resourceCategory = slugifyResourceCategory(resourceCategories[categoryIndex]);
+      const newResourceCategory = slugifyResourceCategory(this.currInputValues[categoryIndex].value); // eslint-disable-line max-len
+
+      // If the category is a new one
+      if (resourceCategory === NEW_CATEGORY_STR) {
+        const params = {
+          resourceName: newResourceCategory,
+        };
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, params, {
+          withCredentials: true,
+        });
+      } else {
+        // Rename resource category
+        const params = {};
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory}/rename/${newResourceCategory}`, params, {
+          withCredentials: true,
+        });
+      }
+
+      window.location.reload();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  deleteHandler = async (event) => {
+    try {
+      const { siteName } = this.props;
+      const { resourceCategories } = this.state;
+      const { id } = event.target;
+      const idArray = id.split('-');
+      const categoryIndex = parseInt(idArray[1], RADIX_PARSE_INT);
+      const resourceCategory = slugifyResourceCategory(resourceCategories[categoryIndex]);
+
+      // Check if there are resourcePages in the category; if there are, do not allow deletion
+      const resourcesPagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory}`, {
+        withCredentials: true,
+      });
+      const { resourcePages } = resourcesPagesResp.data;
+      if (resourcePages.length > 0) throw new Error('There is at least one post or download associated with the resource category');
+
+      // Delete resource category
+      await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory}`, {
+        data: {},
+        withCredentials: true,
+      });
+
+      // Get updated resourceCategories to set in state
+      const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
+        withCredentials: true,
+      });
+      const { resources } = resourcesResp.data;
+      const newResourceCategories = resources.map((resource) => resource.dirName);
+
+      this.setState({ resourceCategories: newResourceCategories });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  render() {
+    const { resourceCategories } = this.state;
+    const { categoryModalToggle, categoryModalIsActive } = this.props;
+    return (
+      <div>
+        <button type="button" onClick={categoryModalToggle}>Edit Categories</button>
+        {categoryModalIsActive
+          ? (
+            <>
+              {resourceCategories.length > 0
+                ? resourceCategories.map((resourceCategory, index) => (
+                  <div key={resourceCategory}>
+                    <input
+                      type="text"
+                      id={`input-${index}`}
+                      defaultValue={prettifyResourceCategory(resourceCategory)}
+                      style={{ textTransform: 'uppercase' }}
+                      ref={(node) => { this.currInputValues[index] = node; }}
+                    />
+                    <button type="button" key={`save-${resourceCategory}`} id={`save-${index}-${resourceCategory}`} onClick={this.saveHandler}>Save</button>
+                    <button type="button" key={`delete-${resourceCategory}`} id={`delete-${index}-${resourceCategory}`} onClick={this.deleteHandler}>Delete</button>
+                  </div>
+                ))
+                : null}
+              <button type="button" onClick={this.createHandler}>Create Category</button>
+            </>
+          )
+          : null}
+      </div>
+    );
+  }
+}
+
+ResourceCategoryModal.propTypes = {
+  siteName: PropTypes.string.isRequired,
+  categoryModalIsActive: PropTypes.bool.isRequired,
+  categoryModalToggle: PropTypes.func.isRequired,
+};

--- a/src/layouts/EditCollectionPage.jsx
+++ b/src/layouts/EditCollectionPage.jsx
@@ -6,7 +6,9 @@ import PropTypes from 'prop-types';
 import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
 import LeftNavPage from '../templates/LeftNavPage';
-import { frontMatterParser, concatFrontMatterMdBody, prependImageSrc, changeFileName } from '../utils';
+import {
+  frontMatterParser, concatFrontMatterMdBody, prependImageSrc, changeFileName,
+} from '../utils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
 import styles from '../styles/App.module.scss';

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -6,7 +6,9 @@ import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
 import { Base64 } from 'js-base64';
 import SimplePage from '../templates/SimplePage';
-import { frontMatterParser, concatFrontMatterMdBody, prependImageSrc, changeFileName } from '../utils';
+import {
+  frontMatterParser, concatFrontMatterMdBody, prependImageSrc, changeFileName,
+} from '../utils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
 import styles from '../styles/App.module.scss';

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -6,7 +6,9 @@ import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
 import { Base64 } from 'js-base64';
 import SimplePage from '../templates/SimplePage';
-import { frontMatterParser, concatFrontMatterMdBody, prependImageSrc, changeFileName } from '../utils';
+import {
+  frontMatterParser, concatFrontMatterMdBody, prependImageSrc,
+} from '../utils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
 import styles from '../styles/App.module.scss';
@@ -15,11 +17,9 @@ export default class EditResourcePage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      content: null,
       sha: null,
       editorValue: '',
       frontMatter: '',
-      tempFileName: '',
     };
   }
 
@@ -34,7 +34,6 @@ export default class EditResourcePage extends Component {
       // split the markdown into front matter and content
       const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
       this.setState({
-        content,
         sha,
         editorValue: mdBody.trim(),
         frontMatter,
@@ -62,8 +61,8 @@ export default class EditResourcePage extends Component {
       const resp = await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, params, {
         withCredentials: true,
       });
-      const { content, sha } = resp.data;
-      this.setState({ content, sha });
+      const { sha } = resp.data;
+      this.setState({ sha });
     } catch (err) {
       console.log(err);
     }
@@ -88,8 +87,8 @@ export default class EditResourcePage extends Component {
       const resp = await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, params, {
         withCredentials: true,
       });
-      const { content, sha } = resp.data;
-      this.setState({ content, sha });
+      const { sha } = resp.data;
+      this.setState({ sha });
     } catch (err) {
       console.log(err);
     }
@@ -103,21 +102,6 @@ export default class EditResourcePage extends Component {
       const params = { sha };
       await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, {
         data: params,
-        withCredentials: true,
-      });
-    } catch (err) {
-      console.log(err);
-    }
-  }
-
-  renamePage = async () => {
-    try {
-      const { match } = this.props;
-      const { siteName, resourceName, fileName } = match.params;
-      const { content, sha, tempFileName } = this.state;
-      const newFileName = tempFileName;
-      const params = { content, sha };
-      await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, params, {
         withCredentials: true,
       });
     } catch (err) {
@@ -154,10 +138,6 @@ export default class EditResourcePage extends Component {
             <br />
             <br />
             <button type="button" onClick={this.deletePage}>Delete</button>
-            <br />
-            <br />
-            <input placeholder="New file name" onChange={(event) => changeFileName(event, this)} />
-            <button type="button" onClick={this.renamePage}>Rename</button>
           </div>
           <div className={styles.rightPane}>
             <SimplePage chunk={prependImageSrc(siteName, marked(editorValue))} />
@@ -174,7 +154,7 @@ EditResourcePage.propTypes = {
     params: PropTypes.shape({
       siteName: PropTypes.string,
       fileName: PropTypes.string,
-      newFileName: PropTypes.string,
+      resourceName: PropTypes.string,
     }),
   }).isRequired,
 };

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -1,0 +1,180 @@
+import React, { Component } from 'react';
+// import { Link } from "react-router-dom";
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import SimpleMDE from 'react-simplemde-editor';
+import marked from 'marked';
+import { Base64 } from 'js-base64';
+import SimplePage from '../templates/SimplePage';
+import { frontMatterParser, concatFrontMatterMdBody, prependImageSrc, changeFileName } from '../utils';
+import 'easymde/dist/easymde.min.css';
+import '../styles/isomer-template.scss';
+import styles from '../styles/App.module.scss';
+
+export default class EditResourcePage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      content: null,
+      sha: null,
+      editorValue: '',
+      frontMatter: '',
+      tempFileName: '',
+    };
+  }
+
+  async componentDidMount() {
+    try {
+      const { match } = this.props;
+      const { siteName, resourceName, fileName } = match.params;
+      const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, {
+        withCredentials: true,
+      });
+      const { content, sha } = resp.data;
+      // split the markdown into front matter and content
+      const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
+      this.setState({
+        content,
+        sha,
+        editorValue: mdBody.trim(),
+        frontMatter,
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  createPage = async () => {
+    try {
+      const { match } = this.props;
+      const { siteName, resourceName, fileName } = match.params;
+      const { editorValue, frontMatter } = this.state;
+
+      // here, we need to add the appropriate front matter before we encode
+      // this part needs to be revised to include permalink and other things depending on page type
+      const upload = concatFrontMatterMdBody(frontMatter, editorValue);
+
+      const base64Content = Base64.encode(upload);
+      const params = {
+        pageName: fileName,
+        content: base64Content,
+      };
+      const resp = await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, params, {
+        withCredentials: true,
+      });
+      const { content, sha } = resp.data;
+      this.setState({ content, sha });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  updatePage = async () => {
+    try {
+      const { match } = this.props;
+      const { siteName, resourceName, fileName } = match.params;
+      const { state } = this;
+      const { editorValue, frontMatter } = state;
+
+      // here, we need to re-add the front matter of the markdown file
+      const upload = concatFrontMatterMdBody(frontMatter, editorValue);
+
+      // encode to Base64 for github
+      const base64Content = Base64.encode(upload);
+      const params = {
+        content: base64Content,
+        sha: state.sha,
+      };
+      const resp = await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, params, {
+        withCredentials: true,
+      });
+      const { content, sha } = resp.data;
+      this.setState({ content, sha });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  deletePage = async () => {
+    try {
+      const { match } = this.props;
+      const { siteName, resourceName, fileName } = match.params;
+      const { sha } = this.state;
+      const params = { sha };
+      await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, {
+        data: params,
+        withCredentials: true,
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  renamePage = async () => {
+    try {
+      const { match } = this.props;
+      const { siteName, resourceName, fileName } = match.params;
+      const { content, sha, tempFileName } = this.state;
+      const newFileName = tempFileName;
+      const params = { content, sha };
+      await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}/pages/${fileName}`, params, {
+        withCredentials: true,
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  onEditorChange = (value) => {
+    this.setState({ editorValue: value });
+  }
+
+  render() {
+    const { match } = this.props;
+    const { siteName, fileName } = match.params;
+    const { sha, editorValue } = this.state;
+    return (
+      <>
+        <h3>
+          Editing page
+          {' '}
+          {fileName}
+        </h3>
+        <div className="d-flex">
+          <div className={`${styles.leftPane} p-3`}>
+            <SimpleMDE
+              onChange={this.onEditorChange}
+              value={editorValue}
+              options={{
+                hideIcons: ['preview', 'side-by-side', 'fullscreen'],
+                showIcons: ['code', 'table'],
+              }}
+            />
+            <button type="button" onClick={sha ? this.updatePage : this.createPage}>Save</button>
+            <br />
+            <br />
+            <button type="button" onClick={this.deletePage}>Delete</button>
+            <br />
+            <br />
+            <input placeholder="New file name" onChange={(event) => changeFileName(event, this)} />
+            <button type="button" onClick={this.renamePage}>Rename</button>
+          </div>
+          <div className={styles.rightPane}>
+            <SimplePage chunk={prependImageSrc(siteName, marked(editorValue))} />
+          </div>
+        </div>
+
+      </>
+    );
+  }
+}
+
+EditResourcePage.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      siteName: PropTypes.string,
+      fileName: PropTypes.string,
+      newFileName: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -1,0 +1,128 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import * as Bluebird from 'bluebird';
+import * as _ from 'lodash';
+import { prettifyResourceFileName } from '../utils';
+import '../styles/isomer-template.scss';
+import TemplateResourceCard from '../templates/ResourceCard';
+
+export default class Resources extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      resourceCategories: [],
+      resourcePages: [],
+      newPageName: null,
+    };
+  }
+
+  async componentDidMount() {
+    try {
+      const { match } = this.props;
+      const { siteName } = match.params;
+
+      const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
+        withCredentials: true,
+      });
+      const { resources: resourceCategories } = resourcesResp.data
+
+      const resourcePagesArray = await Bluebird.map(resourceCategories, async (resourceCategory) => {
+        const resourcePagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory.dirName}`, {
+          withCredentials: true,
+        })
+        const { resourcePages } = resourcePagesResp.data
+
+        return resourcePages.map(resourcePage => {
+          const { title, date, type } = prettifyResourceFileName(resourcePage.fileName)
+          return { title, date, type, fileName: resourcePage.fileName, category: resourceCategory.dirName }
+        })
+      }, { concurrency: 10})
+      
+      const resourcePages = _.compact(_.flattenDeep(resourcePagesArray))
+
+      this.setState({ resourceCategories, resourcePages });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  updateNewPageName = (event) => {
+    event.preventDefault();
+    this.setState({ newPageName: event.target.value });
+  }
+
+  settingsToggle = async (event) => {
+    this.setState((currState) => ({
+      settingsIsActive: !currState.settingsIsActive
+    }))
+  }
+
+  render() {
+    const { resourceCategories, resourcePages, newPageName } = this.state;
+    const { match } = this.props;
+    const { siteName } = match.params;
+    return (
+      <div>
+        <Link to="/sites">Back to Sites</Link>
+        <hr />
+        <h2>{siteName}</h2>
+        <ul>
+          <li>
+            <Link to={`/sites/${siteName}/pages`}>Pages</Link>
+          </li>
+          <li>
+            <Link to={`/sites/${siteName}/collections`}>Collections</Link>
+          </li>
+          <li>
+            <Link to={`/sites/${siteName}/images`}>Images</Link>
+          </li>
+          <li>
+            <Link to={`/sites/${siteName}/files`}>Files</Link>
+          </li>
+          <li>
+            <Link to={`/sites/${siteName}/menus`}>Menus</Link>
+          </li>
+        </ul>
+        <hr />
+        <h3>Resource Pages</h3>
+        {/* Display resource cards */}
+        {resourcePages.length > 0 ?
+          <>
+          {resourcePages.map(resourcePage => (
+            <TemplateResourceCard 
+              type={resourcePage.type}
+              category={resourcePage.category}
+              title={resourcePage.title}
+              date={resourcePage.date}
+              fileName={resourcePage.fileName}
+              siteName={siteName}
+              resourceCategories={resourceCategories}
+              isNewPost={false}
+            />
+          ))}
+          </>
+        :
+          null
+        }
+        <TemplateResourceCard 
+          siteName={siteName}
+          resourceCategories={resourceCategories}
+          isNewPost={true}
+        />
+        <br />
+        <input placeholder="New page name" onChange={this.updateNewPageName} />
+        <Link to={`/sites/${siteName}/pages/${newPageName}`}>Create new page</Link>
+      </div>
+    );
+  }
+}
+
+Resources.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      siteName: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import { prettifyResourceFileName, prettifyResourceCategory, slugifyResourceCategory } from '../utils';
-import TemplateResourceCard from '../templates/ResourceCard';
+import ResourceCard from '../components/ResourceCard';
 import update from 'immutability-helper';
 
 const NEW_CATEGORY_STR = "newcategory"
@@ -146,7 +146,6 @@ class ResourceCategoryModal extends Component{
   }
 }
 
-
 export default class Resources extends Component {
   constructor(props) {
     super(props);
@@ -242,7 +241,7 @@ export default class Resources extends Component {
         {resourcePages.length > 0 ?
           <>
           {resourcePages.map(resourcePage => (
-            <TemplateResourceCard 
+            <ResourceCard 
               type={resourcePage.type}
               category={resourcePage.category}
               title={resourcePage.title}
@@ -257,7 +256,7 @@ export default class Resources extends Component {
         :
           null
         }
-        <TemplateResourceCard 
+        <ResourceCard 
           siteName={siteName}
           resourceCategories={resourceCategories}
           isNewPost={true}

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -133,9 +133,6 @@ export default class Resources extends Component {
           resourceCategories={resourceCategories}
           isNewPost
         />
-        <br />
-        <input placeholder="New page name" onChange={this.updateNewPageName} />
-        <Link to={`/sites/${siteName}/pages/${newPageName}`}>Create new page</Link>
       </div>
     );
   }

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -4,147 +4,9 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
-import { prettifyResourceFileName, prettifyResourceCategory, slugifyResourceCategory } from '../utils';
+import { prettifyResourceFileName } from '../utils';
 import ResourceCard from '../components/ResourceCard';
-import update from 'immutability-helper';
-
-const NEW_CATEGORY_STR = "newcategory"
-
-class ResourceCategoryModal extends Component{
-  constructor(props) {
-    super(props);
-    this.state = {
-      resourceCategories: [],
-    };
-    this.currInputValues = {};
-  }
-
-  async componentDidMount() {
-    try {
-      const { siteName } = this.props;
-      const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
-        withCredentials: true,
-      });
-      const { resources } = resourcesResp.data
-      const resourceCategories = resources.map(resource => resource.dirName)
-
-      this.setState({ resourceCategories });
-    } catch (err) {
-      console.log(err);
-    }
-  }
-
-  // Create new category
-  createHandler = () => {
-    this.setState(currState => ({
-      resourceCategories: update(currState.resourceCategories, {
-        $push: [NEW_CATEGORY_STR]
-      })
-    }))
-  }
-
-  // Save changes to the resource category
-  saveHandler = async(event) => {
-    try {
-      const { siteName } = this.props;
-      const { resourceCategories } = this.state;
-      const { id } = event.target
-      const idArray = id.split('-')
-      const categoryIndex = parseInt(idArray[1])
-      const resourceCategory = slugifyResourceCategory(resourceCategories[categoryIndex])
-      const newResourceCategory = slugifyResourceCategory(this.currInputValues[categoryIndex].value)
-
-      // If the category is a new one
-      if (resourceCategory === NEW_CATEGORY_STR) {
-        const params = {
-          resourceName: newResourceCategory
-        }
-        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, params, {
-          withCredentials: true,
-        });
-      } else {
-        // Rename resource category
-        const params = {}
-        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory}/rename/${newResourceCategory}`, params, {
-          withCredentials: true,
-        });
-      }
-
-      window.location.reload()
-    } catch (err) {
-      console.log(err)
-    }
-  }
-
-  deleteHandler = async(event) => {
-    try {
-      const { siteName } = this.props;
-      const { resourceCategories } = this.state;
-      const { id } = event.target
-      const idArray = id.split('-')
-      const categoryIndex = parseInt(idArray[1])
-      const resourceCategory = slugifyResourceCategory(resourceCategories[categoryIndex])
-
-      // Check if there are resourcePages in the category; if there are, do not allow deletion
-      const resourcesPagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory}`, {
-        withCredentials: true,
-      });
-      const { resourcePages } = resourcesPagesResp.data
-      if (resourcePages.length > 0) throw new Error('There is at least one post or download associated with the resource category')
-
-      // Delete resource category
-      await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory}`, {
-        data: {},
-        withCredentials: true,
-      });
-
-      // Get updated resourceCategories to set in state
-      const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
-        withCredentials: true,
-      });
-      const { resources } = resourcesResp.data
-      const newResourceCategories = resources.map(resource => resource.dirName)
-
-      this.setState({ resourceCategories: newResourceCategories });
-    } catch (err) {
-      console.log(err)
-    }
-  }
-
-  render() {
-    const { resourceCategories } = this.state;
-    const { categoryModalToggle, categoryModalIsActive } = this.props;
-    return (
-      <div>
-        <button type="button" onClick={categoryModalToggle}>Edit Categories</button>
-        {categoryModalIsActive ? 
-          <>
-            {resourceCategories.length > 0 ?
-              resourceCategories.map((resourceCategory, index) => (
-                <div key={resourceCategory}>
-                  <input 
-                    type="text" 
-                    id={`input-${index}`} 
-                    defaultValue={prettifyResourceCategory(resourceCategory)} 
-                    style={{textTransform: 'uppercase'}}
-                    ref={(node) => { this.currInputValues[index] = node;}} 
-                  />
-                  <button type="button" key={`save-${resourceCategory}`} id={`save-${index}-${resourceCategory}`} onClick={this.saveHandler}>Save</button>
-                  <button type="button" key={`delete-${resourceCategory}`} id={`delete-${index}-${resourceCategory}`} onClick={this.deleteHandler}>Delete</button>
-                </div>
-              ))
-            :
-              null
-            }
-            <button type="button" onClick={this.createHandler}>Create Category</button>
-          </>
-        :
-          null 
-        }
-      </div>
-    )
-  }
-}
+import ResourceCategoryModal from '../components/ResourceCategoryModal';
 
 export default class Resources extends Component {
   constructor(props) {
@@ -153,7 +15,7 @@ export default class Resources extends Component {
       resourceCategories: [],
       resourcePages: [],
       newPageName: null,
-      categoryModalIsActive: false
+      categoryModalIsActive: false,
     };
   }
 
@@ -166,24 +28,32 @@ export default class Resources extends Component {
       const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
         withCredentials: true,
       });
-      const { resources: resourceCategories } = resourcesResp.data
+      const { resources: resourceCategories } = resourcesResp.data;
 
-      // Obtain the title, date, type, fileName, category for all resource pages across all categories
-      const resourcePagesArray = await Bluebird.map(resourceCategories, async (resourceCategory) => {
-        const resourcePagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceCategory.dirName}`, {
+      // Obtain the title, date, type, fileName, category for resource pages across all categories
+      const resourcePagesArray = await Bluebird.map(resourceCategories, async (category) => {
+        const resourcePagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category.dirName}`, {
           withCredentials: true,
-        })
-        const { resourcePages } = resourcePagesResp.data
+        });
+        const { resourcePages } = resourcePagesResp.data;
 
         if (resourcePages.length > 0) {
-          return resourcePages.map(resourcePage => {
-            const { title, date, type } = prettifyResourceFileName(resourcePage.fileName)
-            return { title, date, type, fileName: resourcePage.fileName, category: resourceCategory.dirName }
-          })
+          return resourcePages.map((resourcePage) => {
+            const { title, date, type } = prettifyResourceFileName(resourcePage.fileName);
+            return {
+              title,
+              date,
+              type,
+              fileName: resourcePage.fileName,
+              category: category.dirName,
+            };
+          });
         }
-      }, { concurrency: 10})
-      
-      const resourcePages = _.compact(_.flattenDeep(resourcePagesArray))
+
+        return undefined;
+      }, { concurrency: 10 });
+
+      const resourcePages = _.compact(_.flattenDeep(resourcePagesArray));
 
       this.setState({ resourceCategories, resourcePages });
     } catch (err) {
@@ -198,12 +68,14 @@ export default class Resources extends Component {
 
   categoryModalToggle = () => {
     this.setState((currState) => ({
-      categoryModalIsActive: !currState.categoryModalIsActive
-    }))
+      categoryModalIsActive: !currState.categoryModalIsActive,
+    }));
   }
 
   render() {
-    const { resourceCategories, resourcePages, newPageName, categoryModalIsActive } = this.state;
+    const {
+      resourceCategories, resourcePages, newPageName, categoryModalIsActive,
+    } = this.state;
     const { match } = this.props;
     const { siteName } = match.params;
     return (
@@ -231,35 +103,35 @@ export default class Resources extends Component {
         <hr />
         <h3>Resource Pages</h3>
         {/* Manage resource categories */}
-        <ResourceCategoryModal 
+        <ResourceCategoryModal
           siteName={siteName}
           resourceCategories={resourceCategories}
           categoryModalToggle={this.categoryModalToggle}
           categoryModalIsActive={categoryModalIsActive}
         />
         {/* Display resource cards */}
-        {resourcePages.length > 0 ?
-          <>
-          {resourcePages.map(resourcePage => (
-            <ResourceCard 
-              type={resourcePage.type}
-              category={resourcePage.category}
-              title={resourcePage.title}
-              date={resourcePage.date}
-              fileName={resourcePage.fileName}
-              siteName={siteName}
-              resourceCategories={resourceCategories}
-              isNewPost={false}
-            />
-          ))}
-          </>
-        :
-          null
-        }
-        <ResourceCard 
+        {resourcePages.length > 0
+          ? (
+            <>
+              {resourcePages.map((resourcePage) => (
+                <ResourceCard
+                  type={resourcePage.type}
+                  category={resourcePage.category}
+                  title={resourcePage.title}
+                  date={resourcePage.date}
+                  fileName={resourcePage.fileName}
+                  siteName={siteName}
+                  resourceCategories={resourceCategories}
+                  isNewPost={false}
+                />
+              ))}
+            </>
+          )
+          : null}
+        <ResourceCard
           siteName={siteName}
           resourceCategories={resourceCategories}
-          isNewPost={true}
+          isNewPost
         />
         <br />
         <input placeholder="New page name" onChange={this.updateNewPageName} />
@@ -272,7 +144,7 @@ export default class Resources extends Component {
 Resources.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
-      siteName: PropTypes.string,
+      siteName: PropTypes.string.isRequired,
     }),
   }).isRequired,
 };

--- a/src/templates/ResourceCard.jsx
+++ b/src/templates/ResourceCard.jsx
@@ -1,6 +1,7 @@
 import React, { Component }from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { prettifyResourceCategory, slugifyResourceCategory } from '../utils';
 import { frontMatterParser, concatFrontMatterMdBody, enquoteString, dequoteString, generateResourceFileName } from '../utils';
 import { Base64 } from 'js-base64';
 
@@ -19,10 +20,10 @@ const ResourceCardModal = ({
 }) => (
   <div>
     <p>Category</p>
-    <select id="category" defaultValue={category} onChange={changeHandler}>
+    <select id="category" defaultValue={slugifyResourceCategory(category)} onChange={changeHandler}>
       {
         resourceCategories.map(resourceCategory => (
-          <option value={resourceCategory.dirName} label={resourceCategory.dirName}/>
+          <option value={slugifyResourceCategory(resourceCategory.dirName)} label={prettifyResourceCategory(resourceCategory.dirName)}/>
         ))
       }
     </select>
@@ -216,7 +217,7 @@ export default class TemplateResourceCard extends Component {
           <button type="button" onClick={this.settingsToggle}>Create New Post</button>
         :
           <>
-            <p>Category: {category}</p>
+            <p>Category: {prettifyResourceCategory(category)}</p>
             <p>Title: {title}</p>
             <p>Date: {date}</p>
             <p>Type: {type}</p>

--- a/src/templates/ResourceCard.jsx
+++ b/src/templates/ResourceCard.jsx
@@ -1,0 +1,241 @@
+import React, { Component }from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import { frontMatterParser, concatFrontMatterMdBody, enquoteString, dequoteString, generateResourceFileName } from '../utils';
+import { Base64 } from 'js-base64';
+
+const ResourceCardModal = ({
+  title, 
+  category, 
+  date, 
+  permalink, 
+  fileUrl, 
+  resourceCategories, 
+  changeHandler, 
+  saveHandler, 
+  deleteHandler, 
+  permalinkFileUrlToggle,
+  isNewPost
+}) => (
+  <div>
+    <p>Category</p>
+    <select id="category" defaultValue={category} onChange={changeHandler}>
+      {
+        resourceCategories.map(resourceCategory => (
+          <option value={resourceCategory.dirName} label={resourceCategory.dirName}/>
+        ))
+      }
+    </select>
+    <p>Title</p>
+    <input value={dequoteString(title)} id="title" onChange={changeHandler}/>
+    <p>Date</p>
+    <input value={date} id="date" onChange={changeHandler}/>
+    <button type="button" onClick={permalinkFileUrlToggle}>{permalink ? 'Switch to download' : 'Switch to post'}</button>
+    {permalink ?
+      <>
+        <p>Permalink</p>
+        <input value={permalink} id="permalink" onChange={changeHandler}/>
+      </>
+    :
+      <>
+        <p>File URL</p>
+        <input value={fileUrl} id="fileUrl" onChange={changeHandler}/>
+      </>
+    }
+    <button type="button" onClick={saveHandler}>Save</button>
+    { !isNewPost ?
+      <button type="button" onClick={deleteHandler}>Delete</button>
+    :
+      null
+    }
+  </div>
+)
+
+export default class TemplateResourceCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: '', 
+      permalink: null,
+      fileUrl: null,
+      date: '',
+      settingsIsActive: false,
+      mdBody: null,
+      category: null,
+      sha: ''
+    };
+  }
+
+  async componentDidMount() {
+    try {
+      const { category, siteName, fileName, isNewPost } = this.props;
+      if (isNewPost) {
+        const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`, {
+          withCredentials: true,
+        });
+        const { resources: resourceCategories } = resourcesResp.data
+
+        this.setState({ 
+          title: "TITLE", 
+          permalink: "PERMALINK", 
+          date: "DATE", 
+          mdBody: "",
+          category: resourceCategories[0].dirName
+         })
+      } else {
+        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
+          withCredentials: true,
+        })
+  
+        const { content, sha } = resp.data
+        const base64DecodedContent = Base64.decode(content);
+        const { frontMatter, mdBody } = frontMatterParser(base64DecodedContent);
+        const { title, permalink, file_url, date } = frontMatter
+  
+        this.setState({ title, permalink, fileUrl: file_url, date, sha, mdBody, category })
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  settingsToggle = () => {
+    this.setState((currState) => ({
+      settingsIsActive: !currState.settingsIsActive
+    }))
+  }
+
+  permalinkFileUrlToggle = () => {
+    const { permalink } = this.state
+    if (permalink) {
+      this.setState({ permalink: null, fileUrl: "FILE_URL"})
+    } else {
+      this.setState({ permalink: "PERMALINK", fileUrl: null})
+    }
+
+  }
+
+  deleteHandler = async() => {
+    try {
+      const { sha } = this.state
+      const { category, fileName, siteName } = this.props
+      const params = { sha };
+      await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
+        data: params,
+        withCredentials: true,
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  saveHandler = async() => {
+    try {
+      const { title, permalink, fileUrl, date, mdBody, sha, category } = this.state
+      const { fileName, siteName, isNewPost} = this.props
+
+      const frontMatter = { title: enquoteString(title), date }
+      let type = ''
+      if (permalink) {
+        frontMatter.permalink = permalink
+        type = 'post'
+      }
+      if (fileUrl) {
+        frontMatter.file_url = fileUrl
+        type = 'download'
+      }
+
+      const content = concatFrontMatterMdBody(frontMatter, mdBody)
+      const base64EncodedContent = Base64.encode(content);
+
+      let newFileName = generateResourceFileName(dequoteString(title), type, date)
+      let params = {}
+
+      if (newFileName !== fileName) {
+        // We'll need to create a new .md file with a new filename
+        params = {
+          content: base64EncodedContent,
+          pageName: newFileName
+        };
+
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages`, params, {
+          withCredentials: true,
+        })
+
+        // If it is an existing post, delete the existing page
+        if (!isNewPost) {
+          await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
+            data: {
+              sha
+            },
+            withCredentials: true,
+          })
+        }
+      } else {
+        // Save to existing .md file
+        params = {
+          content: base64EncodedContent,
+          sha,
+        };
+  
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, params, {
+          withCredentials: true,
+        })
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  changeHandler = (event) => {
+    const { id, value } = event.target
+    this.setState({[id]: value})
+  }
+
+  render() {
+    const {
+      type,
+      category,
+      title,
+      date,
+      siteName,
+      fileName,
+      resourceCategories,
+      isNewPost
+    } = this.props
+    const { settingsIsActive } = this.state
+    return (
+      <div>
+        { isNewPost ?
+          <button type="button" onClick={this.settingsToggle}>Create New Post</button>
+        :
+          <>
+            <p>Category: {category}</p>
+            <p>Title: {title}</p>
+            <p>Date: {date}</p>
+            <p>Type: {type}</p>
+            <button type="button" onClick={this.settingsToggle}>Settings</button>
+          </>
+        }
+        {settingsIsActive ?
+          <ResourceCardModal 
+            title={this.state.title}
+            category={this.state.category}
+            date={this.state.date}
+            permalink={this.state.permalink}
+            fileUrl={this.state.fileUrl}
+            resourceCategories={resourceCategories}
+            changeHandler={this.changeHandler}
+            saveHandler={this.saveHandler}
+            deleteHandler={this.deleteHandler}
+            permalinkFileUrlToggle={this.permalinkFileUrlToggle}
+            isNewPost={isNewPost}
+          />
+        :
+          null
+        }
+        <Link to={`/sites/${siteName}/resources/${category}/pages/${fileName}`}>Edit</Link>
+      </div>
+    )
+  }
+}

--- a/src/templates/ResourceCard.jsx
+++ b/src/templates/ResourceCard.jsx
@@ -124,6 +124,9 @@ export default class TemplateResourceCard extends Component {
         data: params,
         withCredentials: true,
       })
+
+      // Refresh page
+      window.location.reload();
     } catch (err) {
       console.log(err)
     }
@@ -158,10 +161,6 @@ export default class TemplateResourceCard extends Component {
           pageName: newFileName
         };
 
-        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages`, params, {
-          withCredentials: true,
-        })
-
         // If it is an existing post, delete the existing page
         if (!isNewPost) {
           await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
@@ -171,6 +170,10 @@ export default class TemplateResourceCard extends Component {
             withCredentials: true,
           })
         }
+
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages`, params, {
+          withCredentials: true,
+        })
       } else {
         // Save to existing .md file
         params = {
@@ -182,6 +185,9 @@ export default class TemplateResourceCard extends Component {
           withCredentials: true,
         })
       }
+
+      // Refresh page
+      window.location.reload();
     } catch (err) {
       console.log(err)
     }

--- a/src/templates/pageComponents/LeftNav.jsx
+++ b/src/templates/pageComponents/LeftNav.jsx
@@ -19,9 +19,9 @@ const LeftNav = ({ leftNavPages, fileName }) => (
               return (
                 <li>
                   {
-                    page.fileName === fileName ?
-                      <a className="is-active" href={filePath}>{deslugifyCollectionPage(page.fileName)}</a> :
-                      <a className="" href={filePath}>{deslugifyCollectionPage(page.fileName)}</a>
+                    page.fileName === fileName
+                      ? <a className="is-active" href={filePath}>{deslugifyCollectionPage(page.fileName)}</a>
+                      : <a className="" href={filePath}>{deslugifyCollectionPage(page.fileName)}</a>
                   }
                 </li>
               );

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,7 +111,6 @@ export function enquoteString(str) {
   return enquotedString;
 }
 
-
 export function dequoteString(str) {
   let dequotedString = str;
   if (str[0] === '"') dequotedString = dequotedString.slice(1);
@@ -120,7 +119,8 @@ export function dequoteString(str) {
 }
 
 export function generateResourceFileName(title, type, date) {
-  return `${date}-${type}-${slugify(title)}.md`;
+  const safeTitle = slugify(title).replace(/[^a-zA-Z-]/g, '')
+  return `${date}-${type}-${safeTitle}.md`;
 }
 
 export function prettifyResourceCategory(category) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,3 +122,11 @@ export function dequoteString(str) {
 export function generateResourceFileName(title, type, date) {
   return date + "-" + type + "-" + slugify(title) + ".md"
 }
+
+export function prettifyResourceCategory(category) {
+  return category.replace(/-/g, ' ').toUpperCase()
+}
+
+export function slugifyResourceCategory(category) {
+  return slugify(category).toLowerCase()
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,13 +69,13 @@ const monthMap = {
   '07': 'Jul',
   '08': 'Aug',
   '09': 'Sep',
-  '10': 'Oct',
-  '11': 'Nov',
-  '12': 'Dec'
-}
+  10: 'Oct',
+  11: 'Nov',
+  12: 'Dec',
+};
 
 function monthIntToStr(monthInt) {
-  return monthMap[monthInt]
+  return monthMap[monthInt];
 }
 
 // Takes in a resource file name and prettifies it.
@@ -86,47 +86,47 @@ function monthIntToStr(monthInt) {
 // {type} is either `post` or `download`
 // {title} is a string containing [a-z,A-Z,0-9] and all whitespaces are replaced by hyphens
 export function prettifyResourceFileName(fileName) {
-  const fileNameArray = fileName.split('.md')[0]
-  const tokenArray = fileNameArray.split('-')
-  const day = tokenArray[2]
-  const month = monthIntToStr(tokenArray[1])
-  const year = tokenArray[0]
-  const date = month + ' ' + day + ' ' + year
+  const fileNameArray = fileName.split('.md')[0];
+  const tokenArray = fileNameArray.split('-');
+  const day = tokenArray[2];
+  const month = monthIntToStr(tokenArray[1]);
+  const year = tokenArray[0];
+  const date = `${month} ${day} ${year}`;
 
-  const type = tokenArray[3]
+  const type = tokenArray[3];
 
-  let title = ''
+  let title = '';
   tokenArray.forEach((token, index) => {
     if (index > 3) {
-      title += ' ' + token
+      title += ` ${token}`;
     }
   });
-  return { date, type, title }
+  return { date, type, title };
 }
 
 export function enquoteString(str) {
-  let enquotedString = str
-  if (str[0] !== '"') enquotedString = '"' + enquotedString
-  if (str[str.length-1] !== '"') enquotedString = enquotedString + '"'
-  return enquotedString
+  let enquotedString = str;
+  if (str[0] !== '"') enquotedString = `"${enquotedString}`;
+  if (str[str.length - 1] !== '"') enquotedString += '"';
+  return enquotedString;
 }
 
 
 export function dequoteString(str) {
-  let dequotedString = str
-  if (str[0] === '"') dequotedString = dequotedString.slice(1)
-  if (str[str.length-1] === '"') dequotedString = dequotedString.slice(0,-1)
-  return dequotedString
+  let dequotedString = str;
+  if (str[0] === '"') dequotedString = dequotedString.slice(1);
+  if (str[str.length - 1] === '"') dequotedString = dequotedString.slice(0, -1);
+  return dequotedString;
 }
 
 export function generateResourceFileName(title, type, date) {
-  return date + "-" + type + "-" + slugify(title) + ".md"
+  return `${date}-${type}-${slugify(title)}.md`;
 }
 
 export function prettifyResourceCategory(category) {
-  return category.replace(/-/g, ' ').toUpperCase()
+  return category.replace(/-/g, ' ').toUpperCase();
 }
 
 export function slugifyResourceCategory(category) {
-  return slugify(category).toLowerCase()
+  return slugify(category).toLowerCase();
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 // import dependencies
 import yaml from 'js-yaml';
 import cheerio from 'cheerio';
+import slugify from 'slugify';
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {
@@ -56,4 +57,68 @@ export function changeFileName(event, context) {
   context.setState({
     tempFileName: event.target.value,
   });
+}
+
+const monthMap = {
+  '01': 'Jan',
+  '02': 'Feb',
+  '03': 'Mar',
+  '04': 'Apr',
+  '05': 'May',
+  '06': 'Jun',
+  '07': 'Jul',
+  '08': 'Aug',
+  '09': 'Sep',
+  '10': 'Oct',
+  '11': 'Nov',
+  '12': 'Dec'
+}
+
+function monthIntToStr(monthInt) {
+  return monthMap[monthInt]
+}
+
+// Takes in a resource file name and prettifies it.
+// =================
+// Each fileName comes in the format of `{date}-{type}-{title}.md`
+// A sample fileName is 2019-08-23-post-CEO-made-a-speech.md
+// {date} is YYYY-MM-DD, e.g. 2019-08-23
+// {type} is either `post` or `download`
+// {title} is a string containing [a-z,A-Z,0-9] and all whitespaces are replaced by hyphens
+export function prettifyResourceFileName(fileName) {
+  const fileNameArray = fileName.split('.md')[0]
+  const tokenArray = fileNameArray.split('-')
+  const day = tokenArray[2]
+  const month = monthIntToStr(tokenArray[1])
+  const year = tokenArray[0]
+  const date = month + ' ' + day + ' ' + year
+
+  const type = tokenArray[3]
+
+  let title = ''
+  tokenArray.forEach((token, index) => {
+    if (index > 3) {
+      title += ' ' + token
+    }
+  });
+  return { date, type, title }
+}
+
+export function enquoteString(str) {
+  let enquotedString = str
+  if (str[0] !== '"') enquotedString = '"' + enquotedString
+  if (str[str.length-1] !== '"') enquotedString = enquotedString + '"'
+  return enquotedString
+}
+
+
+export function dequoteString(str) {
+  let dequotedString = str
+  if (str[0] === '"') dequotedString = dequotedString.slice(1)
+  if (str[str.length-1] === '"') dequotedString = dequotedString.slice(0,-1)
+  return dequotedString
+}
+
+export function generateResourceFileName(title, type, date) {
+  return date + "-" + type + "-" + slugify(title) + ".md"
 }


### PR DESCRIPTION
### Overview
This PR adds the resource room functionality to the frontend (https://github.com/isomerpages/isomercms-frontend/issues/26). 

### High latency in the resource room because there are too many API calls

The image below is the InVision design for the resource room. 

![Screenshot 2019-11-11 at 12 39 37 PM](https://user-images.githubusercontent.com/19917616/68561402-61b81380-0480-11ea-8f32-91fdc8f33182.png)

In order to display the `title`, `post-type`, and `date`, the frontend would need to retrieve the data in the frontmatter of each resource page.

However, this means the backend would have had to call many GitHub APIs:
- 1 API call to list directory in the `resources` folder, and then
- 1 API call for each directory to list the names of all files in the directory, and then
- 1 API call for each file to retrieve the front matter.

If there were on average `m` directories and `n` files in each directory, the frontend would have to call `mn+1` GitHub APIs, which could take a really long time. 

### Reducing API calls by caching `title`, `post-type`, and `date` in the resource page filename

Instead, we can reduce the number of GitHub API calls to `m+1` by caching the fields we needed to display in the file names of the resource pages.

And so, the frontend only calls:
- 1 API call to list directory in the `resources` folder (to get the resource categories), and then
- 1 API call for each directory to list the names of all files in the directory (resource category).

And so the resource pages file names follow the format `{date}-{post-type}-{title}.md`, where:
- `date` is a string with the format `YYYY-MM-DD`,
- `post-type` is a string with two types: `post` or `download`,
- `title` is a case-sensitive string that can contain the following characters `a` to `z`, `A` to `Z`,  `0` to `9`, and hyphen.

