### PR TITLE
fix: missing `onSave` prop for MediaSettingsModal in Images layout

### DIFF
--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -212,5 +212,6 @@ MediaSettingsModal.propTypes = {
   type: PropTypes.oneOf(['image', 'file']).isRequired,
   siteName: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
   isPendingUpload: PropTypes.bool.isRequired,
 };

--- a/src/layouts/Files.jsx
+++ b/src/layouts/Files.jsx
@@ -130,6 +130,7 @@ export default class Files extends Component {
             isPendingUpload={false}
             siteName={siteName}
             onClose={() => this.setState({ chosenFile: null })}
+            onSave={() => window.location.reload()}
           />
           )
         }
@@ -143,6 +144,7 @@ export default class Files extends Component {
             isPendingUpload
             siteName={siteName}
             onClose={() => this.setState({ pendingFileUpload: null })}
+            onSave={() => window.location.reload()}
           />
           )
         }

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -125,6 +125,7 @@ export default class Images extends Component {
             siteName={siteName}
             isPendingUpload={false}
             onClose={() => this.setState({ chosenImage: null })}
+            onSave={() => window.location.reload()}
           />
           )
         }
@@ -138,6 +139,7 @@ export default class Images extends Component {
             // eslint-disable-next-line react/jsx-boolean-value
             isPendingUpload={true}
             onClose={() => this.setState({ pendingImageUpload: null })}
+            onSave={() => window.location.reload()}
           />
           )
         }


### PR DESCRIPTION
## Overview
This PR fixes a simple bug where the `onSave` prop was missing for the `MediaSettingsModal` in the `Images` layout. This led to the following error message:

```
Unhandled Rejection (TypeError): onSave is not a function
```

This PR fixes that by defining the `onSave` prop so the `Images` layout is reloaded when a new image is uploaded. It also sets the `onSave` prop as a required prop type.