### PR TITLE
Fix: display issue for breadcrumb

### DIFF
--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -99,7 +99,6 @@ export default class EditResourcePage extends Component {
     const { siteName, fileName, resourceName } = match.params;
     const { title, date, type } = prettifyResourceFileName(fileName);
     const { editorValue, canShowDeleteWarningModal } = this.state;
-    console.log(match)
     return (
       <>
         <Header

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -97,11 +97,13 @@ export default class EditResourcePage extends Component {
   render() {
     const { match } = this.props;
     const { siteName, fileName, resourceName } = match.params;
+    const { title, date, type } = prettifyResourceFileName(fileName);
     const { editorValue, canShowDeleteWarningModal } = this.state;
+    console.log(match)
     return (
       <>
         <Header
-          title={`${prettifyResourceFileName(fileName).title} in ${resourceName}`}
+          title={`${title} in ${resourceName}`}
           backButtonText="Back to Resources"
           backButtonUrl={`/sites/${siteName}/resources`}
         />
@@ -117,7 +119,7 @@ export default class EditResourcePage extends Component {
             />
           </div>
           <div className={editorStyles.pageEditorMain}>
-            <SimplePage chunk={prependImageSrc(siteName, marked(editorValue))} title={`${prettifyResourceFileName(fileName).title} in ${resourceName}`} />
+            <SimplePage chunk={prependImageSrc(siteName, marked(editorValue))} title={`${title} in ${resourceName}`} date={date}/>
           </div>
         </div>
         <div className={editorStyles.pageEditorFooter}>

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -7,7 +7,7 @@ import marked from 'marked';
 import { Base64 } from 'js-base64';
 import SimplePage from '../templates/SimplePage';
 import {
-  frontMatterParser, concatFrontMatterMdBody, prependImageSrc, prettifyResourceFileName,
+  frontMatterParser, concatFrontMatterMdBody, prependImageSrc, retrieveResourceFileMetadata,
 } from '../utils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
@@ -97,7 +97,7 @@ export default class EditResourcePage extends Component {
   render() {
     const { match } = this.props;
     const { siteName, fileName, resourceName } = match.params;
-    const { title, date, type } = prettifyResourceFileName(fileName);
+    const { title, date, type } = retrieveResourceFileMetadata(fileName);
     const { editorValue, canShowDeleteWarningModal } = this.state;
     return (
       <>

--- a/src/layouts/EditResourcePage.jsx
+++ b/src/layouts/EditResourcePage.jsx
@@ -97,7 +97,7 @@ export default class EditResourcePage extends Component {
   render() {
     const { match } = this.props;
     const { siteName, fileName, resourceName } = match.params;
-    const { title, date, type } = retrieveResourceFileMetadata(fileName);
+    const { title, date } = retrieveResourceFileMetadata(fileName);
     const { editorValue, canShowDeleteWarningModal } = this.state;
     return (
       <>

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -18,7 +18,7 @@ const RADIX_PARSE_INT = 10;
 const ResourceCard = ({
   fileName, siteName, category, settingsToggle, resourceIndex,
 }) => {
-  const { title, date, type } = retrieveResourceFileMetadata(fileName);
+  const { title, date } = retrieveResourceFileMetadata(fileName);
   return (
     <div className={`${contentStyles.resource} ${contentStyles.card} ${elementStyles.card}`}>
       <Link to={`/sites/${siteName}/resources/${category}/${fileName}`}>
@@ -26,7 +26,6 @@ const ResourceCard = ({
           <div className={contentStyles.resourceCategory}>{prettifyResourceCategory(category)}</div>
           <h1 className={contentStyles.resourceTitle}>{title}</h1>
           <p className={contentStyles.resourceDate}>{date}</p>
-          <p className={contentStyles.resourceType}>{type}</p>
         </div>
       </Link>
       <div className={contentStyles.resourceIcon}>
@@ -111,7 +110,7 @@ export default class Resources extends Component {
       if (resourceRoomName === undefined) {
         this.setState({ resourceRoomName });
       } else {
-        // Obtain the title, date, type, fileName, category for resource pages across all categories
+        // Obtain the title, date, fileName, category for resource pages across all categories
         const resourcePagesArray = await Bluebird.map(resourceCategories, async (category) => {
           const resourcePagesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${category.dirName}`, {
             withCredentials: true,
@@ -120,11 +119,10 @@ export default class Resources extends Component {
 
           if (resourcePages.length > 0) {
             return resourcePages.map((resourcePage) => {
-              const { title, date, type } = retrieveResourceFileMetadata(resourcePage.fileName);
+              const { title, date } = retrieveResourceFileMetadata(resourcePage.fileName);
               return {
                 title,
                 date,
-                type,
                 fileName: resourcePage.fileName,
                 category: category.dirName,
               };

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
-import { prettifyResourceFileName, prettifyResourceCategory } from '../utils';
+import { retrieveResourceFileMetadata, prettifyResourceCategory } from '../utils';
 import ResourceSettingsModal from '../components/ResourceSettingsModal';
 import ResourceCategoryModal from '../components/ResourceCategoryModal';
 import Header from '../components/Header';
@@ -18,7 +18,7 @@ const RADIX_PARSE_INT = 10;
 const ResourceCard = ({
   fileName, siteName, category, settingsToggle, resourceIndex,
 }) => {
-  const { title, date, type } = prettifyResourceFileName(fileName);
+  const { title, date, type } = retrieveResourceFileMetadata(fileName);
   return (
     <div className={`${contentStyles.resource} ${contentStyles.card} ${elementStyles.card}`}>
       <Link to={`/sites/${siteName}/resources/${category}/${fileName}`}>
@@ -120,7 +120,7 @@ export default class Resources extends Component {
 
           if (resourcePages.length > 0) {
             return resourcePages.map((resourcePage) => {
-              const { title, date, type } = prettifyResourceFileName(resourcePage.fileName);
+              const { title, date, type } = retrieveResourceFileMetadata(resourcePage.fileName);
               return {
                 title,
                 date,

--- a/src/styles/isomer-cms/elements/header.scss
+++ b/src/styles/isomer-cms/elements/header.scss
@@ -26,9 +26,14 @@
     margin: 0 auto;
     flex-basis: 60%;
     text-align: center;
+    overflow:hidden;
 
     h1{
       font-size: 20px;
+      min-width:0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -34,8 +34,7 @@
   width: calc(100vw - #{$page-editor-sidebar-width});
   left: $page-editor-sidebar-width;;
   box-sizing: border-box;
-  padding-right: 50px;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: calc(100vh - #{$header-height} - #{$footer-height});
   background-color: white;
 }

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12098,11 +12098,11 @@ a.navbar-item {
 }
 
 .breadcrumb-container {
-    padding-left: 50px;
+    padding-left: 3.125rem;
     margin: 0 0 !important;
 }
 
 .page-content-body {
-    padding-left: 80px;
+    padding-left: 5rem;
     margin: 0 0 !important;
 }

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12098,11 +12098,11 @@ a.navbar-item {
 }
 
 .breadcrumb-container {
-    left: 50px;
+    padding-left: 50px;
     margin: 0 0 !important;
 }
 
 .page-content-body {
-    left: 80px;
+    padding-left: 80px;
     margin: 0 0 !important;
 }

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -5375,7 +5375,6 @@ a[href$=".pdf"][target="_blank"]:after {
     display: flex;
     font-size: .9375rem;
     overflow: hidden;
-    overflow-x: auto;
     white-space: nowrap;
     margin-bottom: .625rem
 }
@@ -5384,12 +5383,15 @@ a[href$=".pdf"][target="_blank"]:after {
     margin-bottom: 1.5rem
 }
 
-.bp-breadcrumb a {
+.bp-breadcrumb small {
     align-items: center;
     color: #fff;
-    display: flex;
+    display: block;
     justify-content: center;
-    padding: .5em .75em
+    padding: .5em .75em;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width:15rem;
 }
 
 .bp-breadcrumb a:hover {
@@ -5406,10 +5408,10 @@ a[href$=".pdf"][target="_blank"]:after {
 
 .bp-breadcrumb li {
     align-items: center;
-    display: flex
+    display: flex;
 }
 
-.bp-breadcrumb li:first-child a {
+.bp-breadcrumb li:first-child small {
     padding-left: 0
 }
 

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12096,3 +12096,13 @@ a.navbar-item {
     height: calc(85vh - #{$header-height} - #{$footer-height});
     overflow-y: scroll;
 }
+
+.breadcrumb-container {
+    left: 50px;
+    margin: 0 0 !important;
+}
+
+.page-content-body {
+    left: 80px;
+    margin: 0 0 !important;
+}

--- a/src/templates/LeftNavPage.jsx
+++ b/src/templates/LeftNavPage.jsx
@@ -23,7 +23,7 @@ const LeftNavPage = ({
         <div className="bp-container padding--top--lg padding--bottom--xl">
           <div className="row">
             <LeftNav leftNavPages={leftNavPages} fileName={fileName} />
-            <div className="col is-8 is-offset-1-desktop is-12-touch print-content" style={{ left: '80px' }}>
+            <div className="col is-8 is-offset-1-desktop is-12-touch print-content page-content-body">
               <div className="content" dangerouslySetInnerHTML={{ __html: chunk }} />
             </div>
           </div>

--- a/src/templates/SimplePage.jsx
+++ b/src/templates/SimplePage.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import Breadcrumb from './pageComponents/Breadcrumb';
 
 // This following template was taken from the 'Simple Page'
-const SimplePage = ({ chunk, title }) => (
+const SimplePage = ({ chunk, title, date }) => (
   <div>
-    <Breadcrumb title={title} />
+    <Breadcrumb title={title} date={date}/>
     <section className="bp-section">
       <div className="bp-container content padding--top--lg padding--bottom--xl">
         <div className="row">

--- a/src/templates/SimplePage.jsx
+++ b/src/templates/SimplePage.jsx
@@ -9,7 +9,7 @@ const SimplePage = ({ chunk, title }) => (
     <section className="bp-section">
       <div className="bp-container content padding--top--lg padding--bottom--xl">
         <div className="row">
-          <div className="col is-8 is-offset-1-desktop is-12-touch print-content" style={{ left: '80px' }}>
+          <div className="col is-8 is-offset-1-desktop is-12-touch print-content page-content-body">
             <div className="content" dangerouslySetInnerHTML={{ __html: chunk }} />
           </div>
         </div>

--- a/src/templates/pageComponents/Breadcrumb.jsx
+++ b/src/templates/pageComponents/Breadcrumb.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Breadcrumb = ({ title, collection }) => (
+const Breadcrumb = ({ title, date, collection }) => (
   <section className="bp-section is-small bp-section-pagetitle">
     <div className="bp-container breadcrumb-container">
       <div className="row">
@@ -25,6 +25,15 @@ const Breadcrumb = ({ title, collection }) => (
         </div>
       </div>
     </div>
+    {date &&
+      <div className="bp-container breadcrumb-container">
+        <div className="row">
+          <div className="col">
+            <p className="has-text-white">{ date }</p>
+          </div>
+        </div>
+      </div>
+    }
   </section>
 );
 

--- a/src/templates/pageComponents/Breadcrumb.jsx
+++ b/src/templates/pageComponents/Breadcrumb.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const Breadcrumb = ({ title, collection }) => (
   <section className="bp-section is-small bp-section-pagetitle" style={{ width: `${100 / 0.65}%` }}>
-    <div className="bp-container" style={{ right: '50px' }}>
+    <div className="bp-container" style={{ left: '50px' }}>
       <div className="row">
         <div className="col">
           <nav className="bp-breadcrumb" aria-label="breadcrumbs">
@@ -18,7 +18,7 @@ const Breadcrumb = ({ title, collection }) => (
         </div>
       </div>
     </div>
-    <div className="bp-container" style={{ right: '50px' }}>
+    <div className="bp-container" style={{ left: '50px' }}>
       <div className="row">
         <div className="col">
           <h1 className="has-text-white"><b>{ title.split(' ').map((string) => string.charAt(0).toUpperCase() + string.slice(1)).join(' ') }</b></h1>

--- a/src/templates/pageComponents/Breadcrumb.jsx
+++ b/src/templates/pageComponents/Breadcrumb.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Breadcrumb = ({ title, collection }) => (
-  <section className="bp-section is-small bp-section-pagetitle" style={{ width: `${100 / 0.65}%` }}>
+  <section className="bp-section is-small bp-section-pagetitle">
     <div className="bp-container breadcrumb-container">
       <div className="row">
         <div className="col">

--- a/src/templates/pageComponents/Breadcrumb.jsx
+++ b/src/templates/pageComponents/Breadcrumb.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const Breadcrumb = ({ title, collection }) => (
   <section className="bp-section is-small bp-section-pagetitle" style={{ width: `${100 / 0.65}%` }}>
-    <div className="bp-container" style={{ left: '50px' }}>
+    <div className="bp-container breadcrumb-container">
       <div className="row">
         <div className="col">
           <nav className="bp-breadcrumb" aria-label="breadcrumbs">
@@ -18,7 +18,7 @@ const Breadcrumb = ({ title, collection }) => (
         </div>
       </div>
     </div>
-    <div className="bp-container" style={{ left: '50px' }}>
+    <div className="bp-container breadcrumb-container">
       <div className="row">
         <div className="col">
           <h1 className="has-text-white"><b>{ title.split(' ').map((string) => string.charAt(0).toUpperCase() + string.slice(1)).join(' ') }</b></h1>

--- a/src/templates/pageComponents/Breadcrumb.jsx
+++ b/src/templates/pageComponents/Breadcrumb.jsx
@@ -8,11 +8,11 @@ const Breadcrumb = ({ title, date, collection }) => (
         <div className="col">
           <nav className="bp-breadcrumb" aria-label="breadcrumbs">
             <ul>
-              <li><a href="/"><small>HOME</small></a></li>
+              <li><small>HOME</small></li>
               { collection ? (
-                <li><a href="/"><small>{ collection.toUpperCase() }</small></a></li>
+                <li><small>{ collection.toUpperCase() }</small></li>
               ) : null}
-              <li><a href="/"><small>{ title.toUpperCase() }</small></a></li>
+              <li><small>{ title.toUpperCase() }</small></li>
             </ul>
           </nav>
         </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,14 +78,14 @@ function monthIntToStr(monthInt) {
   return monthMap[monthInt];
 }
 
-// Takes in a resource file name and prettifies it.
+// Takes in a resource file name and retrieves the date, type, and title of the resource.
 // =================
 // Each fileName comes in the format of `{date}-{type}-{title}.md`
 // A sample fileName is 2019-08-23-post-CEO-made-a-speech.md
 // {date} is YYYY-MM-DD, e.g. 2019-08-23
 // {type} is either `post` or `download`
 // {title} is a string containing [a-z,A-Z,0-9] and all whitespaces are replaced by hyphens
-export function prettifyResourceFileName(fileName) {
+export function retrieveResourceFileMetadata(fileName) {
   const fileNameArray = fileName.split('.md')[0];
   const tokenArray = fileNameArray.split('-');
   const day = tokenArray[2];

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,11 +93,9 @@ export function retrieveResourceFileMetadata(fileName) {
   const year = tokenArray[0];
   const date = `${day} ${month} ${year}`;
 
-  const type = tokenArray[3];
+  const title = tokenArray.slice(3).join(' ');
 
-  const title = tokenArray.slice(4).join(' ');
-
-  return { date, type, title };
+  return { date, title };
 }
 
 export function enquoteString(str) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,7 @@ export function prettifyResourceFileName(fileName) {
   const day = tokenArray[2];
   const month = monthIntToStr(tokenArray[1]);
   const year = tokenArray[0];
-  const date = `${month} ${day} ${year}`;
+  const date = `${day} ${month} ${year}`;
 
   const type = tokenArray[3];
 


### PR DESCRIPTION
This PR fixes the issue raised in Issue #137. Currently, the display issue exists because the styling for those components were mistakenly given a right offset value instead of a left offset value. To decrease the chances of this occurring in future, the styling has also been refactored out into a separate css class, and the offset has been changed to padding instead. This PR also fixes an issue with the display exceeding the width of the screen.

In addition, this PR also adds in the date to the breadcrumb on resource pages, as raised in Issue #165. The date formatting has also been changed to match the display on the actual website.

The title and breadcrumb have also been modified to be truncated if their length is too long.