### PR TITLE
center settings icon in page cards

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -42,7 +42,7 @@ export default class EditPage extends Component {
       canShowDeleteWarningModal: false,
       images: [],
       isSelectingImage: false,
-      pendingImageUpload: null
+      pendingImageUpload: null,
     };
     this.mdeRef = React.createRef();
   }

--- a/src/layouts/Pages.jsx
+++ b/src/layouts/Pages.jsx
@@ -21,7 +21,7 @@ const PageCard = ({
     { collectionName
       ? <Link to={`/sites/${siteName}/collections/${collectionName}/${pageName}`}>{prettifyPageFileName(pageName)}</Link>
       : <Link to={`/sites/${siteName}/pages/${pageName}`}>{prettifyPageFileName(pageName)}</Link>}
-    <button type="button" onClick={settingsToggle} id={`settings-${pageIndex}`}>
+    <button type="button" className="d-flex flex-column" onClick={settingsToggle} id={`settings-${pageIndex}`}>
       <i id={`settingsIcon-${pageIndex}`} className="bx bx-cog" />
     </button>
   </li>

--- a/src/layouts/Pages.jsx
+++ b/src/layouts/Pages.jsx
@@ -21,7 +21,7 @@ const PageCard = ({
     { collectionName
       ? <Link to={`/sites/${siteName}/collections/${collectionName}/${pageName}`}>{prettifyPageFileName(pageName)}</Link>
       : <Link to={`/sites/${siteName}/pages/${pageName}`}>{prettifyPageFileName(pageName)}</Link>}
-    <button type="button" className="d-flex flex-column" onClick={settingsToggle} id={`settings-${pageIndex}`}>
+    <button type="button" className="d-flex flex-column pr-0" onClick={settingsToggle} id={`settings-${pageIndex}`}>
       <i id={`settingsIcon-${pageIndex}`} className="bx bx-cog" />
     </button>
   </li>


### PR DESCRIPTION
The settings icon in the pages tab will no longer triggers someone's OCD.

### Before
![image](https://user-images.githubusercontent.com/7150533/74639841-8d4a4880-51a9-11ea-84b7-39e63fd228ba.png)


### After
![image](https://user-images.githubusercontent.com/7150533/74639760-6b50c600-51a9-11ea-9b02-dfe51bc5bd7b.png)
