### PR TITLE
Feat/implement sentry error boundary

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,4 @@
 export REACT_APP_CLIENT_ID=''
 export REACT_APP_BACKEND_URL=''
-export ENV=''
+export SENTRY_ENV=''
 export SENTRY_DSN=''

--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,4 @@
 export REACT_APP_CLIENT_ID=''
 export REACT_APP_BACKEND_URL=''
 export ENV=''
+export SENTRY_DSN=''

--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,4 @@
 export REACT_APP_CLIENT_ID=''
 export REACT_APP_BACKEND_URL=''
-export SENTRY_ENV=''
-export SENTRY_DSN=''
+export REACT_APP_SENTRY_ENV=''
+export REACT_APP_SENTRY_DSN=''

--- a/.env-example
+++ b/.env-example
@@ -1,2 +1,3 @@
-export CLIENT_ID=''
-export BACKEND_URL=''
+export REACT_APP_CLIENT_ID=''
+export REACT_APP_BACKEND_URL=''
+export ENV=''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,6 +1685,88 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@sentry/browser": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.27.6.tgz",
+      "integrity": "sha512-pqrojE2ZmLUVz7l/ogtogK0+M2pK3bigYm0fja7vG7F7kXnCAwqAHDYfkFXEvFI8WvNwH+niy28lSoV95lnm0Q==",
+      "requires": {
+        "@sentry/core": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.6.tgz",
+      "integrity": "sha512-izCS5iyc6HAfpW1AsGXLAKetx82C1Sq1siAh97tOlSK58PVJAEH/WMiej9WuZJxCDTOtj94QtoLflssrZyAtFg==",
+      "requires": {
+        "@sentry/hub": "5.27.6",
+        "@sentry/minimal": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.6.tgz",
+      "integrity": "sha512-bOMky3iu7zEghSaWmTayfme5tCpUok841qDCGxGKuyAtOhBDsgGNS/ApNEEDF2fyX0oo4G1cHYPWhX90ZFf/xA==",
+      "requires": {
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.6.tgz",
+      "integrity": "sha512-pKhzVQX9nL4m1dcnb2i2Y47IWVNs+K3wiYLgCB9hl9+ApxppfOc+fquiFoCloST3IuaD4yly2TtbOJgAMWcMxQ==",
+      "requires": {
+        "@sentry/hub": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/react": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-5.27.6.tgz",
+      "integrity": "sha512-PmHXqN3+0dmpPaOeGPf2yU3jKUe1edikNLaM6dfB2qVCxpNfIvP/uQsTx3ntzBPKxnsl93Pkj3/EJP7aWDNIZQ==",
+      "requires": {
+        "@sentry/browser": "5.27.6",
+        "@sentry/minimal": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.27.6.tgz",
+      "integrity": "sha512-ms3vprEId+hi8hcqtf8weqsNGASaDXAZzIOT4g2gASGpwLb5hLuScpM8z6Yhu5FGjb8DektlW5OrXJSsStIozw==",
+      "requires": {
+        "@sentry/hub": "5.27.6",
+        "@sentry/minimal": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.6.tgz",
+      "integrity": "sha512-XOW9W8DrMk++4Hk7gWi9o5VR0o/GrqGfTKyFsHSIjqt2hL6kiMPvKeb2Hhmp7Iq37N2bDmRdWpM5m+68S2Jk6w=="
+    },
+    "@sentry/utils": {
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.6.tgz",
+      "integrity": "sha512-/QMVLv+zrTfiIj2PU+SodSbSzD5MmamMOaljkDsRIVsj6gpkm1/VG1g2+40TZ0FbQ4hCW2F+iR7cnqzZBNmchA==",
+      "requires": {
+        "@sentry/types": "5.27.6",
+        "tslib": "^1.9.3"
+      }
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -2795,6 +2877,11 @@
         "source-map": "^0.5.7"
       },
       "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@atlaskit/tree": "^7.0.2",
+    "@sentry/react": "^5.27.6",
+    "@sentry/tracing": "^5.27.6",
     "axios": "^0.19.0",
     "bluebird": "^3.7.1",
     "bootstrap": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "uuid": "^3.3.3"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "source .env.development.local && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "uuid": "^3.3.3"
   },
   "scripts": {
-    "start": "source .env.development.local && react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import {
   Redirect,
 } from 'react-router-dom';
 import axios from 'axios';
+import * as Sentry from "@sentry/react";
 
 // Layouts
 import AuthCallback from './layouts/AuthCallback'
@@ -24,6 +25,7 @@ import Menus from './layouts/Menus';
 import EditNav from './layouts/EditNav';
 import Settings from './layouts/Settings';
 import ProtectedRoute from './components/ProtectedRoute'
+import FallbackComponent from './components/FallbackComponent'
 
 // Import contexts
 const { LoginContext } = require('./contexts/LoginContext')
@@ -92,7 +94,11 @@ function App() {
   }, [isLoggedIn])
 
   const ProtectedRouteWithProps = (props) => {
-    return <ProtectedRoute {...props} isLoggedIn={isLoggedIn} />
+    return (
+      <Sentry.ErrorBoundary fallback={FallbackComponent}>
+        <ProtectedRoute {...props} isLoggedIn={isLoggedIn} />
+      </Sentry.ErrorBoundary>
+    )
   }
 
   return (

--- a/src/components/FallbackComponent.jsx
+++ b/src/components/FallbackComponent.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+function FallbackComponent(err) {
+    console.log(err)
+    return <div>An error has occurred</div>;
+}
+
+export default FallbackComponent;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import * as Sentry from "@sentry/react";
+import { Integrations } from "@sentry/tracing";
 import './styles/index.scss';
 import 'sgds-govtech/css/sgds.css';
 import App from './App';
+
+if (process.env.ENV !== 'dev') {
+    Sentry.init({
+        dsn: process.env.SENTRY_DSN,
+        integrations: [
+          new Integrations.BrowserTracing(),
+        ],
+    
+        // We recommend adjusting this value in production, or using tracesSampler
+        // for finer control
+        tracesSampleRate: 1.0,
+    });
+}
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import './styles/index.scss';
 import 'sgds-govtech/css/sgds.css';
 import App from './App';
 
-if (process.env.ENV !== 'dev') {
+if (process.env.ENV !== 'staging' || process.env.ENV !== 'production') {
     Sentry.init({
         dsn: process.env.SENTRY_DSN,
         integrations: [

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import './styles/index.scss';
 import 'sgds-govtech/css/sgds.css';
 import App from './App';
 
-if (process.env.REACT_APP_SENTRY_ENV === 'staging' || process.env.REACT_APP_SENTRY_ENV == 'production') {
+if (process.env.REACT_APP_SENTRY_ENV === 'staging' || process.env.REACT_APP_SENTRY_ENV === 'production') {
   Sentry.init({
       dsn: process.env.REACT_APP_SENTRY_DSN,
       integrations: [

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,17 +6,17 @@ import './styles/index.scss';
 import 'sgds-govtech/css/sgds.css';
 import App from './App';
 
-if (process.env.ENV !== 'staging' || process.env.ENV !== 'production') {
-    Sentry.init({
-        dsn: process.env.SENTRY_DSN,
-        integrations: [
-          new Integrations.BrowserTracing(),
-        ],
-    
-        // We recommend adjusting this value in production, or using tracesSampler
-        // for finer control
-        tracesSampleRate: 1.0,
-    });
+if (process.env.REACT_APP_SENTRY_ENV === 'staging' || process.env.REACT_APP_SENTRY_ENV == 'production') {
+  Sentry.init({
+      dsn: process.env.REACT_APP_SENTRY_DSN,
+      integrations: [
+        new Integrations.BrowserTracing(),
+      ],
+  
+      // We recommend adjusting this value in production, or using tracesSampler
+      // for finer control
+      tracesSampleRate: 1.0,
+  });
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Note

This PR introduces the following environment variables to the code:
- `REACT_APP_SENTRY_ENV`: either `dev`, `staging`, or `production`
- `REACT_APP_SENTRY_DSN`: the Sentry DSN which sends error information to our Sentry account

Make sure to add these environment variables before merging to staging or production.

## Overview

This PR adds client-side monitoring for IsomerCMS. We do this using Sentry, which will help us to log the stack trace of any error which occurs in our application. 

We also introduce error boundaries in this PR. React error boundaries catch errors during rendering or in React lifecycle
methods (refer to the official documentation - https://reactjs.org/docs/error-boundaries.html#introducing-error-boundaries) and allow us to render a fallback component when such an error occurs. In this PR, we introduce a placeholder fallback component and we will update it when the designers hand over the design.

However, error boundaries do not catch errors for the following events:
- Event handlers
- Asynchronous code (e.g. setTimeout or requestAnimationFrame callbacks)
- Server side rendering
- Errors thrown in the error boundary itself (rather than its children)

For that we might need to use a separate library such as `react-error-boundary` (https://github.com/bvaughn/react-error-boundary). This can be the subject of another PR, and is logged in issue #263 

Note that while we are using the Sentry error boundaries, which are wrappers over the native React error boundaries, the above errors (event handlers, async code, etc.) will not be caught by the error boundary, but it will still be captured by Sentry. 

## Local Testing Notes

To test that Sentry works, you can set your `SENTRY_ENV` to `staging` and throw an error in your local code (just a `throw new Error('test`)` in one of the button `onClick` handler functions and click on the button). Then, log into Sentry and verify that the error was recorded. 

Note that we only initialize Sentry in staging or production environments since we have a limited number of errors in the free tier for Sentry so we shouldn't waste them in local dev.