### PR TITLE
Fix: prevent re-render of third nav component

### DIFF
--- a/src/templates/pageComponents/LeftNav.jsx
+++ b/src/templates/pageComponents/LeftNav.jsx
@@ -1,88 +1,94 @@
 /* eslint-disable arrow-body-style */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { generateLeftNav } from '../../utils/leftnavGeneration'
 import '../../styles/isomer-template.scss';
 
-const LeftNav = ({ leftNavPages, fileName }) => (
-  <div className="col is-2 is-position-relative has-side-nav is-hidden-touch">
-    <div className="sidenav">
-      <aside className="bp-menu is-gt sidebar__inner">
-        <ul className="bp-menu-list">
-          {
-            generateLeftNav(leftNavPages, fileName)
-          }
-        </ul>
+const LeftNav = ({ leftNavPages, fileName }) => {
+  const [leftNavData, setLeftNavData] = useState()
+  useEffect(() => {
+    setLeftNavData(generateLeftNav(leftNavPages, fileName))
+  }, [])
+  return (
+    <div className="col is-2 is-position-relative has-side-nav is-hidden-touch">
+      <div className="sidenav">
+        <aside className="bp-menu is-gt sidebar__inner">
+          <ul className="bp-menu-list">
+            {
+              leftNavData
+            }
+          </ul>
+          <div
+            dir="ltr"
+            className="resize resize-sensor"
+          >
+            <div
+              className="resize resize-sensor-expand"
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  left: '0px',
+                  top: '0px',
+                  transition: 'all 0s ease 0s',
+                  width: '174px',
+                  height: '126px',
+                }}
+              />
+            </div>
+            <div
+              className="resize resize-sensor-shrink"
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  left: '0px',
+                  top: '0px',
+                  transition: '0s',
+                  width: '200%',
+                  height: '200%',
+                }}
+              />
+            </div>
+          </div>
+        </aside>
+      </div>
+      <div
+        dir="ltr"
+        className="resize resize-sensor"
+      >
         <div
-          dir="ltr"
-          className="resize resize-sensor"
+          className="resize resize-sensor-expand"
         >
           <div
-            className="resize resize-sensor-expand"
-          >
-            <div
-              style={{
-                position: 'absolute',
-                left: '0px',
-                top: '0px',
-                transition: 'all 0s ease 0s',
-                width: '174px',
-                height: '126px',
-              }}
-            />
-          </div>
-          <div
-            className="resize resize-sensor-shrink"
-          >
-            <div
-              style={{
-                position: 'absolute',
-                left: '0px',
-                top: '0px',
-                transition: '0s',
-                width: '200%',
-                height: '200%',
-              }}
-            />
-          </div>
+            style={{
+              position: 'absolute',
+              left: '0px',
+              top: '0px',
+              transition: 'all 0s ease 0s',
+              width: '198px',
+              height: '306px',
+            }}
+          />
         </div>
-      </aside>
-    </div>
-    <div
-      dir="ltr"
-      className="resize resize-sensor"
-    >
-      <div
-        className="resize resize-sensor-expand"
-      >
         <div
-          style={{
-            position: 'absolute',
-            left: '0px',
-            top: '0px',
-            transition: 'all 0s ease 0s',
-            width: '198px',
-            height: '306px',
-          }}
-        />
-      </div>
-      <div
-        className="resize resize-sensor-shrink"
-      >
-        <div
-          style={{
-            position: 'absolute',
-            left: '0px',
-            top: '0px',
-            transition: '0s',
-            width: '200%',
-            height: '200%',
-          }}
-        />
+          className="resize resize-sensor-shrink"
+        >
+          <div
+            style={{
+              position: 'absolute',
+              left: '0px',
+              top: '0px',
+              transition: '0s',
+              width: '200%',
+              height: '200%',
+            }}
+          />
+        </div>
       </div>
     </div>
-  </div>
-);
+  )
+};
 
 LeftNav.propTypes = {
   leftNavPages: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
This PR fixes a bug where editing pages with third navs was extremely laggy. This was due to the way we generated the third nav data - editing anything in the page caused a rerender of the third nav as well, which was computationally expensive. This PR fixes this by generating the the third nav data once upon loading only, to prevent unnecessary rerendering.