### PR TITLE
fix: do not set cookie when checking for isomercms cookie

### DIFF
--- a/src/utils/cookieChecker.js
+++ b/src/utils/cookieChecker.js
@@ -5,6 +5,9 @@ export const doesHttpOnlyCookieExist = (cookieName) => {
 
     document.cookie = cookieName + "=new_value;path=/;" + expires;
     if (document.cookie.indexOf(cookieName + '=') === -1) {
+        const epochTime = new Date(0)
+        const expiredDate = "expires=" + epochTime.toUTCString();
+        document.cookie = cookieName + "=new_value;path=/;" + expiredDate;
         return true;
     } else {
         return false;


### PR DESCRIPTION
Currently, we initialize `isLoggedIn` checking for the existence of an `isomercms` cookie. If the cookie exists, we fail to write to it and the number of cookies doesn't increase. Then, we can initialize `isLoggedIn` to be true. If it doesn't exist, then it creates a new `isomercms` cookie with the value `new_value`.

The problem with this is if the redirection occurs too quickly, then the app attempts to make an api call to the backend with the invalid `isomercms` cookie, instead of the one it receives from the backend, resulting in an auto-logout. This commit fixes that by removing the cookie immediately after it's written and the check is made.