### PR TITLE
fix: redirect to /sites only after login state changes to true

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -12,9 +12,7 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
         <Route {...rest} render={
             props => {
                 if (rest.location.pathname === '/auth') {
-                    if (rest.location.search === authContextString) {
-                        console.log('Redirecting to sites...')
-                        window.history.pushState({}, document.title, '/auth')
+                    if (rest.location.hash === authContextString) {
                         return <WrappedComponent {...rest} {...props} />
                     }
                     return <Redirect to="/" />

--- a/src/layouts/AuthCallback.jsx
+++ b/src/layouts/AuthCallback.jsx
@@ -1,11 +1,15 @@
-import React, { useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Redirect } from 'react-router-dom';
 
 const AuthCallback = ({ setLogin }) => {
+    const [shouldRedirectToSites, setShouldRedirectToSites] = useState(false)
     useEffect(() => {
         setLogin()
+        setShouldRedirectToSites(true)
     })
-    return <Redirect to="/sites" />
+
+    if (shouldRedirectToSites) return <Redirect to="/sites" />
+    return ''
 }
 
 export default AuthCallback

--- a/src/layouts/AuthCallback.jsx
+++ b/src/layouts/AuthCallback.jsx
@@ -1,14 +1,12 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { Redirect } from 'react-router-dom';
 
-const AuthCallback = ({ setLogin }) => {
-    const [shouldRedirectToSites, setShouldRedirectToSites] = useState(false)
+const AuthCallback = ({ setLogin, isLoggedIn }) => {
     useEffect(() => {
         setLogin()
-        setShouldRedirectToSites(true)
     })
 
-    if (shouldRedirectToSites) return <Redirect to="/sites" />
+    if (isLoggedIn) return <Redirect to="/sites" />
     return ''
 }
 


### PR DESCRIPTION
## Overview 
This PR fixes a bug which was introduced in PR #189 

Previously, on the `AuthCallback` component, we set the login state to be true and immediately returned a redirect to the `/sites` page. The problem with this is that it's possible that the redirection occurs before the login state is set.

This PR makes the changes to redirect only AFTER login state has been set by introducing a `shouldRedirectToSites` hook, which the redirection is dependent on.

### Other notes
Note that we currently use a context string, `#isomercms`, to filter access to the `AuthCallback` component. If this filter string is not present, the component will not be accessible.

This leads to a small bug. If the user attempts to access `/auth#isomercms`, they will be presented with the following screen and logged out. We can fix this in a later PR.

<img width="1677" alt="Screenshot 2020-11-03 at 5 41 10 PM" src="https://user-images.githubusercontent.com/31984694/97970123-0226e680-1dfc-11eb-9ec5-de924c356310.png">
