### PR TITLE
style: fix homepage editor styling

### DIFF
--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -9,20 +9,12 @@
   padding: 30px;
   padding-bottom: 100px;
   height: calc(100vh - #{$header-height} - #{$footer-height});
-
 }
 
 .homepageEditorMain{
-  display: flex;
   width: calc(100vw - #{$homepage-editor-sidebar-width});
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  left: $homepage-editor-sidebar-width;
+  height: calc(100vh - #{$header-height} - #{$footer-height});
   box-sizing: border-box;
-  padding-left: 50px;
-  padding-right: 50px;
-  padding-top: 40px;
   overflow-y: scroll;
 }
 

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -3137,7 +3137,7 @@ a.has-text-danger:focus,a.has-text-danger:hover {
 @media screen and (min-width: 1024px) {
     .bp-container {
         max-width:960px;
-        width: 960px
+        width: auto
     }
 
     .bp-container.is-fluid {
@@ -3165,14 +3165,14 @@ a.has-text-danger:focus,a.has-text-danger:hover {
 @media screen and (min-width: 1280px) {
     .bp-container {
         max-width:1216px;
-        width: 1216px
+        width: auto
     }
 }
 
 @media screen and (min-width: 1408px) {
     .bp-container {
         max-width:1280px;
-        width: 1280px
+        width: auto
     }
 }
 


### PR DESCRIPTION
This PR fixes the homepage styling to keep the preview consistent across

Small:
![Screenshot 2019-11-21 at 6 13 07 PM](https://user-images.githubusercontent.com/19917616/69328681-a024ae00-0c8a-11ea-9e01-be4a0707e5bb.png)
 different window sizes

Large: 
<img width="1532" alt="Screenshot 2019-11-21 at 6 12 14 PM" src="https://user-images.githubusercontent.com/19917616/69328626-84b9a300-0c8a-11ea-9e47-e266362eb494.png">
