### PR TITLE
[EditHomepage] Add carousel and infopic constructors so their errors are stored

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -46,6 +46,16 @@ const InfobarSectionConstructor = () => ({
   },
 });
 
+const CarouselConstructor = () => ({
+  carousel: {
+    title: '',
+    subtitle: '',
+    description: '',
+    image: '',
+    alt: '',
+  },
+});
+
 const KeyHighlightConstructor = () => ({
   title: '',
   description: '',
@@ -68,6 +78,8 @@ const enumSection = (type) => {
       return ResourcesSectionConstructor();
     case 'infobar':
       return InfobarSectionConstructor();
+    case 'carousel':
+      return CarouselConstructor();
     default:
       return InfobarSectionConstructor();
   }
@@ -156,6 +168,10 @@ export default class EditHomepage extends Component {
 
         if (section.infobar) {
           sectionsErrors.push(InfobarSectionConstructor());
+        }
+
+        if (section.carousel) {
+          sectionsErrors.push(CarouselConstructor());
         }
 
         // Minimize all sections by default

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -46,13 +46,25 @@ const InfobarSectionConstructor = () => ({
   },
 });
 
-const CarouselConstructor = () => ({
+const CarouselSectionConstructor = () => ({
   carousel: {
     title: '',
     subtitle: '',
     description: '',
     image: '',
     alt: '',
+  },
+});
+
+const InfopicSectionConstructor = () => ({
+  infopic: {
+    title: '',
+    subtitle: '',
+    description: '',
+    image: '',
+    alt: '',
+    button: '',
+    url: '',
   },
 });
 
@@ -78,8 +90,10 @@ const enumSection = (type) => {
       return ResourcesSectionConstructor();
     case 'infobar':
       return InfobarSectionConstructor();
+    case 'infopic':
+      return InfopicSectionConstructor();
     case 'carousel':
-      return CarouselConstructor();
+      return CarouselSectionConstructor();
     default:
       return InfobarSectionConstructor();
   }
@@ -170,8 +184,12 @@ export default class EditHomepage extends Component {
           sectionsErrors.push(InfobarSectionConstructor());
         }
 
+        if (section.infopic) {
+          sectionsErrors.push(InfopicSectionConstructor());
+        }
+
         if (section.carousel) {
-          sectionsErrors.push(CarouselConstructor());
+          sectionsErrors.push(CarouselSectionConstructor());
         }
 
         // Minimize all sections by default


### PR DESCRIPTION
### Overview
Carousel and infopic sections are not being accounted for in `EditHomepage`, which causes it to crash when it encounters a page with a carousel or an infopic (and the carousel/infopic is not the last section). We should add this just so our `EditHomepage` doesn't crash - development of carousel functionality in `EditHomepage` can come later

### Context
Currently, carousel and infopic sections are read from the front matter, but there is no carousel or infopic constructor so there are no carousel or infopic sections in the errors.section array. This results in the `sectionIndex` being used to reference the section errors being wrong. For example, the `errors.sections[sectionIndex].resources` value here would refer to the wrong index if there is a carousel section before the resources section - the sectionIndex will be larger by 1:

```
<EditorResourcesSection
     key={`section-${sectionIndex}`}
     title={section.resources.title}
     subtitle={section.resources.subtitle}
     button={section.resources.button}
     sectionIndex={sectionIndex}
     deleteHandler={this.deleteHandler}
     onFieldChange={this.onFieldChange}
     shouldDisplay={displaySections[sectionIndex]}
     displayHandler={this.displayHandler}
     errors={errors.sections[sectionIndex].resources}
/>
```

This PR fixes that by adding a carousel and infopic constructor and pushing an instance of the carousel and infopic constructor object into `errors.section`.