### PR TITLE
[Feat] Implement media page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import Images from './layouts/Images';
 import EditImage from './layouts/EditImage';
 import Files from './layouts/Files';
 import EditFile from './layouts/EditFile';
+import Media from './layouts/Media';
 import EditHomepage from './layouts/EditHomepage';
 import EditTree from './components/tree/EditTree';
 import Resources from './layouts/Resources';
@@ -43,6 +44,7 @@ function App() {
           <Route path="/sites/:siteName/files" component={Files} />
           <Route path="/sites/:siteName/images/:fileName" component={EditImage} />
           <Route path="/sites/:siteName/images" component={Images} />
+          <Route path="/sites/:siteName/media" component={Media} />
           <Route path="/sites/:siteName/pages/:fileName" component={EditPage} />
           <Route path="/sites/:siteName/pages" component={Pages} />
           <Route path="/sites/:siteName/homepage" component={EditHomepage} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -29,6 +29,10 @@ const sidebarPathDict = [
     title: 'Files',
   },
   {
+    pathname: 'media',
+    title: 'Media',
+  },
+  {
     pathname: 'settings',
     title: 'Settings',
   },

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -21,14 +21,6 @@ const sidebarPathDict = [
     title: 'Resources',
   },
   {
-    pathname: 'images',
-    title: 'Images',
-  },
-  {
-    pathname: 'files',
-    title: 'Files',
-  },
-  {
     pathname: 'media',
     title: 'Media',
   },

--- a/src/layouts/Files.jsx
+++ b/src/layouts/Files.jsx
@@ -2,6 +2,18 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+
+const FileCard = ({
+  siteName, file,
+}) => (
+  <li>
+    <Link to={`/sites/${siteName}/files/${file.fileName}`}>{file.fileName}</Link>
+  </li>
+);
 
 export default class Files extends Component {
   constructor(props) {
@@ -33,46 +45,43 @@ export default class Files extends Component {
 
   render() {
     const { files, newPageName } = this.state;
-    const { match } = this.props;
+    const { match, location } = this.props;
     const { siteName } = match.params;
     return (
-      <div>
-        <Link to="/sites">Back to Sites</Link>
-        <hr />
-        <h2>{siteName}</h2>
-        <ul>
-          <li>
-            <Link to={`/sites/${siteName}/pages`}>Pages</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/collections`}>Collections</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/images`}>Images</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/files`}>Files</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/menus`}>Menus</Link>
-          </li>
-        </ul>
-        <hr />
-        <h3>Files</h3>
-        {files.length > 0
-          ? files.map((file) => (
-            <li>
-              <Link to={`/sites/${siteName}/files/${file.fileName}`}>{file.fileName}</Link>
-            </li>
-          ))
-          : 'No files'}
-        <br />
-        <input placeholder="New file name" onChange={this.updateNewPageName} />
-        <Link to={`/sites/${siteName}/documents/${newPageName}`}>Create new file</Link>
-      </div>
+      <>
+        <Header />
+        {/* main bottom section */}
+        <div className={elementStyles.wrapper}>
+          <Sidebar siteName={siteName} currPath={location.pathname} />
+          {/* main section starts here */}
+          <div className={contentStyles.mainSection}>
+            <div className={contentStyles.sectionHeader}>
+              <h1 className={contentStyles.sectionTitle}>Files</h1>
+            </div>
+            <div className={contentStyles.contentContainerBars}>
+              {/* File cards */}
+              <ul>
+                {files.length > 0
+                  ? files.map((file) => (
+                    <FileCard
+                      siteName={siteName}
+                      file={file}
+                    />
+                  ))
+                  : ''}
+              </ul>
+              {/* End of file cards */}
+            </div>
+          </div>
+          {/* main section ends here */}
+        </div>
+      </>
     );
   }
 }
+//         <input placeholder="New file name" onChange={this.updateNewPageName} />
+//         <Link to={`/sites/${siteName}/documents/${newPageName}`}>Create new file</Link>
+//       </div> */}
 
 Files.propTypes = {
   match: PropTypes.shape({
@@ -80,4 +89,14 @@ Files.propTypes = {
       siteName: PropTypes.string,
     }),
   }).isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+FileCard.propTypes = {
+  file: PropTypes.shape({
+    fileName: PropTypes.string,
+  }).isRequired,
+  siteName: PropTypes.string.isRequired,
 };

--- a/src/layouts/Files.jsx
+++ b/src/layouts/Files.jsx
@@ -57,6 +57,12 @@ export default class Files extends Component {
           <div className={contentStyles.mainSection}>
             <div className={contentStyles.sectionHeader}>
               <h1 className={contentStyles.sectionTitle}>Files</h1>
+              <button
+                type="button"
+                className={elementStyles.blue}
+              >
+                Upload file
+              </button>
             </div>
             <div className={contentStyles.contentContainerBars}>
               {/* File cards */}

--- a/src/layouts/Files.jsx
+++ b/src/layouts/Files.jsx
@@ -38,6 +38,8 @@ export default class Files extends Component {
     }
   }
 
+  // TODO - a modal which allows for the creation/upload of a new file
+  // and this.newPageName is updated onChange
   updateNewPageName = (event) => {
     event.preventDefault();
     this.setState({ newPageName: event.target.value });
@@ -74,7 +76,7 @@ export default class Files extends Component {
                       file={file}
                     />
                   ))
-                  : ''}
+                  : 'There are no files in this repository'}
               </ul>
               {/* End of file cards */}
             </div>
