### PR TITLE
fix: allow users to change category of existing post

### DIFF
--- a/src/components/ResourceSettingsModal.jsx
+++ b/src/components/ResourceSettingsModal.jsx
@@ -34,6 +34,7 @@ export default class ResourceSettingsModal extends Component {
         fileUrl: '',
         date: '',
         category: '',
+        prevCategory: '',
       },
     };
   }
@@ -70,7 +71,7 @@ export default class ResourceSettingsModal extends Component {
         } = frontMatter;
 
         this.setState({
-          title, permalink, fileUrl, date, sha, mdBody, category, resourceCategories,
+          title, permalink, fileUrl, date, sha, mdBody, prevCategory: category, category, resourceCategories,
         });
       }
     } catch (err) {
@@ -109,7 +110,7 @@ export default class ResourceSettingsModal extends Component {
     event.preventDefault();
     try {
       const {
-        title, permalink, fileUrl, date, mdBody, sha, category,
+        title, permalink, fileUrl, date, mdBody, sha, category, prevCategory,
       } = this.state;
       const { fileName, siteName, isNewPost } = this.props;
 
@@ -130,7 +131,7 @@ export default class ResourceSettingsModal extends Component {
       const newFileName = generateResourceFileName(dequoteString(title), type, date);
       let params = {};
 
-      if (newFileName !== fileName) {
+      if (newFileName !== fileName || prevCategory !== category) {
         // We'll need to create a new .md file with a new filename
         params = {
           content: base64EncodedContent,
@@ -139,7 +140,7 @@ export default class ResourceSettingsModal extends Component {
 
         // If it is an existing post, delete the existing page
         if (!isNewPost) {
-          await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category}/pages/${fileName}`, {
+          await axios.delete(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${prevCategory}/pages/${fileName}`, {
             data: {
               sha,
             },

--- a/src/components/ResourceSettingsModal.jsx
+++ b/src/components/ResourceSettingsModal.jsx
@@ -71,7 +71,15 @@ export default class ResourceSettingsModal extends Component {
         } = frontMatter;
 
         this.setState({
-          title, permalink, fileUrl, date, sha, mdBody, prevCategory: category, category, resourceCategories,
+          title, 
+          permalink, 
+          fileUrl, 
+          date, 
+          sha, 
+          mdBody, 
+          prevCategory: category, 
+          category, 
+          resourceCategories,
         });
       }
     } catch (err) {
@@ -80,7 +88,6 @@ export default class ResourceSettingsModal extends Component {
   }
 
   handlePermalinkFileUrlToggle = (event) => {
-    const { permalink } = this.state;
     const { target: { value } } = event;
     if (value === 'file') {
       this.setState({ permalink: null, fileUrl: '/file/url/' });


### PR DESCRIPTION
### Overview 
This PR fixes the bug in the resource settings modal where users cannot change the resource category of an existing post.

### Bug
This bug occurs because the `saveHandler` method does not track the previous category of the post. Take for example a post with the category `foo`. When a user clicks on the Resource Settings modal and changes the category to `bar`, line 142 (of the previous `ResourceSettingsModal.jsx` code) attempts to delete the old file belonging to the Resource Category: `bar`. However, the resource file does not exist.

### Fix
Track the `prevCategory` so that the `saveHandler` method correctly deletes the previous resource file.

