### PR TITLE
feat: improve loading ux

### DIFF
--- a/src/layouts/Pages.jsx
+++ b/src/layouts/Pages.jsx
@@ -30,7 +30,7 @@ export default class Pages extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      pages: [],
+      pages: undefined,
       settingsIsActive: false,
       selectedFile: {},
       createNewPage: false,
@@ -133,22 +133,27 @@ Create New Page
             <div className={contentStyles.contentContainerBars}>
 
               {/* Page cards */}
-              <ul>
-                <li>
-                  <Link to={`/sites/${siteName}/homepage`}>Homepage</Link>
-                </li>
-                {pages.length > 0
-                  ? pages.map((page, pageIndex) => (
-                    <PageCard
-                      siteName={siteName}
-                      pageName={page.fileName}
-                      pageIndex={pageIndex}
-                      settingsToggle={this.settingsToggle}
-                      collectionName={page.collectionName ? page.collectionName : ''}
-                    />
-                  ))
-                  : 'Loading Pages...'}
-              </ul>
+              {/* Display loader if pages have not been retrieved from API call */}
+              { pages
+                ? (
+                  <ul>
+                    <li>
+                      <Link to={`/sites/${siteName}/homepage`}>Homepage</Link>
+                    </li>
+                    {pages.length > 0
+                      ? pages.map((page, pageIndex) => (
+                        <PageCard
+                          siteName={siteName}
+                          pageName={page.fileName}
+                          pageIndex={pageIndex}
+                          settingsToggle={this.settingsToggle}
+                          collectionName={page.collectionName ? page.collectionName : ''}
+                        />
+                      ))
+                      : null}
+                  </ul>
+                )
+                : 'Loading Pages...'}
               {/* End of page cards */}
             </div>
           </div>

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -259,7 +259,7 @@ export default class Resources extends Component {
                     <>
                       { resourcePages
                         ? (
-                          <ResourcePages 
+                          <ResourcePages
                             resourcePages={resourcePages}
                             siteName={siteName}
                             settingsToggle={this.settingsToggle}
@@ -296,10 +296,10 @@ ResourcePages.propTypes = {
       siteName: PropTypes.string.isRequired,
       category: PropTypes.string.isRequired,
       fileName: PropTypes.string.isRequired,
-    })
-  ),
+    }),
+  ).isRequired,
   siteName: PropTypes.string.isRequired,
