### PR TITLE
feat: limit image upload size to be under 1 MB

### DIFF
--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * This Alert component is the React extension of Bootstrap's alert component
+ * https://getbootstrap.com/docs/4.4/components/alerts/
+ * @param {string} message - message to show
+ * @param {string} type - color of alert box
+ */
+const Alert = ({ message, type }) => (
+  <div className="d-flex justify-content-center fixed-bottom mt-3">
+    <div className={`alert alert-${type}`} role="alert">
+      { message }
+    </div>
+  </div>
+);
+
+Alert.propTypes = {
+  message: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark']).isRequired,
+};
+
+export default Alert;

--- a/src/components/ImagesModal.jsx
+++ b/src/components/ImagesModal.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -32,17 +32,39 @@ export const ImageCard = ({
 );
 
 
-export default class ImagesModal extends PureComponent {
+export default class ImagesModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      canShowUploadSizeError: false,
+    };
+  }
+
+  onImageUploadSelect = (event) => {
+    const { readImageToUpload } = this.props;
+    const imgSize = event.target.files[0].size / 1024 / 1024; // Gives size in MB
+    if (imgSize > 1) {
+      this.setState(
+        { canShowUploadSizeError: true },
+        () => setTimeout(() => { this.setState({ canShowUploadSizeError: false }); }, 3000),
+      );
+      return;
+    }
+
+    readImageToUpload(event);
+  }
+
   render() {
     const {
       siteName,
       images,
       onClose,
       onImageSelect,
-      readImageToUpload,
       selectedImage,
       setSelectedImage,
     } = this.props;
+
+    const { canShowUploadSizeError } = this.state;
     return (!!images.length
       && (
         <div className={elementStyles.overlay}>
@@ -65,7 +87,7 @@ export default class ImagesModal extends PureComponent {
                 onClick={() => document.getElementById('file-upload').click()}
               />
               <input
-                onChange={readImageToUpload}
+                onChange={this.onImageUploadSelect}
                 onClick={(event) => {
                   // eslint-disable-next-line no-param-reassign
                   event.target.value = '';
@@ -87,6 +109,16 @@ export default class ImagesModal extends PureComponent {
               ))}
             </div>
           </div>
+          {
+            canShowUploadSizeError
+            && (
+            <div className="d-flex justify-content-center fixed-bottom mt-3">
+              <div className="alert alert-danger" role="alert">
+                {'Image size must be < 1MB!'}
+              </div>
+            </div>
+            )
+          }
         </div>
       )
     );

--- a/src/components/ImagesModal.jsx
+++ b/src/components/ImagesModal.jsx
@@ -4,6 +4,7 @@ import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import { ImageUploadCard } from '../layouts/Images';
 import LoadingButton from './LoadingButton';
+import Alert from './Alert';
 
 export const ImageCard = ({
   image,
@@ -112,11 +113,10 @@ export default class ImagesModal extends Component {
           {
             canShowUploadSizeError
             && (
-            <div className="d-flex justify-content-center fixed-bottom mt-3">
-              <div className="alert alert-danger" role="alert">
-                {'Image size must be < 1MB!'}
-              </div>
-            </div>
+              <Alert
+                message="Image size must be < 1MB!"
+                type="danger"
+              />
             )
           }
         </div>

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -45,7 +45,6 @@ export default class EditPage extends Component {
       isSelectingImage: false,
       pendingImageUpload: null,
       selectedImage: '',
-      canShowUploadSizeError: false,
     };
     this.mdeRef = React.createRef();
   }
@@ -162,14 +161,6 @@ export default class EditPage extends Component {
   readImageToUpload = async (event) => {
     const imgReader = new FileReader();
     const imgName = event.target.files[0].name;
-    const imgSize = event.target.files[0].size / 1024 / 1024; // Gives size in MB
-    if (imgSize > 1) {
-      this.setState(
-        { canShowUploadSizeError: true },
-        () => setTimeout(() => { this.setState({ canShowUploadSizeError: false }); }, 3000),
-      );
-      return;
-    }
     imgReader.onload = (() => {
       /** Github only requires the content of the image
        * imgReader returns  `data:image/png;base64, {fileContent}`
@@ -196,7 +187,6 @@ export default class EditPage extends Component {
       isSelectingImage,
       pendingImageUpload,
       selectedImage,
-      canShowUploadSizeError,
     } = this.state;
     return (
       <>
@@ -296,16 +286,6 @@ export default class EditPage extends Component {
             onDelete={this.deletePage}
             type="page"
           />
-          )
-        }
-        {
-          canShowUploadSizeError
-          && (
-          <div className="d-flex justify-content-center fixed-bottom mt-3">
-            <div className="alert alert-danger" role="alert">
-              {'Image size must be < 1MB!'}
-            </div>
-          </div>
           )
         }
       </>

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -45,6 +45,7 @@ export default class EditPage extends Component {
       isSelectingImage: false,
       pendingImageUpload: null,
       selectedImage: '',
+      canShowUploadSizeError: false,
     };
     this.mdeRef = React.createRef();
   }
@@ -161,6 +162,14 @@ export default class EditPage extends Component {
   readImageToUpload = async (event) => {
     const imgReader = new FileReader();
     const imgName = event.target.files[0].name;
+    const imgSize = event.target.files[0].size / 1024 / 1024; // Gives size in MB
+    if (imgSize > 1) {
+      this.setState(
+        { canShowUploadSizeError: true },
+        () => setTimeout(() => { this.setState({ canShowUploadSizeError: false }); }, 3000),
+      );
+      return;
+    }
     imgReader.onload = (() => {
       /** Github only requires the content of the image
        * imgReader returns  `data:image/png;base64, {fileContent}`
@@ -187,6 +196,7 @@ export default class EditPage extends Component {
       isSelectingImage,
       pendingImageUpload,
       selectedImage,
+      canShowUploadSizeError,
     } = this.state;
     return (
       <>
@@ -286,6 +296,16 @@ export default class EditPage extends Component {
             onDelete={this.deletePage}
             type="page"
           />
+          )
+        }
+        {
+          canShowUploadSizeError
+          && (
+          <div className="d-flex justify-content-center fixed-bottom mt-3">
+            <div className="alert alert-danger" role="alert">
+              {'Image size must be < 1MB!'}
+            </div>
+          </div>
           )
         }
       </>

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -23,7 +23,7 @@ export default class Images extends Component {
       images: [],
       chosenImage: null,
       pendingImageUpload: null,
-      showingUploadSizeError: false,
+      canShowUploadSizeError: false,
     };
   }
 
@@ -61,7 +61,10 @@ export default class Images extends Component {
     const imgName = event.target.files[0].name;
     const imgSize = event.target.files[0].size / 1024 / 1024; // Gives size in MB
     if (imgSize > 1) {
-      this.setState({ showingUploadSizeError: true }, () => setTimeout(() => { this.setState({ showingUploadSizeError: false }); }, 3000));
+      this.setState(
+        { canShowUploadSizeError: true },
+        () => setTimeout(() => { this.setState({ canShowUploadSizeError: false }); }, 3000),
+      );
       return;
     }
     imgReader.onload = (() => {
@@ -82,7 +85,7 @@ export default class Images extends Component {
       images,
       chosenImage,
       pendingImageUpload,
-      showingUploadSizeError,
+      canShowUploadSizeError,
     } = this.state;
     const { match, location } = this.props;
     const { siteName } = match.params;
@@ -157,7 +160,7 @@ export default class Images extends Component {
           )
         }
         {
-          showingUploadSizeError
+          canShowUploadSizeError
           && (
           <div className="d-flex justify-content-center fixed-bottom mt-3">
             <div className="alert alert-danger" role="alert">

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -23,6 +23,7 @@ export default class Images extends Component {
       images: [],
       chosenImage: null,
       pendingImageUpload: null,
+      showingUploadSizeError: false,
     };
   }
 
@@ -58,6 +59,11 @@ export default class Images extends Component {
   onImageSelect = async (event) => {
     const imgReader = new FileReader();
     const imgName = event.target.files[0].name;
+    const imgSize = event.target.files[0].size / 1024 / 1024; // Gives size in MB
+    if (imgSize > 1) {
+      this.setState({ showingUploadSizeError: true }, () => setTimeout(() => { this.setState({ showingUploadSizeError: false }); }, 3000));
+      return;
+    }
     imgReader.onload = (() => {
       /** Github only requires the content of the image
        * imgReader returns  `data:image/png;base64, {fileContent}`
@@ -72,7 +78,12 @@ export default class Images extends Component {
   }
 
   render() {
-    const { images, chosenImage, pendingImageUpload } = this.state;
+    const {
+      images,
+      chosenImage,
+      pendingImageUpload,
+      showingUploadSizeError,
+    } = this.state;
     const { match, location } = this.props;
     const { siteName } = match.params;
     return (
@@ -143,6 +154,16 @@ export default class Images extends Component {
             isPendingUpload={true}
             onClose={() => this.setState({ pendingImageUpload: null })}
           />
+          )
+        }
+        {
+          showingUploadSizeError
+          && (
+          <div className="d-flex justify-content-center fixed-bottom mt-3">
+            <div className="alert alert-danger" role="alert">
+              {'Image size must be < 1MB!'}
+            </div>
+          </div>
           )
         }
       </>

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -9,6 +9,7 @@ import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
 import MediaUploadCard from '../components/media/MediaUploadCard';
 import MediaCard from '../components/media/MediaCard';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
+import Alert from '../components/Alert';
 
 const ImageCard = ({ image, siteName, onClick }) => MediaCard({
   type: 'image', siteName, onClick, media: image,
@@ -162,11 +163,10 @@ export default class Images extends Component {
         {
           canShowUploadSizeError
           && (
-          <div className="d-flex justify-content-center fixed-bottom mt-3">
-            <div className="alert alert-danger" role="alert">
-              {'Image size must be < 1MB!'}
-            </div>
-          </div>
+            <Alert
+              type="danger"
+              message="Image size must be < 1MB!"
+            />
           )
         }
       </>


### PR DESCRIPTION
This PR:
- [x] Limits image uploads through the "Images Modal" component & "Images" tab to be under 1 MB.

**P.S** ~This should be rebased on top of staging once the `revamp-files-tab` branch is merged in as this PR is built on top of the changes made in that branch~

### Images Tab
![image](https://user-images.githubusercontent.com/7150533/75128389-d006a600-56fe-11ea-9552-c35da7598bd7.png)
### Images Modal
![image](https://user-images.githubusercontent.com/7150533/75128397-db59d180-56fe-11ea-9746-483f97e2f630.png)
