### PR TITLE
feat: adds hyperlink modal to prompt users for input text and link

### DIFF
--- a/src/components/HyperlinkModal.jsx
+++ b/src/components/HyperlinkModal.jsx
@@ -10,25 +10,25 @@ axios.defaults.withCredentials = true
 
 export default class HyperlinkModal extends Component {
   constructor(props) {
-		super(props);
+    super(props);
     this.state = {
-			text: props.text,
+      text: props.text,
       link: '',
     };
   }
 
   changeHandler = (event) => {
-		const { id, value } = event.target;
-		this.setState({
-			[id]: value,
-		});
+    const { id, value } = event.target;
+    this.setState({
+      [id]: value,
+    });
   };
 
   render() {
-		const {
-			onSave,
-			onClose,
-		} = this.props;
+    const {
+      onSave,
+      onClose,
+    } = this.props;
 		
     const {
       text,

--- a/src/components/HyperlinkModal.jsx
+++ b/src/components/HyperlinkModal.jsx
@@ -77,6 +77,6 @@ export default class HyperlinkModal extends Component {
 }
 
 HyperlinkModal.propTypes = {
-	onSave: PropTypes.func.isRequired,
-	onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };

--- a/src/components/HyperlinkModal.jsx
+++ b/src/components/HyperlinkModal.jsx
@@ -21,8 +21,8 @@ export default class HyperlinkModal extends Component {
 		const { id, value } = event.target;
 		this.setState({
 			[id]: value,
-		})
-  }
+		});
+  };
 
   render() {
 		const {

--- a/src/components/HyperlinkModal.jsx
+++ b/src/components/HyperlinkModal.jsx
@@ -1,0 +1,82 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import FormField from './FormField';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import SaveDeleteButtons from './SaveDeleteButtons';
+
+// axios settings
+axios.defaults.withCredentials = true
+
+export default class HyperlinkModal extends Component {
+  constructor(props) {
+		super(props);
+    this.state = {
+			text: props.text,
+      link: '',
+    };
+  }
+
+  changeHandler = (event) => {
+		const { id, value } = event.target;
+		this.setState({
+			[id]: value,
+		})
+  }
+
+  render() {
+		const {
+			onSave,
+			onClose,
+		} = this.props;
+		
+    const {
+      text,
+      link,
+    } = this.state;
+
+    return (
+      <>
+        <div className={elementStyles.overlay}>
+          
+          <div className={elementStyles['modal-settings']}>
+            <div className={elementStyles.modalHeader}>
+              <h1>Insert hyperlink</h1>
+              <button type="button" onClick={onClose}>
+                <i className="bx bx-x" />
+              </button>
+            </div>
+            <div className={elementStyles.modalContent}>
+              <div className={elementStyles.modalFormFields}>
+                <FormField
+                  title="Text"
+                  id="text"
+                  value={text}
+                  isRequired={true}
+                  onFieldChange={this.changeHandler}
+                />
+                <FormField	
+                  title="Link"
+                  id="link"
+                  value={link}
+                  isRequired={true}
+                  onFieldChange={this.changeHandler}
+                />
+              </div>
+              <SaveDeleteButtons 
+                isDisabled={false}
+                hasDeleteButton={false}
+                saveCallback={() => {onSave(text,link)}}
+              />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+HyperlinkModal.propTypes = {
+	onSave: PropTypes.func.isRequired,
+	onClose: PropTypes.func.isRequired,
+};

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -356,8 +356,10 @@ export default class EditPage extends Component {
                   },
                   {
                     name: 'link',
-                    action: () => { this.onHyperlinkOpen() },
-                    className: 'fa fa-link-o',
+                    action: async () => { 
+                      this.onHyperlinkOpen() 
+                    },
+                    className: 'fa fa-link',
                     title: 'Insert Link',
                     default: true,
                   },

--- a/src/utils/markdownToolbar.jsx
+++ b/src/utils/markdownToolbar.jsx
@@ -83,14 +83,6 @@ export const orderedListButton = {
   default: true,
 };
 
-export const linkButton = {
-  name: 'link',
-  action: drawLink,
-  className: 'fa fa-link',
-  title: 'Create Link',
-  default: true,
-};
-
 export const tableButton = {
   name: 'table',
   action: drawTable,


### PR DESCRIPTION
This PR addresses issue #194, creating a popup modal when users click on the link button for the users to populate. The popup modal is previewed as below, and will take selected text (if any) as input to the text form field, otherwise the form field has a default value of "".

<img width="1792" alt="Screenshot 2020-11-09 at 3 43 34 PM" src="https://user-images.githubusercontent.com/39231249/98555529-5588b100-22a2-11eb-8f7f-9bae7f35f401.png">

The look of the hyperlink modal above has been approved by the designers, but we are still discussing whether something similar can be applied to inserting alt-text for images. That change can be applied in a future PR as this seems like it would take more significant research.

### Future considerations
Depending on the discussion for image alt-text, it might be worth considering if we should create a more general popup modal to subclass.