### PR TITLE
Fix: proper intialization of section errors

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -171,6 +171,13 @@ export default class EditHomepage extends Component {
               },
             });
           }
+          if (!dropdown && !keyHighlights) {
+            sectionsErrors.push({
+              hero: {
+                title: '', subtitle: '', background: '', button: '', url: '',
+              },
+            });
+          }
         }
 
         // Check if there is already a resources section
@@ -1027,7 +1034,7 @@ export default class EditHomepage extends Component {
                                 url={section.hero.url}
                                 dropdown={section.hero.dropdown}
                                 sectionIndex={sectionIndex}
-                                highlights={section.hero.key_highlights}
+                                highlights={section.hero.key_highlights ? section.hero.key_highlights : []}
                                 onFieldChange={this.onFieldChange}
                                 createHandler={this.createHandler}
                                 deleteHandler={(event, type) => this.setState({ itemPendingForDelete: { id: event.target.id, type } })}


### PR DESCRIPTION
This PR fixes the bug raised in issue https://github.com/isomerpages/isomercms-frontend/issues/267. The reason for this issue was our assumption that a page had either a dropdown or highlights - given the relaxation of compulsory fields in the hero section, it became possible for a page to have neither, in which case our error initialization was not performed correctly. This PR fixes that issue by checking for this case.