### PR TITLE
fix: image filename validation bug

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -605,7 +605,10 @@ const validateFileName = (value) => {
   }
 
   const fileNameArr = value.split('.')
-  if (fileNameArr.length !== 2 || !fileNameExtensionRegexTest.test(fileNameArr[1])) {
+  if (fileNameArr.length !== 2 ) {
+    return 'Invalid filename: filename can only contain one full stop and must follow the structure {name}.{extension}'
+  }
+  if (!fileNameExtensionRegexTest.test(fileNameArr[1])) {
     return 'Invalid filename: filename must end with a valid file extension (.JPG, .png, .pdf, etc.)'
   }
   if (fileNameArr[0] === '') return 'Invalid filename: please specify a filename'


### PR DESCRIPTION
## Overview

This PR fixes a simple image filename validation bug. Currently, file names which contain more than one full stop, such as
'Screenshot 2020-10-28 at 10.51.26 PM.png' are provided with the current error message: `Invalid filename: filename must end with a valid file extension (.JPG, .png, .pdf, etc.)`

<img width="832" alt="Screenshot 2020-10-29 at 6 00 55 PM" src="https://user-images.githubusercontent.com/31984694/97637734-268a6800-1a76-11eb-89b1-82ee6623322c.png">


However, this is not an accurate descriptor of the problem. This commit creates a separate error message for situations where there are more than one full stop in the filename. The new error message now reads: `Invalid filename: filename can only contain one full stop and must follow the structure {name}.{extension}`