### PR TITLE
[WIP] improvement: resources file url

### DIFF
--- a/src/components/FormFieldFile.jsx
+++ b/src/components/FormFieldFile.jsx
@@ -2,19 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
-const FormField = ({
+const FormFieldFile = ({
   title,
   defaultValue,
   value,
   id,
   errorMessage,
-  onFieldChange,
   isRequired,
   style,
+  onFileSelect,
+  inlineButtonText,
 }) => (
   <>
     <p className={elementStyles.formLabel}>{title}</p>
-    <div className="d-flex">
+    <div className="d-flex border">
       <input
         type="text"
         placeholder={title}
@@ -23,18 +24,30 @@ const FormField = ({
         id={id}
         autoComplete="off"
         required={isRequired}
-        className={errorMessage ? `${elementStyles.error}` : null}
+        className={errorMessage ? `${elementStyles.error}` : 'border-0'}
         style={style}
-        onChange={onFieldChange}
+        disabled
       />
+      {
+        inlineButtonText
+        && (
+        <button
+          type="button"
+          className={`${elementStyles.blue} text-nowrap`}
+          onClick={onFileSelect}
+        >
+          { inlineButtonText }
+        </button>
+        )
+      }
     </div>
     <span className={elementStyles.error}>{errorMessage}</span>
   </>
 );
 
-export default FormField;
+export default FormFieldFile;
 
-FormField.propTypes = {
+FormFieldFile.propTypes = {
   title: PropTypes.string.isRequired,
   defaultValue: PropTypes.string,
   value: PropTypes.string.isRequired,
@@ -43,9 +56,11 @@ FormField.propTypes = {
   onFieldChange: PropTypes.func.isRequired,
   isRequired: PropTypes.bool.isRequired,
   style: PropTypes.string,
+  inlineButtonText: PropTypes.string,
 };
 
-FormField.defaultProps = {
+FormFieldFile.defaultProps = {
   defaultValue: undefined,
   style: undefined,
+  inlineButtonText: '',
 };

--- a/src/components/FormFieldFile.jsx
+++ b/src/components/FormFieldFile.jsx
@@ -10,7 +10,7 @@ const FormFieldFile = ({
   errorMessage,
   isRequired,
   style,
-  onFileSelect,
+  onInlineButtonClick,
   inlineButtonText,
 }) => (
   <>
@@ -34,7 +34,7 @@ const FormFieldFile = ({
         <button
           type="button"
           className={`${elementStyles.blue} text-nowrap`}
-          onClick={onFileSelect}
+          onClick={onInlineButtonClick}
         >
           { inlineButtonText }
         </button>
@@ -53,10 +53,10 @@ FormFieldFile.propTypes = {
   value: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   errorMessage: PropTypes.string.isRequired,
-  onFieldChange: PropTypes.func.isRequired,
   isRequired: PropTypes.bool.isRequired,
   style: PropTypes.string,
   inlineButtonText: PropTypes.string,
+  onInlineButtonClick: PropTypes.func.isRequired,
 };
 
 FormFieldFile.defaultProps = {

--- a/src/components/ResourceSettingsModal.jsx
+++ b/src/components/ResourceSettingsModal.jsx
@@ -4,6 +4,7 @@ import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import * as _ from 'lodash';
 import FormField from './FormField';
+import FormFieldFile from './FormFieldFile';
 import LoadingButton from './LoadingButton';
 import {
   prettifyResourceCategory,
@@ -286,13 +287,14 @@ export default class ResourceSettingsModal extends Component {
                   : (
                     <>
                       {/* File URL */}
-                      <FormField
-                        title="File URL"
+                      <FormFieldFile
+                        title="Select File"
                         id="fileUrl"
-                        value={fileUrl}
+                        value={fileUrl.split('/').pop()}
                         errorMessage={errors.fileUrl}
                         isRequired
                         onFieldChange={this.changeHandler}
+                        inlineButtonText="Select File"
                       />
                     </>
                   )}


### PR DESCRIPTION
This PR aims to replace the current way users input the file URL for their resources by introducing a button that they can click and select a list of files from, instead of inputting the URLs themselves.

This PR should only be worked on after the `revamp-files-tab` PR is approved, as this PR should introduce changes that are built upon the `revamp-files-tab` branch.

