### PR TITLE
Feat/disable save when loading

### DIFF
--- a/src/components/CollectionPageSettingsModal.jsx
+++ b/src/components/CollectionPageSettingsModal.jsx
@@ -7,6 +7,7 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import {
   frontMatterParser, concatFrontMatterMdBody, generateCollectionPageFileName,
 } from '../utils';
+import LoadingButton from './LoadingButton';
 
 // Constants
 const PERMALINK_REGEX = '^(/([a-z]+([-][a-z]+)*/)+)$';
@@ -53,8 +54,7 @@ export default class CollectionPageSettingsModal extends Component {
     }
   }
 
-  saveHandler = async (event) => {
-    event.preventDefault();
+  saveHandler = async () => {
     try {
       const { siteName, fileName, collectionName } = this.props;
       const {
@@ -169,7 +169,7 @@ export default class CollectionPageSettingsModal extends Component {
   }
 
   render() {
-    const { title, permalink, errors } = this.state;
+    const { title, permalink, errors, sha } = this.state;
     const { settingsToggle } = this.props;
 
     // Page settings form has errors - disable save button
@@ -184,7 +184,7 @@ export default class CollectionPageSettingsModal extends Component {
               <i className="bx bx-x" />
             </button>
           </div>
-          <form className={elementStyles.modalContent} onSubmit={this.saveHandler}>
+          <div className={elementStyles.modalContent}>
             <div className={elementStyles.modalFormFields}>
               <p className={elementStyles.formLabel}>Title</p>
               <input
@@ -216,10 +216,20 @@ Permalink (e.g. /foo/, /foo-bar/, or /foo/bar/)
               <span className={elementStyles.error}>{errors.permalink}</span>
             </div>
             <div className={elementStyles.modalButtons}>
-              <button type="submit" className={`${hasErrors ? elementStyles.disabled : elementStyles.blue}`} disabled={hasErrors} value="submit">Save</button>
-              <button type="button" className={elementStyles.warning} onClick={this.deleteHandler}>Delete</button>
+              <LoadingButton
+                label="Save"
+                disabled={hasErrors}
+                className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
+                callback={this.saveHandler}
+              />
+              <LoadingButton
+                label="Delete"
+                disabled={!sha}
+                className={elementStyles.warning}
+                callback={this.deleteHandler}
+              />
             </div>
-          </form>
+          </div>
         </div>
       </div>
     );

--- a/src/components/CollectionPageSettingsModal.jsx
+++ b/src/components/CollectionPageSettingsModal.jsx
@@ -219,12 +219,14 @@ Permalink (e.g. /foo/, /foo-bar/, or /foo/bar/)
               <LoadingButton
                 label="Save"
                 disabled={hasErrors}
+                disabledStyle={elementStyles.disabled}
                 className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
                 callback={this.saveHandler}
               />
               <LoadingButton
                 label="Delete"
                 disabled={!sha}
+                disabledStyle={elementStyles.disabled}
                 className={elementStyles.warning}
                 callback={this.deleteHandler}
               />

--- a/src/components/ImageSettingsModal.jsx
+++ b/src/components/ImageSettingsModal.jsx
@@ -107,7 +107,7 @@ export default class ImageSettingsModal extends Component {
               <LoadingButton
                 label="Save"
                 disabled={!!errorMessage}
-                className={errorMessage ? elementStyles.disabled : elementStyles.blue}
+                className={(errorMessage || !sha) ? elementStyles.disabled : elementStyles.blue}
                 callback={this.renameImage}
               />
               <LoadingButton

--- a/src/components/ImageSettingsModal.jsx
+++ b/src/components/ImageSettingsModal.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import FormField from './FormField';
-import LoadingButton from '../components/LoadingButton';
+import LoadingButton from './LoadingButton';
 import { validateFileName } from '../utils/validators';
 
 

--- a/src/components/ImageSettingsModal.jsx
+++ b/src/components/ImageSettingsModal.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import FormField from './FormField';
+import LoadingButton from '../components/LoadingButton';
 import { validateFileName } from '../utils/validators';
 
 
@@ -103,8 +104,18 @@ export default class ImageSettingsModal extends Component {
               />
             </div>
             <div className={elementStyles.modalButtons}>
-              <button type="button" className={errorMessage ? elementStyles.disabled : elementStyles.blue} disabled={!!errorMessage} onClick={this.renameImage}>Save</button>
-              <button type="button" className={sha ? elementStyles.warning : elementStyles.disabled} onClick={this.deleteImage} disabled={!sha}>Delete</button>
+              <LoadingButton
+                label="Save"
+                disabled={!!errorMessage}
+                className={errorMessage ? elementStyles.disabled : elementStyles.blue}
+                callback={this.renameImage}
+              />
+              <LoadingButton
+                label="Delete"
+                disabled={!sha}
+                className={sha ? elementStyles.warning : elementStyles.disabled}
+                callback={this.deleteImage}
+              />
             </div>
           </form>
         </div>

--- a/src/components/ImageSettingsModal.jsx
+++ b/src/components/ImageSettingsModal.jsx
@@ -107,12 +107,14 @@ export default class ImageSettingsModal extends Component {
               <LoadingButton
                 label="Save"
                 disabled={!!errorMessage}
+                disabledStyle={elementStyles.disabled}
                 className={(errorMessage || !sha) ? elementStyles.disabled : elementStyles.blue}
                 callback={this.renameImage}
               />
               <LoadingButton
                 label="Delete"
                 disabled={!sha}
+                disabledStyle={elementStyles.disabled}
                 className={sha ? elementStyles.warning : elementStyles.disabled}
                 callback={this.deleteImage}
               />

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+
+export default function LoadingButton(props) {
+  // extract props
+  const {
+    label,
+    disabled,
+    className,
+    callback,
+  } = props;
+
+  // track whether button is loading or not
+  const [isLoading, setButtonLoading] = React.useState(false);
+  return (
+    <button
+      type="button"
+      className={isLoading ? elementStyles.disabled : className}
+      disabled={disabled}
+      onClick={() => {
+        setButtonLoading(true);
+        callback().then(() => setButtonLoading(false));
+      }}
+    >
+      {isLoading
+        ? (
+          <div className="spinner-border text-primary" role="status">
+            <span className="sr-only">Loading...</span>
+          </div>
+        ) : label}
+    </button>
+  );
+}
+
+LoadingButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  className: PropTypes.string.isRequired,
+  callback: PropTypes.func.isRequired,
+};

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -9,6 +9,7 @@ export default function LoadingButton(props) {
     disabled,
     className,
     callback,
+    ...remainingProps
   } = props;
 
   // track whether button is loading or not
@@ -22,6 +23,8 @@ export default function LoadingButton(props) {
         setButtonLoading(true);
         callback().then(() => setButtonLoading(false));
       }}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...remainingProps}
     >
       {isLoading
         ? (

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -17,7 +17,7 @@ export default function LoadingButton(props) {
     <button
       type="button"
       className={isLoading ? elementStyles.disabled : className}
-      disabled={disabled}
+      disabled={isLoading ? true : disabled}
       onClick={() => {
         setButtonLoading(true);
         callback().then(() => setButtonLoading(false));
@@ -33,7 +33,11 @@ export default function LoadingButton(props) {
 
 LoadingButton.propTypes = {
   label: PropTypes.string.isRequired,
-  disabled: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   className: PropTypes.string.isRequired,
   callback: PropTypes.func.isRequired,
+};
+
+LoadingButton.defaultProps = {
+  disabled: false,
 };

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -19,9 +19,10 @@ export default function LoadingButton(props) {
       type="button"
       className={isLoading ? disabledStyle : className}
       disabled={isLoading ? true : disabled}
-      onClick={() => {
+      onClick={async () => {
         setButtonLoading(true);
-        callback().then(() => setButtonLoading(false));
+        await callback();
+        setButtonLoading(false);
       }}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...remainingProps}

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -25,9 +25,7 @@ export default function LoadingButton(props) {
     >
       {isLoading
         ? (
-          <div className="spinner-border text-primary" role="status">
-            <span className="sr-only">Loading...</span>
-          </div>
+          <div className="spinner-border text-primary" role="status" />
         ) : label}
     </button>
   );

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 export default function LoadingButton(props) {
   // extract props
   const {
     label,
     disabled,
+    disabledStyle,
     className,
     callback,
     ...remainingProps
@@ -17,7 +17,7 @@ export default function LoadingButton(props) {
   return (
     <button
       type="button"
-      className={isLoading ? elementStyles.disabled : className}
+      className={isLoading ? disabledStyle : className}
       disabled={isLoading ? true : disabled}
       onClick={() => {
         setButtonLoading(true);
@@ -37,6 +37,7 @@ export default function LoadingButton(props) {
 LoadingButton.propTypes = {
   label: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  disabledStyle: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   callback: PropTypes.func.isRequired,
 };

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -175,6 +175,7 @@ export default class PageSettingsModal extends Component {
               <LoadingButton
                 label="Save"
                 disabled={hasErrors}
+                disabledStyle={elementStyles.disabled}
                 className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
                 callback={this.saveHandler}
               />
@@ -183,6 +184,7 @@ export default class PageSettingsModal extends Component {
                   <LoadingButton
                     label="Delete"
                     disabled={!sha}
+                    disabledStyle={elementStyles.disabled}
                     className={elementStyles.warning}
                     callback={this.deleteHandler}
                   />

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -172,23 +172,33 @@ export default class PageSettingsModal extends Component {
               />
             </div>
             <div className={elementStyles.modalButtons}>
-              <LoadingButton
-                label="Save"
-                disabled={hasErrors}
-                disabledStyle={elementStyles.disabled}
-                className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
-                callback={this.saveHandler}
-              />
               {!isNewPage
                 ? (
+                  <>
+                    <LoadingButton
+                      label="Save"
+                      disabled={hasErrors}
+                      disabledStyle={elementStyles.disabled}
+                      className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
+                      callback={this.saveHandler}
+                    />
+                    <LoadingButton
+                      label="Delete"
+                      disabled={!sha}
+                      disabledStyle={elementStyles.disabled}
+                      className={elementStyles.warning}
+                      callback={this.deleteHandler}
+                    />
+                  </>
+                ) : (
                   <LoadingButton
-                    label="Delete"
-                    disabled={!sha}
+                    label="Save"
+                    disabled={hasErrors}
                     disabledStyle={elementStyles.disabled}
-                    className={elementStyles.warning}
-                    callback={this.deleteHandler}
+                    className={(hasErrors) ? elementStyles.disabled : elementStyles.blue}
+                    callback={this.saveHandler}
                   />
-                ) : null}
+                )}
             </div>
           </div>
         </div>

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -8,6 +8,7 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import {
   frontMatterParser, concatFrontMatterMdBody, generatePageFileName,
 } from '../utils';
+import LoadingButton from './LoadingButton';
 import { validatePageSettings } from '../utils/validators';
 
 export default class PageSettingsModal extends Component {
@@ -49,8 +50,7 @@ export default class PageSettingsModal extends Component {
     }
   }
 
-  saveHandler = async (event) => {
-    event.preventDefault();
+  saveHandler = async () => {
     try {
       const { siteName, fileName, isNewPage } = this.props;
       const {
@@ -132,7 +132,12 @@ export default class PageSettingsModal extends Component {
   }
 
   render() {
-    const { title, permalink, errors } = this.state;
+    const {
+      title,
+      permalink,
+      errors,
+      sha,
+    } = this.state;
     const { settingsToggle, isNewPage } = this.props;
 
     // Page settings form has errors - disable save button
@@ -147,7 +152,7 @@ export default class PageSettingsModal extends Component {
               <i className="bx bx-x" />
             </button>
           </div>
-          <form className={elementStyles.modalContent} onSubmit={this.saveHandler}>
+          <div className={elementStyles.modalContent}>
             <div className={elementStyles.modalFormFields}>
               <FormField
                 title="Title"
@@ -167,12 +172,23 @@ export default class PageSettingsModal extends Component {
               />
             </div>
             <div className={elementStyles.modalButtons}>
-              <button type="submit" className={`${hasErrors ? elementStyles.disabled : elementStyles.blue}`} disabled={hasErrors} value="submit">Save</button>
+              <LoadingButton
+                label="Save"
+                disabled={hasErrors}
+                className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
+                callback={this.saveHandler}
+              />
               {!isNewPage
-                ? <button type="button" className={elementStyles.warning} onClick={this.deleteHandler}>Delete</button>
-                : null}
+                ? (
+                  <LoadingButton
+                    label="Delete"
+                    disabled={!sha}
+                    className={elementStyles.warning}
+                    callback={this.deleteHandler}
+                  />
+                ) : null}
             </div>
-          </form>
+          </div>
         </div>
       </div>
     );

--- a/src/components/ResourceCategoryModal.jsx
+++ b/src/components/ResourceCategoryModal.jsx
@@ -6,6 +6,7 @@ import update from 'immutability-helper';
 import { prettifyResourceCategory, slugifyResourceCategory } from '../utils';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import FormField from './FormField';
+import LoadingButton from './LoadingButton';
 import { validateResourceCategory } from '../utils/validators';
 
 // Constants
@@ -184,6 +185,19 @@ export default class ResourceCategoryModal extends Component {
                             isRequired
                             onFieldChange={this.changeHandler}
                           />
+                          {/* <LoadingButton
+                            label="Save"
+                            disabled={hasErrors}
+                            className={hasErrors ? elementStyles.disabled : elementStyles.blue}
+                            id={`save-${index}`}
+                            callback={this.saveHandler}
+                          />
+                          <LoadingButton
+                            label="Delete"
+                            className={elementStyles.warning}
+                            id={`delete-${index}`}
+                            callback={this.deleteHandler}
+                          /> */}
                           <button type="button" className={hasErrors ? elementStyles.disabled : elementStyles.blue} id={`save-${index}`} disabled={hasErrors} onClick={this.saveHandler}>Save</button>
                           <button type="button" className={elementStyles.warning} id={`delete-${index}`} onClick={this.deleteHandler}>Delete</button>
                         </div>

--- a/src/components/ResourceSettingsModal.jsx
+++ b/src/components/ResourceSettingsModal.jsx
@@ -4,6 +4,7 @@ import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import * as _ from 'lodash';
 import FormField from './FormField';
+import LoadingButton from './LoadingButton';
 import {
   prettifyResourceCategory,
   slugifyResourceCategory,
@@ -113,8 +114,7 @@ export default class ResourceSettingsModal extends Component {
     }
   }
 
-  saveHandler = async (event) => {
-    event.preventDefault();
+  saveHandler = async () => {
     try {
       const {
         title, permalink, fileUrl, date, mdBody, sha, category, prevCategory,
@@ -198,6 +198,7 @@ export default class ResourceSettingsModal extends Component {
       permalink,
       fileUrl,
       errors,
+      sha,
     } = this.state;
     const { settingsToggle, isNewPost } = this.props;
 
@@ -213,7 +214,7 @@ export default class ResourceSettingsModal extends Component {
               <i id="settingsIcon-CLOSE" className="bx bx-x" />
             </button>
           </div>
-          <form className={elementStyles.modalContent} onSubmit={this.saveHandler}>
+          <div className={elementStyles.modalContent}>
             <div className={elementStyles.modalFormFields}>
 
               {/* Title */}
@@ -296,12 +297,23 @@ export default class ResourceSettingsModal extends Component {
 
             {/* Save or Delete buttons */}
             <div className={elementStyles.modalButtons}>
-              <button type="submit" className={`${hasErrors ? elementStyles.disabled : elementStyles.blue}`} disabled={hasErrors} value="submit">Save</button>
+              <LoadingButton
+                label="Save"
+                disabled={hasErrors}
+                className={(isNewPost ? hasErrors : (hasErrors || !sha)) ? elementStyles.disabled : elementStyles.blue}
+                callback={this.saveHandler}
+              />
               { !isNewPost
-                ? <button type="button" className={elementStyles.warning} onClick={this.deleteHandler}>Delete</button>
-                : null}
+                ? (
+                  <LoadingButton
+                    label="Delete"
+                    disabled={!sha}
+                    className={!sha ? elementStyles.disabled : elementStyles.warning}
+                    callback={this.deleteHandler}
+                  />
+                ) : null}
             </div>
-          </form>
+          </div>
         </div>
       </div>
     );

--- a/src/components/ResourceSettingsModal.jsx
+++ b/src/components/ResourceSettingsModal.jsx
@@ -300,6 +300,7 @@ export default class ResourceSettingsModal extends Component {
               <LoadingButton
                 label="Save"
                 disabled={hasErrors}
+                disabledStyle={elementStyles.disabled}
                 className={(isNewPost ? hasErrors : (hasErrors || !sha)) ? elementStyles.disabled : elementStyles.blue}
                 callback={this.saveHandler}
               />
@@ -308,6 +309,7 @@ export default class ResourceSettingsModal extends Component {
                   <LoadingButton
                     label="Delete"
                     disabled={!sha}
+                    disabledStyle={elementStyles.disabled}
                     className={!sha ? elementStyles.disabled : elementStyles.warning}
                     callback={this.deleteHandler}
                   />

--- a/src/layouts/EditCollectionPage.jsx
+++ b/src/layouts/EditCollectionPage.jsx
@@ -14,6 +14,7 @@ import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
 
 export default class EditCollectionPage extends Component {
   constructor(props) {
@@ -174,8 +175,16 @@ export default class EditCollectionPage extends Component {
           </div>
         </div>
         <div className={editorStyles.pageEditorFooter}>
-          <button type="button" className={elementStyles.blue} onClick={this.updatePage}>Save</button>
-          <button type="button" className={elementStyles.warning} onClick={this.deletePage}>Delete</button>
+          <LoadingButton
+            label="Save"
+            className={elementStyles.blue}
+            callback={this.updatePage}
+          />
+          <LoadingButton
+            label="Delete"
+            className={elementStyles.warning}
+            callback={this.deletePage}
+          />
         </div>
       </>
     );

--- a/src/layouts/EditCollectionPage.jsx
+++ b/src/layouts/EditCollectionPage.jsx
@@ -177,11 +177,13 @@ export default class EditCollectionPage extends Component {
         <div className={editorStyles.pageEditorFooter}>
           <LoadingButton
             label="Save"
+            disabledStyle={elementStyles.disabled}
             className={elementStyles.blue}
             callback={this.updatePage}
           />
           <LoadingButton
             label="Delete"
+            disabledStyle={elementStyles.disabled}
             className={elementStyles.warning}
             callback={this.deletePage}
           />

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -21,6 +21,7 @@ import NewSectionCreator from '../components/homepage/NewSectionCreator';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
 import { validateSections, validateHighlights, validateDropdownElems } from '../utils/validators';
 
 /* eslint-disable react/jsx-props-no-spreading */
@@ -717,8 +718,7 @@ export default class EditHomepage extends Component {
     }
   }
 
-  savePage = async (event) => {
-    event.preventDefault();
+  savePage = async () => {
     try {
       const { state } = this;
       const { match } = this.props;
@@ -892,6 +892,7 @@ export default class EditHomepage extends Component {
       displayHighlights,
       displayDropdownElems,
       errors,
+      sha,
     } = this.state;
     const { match } = this.props;
     const { siteName } = match.params;
@@ -930,7 +931,7 @@ export default class EditHomepage extends Component {
           backButtonText="Back to Pages"
           backButtonUrl={`/sites/${siteName}/pages`}
         />
-        <form onSubmit={this.savePage} className={elementStyles.wrapper}>
+        <div className={elementStyles.wrapper}>
           <div className={editorStyles.homepageEditorSidebar}>
             <div>
               {/* Site-wide configuration */}
@@ -1226,9 +1227,14 @@ export default class EditHomepage extends Component {
             ))}
           </div>
           <div className={editorStyles.pageEditorFooter}>
-            <button type="submit" className={hasErrors ? elementStyles.disabled : elementStyles.blue} disabled={hasErrors}>Save</button>
+            <LoadingButton
+              label="Save"
+              disabled={hasErrors}
+              className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
+              callback={this.savePage}
+            />
           </div>
-        </form>
+        </div>
       </>
     );
   }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1230,6 +1230,7 @@ export default class EditHomepage extends Component {
             <LoadingButton
               label="Save"
               disabled={hasErrors}
+              disabledStyle={elementStyles.disabled}
               className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
               callback={this.savePage}
             />

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -14,6 +14,7 @@ import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
 
 export default class EditPage extends Component {
   constructor(props) {
@@ -117,8 +118,16 @@ export default class EditPage extends Component {
           </div>
         </div>
         <div className={editorStyles.pageEditorFooter}>
-          <button type="button" className={elementStyles.blue} onClick={this.updatePage}>Save</button>
-          <button type="button" className={elementStyles.warning} onClick={this.deletePage}>Delete</button>
+          <LoadingButton
+            label="Save"
+            className={elementStyles.blue}
+            callback={this.updatePage}
+          />
+          <LoadingButton
+            label="Delete"
+            className={elementStyles.warning}
+            callback={this.deletePage}
+          />
         </div>
       </>
     );

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -120,11 +120,13 @@ export default class EditPage extends Component {
         <div className={editorStyles.pageEditorFooter}>
           <LoadingButton
             label="Save"
+            disabledStyle={elementStyles.disabled}
             className={elementStyles.blue}
             callback={this.updatePage}
           />
           <LoadingButton
             label="Delete"
+            disabledStyle={elementStyles.disabled}
             className={elementStyles.warning}
             callback={this.deletePage}
           />

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -120,11 +120,13 @@ export default class EditResourcePage extends Component {
         <div className={editorStyles.pageEditorFooter}>
           <LoadingButton
             label="Save"
+            disabledStyle={elementStyles.disabled}
             className={elementStyles.blue}
             callback={this.updatePage}
           />
           <LoadingButton
             label="Delete"
+            disabledStyle={elementStyles.disabled}
             className={elementStyles.warning}
             callback={this.deletePage}
           />

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -14,6 +14,7 @@ import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
 
 export default class EditResourcePage extends Component {
   constructor(props) {
@@ -117,8 +118,16 @@ export default class EditResourcePage extends Component {
           </div>
         </div>
         <div className={editorStyles.pageEditorFooter}>
-          <button type="button" className={elementStyles.blue} onClick={this.updatePage}>Save</button>
-          <button type="button" className={elementStyles.warning} onClick={this.deletePage}>Delete</button>
+          <LoadingButton
+            label="Save"
+            className={elementStyles.blue}
+            callback={this.updatePage}
+          />
+          <LoadingButton
+            label="Delete"
+            className={elementStyles.warning}
+            callback={this.deletePage}
+          />
         </div>
       </>
     );

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -351,7 +351,7 @@ export default class Settings extends Component {
       <>
         <Header showButton={false} />
         {/* main bottom section */}
-        <div
+        <form
           className={elementStyles.wrapper}
         >
           {/* Color picker modal */}
@@ -468,7 +468,7 @@ export default class Settings extends Component {
               </div>
             </div>
           </div>
-        </div>
+        </form>
       </>
     );
   }

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import * as _ from 'lodash';
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
+import LoadingButton from '../components/LoadingButton';
 import ColorPicker from '../components/ColorPicker';
 import FormField from '../components/FormField';
 import FormFieldImage from '../components/FormFieldImage';
@@ -50,6 +51,7 @@ const stateFields = {
     youtube: '',
     instagram: '',
   },
+  socialMediaSha: '',
 };
 
 export default class Settings extends Component {
@@ -184,8 +186,7 @@ export default class Settings extends Component {
     }
   };
 
-  saveSettings = async (event) => {
-    event.preventDefault();
+  saveSettings = async () => {
     try {
       const { state } = this;
       const { match } = this.props;
@@ -329,6 +330,7 @@ export default class Settings extends Component {
       resources_name: resourcesName,
       colors,
       socialMediaContent,
+      socialMediaSha,
       errors,
     } = this.state;
     const { 'primary-color': primaryColor, 'secondary-color': secondaryColor, 'media-colors': mediaColors } = colors;
@@ -349,8 +351,7 @@ export default class Settings extends Component {
       <>
         <Header showButton={false} />
         {/* main bottom section */}
-        <form
-          onSubmit={this.saveSettings}
+        <div
           className={elementStyles.wrapper}
         >
           {/* Color picker modal */}
@@ -455,17 +456,19 @@ export default class Settings extends Component {
                 <br />
               </div>
               <div className={elementStyles.formSave}>
-                <button
-                  type="submit"
-                  className={hasErrors ? elementStyles.formSaveButtonDisabled : elementStyles.formSaveButtonActive}
+                <LoadingButton
+                  label="Save"
                   disabled={hasErrors}
-                >
-                  Save
-                </button>
+                  disabledStyle={elementStyles.formSaveButtonDisabled}
+                  className={(hasErrors || !socialMediaSha)
+                    ? elementStyles.formSaveButtonDisabled
+                    : elementStyles.formSaveButtonActive}
+                  callback={this.saveSettings}
+                />
               </div>
             </div>
           </div>
-        </form>
+        </div>
       </>
     );
   }


### PR DESCRIPTION
## Overview
This PR introduces a `LoadingButton` component which disables all `Save` and `Delete` buttons when it is clicked. When one of these buttons are clicked, we disable the button and replace the text in the button with a spinning loader. 

![2019-12-20 13 54 16](https://user-images.githubusercontent.com/31984694/71233396-6e0d7700-2330-11ea-8769-530125c2f8cf.gif)

The components and pages which are affected include:
- `PageSettingsModal` and `CollectionPageSettingsModal`
- `ImageSettingsModal`
- `ResourceSettingsModal`
- `EditPage` and `EditCollectionPage`
- `EditHomepage`
- `EditResourcePage`
- `Settings`

## To-do 
-  Currently, the button does **not** work with the `ResourceCategoryModal`
- @artylope to adjust the height of the button so that it doesn't change size when the loading spinner appears