### PR TITLE
fix: modify markdown parsing logic

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ export function frontMatterParser(content) {
   // format file to extract yaml front matter
   const results = content.split('---');
   const frontMatter = yaml.safeLoad(results[1]); // get the front matter as an object
-  const mdBody = results[2];
+  const mdBody = results.slice(2).join('---');
 
   return {
     frontMatter,


### PR DESCRIPTION
Currently, we parse content by splitting on `---` to obtain the front matter and assume that there are no other `---` blocks in the content. However, if there exists another `---` block in the content part of the markdown file, we will lose all content after that `---`. This PR fixes that.