### PR TITLE
feat: create a function to read the navigation bar from the tree

### DIFF
--- a/src/components/tree/EditTree.jsx
+++ b/src/components/tree/EditTree.jsx
@@ -3,7 +3,13 @@ import Tree, { mutateTree, moveItemOnTree } from '@atlaskit/tree';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import TreeBuilder from '../utils/tree-builder';
-import { dataIterator, ListItem, draggableWrapper } from '../utils/tree-utils';
+import {
+  dataIterator,
+  ListItem,
+  draggableWrapper,
+  // flattenTree,
+  // treeReader,
+} from '../utils/tree-utils';
 
 const rootNode = new TreeBuilder('root', 'root', '');
 
@@ -37,7 +43,6 @@ export default class EditTree extends Component {
           new TreeBuilder('Unlinked Pages', 'section'),
         ),
       );
-
       this.setState({ tree });
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
This PR introduces a function `treeReader` which takes in a flattened tree, and returns a list of objects which represent the items in the navigation bar.

The flattened tree can be obtained by passing the `tree` object through the function `flattenTree` found in `tree-utils`.