### PR TITLE
[Feat] Flatten media tab

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -17,8 +17,12 @@ const sidebarPathDict = [
     title: 'Resources',
   },
   {
-    pathname: 'media',
-    title: 'Media',
+    pathname: 'images',
+    title: 'Images',
+  },
+  {
+    pathname: 'files',
+    title: 'Files',
   },
   {
     pathname: 'settings',


### PR DESCRIPTION
This PR flattens the media tab and replaces it with it's children (files' and 'images'). Here are the visual changes.


Before:
![image](https://user-images.githubusercontent.com/7150533/70494276-ae594200-1b45-11ea-8eee-c226fcbcce8a.png)
After:
![image](https://user-images.githubusercontent.com/7150533/70494289-b4e7b980-1b45-11ea-89c3-c304b31b46fe.png)