@@ -85,9 +87,6 @@ export default class Files extends Component {
     );
   }
 }
-//         <input placeholder="New file name" onChange={this.updateNewPageName} />
-//         <Link to={`/sites/${siteName}/documents/${newPageName}`}>Create new file</Link>
-//       </div> */}
 
 Files.propTypes = {
   match: PropTypes.shape({

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -2,6 +2,18 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+
+const ImageCard = ({
+  siteName, image,
+}) => (
+  <li>
+    <Link to={`/sites/${siteName}/images/${image.fileName}`}>{image.fileName}</Link>
+  </li>
+);
 
 export default class Images extends Component {
   constructor(props) {
@@ -9,6 +21,7 @@ export default class Images extends Component {
     this.state = {
       images: [],
       newImageName: '',
+      settingsIsActive: false,
     };
   }
 
@@ -24,6 +37,16 @@ export default class Images extends Component {
     } catch (err) {
       console.log(err);
     }
+  }
+
+  settingsToggle = (event) => {
+    const { id } = event.target;
+    const idArray = id.split('-');
+
+    // Upload a new image
+    this.setState((currState) => ({
+      settingsIsActive: !currState.settingsIsActive,
+    }));
   }
 
   updateNewPageName = (event) => {
@@ -72,56 +95,43 @@ export default class Images extends Component {
 
   render() {
     const { images, newImageName, newImageContent } = this.state;
-    const { match } = this.props;
+    const { match, location } = this.props;
     const { siteName } = match.params;
     return (
-      <div>
-        <Link to="/sites">Back to Sites</Link>
-        <hr />
-        <h2>{siteName}</h2>
-        <ul>
-          <li>
-            <Link to={`/sites/${siteName}/pages`}>Pages</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/collections`}>Collections</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/images`}>Images</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/files`}>Files</Link>
-          </li>
-          <li>
-            <Link to={`/sites/${siteName}/menus`}>Menus</Link>
-          </li>
-        </ul>
-        <hr />
-        <h3>Images</h3>
-        {images.length > 0
-          ? images.map((image) => (
-            <li>
-              <Link to={`/sites/${siteName}/images/${image.fileName}`}>{image.fileName}</Link>
-            </li>
-          ))
-          : 'No images'}
-        <br />
-
-        <div className="d-flex">
-          <input
-            type="file"
-            onChange={this.onImageSelect}
-            accept="image/png, image/jpeg"
-          />
-          {
-            newImageContent
-              ? <img alt="" src={`data:image/jpeg;base64,${newImageContent}`} />
-              : null
-          }
+      <>
+        <Header />
+        {/* main bottom section */}
+        <div className={elementStyles.wrapper}>
+          <Sidebar siteName={siteName} currPath={location.pathname} />
+          {/* main section starts here */}
+          <div className={contentStyles.mainSection}>
+            <div className={contentStyles.sectionHeader}>
+              <h1 className={contentStyles.sectionTitle}>Images</h1>
+              <button
+                type="button"
+                className={elementStyles.blue}
+              >
+                Upload new image
+              </button>
+            </div>
+            <div className={contentStyles.contentContainerBars}>
+              {/* Image cards */}
+              <ul>
+                {images.length > 0
+                  ? images.map((image) => (
+                    <ImageCard
+                      siteName={siteName}
+                      image={image}
+                    />
+                  ))
+                  : 'There are no images in this repository'}
+              </ul>
+              {/* End of image cards */}
+            </div>
+          </div>
+          {/* main section ends here */}
         </div>
-
-        <button type="button" onClick={() => this.uploadImage(newImageName, newImageContent)}>Upload new image</button>
-      </div>
+      </>
     );
   }
 }
@@ -132,4 +142,14 @@ Images.propTypes = {
       siteName: PropTypes.string,
     }),
   }).isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+ImageCard.propTypes = {
+  image: PropTypes.shape({
+    fileName: PropTypes.string,
+  }).isRequired,
+  siteName: PropTypes.string.isRequired,
 };

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -1,0 +1,94 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import Bluebird from 'bluebird';
+import PropTypes from 'prop-types';
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+
+// Counts the number of objects in an array
+// If the submitted object is an object, then the length of the list is 0
+const objectCounter = (item) => (
+  item.length ? item.length : 0
+);
+
+export default class Media extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      numImages: '',
+      numFiles: '',
+    };
+  }
+
+  async componentDidMount() {
+    try {
+      const { match } = this.props;
+      const { siteName } = match.params;
+
+      await Bluebird.all(
+        ['images', 'documents'].map(
+          (endpoint) => (
+            axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${endpoint}`, {
+              withCredentials: true,
+            })
+          ),
+        ),
+      ).spread((imageResp, documentResp) => {
+        this.setState({
+          numImages: objectCounter(imageResp.data.images),
+          numFiles: objectCounter(documentResp.data.documents),
+        });
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  render() {
+    const { numImages, numFiles } = this.state;
+    const { match, location } = this.props;
+    const { siteName } = match.params;
+    return (
+      <>
+        <Header />
+        {/* main bottom section */}
+        <div className={elementStyles.wrapper}>
+          <Sidebar siteName={siteName} currPath={location.pathname} />
+
+          {/* main section starts here */}
+          <div className={contentStyles.mainSection}>
+            <div className={contentStyles.sectionHeader}>
+              <h1 className={contentStyles.sectionTitle}>Media</h1>
+            </div>
+            <div className={contentStyles.contentContainerBars}>
+              <ul>
+                <li>
+                  <Link to={`/sites/${siteName}/images`}>Images</Link>
+                  {`${numImages} images`}
+                </li>
+                <li>
+                  <Link to={`/sites/${siteName}/files`}>Files</Link>
+                  {`${numFiles} files`}
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </>
+    )  
+  }
+}
+
+Media.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      siteName: PropTypes.string,
+    }),
+  }).isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -67,11 +67,9 @@ export default class Media extends Component {
               <ul>
                 <li>
                   <Link to={`/sites/${siteName}/images`}>Images</Link>
-                  {`${numImages} images`}
                 </li>
                 <li>
                   <Link to={`/sites/${siteName}/files`}>Files</Link>
-                  {`${numFiles} files`}
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
This PR accomplishes the following objectives:
- Create a `Media` option in the `Sidebar` which contains links to `Images` and `Files`
- Remove `Images` and `Files` from the `Sidebar`
- Implement `Pages`-like styling for both the `Images` and `Files` pages