### PR TITLE
[feat] Allow rename before image upload in EditPage, refactor ImageModal

### DIFF
--- a/src/components/ImageSettingsModal.jsx
+++ b/src/components/ImageSettingsModal.jsx
@@ -39,7 +39,7 @@ export default class ImageSettingsModal extends Component {
   }
 
   renameImage = async () => {
-    const { match, image, isPendingUpload } = this.props;
+    const { match, image, isPendingUpload, toReload, onClose } = this.props;
     const { siteName } = match.params;
     const {
       newFileName,
@@ -70,8 +70,13 @@ export default class ImageSettingsModal extends Component {
         withCredentials: true,
       });
     }
+
     // reload after action
-    window.location.reload();
+    if (toReload) {
+      window.location.reload();
+    } else {
+      onClose();
+    }
   }
 
   deleteImage = async () => {
@@ -137,20 +142,32 @@ export default class ImageSettingsModal extends Component {
               />
             </div>
             <div className={elementStyles.modalButtons}>
-              <LoadingButton
-                label="Save"
-                disabled={!!errorMessage}
-                disabledStyle={elementStyles.disabled}
-                className={(errorMessage || !sha) ? elementStyles.disabled : elementStyles.blue}
-                callback={this.renameImage}
-              />
-              <LoadingButton
-                label="Delete"
-                disabled={!sha}
-                disabledStyle={elementStyles.disabled}
-                className={sha ? elementStyles.warning : elementStyles.disabled}
-                callback={this.deleteImage}
-              />
+              {isPendingUpload
+              ? (
+                <LoadingButton
+                  label="Save"
+                  disabledStyle={elementStyles.disabled}
+                  className={elementStyles.blue}
+                  callback={this.renameImage}
+                />
+              ) : (
+                <>
+                  <LoadingButton
+                    label="Save"
+                    disabled={(errorMessage || !sha)}
+                    disabledStyle={elementStyles.disabled}
+                    className={(errorMessage || !sha) ? elementStyles.disabled : elementStyles.blue}
+                    callback={this.renameImage}
+                  />
+                  <LoadingButton
+                    label="Delete"
+                    disabled={!sha}
+                    disabledStyle={elementStyles.disabled}
+                    className={sha ? elementStyles.warning : elementStyles.disabled}
+                    callback={this.deleteImage}
+                  />
+                </>
+              )}
             </div>
           </form>
         </div>
@@ -172,4 +189,9 @@ ImageSettingsModal.propTypes = {
   }).isRequired,
   isPendingUpload: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  toReload: PropTypes.bool,
 };
+
+ImageSettingsModal.defaultProps = {
+  toReload: true,
+}

--- a/src/components/ImagesModal.jsx
+++ b/src/components/ImagesModal.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
@@ -25,72 +25,9 @@ export const ImageCard = ({ image, siteName, onClick }) => (
 );
 
 
-export default class ImagesModal extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      images: [],
-    };
-  }
-
-  async componentDidMount() {
-    const { siteName } = this.props;
-    try {
-      this.getImage(siteName);
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  getImage = async (siteName) => {
-    const { data: { images } } = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, {
-      withCredentials: true,
-    });
-    this.setState({ images });
-  }
-
-  uploadImage = async (imageName, imageContent) => {
-    try {
-      const { siteName } = this.props;
-      const params = {
-        imageName,
-        content: imageContent,
-      };
-
-      // add a loading screen while file is being uploaded
-      await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, params, {
-        withCredentials: true,
-      });
-
-      // trigger a re-render of the modal
-      const { data: { images } } = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, {
-        withCredentials: true,
-      });
-      this.setState({ images });
-    } catch (err) {
-      console.log(err);
-    }
-  }
-
-  onImageSelect = async (event) => {
-    const imgReader = new FileReader();
-    const imgName = event.target.files[0].name;
-    imgReader.onload = (() => {
-      /** Github only requires the content of the image
-       * imgReader returns  `data:image/png;base64, {fileContent}`
-       * hence the split
-       */
-
-      const imgData = imgReader.result.split(',')[1];
-
-      this.uploadImage(imgName, imgData);
-    });
-    imgReader.readAsDataURL(event.target.files[0]);
-  }
-
+export default class ImagesModal extends PureComponent {
   render() {
-    const { siteName, onClose, onImageSelect } = this.props;
-    const { images } = this.state;
+    const { siteName, images, onClose, onImageSelect, readImageToUpload } = this.props;
     return (!!images.length
       && (
         <div className={elementStyles.overlay}>
@@ -107,7 +44,7 @@ export default class ImagesModal extends Component {
                 onClick={() => document.getElementById('file-upload').click()}
               />
               <input
-                onChange={this.onImageSelect}
+                onChange={readImageToUpload}
                 type="file"
                 id="file-upload"
                 accept="image/png, image/jpeg, image/gif"
@@ -125,10 +62,9 @@ export default class ImagesModal extends Component {
             </div>
           </div>
         </div>
-
       )
     );
-  }
+  };
 }
 
 ImageCard.propTypes = {


### PR DESCRIPTION
## Overview

This PR achieves a couple of things:
1. It allows the user to rename an image before uploading an image in the `EditPage` component (previously implemented for the `Images` tab in #105).
2. It refactors the `ImageModal` component to be a React `PureComponent`. This provides performance benefits when rendering newly uploaded images. We can use `PureComponent` because the shallow comparison performed by `PureComponent` (which only compares references for objects/nested state) is sufficient because we do not and will not allow users to replace the content of an image while retaining the file name. 

### Renaming before upload

This functionality is facilitated by storing `images` in the parent `EditPage` instead of inside `ImageModal`. If `images` were stored inside `ImageModal`, we would need to define a modal inside a modal, which would prevent us from taking advantage of the performance benefits afforded by using `PureComponent`.  The flow for uploading an image in `EditPage` thus becomes:
- Click on Image button in editor. This triggers a call to retrieve images and then toggle so that `ImageModal` appears
- Click on upload new image in `ImageModal`. This allows the user to select an image to upload.
- Select the image to upload. Upon selection, the user is faced with the `ImageSettingsModal` to rename the image. Upon clicking save, `EditPage` retrieves the images again so that the newly uploaded image is reflected in `ImageModal` and the `ImageSettingsModal` is closed.