### PR TITLE
style: create class for sites section title

### DIFF
--- a/src/layouts/Sites.jsx
+++ b/src/layouts/Sites.jsx
@@ -4,7 +4,6 @@ import Header from '../components/Header';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import siteStyles from '../styles/isomer-cms/pages/Sites.module.scss';
 
-
 export default class Sites extends Component {
   constructor(props) {
     super(props);
@@ -33,7 +32,9 @@ export default class Sites extends Component {
         <div className={elementStyles.wrapper}>
           <div className={siteStyles.sitesContainer}>
             <div className={siteStyles.sectionHeader}>
-              <h1>Sites</h1>
+              <div className={siteStyles.sectionTitle}>
+                <b>Sites</b>
+              </div>
             </div>
             <div className={siteStyles.sites}>
               {siteNames.map((siteName) => (

--- a/src/styles/isomer-cms/pages/Sites.module.scss
+++ b/src/styles/isomer-cms/pages/Sites.module.scss
@@ -22,6 +22,12 @@
   .sectionHeader{
     width: $sites-container-width;
     margin-left: $site-margin-horizontal*2;
+
+    .sectionTitle{
+      font-size: 28px;
+      color: $isomer-blue;
+      text-align: left;
+    }
   }
 
 
@@ -40,7 +46,6 @@
       flex-direction: rows;
       justify-content: center;
       align-items: center;
-
 
       .site{
         @include single-site;


### PR DESCRIPTION
This PR styles the Sites title on the Sites page so that it looks like the following:

![Screenshot 2019-11-20 at 3 05 38 PM](https://user-images.githubusercontent.com/19917616/69216461-3d0e1b00-0ba7-11ea-9ea3-1bf5c9870da0.png)
