### PR TITLE
BREAKING CHANGE: Include collection pages in the `Pages` tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ function App() {
           <Route exact path="/" component={Home} />
           <Route path="/sites/:siteName/collections/:collectionName/:fileName" component={EditCollectionPage} />
           <Route path="/sites/:siteName/collections/:collectionName" component={CollectionPages} />
-          <Route path="/sites/:siteName/collections" component={Collections} />
+          {/* <Route path="/sites/:siteName/collections" component={Collections} /> */}
           <Route path="/sites/:siteName/files/:fileName" component={EditFile} />
           <Route path="/sites/:siteName/files" component={Files} />
           <Route path="/sites/:siteName/images/:fileName" component={EditImage} />

--- a/src/components/CollectionPageSettingsModal.jsx
+++ b/src/components/CollectionPageSettingsModal.jsx
@@ -1,0 +1,231 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import { Base64 } from 'js-base64';
+import * as _ from 'lodash';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import {
+  frontMatterParser, concatFrontMatterMdBody, generateCollectionPageFileName,
+} from '../utils';
+
+// Constants
+const PERMALINK_REGEX = '^(/([a-z]+([-][a-z]+)*/)+)$';
+const permalinkRegexTest = RegExp(PERMALINK_REGEX);
+const PERMALINK_MIN_LENGTH = 4;
+const PERMALINK_MAX_LENGTH = 50;
+const TITLE_MIN_LENGTH = 4;
+const TITLE_MAX_LENGTH = 100;
+
+export default class CollectionPageSettingsModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      sha: '',
+      title: '',
+      permalink: '',
+      mdBody: '',
+      errors: {
+        title: '',
+        permalink: '',
+      },
+    };
+  }
+
+  async componentDidMount() {
+    try {
+      const {
+        siteName, fileName, collectionName,
+      } = this.props;
+
+      const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages/${fileName}`, {
+        withCredentials: true,
+      });
+      const { sha, content } = resp.data;
+
+      // split the markdown into front matter and content
+      const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
+      const { title, permalink, third_nav_title: thirdNavTitle } = frontMatter;
+      this.setState({
+        sha, title, permalink, mdBody, thirdNavTitle,
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  saveHandler = async () => {
+    try {
+      const { siteName, fileName, collectionName } = this.props;
+      const {
+        sha, title, permalink, mdBody, thirdNavTitle,
+      } = this.state;
+      const groupIdentifier = fileName.split('-')[0];
+
+      const frontMatter = thirdNavTitle
+        ? { title, permalink, third_nav_title: thirdNavTitle }
+        : { title, permalink };
+
+      // here, we need to re-add the front matter of the markdown file
+      const upload = concatFrontMatterMdBody(frontMatter, mdBody);
+      const newFileName = generateCollectionPageFileName(title, groupIdentifier);
+
+      // encode to Base64 for github
+      const base64Content = Base64.encode(upload);
+
+      if (newFileName === fileName) {
+        // Update existing file
+        const params = {
+          content: base64Content,
+          sha,
+        };
+
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages/${fileName}`, params, {
+          withCredentials: true,
+        });
+      } else {
+        await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages/${fileName}`, {
+          data: { sha },
+          withCredentials: true,
+        });
+
+        // Create new page
+        const params = {
+          pageName: newFileName,
+          content: base64Content,
+        };
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages`, params, {
+          withCredentials: true,
+        });
+      }
+
+      // Refresh page
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  deleteHandler = async () => {
+    try {
+      const { siteName, fileName, collectionName } = this.props;
+      const { sha } = this.state;
+      const params = { sha };
+      await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages/${fileName}`, {
+        data: params,
+        withCredentials: true,
+      });
+
+      window.location.reload();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  changeHandler = (event) => {
+    const { id, value } = event.target;
+    let errorMessage = '';
+    switch (id) {
+      case 'permalink': {
+        // Permalink is too short
+        if (value.length < PERMALINK_MIN_LENGTH) {
+          errorMessage = `The permalink should be longer than ${PERMALINK_MIN_LENGTH} characters.`;
+        }
+
+        // Permalink is too long
+        if (value.length > PERMALINK_MAX_LENGTH) {
+          errorMessage = `The permalink should be shorter than ${PERMALINK_MAX_LENGTH} characters.`;
+        }
+
+        // Permalink fails regex
+        if (!permalinkRegexTest.test(value)) {
+          console.log('IN REGEX FAIL', value);
+          errorMessage = `The permalink should start and end with slashes and contain 
+            lowercase words separated by hyphens only.
+            `;
+        }
+        break;
+      }
+      case 'title': {
+        // Title is too short
+        if (value.length < TITLE_MIN_LENGTH) {
+          errorMessage = `The title should be longer than ${TITLE_MIN_LENGTH} characters.`;
+        }
+        // Title is too long
+        if (value.length > TITLE_MAX_LENGTH) {
+          errorMessage = `The title should be shorter than ${TITLE_MAX_LENGTH} characters.`;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    this.setState({
+      errors: {
+        [id]: errorMessage,
+      },
+      [id]: value,
+    });
+  }
+
+  render() {
+    const { title, permalink, errors } = this.state;
+    const { settingsToggle } = this.props;
+
+    // Page settings form has errors - disable save button
+    const hasErrors = _.some(errors, (field) => field.length > 0);
+
+    return (
+      <div className={elementStyles.overlay}>
+        <div className={elementStyles.modal}>
+          <div className={elementStyles.modalHeader}>
+            <button type="button" onClick={settingsToggle}>
+              <i className="bx bx-x" />
+            </button>
+          </div>
+          <form className={elementStyles.modalContent} onSubmit={this.saveHandler}>
+            <div className={elementStyles.modalFormFields}>
+              <p className={elementStyles.formLabel}>Title</p>
+              <input
+                value={title}
+                id="title"
+                required
+                autoComplete="off"
+                onChange={this.changeHandler}
+                className={errors.title ? `${elementStyles.error}` : null}
+              />
+              <span className={elementStyles.error}>
+                {' '}
+                {errors.title}
+                {' '}
+              </span>
+              <p
+                className={elementStyles.formLabel}
+              >
+Permalink (e.g. /foo/, /foo-bar/, or /foo/bar/)
+              </p>
+              <input
+                value={permalink}
+                id="permalink"
+                required
+                onChange={this.changeHandler}
+                autoComplete="off"
+                className={errors.permalink ? `${elementStyles.error}` : null}
+              />
+              <span className={elementStyles.error}>{errors.permalink}</span>
+            </div>
+            <div className={elementStyles.modalButtons}>
+              <button type="submit" className={`${hasErrors ? elementStyles.disabled : elementStyles.blue}`} disabled={hasErrors} value="submit">Save</button>
+              <button type="button" className={elementStyles.warning} onClick={this.deleteHandler}>Delete</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}
+
+CollectionPageSettingsModal.propTypes = {
+  settingsToggle: PropTypes.func.isRequired,
+  siteName: PropTypes.string.isRequired,
+  fileName: PropTypes.string.isRequired,
+  collectionName: PropTypes.string.isRequired,
+};

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,10 +9,6 @@ const sidebarPathDict = [
     title: 'Pages',
   },
   {
-    pathname: 'collections',
-    title: 'Collections',
-  },
-  {
     pathname: 'menus',
     title: 'Menus',
   },

--- a/src/layouts/EditCollectionPage.jsx
+++ b/src/layouts/EditCollectionPage.jsx
@@ -35,11 +35,18 @@ export default class EditCollectionPage extends Component {
       const { content, sha } = resp.data;
       // split the markdown into front matter and content
       const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
+
+      const collectionPagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}`, {
+        withCredentials: true,
+      });
+      const { collectionPages: leftNavPages } = collectionPagesResp.data;
+
       this.setState({
         content,
         sha,
         editorValue: mdBody.trim(),
         frontMatter,
+        leftNavPages,
       });
     } catch (err) {
       console.log(err);
@@ -133,7 +140,7 @@ export default class EditCollectionPage extends Component {
   render() {
     const { match, location } = this.props;
     const { siteName, collectionName, fileName } = match.params;
-    const { leftNavPages } = location.state;
+    const { leftNavPages } = this.state;
     const { sha, editorValue } = this.state;
     return (
       <>
@@ -162,11 +169,13 @@ export default class EditCollectionPage extends Component {
             <button type="button" onClick={this.renamePage}>Rename</button>
           </div>
           <div className={styles.rightPane}>
+            { leftNavPages && (
             <LeftNavPage
               chunk={prependImageSrc(siteName, marked(editorValue))}
               leftNavPages={leftNavPages}
               fileName={fileName}
             />
+            )}
           </div>
         </div>
 

--- a/src/layouts/Pages.jsx
+++ b/src/layouts/Pages.jsx
@@ -14,10 +14,12 @@ import { prettifyPageFileName } from '../utils';
 const RADIX_PARSE_INT = 10;
 
 const PageCard = ({
-  siteName, pageName, pageIndex, settingsToggle,
+  siteName, pageName, pageIndex, settingsToggle, collectionName,
 }) => (
   <li>
-    <Link to={`/sites/${siteName}/pages/${pageName}`}>{prettifyPageFileName(pageName)}</Link>
+    { collectionName
+      ? <Link to={`/sites/${siteName}/collections/${collectionName}/${pageName}`}>{prettifyPageFileName(pageName)}</Link>
+      : <Link to={`/sites/${siteName}/pages/${pageName}`}>{prettifyPageFileName(pageName)}</Link>}
     <button type="button" onClick={settingsToggle} id={`settings-${pageIndex}`}>
       <i id={`settingsIcon-${pageIndex}`} className="bx bx-cog" />
     </button>
@@ -142,6 +144,7 @@ Create New Page
                       pageName={page.fileName}
                       pageIndex={pageIndex}
                       settingsToggle={this.settingsToggle}
+                      collectionName={page.collectionName ? page.collectionName : ''}
                     />
                   ))
                   : 'Loading Pages...'}
@@ -161,6 +164,7 @@ PageCard.propTypes = {
   pageName: PropTypes.string.isRequired,
   pageIndex: PropTypes.number.isRequired,
   settingsToggle: PropTypes.func.isRequired,
+  collectionName: PropTypes.string.isRequired,
 };
 
 Pages.propTypes = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -137,3 +137,8 @@ export function prettifyPageFileName(fileName) {
 export function generatePageFileName(title) {
   return `${slugify(title).replace(/[^a-zA-Z-]/g, '')}.md`;
 }
+
+export function generateCollectionPageFileName(title, groupIdentifier) {
+  console.log(slugify(title));
+  return `${groupIdentifier}-${slugify(title).replace(/[^a-zA-Z-]/g, '')}.md`;
+}


### PR DESCRIPTION
This PR does the following:
1) Removes `Collections` tab and displays the displaced collection pages in the `Pages` tab instead
2) Introduces a new modal for editing the frontmatter of the collection pages (`CollectionPagesSettingsModal`)
3) Users who click on the page cards of collection pages will still be directed to edit on the `/sites/:siteName/collections/:collectionName/:pageName` endpoint instead of the default `/sites/:siteName/pages/:pageName` endpoint.

**NOTE**
This is a pull request that needs to be merged along with the [PR](https://github.com/isomerpages/isomercms-backend/pull/31) for the backend or else it will break.