### PR TITLE
fix: make EditNav preview mobile responsive

### DIFF
--- a/src/components/NavigationPreview.jsx
+++ b/src/components/NavigationPreview.jsx
@@ -16,7 +16,7 @@ const NavPreview = ({ navItems }) => (
       </div>
       <div id="navbarExampleTransparentExample" className="bp-container is-fluid margin--none navbar-menu">
         <div className="navbar-start">
-          <div className="navbar-item is-hidden-widescreen is-search-bar">
+          {/* <div className="navbar-item is-hidden-widescreen is-search-bar">
             <form action="/search/" method="get">
               <div className="field has-addons">
                 <div className="control has-icons-left is-expanded">
@@ -27,7 +27,7 @@ const NavPreview = ({ navItems }) => (
                 </div>
               </div>
             </form>
-          </div>
+          </div> */}
           {
                 navItems.map((navItem) => {
                   switch (navItem.type) {

--- a/src/components/NavigationPreview.jsx
+++ b/src/components/NavigationPreview.jsx
@@ -40,7 +40,7 @@ const NavPreview = ({ navItems }) => (
                           </a>
                           <div className="navbar-dropdown">
                             {navItem.leftNavPages && navItem.leftNavPages.map((leftNavPage) => (
-                              <a className="navbar-item sub-link" href="/">
+                              <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
                                 { leftNavPage.title }
                               </a>
                             ))}

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -6666,7 +6666,7 @@ html.has-navbar-fixed-bottom {
 }
 
 .navbar-menu {
-    display: none
+    display: block
 }
 
 .navbar-item,.navbar-link {


### PR DESCRIPTION
### Overview
Currently, the EditNav preview disappears when the window size is small.

### Fix
This PR will make the navigation preview in the EditNav page visible even when the window size is small. 

<img width="1532" alt="Screen Shot 2019-11-25 at 11 26 32 AM" src="https://user-images.githubusercontent.com/19917616/69510156-9a72e500-0f76-11ea-8b98-6f813c3e3b6e.png">

<img width="1038" alt="Screen Shot 2019-11-25 at 11 33 19 AM" src="https://user-images.githubusercontent.com/19917616/69510379-c0e55000-0f77-11ea-83fb-849e0d944a52.png">


