### PR TITLE
Fix/edit homepage ui fixes

### DIFF
--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -38,7 +38,7 @@ const EditorHeroSection = ({
   <div className={elementStyles.card}>
     <div className={elementStyles.cardHeader}>
       <h2>Hero section</h2>
-      <button type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -38,7 +38,7 @@ const EditorHeroSection = ({
   <div className={elementStyles.card}>
     <div className={elementStyles.cardHeader}>
       <h2>Hero section</h2>
-      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button className="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>
@@ -137,7 +137,7 @@ const EditorHeroSection = ({
                                         url={highlight.url}
                                         highlightIndex={highlightIndex}
                                         onFieldChange={onFieldChange}
-                                        shouldDisplay={displayHighlights[highlightIndex]}
+                                        shouldDisplay={displayHighlights[highlightIndex] ? displayHighlights[highlightIndex] : false}
                                         displayHandler={displayHandler}
                                         shouldAllowMoreHighlights={
                                           highlights.length < MAX_NUM_KEY_HIGHLIGHTS
@@ -182,18 +182,18 @@ EditorHeroSection.propTypes = {
   deleteHandler: PropTypes.func.isRequired,
   shouldDisplay: PropTypes.bool.isRequired,
   displayHandler: PropTypes.func.isRequired,
-  displayHighlights: PropTypes.func.isRequired,
+  displayHighlights: PropTypes.arrayOf(PropTypes.bool).isRequired,
   displayDropdownElems: PropTypes.arrayOf(PropTypes.bool.isRequired).isRequired,
   highlights: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string.isRequired,
       description: PropTypes.string.isRequired,
       url: PropTypes.string.isRequired,
-      highlightIndex: PropTypes.number.isRequired,
-      createHandler: PropTypes.func.isRequired,
-      deleteHandler: PropTypes.func.isRequired,
-      onFieldChange: PropTypes.func.isRequired,
-      allowMoreHighlights: PropTypes.bool.isRequired,
+      highlightIndex: PropTypes.number,
+      createHandler: PropTypes.func,
+      deleteHandler: PropTypes.func,
+      onFieldChange: PropTypes.func,
+      allowMoreHighlights: PropTypes.bool,
     }),
   ),
   dropdown: PropTypes.shape({
@@ -216,7 +216,7 @@ EditorHeroSection.propTypes = {
           background: PropTypes.string.isRequired,
           button: PropTypes.string.isRequired,
           url: PropTypes.string.isRequired,
-          dropdown: PropTypes.string.isRequired,
+          dropdown: PropTypes.string,
         }),
       }),
     ),

--- a/src/components/homepage/InfobarSection.jsx
+++ b/src/components/homepage/InfobarSection.jsx
@@ -25,7 +25,7 @@ const EditorInfobarSection = ({
       <h2>
         Infobar section: {title}
       </h2>
-      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button className="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/InfobarSection.jsx
+++ b/src/components/homepage/InfobarSection.jsx
@@ -25,7 +25,7 @@ const EditorInfobarSection = ({
       <h2>
         Infobar section: {title}
       </h2>
-      <button type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/InfopicSection.jsx
+++ b/src/components/homepage/InfopicSection.jsx
@@ -29,7 +29,7 @@ const EditorInfopicSection = ({
       <h2>
         Infopic section: {title}
       </h2>
-      <button type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/InfopicSection.jsx
+++ b/src/components/homepage/InfopicSection.jsx
@@ -29,7 +29,7 @@ const EditorInfopicSection = ({
       <h2>
         Infopic section: {title}
       </h2>
-      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button className="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>
@@ -113,9 +113,9 @@ EditorInfopicSection.propTypes = {
   description: PropTypes.string.isRequired,
   sectionIndex: PropTypes.number.isRequired,
   button: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
-  imageUrl: PropTypes.string.isRequired,
-  imageAlt: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  imageUrl: PropTypes.string,
+  imageAlt: PropTypes.string,
   onFieldChange: PropTypes.func.isRequired,
   deleteHandler: PropTypes.func.isRequired,
   shouldDisplay: PropTypes.bool.isRequired,
@@ -126,7 +126,7 @@ EditorInfopicSection.propTypes = {
     description: PropTypes.string.isRequired,
     button: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    imageUrl: PropTypes.string.isRequired,
-    imageAlt: PropTypes.string.isRequired,
+    imageUrl: PropTypes.string,
+    imageAlt: PropTypes.string,
   }).isRequired,
 };

--- a/src/components/homepage/KeyHighlight.jsx
+++ b/src/components/homepage/KeyHighlight.jsx
@@ -24,7 +24,7 @@ const KeyHighlight = ({
       <h2>
         {title}
       </h2>
-      <button type="button" id={`highlight-${highlightIndex}-toggle`} onClick={displayHandler}>
+      <button class="pl-3" type="button" id={`highlight-${highlightIndex}-toggle`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`highlight-${highlightIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/KeyHighlight.jsx
+++ b/src/components/homepage/KeyHighlight.jsx
@@ -24,7 +24,7 @@ const KeyHighlight = ({
       <h2>
         {title}
       </h2>
-      <button class="pl-3" type="button" id={`highlight-${highlightIndex}-toggle`} onClick={displayHandler}>
+      <button className="pl-3" type="button" id={`highlight-${highlightIndex}-toggle`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`highlight-${highlightIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/ResourcesSection.jsx
+++ b/src/components/homepage/ResourcesSection.jsx
@@ -23,7 +23,7 @@ const EditorResourcesSection = ({
       <h2>
         Resources section: {title}
       </h2>
-      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button className="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>

--- a/src/components/homepage/ResourcesSection.jsx
+++ b/src/components/homepage/ResourcesSection.jsx
@@ -23,7 +23,7 @@ const EditorResourcesSection = ({
       <h2>
         Resources section: {title}
       </h2>
-      <button type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
+      <button class="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>
         <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`section-${sectionIndex}-icon`} />
       </button>
     </div>

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -247,14 +247,14 @@ export default class EditHomepage extends Component {
           // This needs to be done separately because it relies on the state of another field
           if (
             field === 'url' && !value && this.state.frontMatter.sections[sectionIndex][sectionType].button
-            && !(!this.state.frontMatter.sections[sectionIndex][sectionType].button && !this.state.frontMatter.sections[sectionIndex][sectionType].url)
+            && (this.state.frontMatter.sections[sectionIndex][sectionType].button || this.state.frontMatter.sections[sectionIndex][sectionType].url)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType][field] = errorMessage
           } else if (
             field === 'button' && !this.state.frontMatter.sections[sectionIndex][sectionType].url
-            && !(!this.state.frontMatter.sections[sectionIndex][sectionType].button && !this.state.frontMatter.sections[sectionIndex][sectionType].url)
+            && (this.state.frontMatter.sections[sectionIndex][sectionType].button || this.state.frontMatter.sections[sectionIndex][sectionType].url)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -197,6 +197,7 @@ export default class EditHomepage extends Component {
 
       this.setState({
         frontMatter,
+        originalFrontMatter: _.cloneDeep(frontMatter),
         sha,
         hasResources,
         displaySections,
@@ -897,6 +898,7 @@ export default class EditHomepage extends Component {
   render() {
     const {
       frontMatter,
+      originalFrontMatter,
       hasResources,
       dropdownIsActive,
       displaySections,
@@ -950,6 +952,8 @@ export default class EditHomepage extends Component {
         }
         <Header
           title="Homepage"
+          shouldAllowEditPageBackNav={JSON.stringify(originalFrontMatter) === JSON.stringify(frontMatter)}
+          isEditPage="true"
           backButtonText="Back to My Workspace"
           backButtonUrl={`/sites/${siteName}/workspace`}
         />

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -242,6 +242,34 @@ export default class EditHomepage extends Component {
 
           sections[sectionIndex][sectionType][field] = value;
 
+          // Set special error message if hero button has text but hero url is empty
+          // This needs to be done separately because it relies on the state of another field
+          if (sectionIndex === 0 && sectionType === 'hero' && field === 'url' && !value && this.state.frontMatter.sections[0].hero.button) {
+            const errorMessage = 'Please specify a URL for your button'
+            const newSectionError = _.cloneDeep(errors.sections[sectionIndex])
+            newSectionError[sectionType][field] = errorMessage
+
+            const newErrors = update(errors, {
+              sections: {
+                [sectionIndex]: {
+                  $set: newSectionError,
+                },
+              },
+            });
+
+            this.setState((currState) => ({
+              ...currState,
+              frontMatter: {
+                ...currState.frontMatter,
+                sections,
+              },
+              errors: newErrors,
+            }));
+
+            this.scrollRefs[sectionIndex].scrollIntoView();
+            break;
+          }
+
           const newErrors = update(errors, {
             sections: {
               [sectionIndex]: {

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -992,7 +992,6 @@ export default class EditHomepage extends Component {
                 <p><b>Site notification</b></p>
                 <input
                   placeholder="Notification"
-                  defaultValue={frontMatter.notification}
                   value={frontMatter.notification}
                   id="site-notification"
                   onChange={this.onFieldChange} />

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -239,7 +239,6 @@ export default class EditHomepage extends Component {
           const sectionIndex = parseInt(idArray[1], RADIX_PARSE_INT);
           const sectionType = idArray[2]; // e.g. "hero" or "infobar" or "resources"
           const field = idArray[3]; // e.g. "title" or "subtitle"
-
           sections[sectionIndex][sectionType][field] = value;
 
           let newSectionError
@@ -247,15 +246,15 @@ export default class EditHomepage extends Component {
           // Set special error message if hero button has text but hero url is empty
           // This needs to be done separately because it relies on the state of another field
           if (
-            field === 'url' && !value && this.state.frontMatter.sections[sectionIndex].hero.button
-            && !(!this.state.frontMatter.sections[sectionIndex].hero.button && !this.state.frontMatter.sections[sectionIndex].hero.url)
+            field === 'url' && !value && this.state.frontMatter.sections[sectionIndex][sectionType].button
+            && !(!this.state.frontMatter.sections[sectionIndex][sectionType].button && !this.state.frontMatter.sections[sectionIndex][sectionType].url)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType][field] = errorMessage
           } else if (
-            field === 'button' && !this.state.frontMatter.sections[sectionIndex].hero.url
-            && !(!this.state.frontMatter.sections[sectionIndex].hero.button && !this.state.frontMatter.sections[sectionIndex].hero.url)
+            field === 'button' && !this.state.frontMatter.sections[sectionIndex][sectionType].url
+            && !(!this.state.frontMatter.sections[sectionIndex][sectionType].button && !this.state.frontMatter.sections[sectionIndex][sectionType].url)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
@@ -263,7 +262,7 @@ export default class EditHomepage extends Component {
           } else {
             newSectionError = validateSections(errors.sections[sectionIndex], sectionType, field, value)
 
-            if (!this.state.frontMatter.sections[0].hero.button && !this.state.frontMatter.sections[0].hero.url) {
+            if (!this.state.frontMatter.sections[sectionIndex][sectionType].button && !this.state.frontMatter.sections[sectionIndex][sectionType].url) {
               newSectionError[sectionType]['button'] = ''
               newSectionError[sectionType]['url'] = ''
             }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -242,38 +242,37 @@ export default class EditHomepage extends Component {
 
           sections[sectionIndex][sectionType][field] = value;
 
+          let newSectionError
+
           // Set special error message if hero button has text but hero url is empty
           // This needs to be done separately because it relies on the state of another field
-          if (sectionIndex === 0 && sectionType === 'hero' && field === 'url' && !value && this.state.frontMatter.sections[0].hero.button) {
+          if (
+            field === 'url' && !value && this.state.frontMatter.sections[sectionIndex].hero.button
+            && !(!this.state.frontMatter.sections[sectionIndex].hero.button && !this.state.frontMatter.sections[sectionIndex].hero.url)
+          ) {
             const errorMessage = 'Please specify a URL for your button'
-            const newSectionError = _.cloneDeep(errors.sections[sectionIndex])
+            newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType][field] = errorMessage
+          } else if (
+            field === 'button' && !this.state.frontMatter.sections[sectionIndex].hero.url
+            && !(!this.state.frontMatter.sections[sectionIndex].hero.button && !this.state.frontMatter.sections[sectionIndex].hero.url)
+          ) {
+            const errorMessage = 'Please specify a URL for your button'
+            newSectionError = _.cloneDeep(errors.sections[sectionIndex])
+            newSectionError[sectionType]['url'] = errorMessage
+          } else {
+            newSectionError = validateSections(errors.sections[sectionIndex], sectionType, field, value)
 
-            const newErrors = update(errors, {
-              sections: {
-                [sectionIndex]: {
-                  $set: newSectionError,
-                },
-              },
-            });
-
-            this.setState((currState) => ({
-              ...currState,
-              frontMatter: {
-                ...currState.frontMatter,
-                sections,
-              },
-              errors: newErrors,
-            }));
-
-            this.scrollRefs[sectionIndex].scrollIntoView();
-            break;
+            if (!this.state.frontMatter.sections[0].hero.button && !this.state.frontMatter.sections[0].hero.url) {
+              newSectionError[sectionType]['button'] = ''
+              newSectionError[sectionType]['url'] = ''
+            }
           }
 
           const newErrors = update(errors, {
             sections: {
               [sectionIndex]: {
-                $set: validateSections(errors.sections[sectionIndex], sectionType, field, value),
+                $set: newSectionError,
               },
             },
           });

--- a/src/templates/homepage/HeroSection.jsx
+++ b/src/templates/homepage/HeroSection.jsx
@@ -87,8 +87,8 @@ const KeyHighlights = ({ highlights }) => (
   <section id="key-highlights" className="bp-section is-paddingless">
     <div className="bp-container">
       <div className="row is-gapless has-text-centered">
-        {highlights.map(({ title, description }) => (
-          <KeyHighlightElem title={title} description={description} />
+        {highlights.map(({ title, description }, idx) => (
+          <KeyHighlightElem title={title} description={description} key={`${title}-${idx}`} />
         ))}
       </div>
     </div>

--- a/src/templates/homepage/InfopicLeftSection.jsx
+++ b/src/templates/homepage/InfopicLeftSection.jsx
@@ -109,7 +109,7 @@ TemplateInfopicLeftSection.propTypes = {
   description: PropTypes.string,
   button: PropTypes.string.isRequired,
   imageUrl: PropTypes.string.isRequired,
-  imageAlt: PropTypes.string.isRequired,
+  imageAlt: PropTypes.string,
   sectionIndex: PropTypes.number.isRequired,
   siteName: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## Overview

This PR makes miscellaneous UI fixes to the `EditHomepage` layout as requested by the designers:
- If there is a button name, but button URL is empty, we should raise an error message
- Implement same behavior on EditPage (warning before exit) on EditHomepage
- Make the click area for the EditHomepage sections larger (just a bit more to the left of the chevron icon)
