### PR TITLE
style: fix letter spacing issue caused by isomer-template CSS

### DIFF
--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -41,6 +41,7 @@ h1,h2,h3,h4,h5,h6{
   font-weight: 700 !important;
   margin: 0;
   padding: 0;
+  letter-spacing: 0 !important;
 }
 
 i {


### PR DESCRIPTION
This PR fixes the letter spacing issue caused by the isomer-template CSS. At present, the isomer template CSS lives in a `.css` file, which means that the styles get applied to all HTML elements in the CMS as well.

As a result, the letter spacing in the header segment looks too tightly packed (see below).

<img width="1532" alt="Screenshot 2019-11-22 at 4 17 58 PM" src="https://user-images.githubusercontent.com/19917616/69409467-f73a8980-0d43-11ea-9243-b64b814ec2c3.png">

To overcome this issue, we could rewrite the isomer template CSS into React scoped CSS, but that would take some time. Instead, as a stop gap measure, I propose adding a `letter-spacing: 0px !important` to override the letter-spacing imposed by the isomer template CSS.

<img width="1532" alt="Screenshot 2019-11-22 at 4 16 54 PM" src="https://user-images.githubusercontent.com/19917616/69409459-f1dd3f00-0d43-11ea-933a-2d631e87b736.png">