### PR TITLE
feat: mask markdown editor until page content has loaded

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -107,6 +107,7 @@ export default class EditPage extends Component {
       selectionText: '',
       isFileStagedForUpload: false,
       stagedFileDetails: {},
+      isLoadingPageContent: true,
     };
     this.mdeRef = React.createRef();
     this.apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })
@@ -153,6 +154,7 @@ export default class EditPage extends Component {
         editorValue: mdBody.trim(),
         frontMatter,
         leftNavPages,
+        isLoadingPageContent: false,
       });
     } catch (err) {
       console.log(err);
@@ -295,6 +297,7 @@ export default class EditPage extends Component {
       stagedFileDetails,
       leftNavPages,
       selectionText,
+      isLoadingPageContent,
     } = this.state;
 
     const html = marked(editorValue)
@@ -344,7 +347,13 @@ export default class EditPage extends Component {
             />
             )
           }
-          <div className={editorStyles.pageEditorSidebar}>
+          <div className={`${editorStyles.pageEditorSidebar} ${isLoadingPageContent ? editorStyles.pageEditorSidebarLoading : null}`} >
+            {
+              isLoadingPageContent
+              ? (
+                <div className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`} />
+              ) : ''
+            }
             <SimpleMDE
               id="simplemde-editor"
               className="h-100"

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -27,6 +27,23 @@
   padding: 30px;
   padding-bottom: 100px;
   height: calc(100vh - #{$header-height} - #{$footer-height});
+  position: relative;
+}
+
+.pageEditorSidebarLoading{
+  opacity: 0.5;
+  pointer-events: none;
+
+  .sidebarLoadingIcon{
+    position: absolute;
+    z-index: 2;
+    top: 50%;
+    left: 50%;
+  }
+
+  .hideSidebarLoadingIcon{
+    visibility: hidden;
+  }
 }
 
 .pageEditorMain{


### PR DESCRIPTION
This PR addresses issue #233 

## Overview
Currently, when users enter the EditPage layout, they can enter text into the EasyMDE editor right away. However, whatever content they enter will be replaced when the page content finally loads. This is a bad UI experience and this commit seeks to change that by blocking access to the editor until all page content has loaded.

There is no native way of masking the EasyMDE editor that we're using (refer to the issue on their repo https://github.com/Ionaru/easy-markdown-editor/issues/49) so we need to manually apply a mask to prevent the user from editing content until the page content is loaded.

**Loading**
<img width="1674" alt="Screenshot 2020-11-19 at 1 12 26 AM" src="https://user-images.githubusercontent.com/31984694/99563833-a3b95500-2a04-11eb-8e4f-8097c84eef63.png">

**After load**
<img width="1674" alt="Screenshot 2020-11-19 at 1 12 20 AM" src="https://user-images.githubusercontent.com/31984694/99563878-b2077100-2a04-11eb-8506-f49bbf669a31.png">

### Follow-up 

Do we need to add some kind of feedback on the page preview side? Or is the loading spinner on the editor sufficient?