### PR TITLE
fix: rename prevCategory to originalCategory

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -188,7 +188,7 @@ export async function saveFileAndRetrieveUrl(fileInfo) {
     mdBody,
     sha,
     category,
-    prevCategory,
+    originalCategory,
     baseApiUrl,
     type,
     thirdNavTitle,
@@ -220,7 +220,7 @@ export async function saveFileAndRetrieveUrl(fileInfo) {
     frontMatter.file_url = fileUrl;
   }
   let newBaseApiUrl
-  if (prevCategory) {
+  if (originalCategory) {
     // baseApiUrl can be used as is because user cannot change categories
     newBaseApiUrl = baseApiUrl
   } else {
@@ -237,7 +237,7 @@ export async function saveFileAndRetrieveUrl(fileInfo) {
   const base64EncodedContent = Base64.encode(content);
 
   let params = {};
-  if (newFileName !== fileName || prevCategory !== category) {
+  if (newFileName !== fileName || originalCategory !== category) {
     // We'll need to create a new .md file with a new filename
     params = {
       content: base64EncodedContent,


### PR DESCRIPTION
## Overview 
In a previous change, the `prevCategory` variable was renamed to `originalCategory`. This variable is passed down as a function argument to the `saveAndRetrieveUrl` function, but we forgot to change the reference to `prevCategory` from within the function, resulting in failed API calls.

This commit fixes that typo by renaming all instances of `prevCategory` to `originalCategory`.