### PR TITLE
Feat/prevent navigation if unsaved changes

### DIFF
--- a/src/components/GenericWarningModal.jsx
+++ b/src/components/GenericWarningModal.jsx
@@ -4,14 +4,12 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import LoadingButton from './LoadingButton';
 
 
-const GenericWarningModal = ({ displayTitle, displayText, onProceed, onCancel, type }) => (
+const GenericWarningModal = ({ displayTitle, displayText, onProceed, onCancel }) => (
   <div className={elementStyles.overlay}>
     <div className={elementStyles['modal-warning']}>
       <div className={elementStyles.modalHeader}>
         <h1>
           {displayTitle}
-          {' '}
-          { type }
         </h1>
       </div>
       <form className={elementStyles.modalContent}>
@@ -36,9 +34,10 @@ const GenericWarningModal = ({ displayTitle, displayText, onProceed, onCancel, t
 );
 
 GenericWarningModal.propTypes = {
+  displayTitle: PropTypes.string.isRequired,
+  displayText: PropTypes.string.isRequired,
   onProceed: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  type: PropTypes.string.isRequired,
 };
 
 export default GenericWarningModal;

--- a/src/components/GenericWarningModal.jsx
+++ b/src/components/GenericWarningModal.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import LoadingButton from './LoadingButton';
+
+
+const GenericWarningModal = ({ displayTitle, displayText, onProceed, onCancel, type }) => (
+  <div className={elementStyles.overlay}>
+    <div className={elementStyles['modal-warning']}>
+      <div className={elementStyles.modalHeader}>
+        <h1>
+          {displayTitle}
+          {' '}
+          { type }
+        </h1>
+      </div>
+      <form className={elementStyles.modalContent}>
+        <p>{displayText}</p>
+        <div className={elementStyles.modalButtons}>
+            <LoadingButton
+                label="Yes"
+                disabledStyle={elementStyles.disabled}
+                className={`ml-auto ${elementStyles.blue}`}
+                callback={onProceed}
+            />
+            <LoadingButton
+                label="No"
+                disabledStyle={elementStyles.disabled}
+                className={elementStyles.warning}
+                callback={onCancel}
+            />
+        </div>
+      </form>
+    </div>
+  </div>
+);
+
+GenericWarningModal.propTypes = {
+  onProceed: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
+};
+
+export default GenericWarningModal;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,6 +13,7 @@ const Header = ({
   showButton, title, backButtonText, backButtonUrl,
 }) => {
   const [shouldRedirect, setShouldRedirect] = useState(false)
+  const [shouldPerformBackNav, setShouldPerformBackNav] = useState(false)
 
   const clearCookie = async () => {
     try {
@@ -25,17 +26,21 @@ const Header = ({
     }
   }
 
+  const toggleBackNav = () => {
+    setShouldPerformBackNav(!shouldPerformBackNav)
+  }
+
   return (
     <div className={elementStyles.header}>
       {/* Back button section */}
       <div className={elementStyles.headerLeft}>
         { !showButton ? null : (
-          <a href={backButtonUrl}>
-            <button className={elementStyles.default} type="button">
+          <div>
+            <button className={elementStyles.default} onClick={toggleBackNav} type="button">
               <i className="bx bx-chevron-left" />
               {backButtonText}
             </button>
-          </a>
+          </div>
         )}
       </div>
       {/* Middle section */}
@@ -54,6 +59,13 @@ const Header = ({
           Log Out
         </button>
       </div>
+      { shouldPerformBackNav && 
+        <Redirect
+          to={{
+            pathname: backButtonUrl
+          }}
+        />
+      }
       { shouldRedirect && 
         <Redirect
           to={{

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Redirect } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+import GenericWarningModal from './GenericWarningModal'
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 // axios settings
@@ -10,10 +11,11 @@ axios.defaults.withCredentials = true
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
 const Header = ({
-  showButton, title, backButtonText, backButtonUrl,
+  showButton, title, isEditPage, backButtonText, backButtonUrl,
 }) => {
   const [shouldRedirect, setShouldRedirect] = useState(false)
   const [shouldPerformBackNav, setShouldPerformBackNav] = useState(false)
+  const [showBackNavWarningModal, setShowBackNavWarningModal] = useState(false)
 
   const clearCookie = async () => {
     try {
@@ -30,13 +32,18 @@ const Header = ({
     setShouldPerformBackNav(!shouldPerformBackNav)
   }
 
+  const handleBackNav = () => {
+    if (isEditPage) setShowBackNavWarningModal(true)
+    else toggleBackNav()
+  }
+
   return (
     <div className={elementStyles.header}>
       {/* Back button section */}
       <div className={elementStyles.headerLeft}>
         { !showButton ? null : (
           <div>
-            <button className={elementStyles.default} onClick={toggleBackNav} type="button">
+            <button className={elementStyles.default} onClick={handleBackNav} type="button">
               <i className="bx bx-chevron-left" />
               {backButtonText}
             </button>
@@ -71,6 +78,15 @@ const Header = ({
           to={{
             pathname: '/'
           }}
+        />
+      }
+      {
+        showBackNavWarningModal &&
+        <GenericWarningModal
+          displayTitle="Warning"
+          displayText="You have unsaved changes. Are you sure you want to navigate away from this page?"
+          onProceed={toggleBackNav}
+          onCancel={() => setShowBackNavWarningModal(false)}
         />
       }
     </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,7 +11,7 @@ axios.defaults.withCredentials = true
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
 const Header = ({
-  showButton, title, isEditPage, backButtonText, backButtonUrl,
+  showButton, title, isEditPage, shouldAllowEditPageBackNav, backButtonText, backButtonUrl,
 }) => {
   const [shouldRedirect, setShouldRedirect] = useState(false)
   const [shouldPerformBackNav, setShouldPerformBackNav] = useState(false)
@@ -33,7 +33,7 @@ const Header = ({
   }
 
   const handleBackNav = () => {
-    if (isEditPage) setShowBackNavWarningModal(true)
+    if (isEditPage && !shouldAllowEditPageBackNav) setShowBackNavWarningModal(true)
     else toggleBackNav()
   }
 

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -44,6 +44,7 @@ export default class EditPage extends Component {
     const { siteName, fileName, resourceName } = match.params;
     this.state = {
       sha: null,
+      originalMdValue: '',
       editorValue: '',
       frontMatter: '',
       canShowDeleteWarningModal: false,
@@ -71,6 +72,7 @@ export default class EditPage extends Component {
       const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
       this.setState({
         sha,
+        originalMdValue: mdBody.trim(),
         editorValue: mdBody.trim(),
         frontMatter,
       });
@@ -182,6 +184,7 @@ export default class EditPage extends Component {
     const { siteName, fileName } = match.params;
     const { title, date } = isResourcePage ? retrieveResourceFileMetadata(fileName) : { title: prettifyPageFileName(fileName), date: '' }
     const {
+      originalMdValue,
       editorValue,
       canShowDeleteWarningModal,
       isSelectingImage,
@@ -191,7 +194,9 @@ export default class EditPage extends Component {
     return (
       <>
         <Header
-          title={title}
+          title={prettifyPageFileName(fileName)}
+          shouldAllowEditPageBackNav={originalMdValue === editorValue}
+          isEditPage="true"
           backButtonText={`Back to ${isResourcePage ? 'Resources' : 'Pages'}`}
           backButtonUrl={isResourcePage ?`/sites/${siteName}/resources` : `/sites/${siteName}/pages`}
         />


### PR DESCRIPTION
## Overview

This PR introduces a warning modal which asks the user for confirmation if they try to navigate away from an `Edit` page when they have unsaved changes. This prevents accidental loss of data due to accidental clicks on the back button. This is achieved by adding new conditions in the `Header` component which will trigger the warning modal if met.

<img width="1660" alt="Screenshot 2020-10-20 at 5 52 49 PM" src="https://user-images.githubusercontent.com/31984694/96570784-59599100-12fd-11eb-9efd-7d4a6ef2851b.png">

### Caveat

However, this does not trigger a warning modal if a user tries to navigate away from the page using the URL bar. In such a case, we want to listen for the `window.onbeforeunload` event, make sure to prevent default behavior, and trigger the warning modal to ask if the user is sure they want to navigate away from the page. This is something we can do in a separate PR.