### PR TITLE
fix(resource-card): reduce setting icon hitbox

### DIFF
--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -29,14 +29,15 @@ const ResourceCard = ({
           <p className={contentStyles.resourceType}>{type}</p>
         </div>
       </Link>
-      <button
-        type="button"
-        id={`settings-${resourceIndex}`}
-        onClick={settingsToggle}
-        className={contentStyles.resourceIcon}
-      >
-        <i id={`settingsIcon-${resourceIndex}`} className="bx bx-cog" />
-      </button>
+      <div className={contentStyles.resourceIcon}>
+        <button
+          type="button"
+          id={`settings-${resourceIndex}`}
+          onClick={settingsToggle}
+        >
+          <i id={`settingsIcon-${resourceIndex}`} className="bx bx-cog" />
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This PR reduces the resource card setting icon hitbox.

### Before
![image](https://user-images.githubusercontent.com/7150533/74820258-acc5aa80-533c-11ea-9b90-d3c8c4707636.png)

### After
![image](https://user-images.githubusercontent.com/7150533/74820275-b818d600-533c-11ea-854c-62c5fff59218.png)
