### PR TITLE
feat: add radio button to switch resource types

### DIFF
--- a/src/components/ResourceSettingsModal.jsx
+++ b/src/components/ResourceSettingsModal.jsx
@@ -78,9 +78,10 @@ export default class ResourceSettingsModal extends Component {
     }
   }
 
-  permalinkFileUrlToggle = () => {
+  handlePermalinkFileUrlToggle = (event) => {
     const { permalink } = this.state;
-    if (permalink) {
+    const { target: { value } } = event;
+    if (value === 'file') {
       this.setState({ permalink: null, fileUrl: '/file/url/' });
     } else {
       this.setState({ permalink: '/permalink/', fileUrl: null });
@@ -246,7 +247,16 @@ export default class ResourceSettingsModal extends Component {
               <p className={elementStyles.formLabel}>Resource Type</p>
 
               {/* Permalink or File URL */}
-              <button type="button" onClick={this.permalinkFileUrlToggle}>{permalink ? 'Switch to download' : 'Switch to post'}</button>
+              <div className="d-flex">
+                <label htmlFor="radio-post" className="flex-fill">
+                  <input type="radio" id="radio-post" name="resource-type" value="post" onClick={this.handlePermalinkFileUrlToggle} checked={!!permalink} />
+                  Post Content
+                </label>
+                <label htmlFor="radio-post" className="flex-fill">
+                  <input type="radio" id="radio-file" name="resource-type" value="file" onClick={this.handlePermalinkFileUrlToggle} checked={!permalink} />
+                  Downloadable File
+                </label>
+              </div>
               {permalink
                 ? (
                   <>

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -32,3 +32,8 @@ input,textarea{
     outline:none;
   }
 }
+
+input[type=radio] {
+  width: auto;
+  margin-right: 8px;
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -468,20 +468,20 @@ const validateResourceSettings = (id, value) => {
     }
     case 'fileUrl': {
       // File URL is too short
-      if (value.length < RESOURCE_SETTINGS_PERMALINK_MIN_LENGTH) {
-        errorMessage = `The permalink should be longer than ${RESOURCE_SETTINGS_PERMALINK_MIN_LENGTH} characters.`;
-      }
-      // File URL is too long
-      if (value.length > RESOURCE_SETTINGS_PERMALINK_MAX_LENGTH) {
-        errorMessage = `The permalink should be shorter than ${RESOURCE_SETTINGS_PERMALINK_MAX_LENGTH} characters.`;
-      }
+      // if (value.length < RESOURCE_SETTINGS_PERMALINK_MIN_LENGTH) {
+      //   errorMessage = `The file URL should be longer than ${RESOURCE_SETTINGS_PERMALINK_MIN_LENGTH} characters.`;
+      // }
+      // // File URL is too long
+      // if (value.length > RESOURCE_SETTINGS_PERMALINK_MAX_LENGTH) {
+      //   errorMessage = `The file URL should be shorter than ${RESOURCE_SETTINGS_PERMALINK_MAX_LENGTH} characters.`;
+      // }
       // File URL fails regex
-      if (!permalinkRegexTest.test(value)) {
-        console.log('FAILED');
-        errorMessage = `The permalink should start and end with slashes and contain 
-          lowercase words separated by hyphens only.
-          `;
-      }
+      // if (!permalinkRegexTest.test(value)) {
+      //   console.log('FAILED');
+      //   errorMessage = `The permalink should start and end with slashes and contain 
+      //     lowercase words separated by hyphens only.
+      //     `;
+      // }
       // TO-DO
       // Check if file exists
       break;


### PR DESCRIPTION
This PR replaces the button to switch resource types in the resource settings modal into
radio buttons as users were confused by the button during round 2 of
user tests. Here's a preview of the change:
### Before
![image](https://user-images.githubusercontent.com/7150533/69934393-c230f280-150c-11ea-9da7-f89997299525.png)
### After
![image](https://user-images.githubusercontent.com/7150533/69934370-b0e7e600-150c-11ea-8966-9739e63510a3.png)
