### PR TITLE
fix: update Settings page to read from updated backend response

### DIFF
--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -51,7 +51,7 @@ const stateFields = {
     youtube: '',
     instagram: '',
   },
-  socialMediaSha: '',
+  footerSha: '',
 };
 
 export default class Settings extends Component {
@@ -82,8 +82,8 @@ export default class Settings extends Component {
       const { settings } = resp.data;
       const {
         configFieldsRequired,
-        socialMediaContent,
-        socialMediaSha,
+        footerContent,
+        footerSha,
       } = settings;
 
       // set state properly
@@ -93,9 +93,9 @@ export default class Settings extends Component {
         ...configFieldsRequired,
         socialMediaContent: {
           ...currState.socialMediaContent,
-          ...socialMediaContent,
+          ...footerContent.social_media,
         },
-        socialMediaSha,
+        footerSha,
       }));
     } catch (err) {
       console.log(err);
@@ -211,12 +211,12 @@ export default class Settings extends Component {
       };
 
       // obtain sha value
-      const { socialMediaSha } = state;
+      const { footerSha } = state;
 
       const params = {
         socialMediaSettings,
         configSettings,
-        socialMediaSha,
+        footerSha,
       };
 
       await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`, params, {
@@ -330,7 +330,7 @@ export default class Settings extends Component {
       resources_name: resourcesName,
       colors,
       socialMediaContent,
-      socialMediaSha,
+      footerSha,
       errors,
     } = this.state;
     const { 'primary-color': primaryColor, 'secondary-color': secondaryColor, 'media-colors': mediaColors } = colors;
@@ -460,7 +460,7 @@ export default class Settings extends Component {
                   label="Save"
                   disabled={hasErrors}
                   disabledStyle={elementStyles.formSaveButtonDisabled}
-                  className={(hasErrors || !socialMediaSha)
+                  className={(hasErrors || !footerSha)
                     ? elementStyles.formSaveButtonDisabled
                     : elementStyles.formSaveButtonActive}
                   callback={this.saveSettings}

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -44,6 +44,12 @@ const stateFields = {
       },
     ],
   },
+  otherFooterSettings: {
+    contact_us: '',
+    show_reach: true, // true by default
+    feedback: '',
+    faq: '',
+  },
   socialMediaContent: {
     facebook: '',
     linkedin: '',
@@ -91,6 +97,13 @@ export default class Settings extends Component {
         ...currState,
         siteName,
         ...configFieldsRequired,
+        otherFooterSettings: {
+          ...currState.socialMediaContent,
+          contact_us: footerContent.contact_us,
+          show_reach: footerContent.show_reach,
+          feedback: footerContent.feedback,
+          faq: footerContent.faq,
+        },
         socialMediaContent: {
           ...currState.socialMediaContent,
           ...footerContent.social_media,
@@ -192,8 +205,9 @@ export default class Settings extends Component {
       const { match } = this.props;
       const { siteName } = match.params;
 
-      // settings is obtained from _config.yml and social-media.yml
+      // settings is obtained from _config.yml and footer.yml
       const socialMediaSettings = state.socialMediaContent;
+      const { otherFooterSettings } = state;
 
       // obtain config settings object
       const {
@@ -214,7 +228,10 @@ export default class Settings extends Component {
       const { footerSha } = state;
 
       const params = {
-        socialMediaSettings,
+        footerSettings: {
+          ...otherFooterSettings,
+          social_media: socialMediaSettings,
+        },
         configSettings,
         footerSha,
       };

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -46,7 +46,7 @@ const stateFields = {
   },
   otherFooterSettings: {
     contact_us: '',
-    show_reach: true, // true by default
+    show_reach: '',
     feedback: '',
     faq: '',
   },
@@ -98,7 +98,7 @@ export default class Settings extends Component {
         siteName,
         ...configFieldsRequired,
         otherFooterSettings: {
-          ...currState.socialMediaContent,
+          ...currState.otherFooterSettings,
           contact_us: footerContent.contact_us,
           show_reach: footerContent.show_reach,
           feedback: footerContent.feedback,
@@ -151,7 +151,15 @@ export default class Settings extends Component {
     } = event.target;
     // const errorMessage = validateSettings(id, value);
 
-    if (grandparentElementId === 'social-media-fields') {
+    if (grandparentElementId === 'footer-fields') {
+      this.setState((currState) => ({
+        ...currState,
+        otherFooterSettings: {
+          ...currState.otherFooterSettings,
+          [id]: value,
+        },
+      }));
+    } else if (grandparentElementId === 'social-media-fields') {
       const errorMessage = validateSocialMedia(value, id);
       this.setState((currState) => ({
         ...currState,
@@ -347,6 +355,7 @@ export default class Settings extends Component {
       resources_name: resourcesName,
       colors,
       socialMediaContent,
+      otherFooterSettings,
       footerSha,
       errors,
     } = this.state;
@@ -464,6 +473,21 @@ export default class Settings extends Component {
                       value={socialMediaContent[socialMediaPage]}
                       key={`${socialMediaPage}-form`}
                       errorMessage={errors.socialMediaContent[socialMediaPage]}
+                      isRequired={false}
+                      onFieldChange={this.changeHandler}
+                    />
+                  ))}
+                </div>
+                {/* Footer fields */}
+                <div id="footer-fields">
+                  <p className={elementStyles.formSectionHeader}>Footer</p>
+                  {Object.keys(otherFooterSettings).map((footerSetting) => (
+                    <FormFieldHorizontal
+                      title={footerSetting.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                      id={footerSetting}
+                      value={otherFooterSettings[footerSetting]}
+                      key={`${footerSetting}-form`}
+                      errorMessage={errors.otherFooterSettings[footerSetting]}
                       isRequired={false}
                       onFieldChange={this.changeHandler}
                     />


### PR DESCRIPTION
**Note:** This PR is to be reviewed together with PR #[60](https://github.com/isomerpages/isomercms-backend/pull/60) on the backend repo.

## Overview

This PR accomplishes several things:
1. Updates the `Settings` layout to read from the updated backend response, which now sends footer-related content from the repo's `_data/footer.yml` file instead of just social media content from the repo's `_data/social-media.yml` file. 
2. Allow users to edit the new footer fields available: `Contact Us`, `Show Reach`, `Feedback`, and `Faq`

#### *Before*
<img width="1659" alt="Screenshot 2020-10-14 at 7 14 36 PM" src="https://user-images.githubusercontent.com/31984694/95981732-b06ceb00-0e51-11eb-9eca-f87a322960b4.png">

#### *After*
<img width="1663" alt="Screenshot 2020-10-14 at 7 14 14 PM" src="https://user-images.githubusercontent.com/31984694/95981746-b6fb6280-0e51-11eb-8389-a43707ca57e6.png">
