### PR TITLE
fix: remove validation for permalinks on the homepage page

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -95,11 +95,11 @@ const validateHighlights = (highlightError, field, value) => {
     }
     case 'url': {
       // Permalink fails regex
-      if (!permalinkRegexTest.test(value)) {
-        errorMessage = `The url should start and end with slashes and contain 
-          lowercase words separated by hyphens only.
-          `;
-      }
+      // if (!permalinkRegexTest.test(value)) {
+      //   errorMessage = `The url should start and end with slashes and contain
+      //     lowercase words separated by hyphens only.
+      //     `;
+      // }
       // TO-DO: allow external links
       // TO-DO: Validate that link actually links to a page?
       break;
@@ -129,11 +129,11 @@ const validateDropdownElems = (dropdownElemError, field, value) => {
     }
     case 'url': {
       // Permalink fails regex
-      if (!permalinkRegexTest.test(value)) {
-        errorMessage = `The url should start and end with slashes and contain 
-          lowercase words separated by hyphens only.
-          `;
-      }
+      // if (!permalinkRegexTest.test(value)) {
+      //   errorMessage = `The url should start and end with slashes and contain
+      //     lowercase words separated by hyphens only.
+      //     `;
+      // }
       // TO-DO: allow external links
       // TO-DO: Validate that link actually links to a page?
       break;
@@ -198,11 +198,11 @@ const validateHeroSection = (sectionError, sectionType, field, value) => {
       break;
     }
     case 'url': {
-      if (!permalinkRegexTest.test(value)) {
-        errorMessage = `The url should start and end with slashes and contain 
-          lowercase words separated by hyphens only.
-          `;
-      }
+      // if (!permalinkRegexTest.test(value)) {
+      //   errorMessage = `The url should start and end with slashes and contain
+      //     lowercase words separated by hyphens only.
+      //     `;
+      // }
       // TO-DO: Allow external URLs
       break;
     }
@@ -306,11 +306,11 @@ const validateInfobarSection = (sectionError, sectionType, field, value) => {
       break;
     }
     case 'url': {
-      if (!permalinkRegexTest.test(value)) {
-        errorMessage = `The url should start and end with slashes and contain 
-          lowercase words separated by hyphens only.
-          `;
-      }
+      // if (!permalinkRegexTest.test(value)) {
+      //   errorMessage = `The url should start and end with slashes and contain
+      //     lowercase words separated by hyphens only.
+      //     `;
+      // }
       // TO-DO: Allow external URLs
       break;
     }


### PR DESCRIPTION
The HLB staging site has many permalinks linking out to external sites. Because our permalink/URL validation only works for internal links (i.e. links to other parts of the same Isomer website), the use of permalinks will fail the validation in our CMS user test.

I propose to disable permalink validation on the Homepage until we have completed a more sophisticated permalink validation function.