### PR TITLE
hotfix: add missing `isLoggedIn` prop

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -13,7 +13,7 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
             props => {
                 if (rest.location.pathname === '/auth') {
                     if (rest.location.hash === authContextString) {
-                        return <WrappedComponent {...rest} {...props} />
+                        return <WrappedComponent {...rest} {...props} isLoggedIn={isLoggedIn} />
                     }
                     return <Redirect to="/" />
                 }

--- a/src/layouts/AuthCallback.jsx
+++ b/src/layouts/AuthCallback.jsx
@@ -3,8 +3,8 @@ import { Redirect } from 'react-router-dom';
 
 const AuthCallback = ({ setLogin, isLoggedIn }) => {
     useEffect(() => {
-        setLogin()
-    })
+        if (!isLoggedIn) setLogin()
+    }, [isLoggedIn])
 
     if (isLoggedIn) return <Redirect to="/sites" />
     return ''


### PR DESCRIPTION
This PR adds the missing `isLoggedIn` prop to wrapped component inside `ProtectedRoute`.

It also ensures that the `setLogin` callback is run if the login state is false.