-}
+};
 
 ResourceCard.propTypes = {
   fileName: PropTypes.string.isRequired,

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -41,6 +41,30 @@ const ResourceCard = ({
   );
 };
 
+const ResourcePages = ({
+  resourcePages, settingsToggle, siteName
+}) => (
+  <>
+  {/* Display resource cards */}
+  {resourcePages.length > 0
+    ? (
+      <>
+        {resourcePages.map((resourcePage, resourceIndex) => (
+          <ResourceCard
+            category={resourcePage.category}
+            fileName={resourcePage.fileName}
+            siteName={siteName}
+            settingsToggle={settingsToggle}
+            resourceIndex={resourceIndex}
+          />
+        ))}
+      </>
+    )
+    : null}
+  <CreateResourceCard settingsToggle={settingsToggle} />
+</>
+)
+
 const CreateResourceCard = ({ settingsToggle }) => (
   <button
     type="button"
@@ -235,25 +259,11 @@ export default class Resources extends Component {
                     <>
                       { resourcePages
                         ? (
-                          <>
-                            {/* Display resource cards */}
-                            {resourcePages.length > 0
-                              ? (
-                                <>
-                                  {resourcePages.map((resourcePage, resourceIndex) => (
-                                    <ResourceCard
-                                      category={resourcePage.category}
-                                      fileName={resourcePage.fileName}
-                                      siteName={siteName}
-                                      settingsToggle={this.settingsToggle}
-                                      resourceIndex={resourceIndex}
-                                    />
-                                  ))}
-                                </>
-                              )
-                              : null}
-                            <CreateResourceCard settingsToggle={this.settingsToggle} />
-                          </>
+                          <ResourcePages 
+                            resourcePages={resourcePages}
+                            siteName={siteName}
+                            settingsToggle={this.settingsToggle}
+                          />
                         )
                         : 'Loading resources...'}
                     </>
@@ -278,6 +288,17 @@ Resources.propTypes = {
     pathname: PropTypes.string.isRequired,
   }).isRequired,
 };
+
+ResourcePages.propTypes = {
+  settingsToggle: PropTypes.func.isRequired,
+  resourcePages: PropTypes.arrayOf(
+    PropTypes.shape({
+      siteName: PropTypes.string.isRequired,
+      category: PropTypes.string.isRequired,
+      fileName: PropTypes.string.isRequired,
+    })
+  )
+}
 
 ResourceCard.propTypes = {
   fileName: PropTypes.string.isRequired,

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -42,27 +42,27 @@ const ResourceCard = ({
 };
 
 const ResourcePages = ({
-  resourcePages, settingsToggle, siteName
+  resourcePages, settingsToggle, siteName,
 }) => (
   <>
-  {/* Display resource cards */}
-  {resourcePages.length > 0
-    ? (
-      <>
-        {resourcePages.map((resourcePage, resourceIndex) => (
-          <ResourceCard
-            category={resourcePage.category}
-            fileName={resourcePage.fileName}
-            siteName={siteName}
-            settingsToggle={settingsToggle}
-            resourceIndex={resourceIndex}
-          />
-        ))}
-      </>
-    )
-    : null}
-  <CreateResourceCard settingsToggle={settingsToggle} />
-</>
+    {/* Display resource cards */}
+    {resourcePages.length > 0
+      ? (
+        <>
+          {resourcePages.map((resourcePage, resourceIndex) => (
+            <ResourceCard
+              category={resourcePage.category}
+              fileName={resourcePage.fileName}
+              siteName={siteName}
+              settingsToggle={settingsToggle}
+              resourceIndex={resourceIndex}
+            />
+          ))}
+        </>
+      )
+      : null}
+    <CreateResourceCard settingsToggle={settingsToggle} />
+  </>
 )
 
 const CreateResourceCard = ({ settingsToggle }) => (
@@ -297,7 +297,8 @@ ResourcePages.propTypes = {
       category: PropTypes.string.isRequired,
       fileName: PropTypes.string.isRequired,
     })
-  )
+  ),
+  siteName: PropTypes.string.isRequired,
 }
 
 ResourceCard.propTypes = {

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -58,7 +58,7 @@ export default class Resources extends Component {
     super(props);
     this.state = {
       resourceCategories: [],
-      resourcePages: [],
+      resourcePages: undefined,
       categoryModalIsActive: false,
       settingsIsActive: false,
       resourceRoomName: 'resource room',
@@ -233,23 +233,29 @@ export default class Resources extends Component {
                   )
                   : (
                     <>
-                      {/* Display resource cards */}
-                      {resourcePages.length > 0
+                      { resourcePages
                         ? (
                           <>
-                            {resourcePages.map((resourcePage, resourceIndex) => (
-                              <ResourceCard
-                                category={resourcePage.category}
-                                fileName={resourcePage.fileName}
-                                siteName={siteName}
-                                settingsToggle={this.settingsToggle}
-                                resourceIndex={resourceIndex}
-                              />
-                            ))}
+                            {/* Display resource cards */}
+                            {resourcePages.length > 0
+                              ? (
+                                <>
+                                  {resourcePages.map((resourcePage, resourceIndex) => (
+                                    <ResourceCard
+                                      category={resourcePage.category}
+                                      fileName={resourcePage.fileName}
+                                      siteName={siteName}
+                                      settingsToggle={this.settingsToggle}
+                                      resourceIndex={resourceIndex}
+                                    />
+                                  ))}
+                                </>
+                              )
+                              : null}
+                            <CreateResourceCard settingsToggle={this.settingsToggle} />
                           </>
                         )
-                        : null}
-                      <CreateResourceCard settingsToggle={this.settingsToggle} />
+                        : 'Loading resources...'}
                     </>
                   )}
               </div>


### PR DESCRIPTION
This PR improves the UX for page loading in Pages and Resources. 

At present, some page elements  that the user should not be able to interact with are displayed while the page is still loading. This PR hides these page elements and only displays them when the page is fully loaded.