### PR TITLE
fix: remove DELETE API call when creating new page

### DIFF
--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -78,7 +78,7 @@ export default class PageSettingsModal extends Component {
         });
       } else {
         // A new file needs to be created
-        if (newFileName !== fileName) {
+        if (newFileName !== fileName && !isNewPage) {
           // Delete existing page
           await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}`, {
             data: { sha },


### PR DESCRIPTION
This PR fixes https://github.com/isomerpages/isomercms-frontend/issues/92.

The bug exists because `newFileName !== fileName`, since `newFileName` is undefined when creating a new file. The fix is to add another condition to the statement that checks if the user is trying to create a new file.