### PR TITLE
allow users to modify page frontmatter from Pages page

### DIFF
--- a/src/components/PageCard.jsx
+++ b/src/components/PageCard.jsx
@@ -1,0 +1,148 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import { Base64 } from 'js-base64';
+import {
+  prettifyPageFileName, frontMatterParser, concatFrontMatterMdBody, generatePageFileName,
+} from '../utils';
+
+export default class PageCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      sha: '',
+      title: '',
+      permalink: '',
+      settingsIsActive: false,
+      mdBody: null,
+    };
+  }
+
+  async componentDidMount() {
+    try {
+      const { siteName, fileName } = this.props;
+      const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}`, {
+        withCredentials: true,
+      });
+      const { sha, content } = resp.data;
+
+      // split the markdown into front matter and content
+      const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
+      const { title, permalink } = frontMatter;
+      this.setState({
+        sha, title, permalink, mdBody,
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  saveHandler = async () => {
+    try {
+      const { siteName, fileName } = this.props;
+      const {
+        sha, title, permalink, mdBody,
+      } = this.state;
+
+      const frontMatter = { title, permalink };
+
+      // here, we need to re-add the front matter of the markdown file
+      const upload = concatFrontMatterMdBody(frontMatter, mdBody);
+
+      // encode to Base64 for github
+      const base64Content = Base64.encode(upload);
+      const newFileName = generatePageFileName(title);
+
+      // A new file does not need to be created; the title has not changed
+      if (newFileName === fileName) {
+        const params = {
+          content: base64Content,
+          sha,
+        };
+
+        // Update existing file
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}`, params, {
+          withCredentials: true,
+        });
+      } else {
+        // A new file needs to be created
+        // Delete existing page
+        await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}`, {
+          data: { sha },
+          withCredentials: true,
+        });
+
+        // Create new page
+        const params = {
+          pageName: newFileName,
+          content: base64Content,
+        };
+
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages`, params, {
+          withCredentials: true,
+        });
+      }
+
+      // Refresh page
+      window.location.reload();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  deleteHandler = async () => {
+    try {
+      const { siteName, fileName } = this.props;
+      const { sha } = this.state;
+      const params = { sha };
+      await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}`, {
+        data: params,
+        withCredentials: true,
+      });
+
+      window.location.reload();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  changeHandler = (event) => {
+    const { id, value } = event.target;
+    this.setState({ [id]: value });
+  }
+
+  settingsToggle = () => {
+    this.setState((currState) => ({
+      settingsIsActive: !currState.settingsIsActive,
+    }));
+  }
+
+  render() {
+    const { siteName, fileName } = this.props;
+    const { settingsIsActive, title, permalink } = this.state;
+    return (
+      <>
+        <Link to={`/sites/${siteName}/pages/${fileName}`}>{prettifyPageFileName(fileName)}</Link>
+        <button type="button" onClick={this.settingsToggle}>Settings</button>
+        { settingsIsActive
+          ? (
+            <>
+              <p>Title</p>
+              <input defaultValue={title} id="title" onChange={this.changeHandler} />
+              <p>Permalink</p>
+              <input defaultValue={permalink} id="permalink" onChange={this.changeHandler} />
+              <button type="button" onClick={this.saveHandler}>Save</button>
+              <button type="button" onClick={this.deleteHandler}>Delete</button>
+            </>
+          )
+          : null}
+      </>
+    );
+  }
+}
+
+PageCard.propTypes = {
+  siteName: PropTypes.string.isRequired,
+  fileName: PropTypes.string.isRequired,
+};

--- a/src/layouts/Pages.jsx
+++ b/src/layouts/Pages.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+import PageCard from '../components/PageCard';
 
 export default class Pages extends Component {
   constructor(props) {
@@ -62,7 +63,10 @@ export default class Pages extends Component {
         {pages.length > 0
           ? pages.map((page) => (
             <li>
-              <Link to={`/sites/${siteName}/pages/${page.fileName}`}>{page.fileName}</Link>
+              <PageCard
+                fileName={page.fileName}
+                siteName={siteName}
+              />
             </li>
           ))
           : 'No pages'}

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,5 +135,5 @@ export function prettifyPageFileName(fileName) {
 }
 
 export function generatePageFileName(title) {
-  return slugify(title).replace(/[^a-zA-Z-]/g, '');
+  return slugify(title).replace(/[^a-zA-Z-]/g, '') + '.md';
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,12 +95,8 @@ export function prettifyResourceFileName(fileName) {
 
   const type = tokenArray[3];
 
-  let title = '';
-  tokenArray.forEach((token, index) => {
-    if (index > 3) {
-      title += ` ${token}`;
-    }
-  });
+  let title = tokenArray.slice(4).join(" ")
+  
   return { date, type, title };
 }
 
@@ -119,7 +115,7 @@ export function dequoteString(str) {
 }
 
 export function generateResourceFileName(title, type, date) {
-  const safeTitle = slugify(title).replace(/[^a-zA-Z-]/g, '')
+  const safeTitle = slugify(title).replace(/[^a-zA-Z-]/g, '');
   return `${date}-${type}-${safeTitle}.md`;
 }
 
@@ -129,4 +125,15 @@ export function prettifyResourceCategory(category) {
 
 export function slugifyResourceCategory(category) {
   return slugify(category).toLowerCase();
+}
+
+export function prettifyPageFileName(fileName) {
+  const fileNameArray = fileName.split('.md')[0];
+  const tokenArray = fileNameArray.split('-');
+
+  return tokenArray.join(" ");
+}
+
+export function generatePageFileName(title) {
+  return slugify(title).replace(/[^a-zA-Z-]/g, '');
 }


### PR DESCRIPTION
### Overview
This PR addresses https://github.com/isomerpages/isomercms-frontend/issues/43. This PR should be reviewed after https://github.com/isomerpages/isomercms-frontend/pull/42.

Users can now:
- edit the page settings (title, permalink)
- delete an existing page

### Page title is cached in the GitHub filename to reduce the number of API calls
A similar title caching mechamism was implemented to PR for the Pages page as described in the [Resource Room](https://github.com/isomerpages/isomercms-frontend/pull/42).


