### PR TITLE
Feat/implement resource type handling from file name

### DIFF
--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -149,6 +149,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                                     siteName={siteName}
                                     fileName={page.fileName}
                                     title={page.title}
+                                    resourceType={page.type}
                                     date={page.date}
                                     isResource={isResource}
                                     allCategories={allCategories}

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -182,7 +182,7 @@ const ComponentSettingsModal = ({
                 setFileUrl(frontMatter.file_url)
                 setOriginalFileUrl(frontMatter.file_url)
 
-                setResourceDate(type === 'resource' ? retrieveResourceFileMetadata(fileName).date : frontMatter.date)
+                setResourceDate(type === 'resource' ? retrieveResourceFileMetadata(fileName).date : '')
                 setOriginalThirdNavTitle(frontMatter.third_nav_title)
                 setThirdNavTitle(frontMatter.third_nav_title)
               }

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -16,6 +16,7 @@ import {
   generateCollectionPageFileName,
   generateResourceFileName,
   saveFileAndRetrieveUrl,
+  retrieveResourceFileMetadata,
 } from '../utils';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import { validatePageSettings, validateResourceSettings } from '../utils/validators';
@@ -181,7 +182,7 @@ const ComponentSettingsModal = ({
                 setFileUrl(frontMatter.file_url)
                 setOriginalFileUrl(frontMatter.file_url)
 
-                setResourceDate(frontMatter.date)
+                setResourceDate(type === 'resource' ? retrieveResourceFileMetadata(fileName).date : frontMatter.date)
                 setOriginalThirdNavTitle(frontMatter.third_nav_title)
                 setThirdNavTitle(frontMatter.third_nav_title)
               }
@@ -242,6 +243,7 @@ const ComponentSettingsModal = ({
                 originalCategory,
                 collectionPageData,
                 type,
+                resourceType: isPost ? 'post' : 'file',
                 fileName,
                 isNewFile,
                 siteName,

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -27,6 +27,7 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 import {
   prettifyCollectionPageFileName,
   prettifyPageFileName,
+  prettifyDate,
   retrieveResourceFileMetadata,
 } from '../utils';
 
@@ -34,7 +35,7 @@ import {
 axios.defaults.withCredentials = true
 
 const OverviewCard = ({
-  date, category, settingsToggle, itemIndex, siteName, fileName, isResource, isHomepage, allCategories
+  date, category, settingsToggle, itemIndex, siteName, fileName, isResource, isHomepage, allCategories, resourceType
 }) => {
   const dropdownRef = useRef(null)
   const fileMoveDropdownRef = useRef(null)
@@ -71,7 +72,7 @@ const OverviewCard = ({
       const base64DecodedContent = Base64.decode(content);
       const { frontMatter, mdBody } = frontMatterParser(base64DecodedContent);
       const {
-        title, permalink, file_url: fileUrl, date, third_nav_title: thirdNavTitle,
+        title, permalink, file_url: fileUrl, third_nav_title: thirdNavTitle,
       } = frontMatter;
 
       let collectionPageData
@@ -90,6 +91,7 @@ const OverviewCard = ({
         category: chosenCategory,
         originalCategory: category,
         type: isResource ? 'resource' : 'page',
+        resourceType,
         originalThirdNavTitle: thirdNavTitle,
         fileName,
         isNewFile: false,
@@ -234,7 +236,7 @@ const OverviewCard = ({
       <div id={itemIndex} className={contentStyles.componentInfo}>
         <div className={contentStyles.componentCategory}>{category ? category : ''}</div>
         <h1 className={contentStyles.componentTitle}>{generateTitle()}</h1>
-        <p className={contentStyles.componentDate}>{date ? date : ''}</p>
+        <p className={contentStyles.componentDate}>{`${date ? prettifyDate(date) : ''}${resourceType ? `/${resourceType.toUpperCase()}` : ''}`}</p>
       </div>
       {settingsToggle &&
         <div className="position-relative mt-auto">

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -215,24 +215,8 @@ const OverviewCard = ({
     setCanShowDropdown(!canShowDropdown)
   }
 
-  return (
+  const CardContent = (
     <>
-    {
-      canShowGenericWarningModal &&
-      <GenericWarningModal
-        displayTitle="Warning"
-        displayText="Moving a page to a different collection might lead to user confusion. You may wish to change the permalink for this page afterwards."
-        onProceed={moveFile}
-        onCancel={() => {
-          setChosenCategory()
-          setIsNewCollection(false)
-          setCanShowGenericWarningModal(false)
-        }}
-        proceedText="Continue"
-        cancelText="Cancel"
-      />
-    }
-    <Link className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.card}`} to={generateLink()}>
       <div id={itemIndex} className={contentStyles.componentInfo}>
         <div className={contentStyles.componentCategory}>{category ? category : ''}</div>
         <h1 className={contentStyles.componentTitle}>{generateTitle()}</h1>
@@ -340,7 +324,36 @@ const OverviewCard = ({
           </div>}
         </div>
       }
-    </Link>
+    </>
+  )
+  
+  return (
+    <>
+    {
+      resourceType !== 'file'
+      ?
+        <Link className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.card}`} to={generateLink()}>
+          {CardContent}
+        </Link>
+      : <div className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.card}`}>
+          {CardContent}
+        </div>
+    }
+    {
+      canShowGenericWarningModal &&
+      <GenericWarningModal
+        displayTitle="Warning"
+        displayText="Moving a page to a different collection might lead to user confusion. You may wish to change the permalink for this page afterwards."
+        onProceed={moveFile}
+        onCancel={() => {
+          setChosenCategory()
+          setIsNewCollection(false)
+          setCanShowGenericWarningModal(false)
+        }}
+        proceedText="Continue"
+        cancelText="Cancel"
+      />
+    }
     {
       canShowDeleteWarningModal
       && (

--- a/src/layouts/CategoryPages.jsx
+++ b/src/layouts/CategoryPages.jsx
@@ -45,9 +45,10 @@ const CategoryPages = ({ match, location, isResource }) => {
 
         if (resourcePages.length > 0) {
           const retrievedResourcePages = resourcePages.map((resourcePage) => {
-            const { title, date } = retrieveResourceFileMetadata(resourcePage.fileName);
+            const { title, type, date } = retrieveResourceFileMetadata(resourcePage.fileName);
             return {
               title,
+              type,
               date,
               fileName: resourcePage.fileName,
             };

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -329,7 +329,7 @@ export default class EditPage extends Component {
   render() {
     const { match, isCollectionPage, isResourcePage } = this.props;
     const { siteName, fileName, collectionName, resourceName } = match.params;
-    const { title, date } = extractMetadataFromFilename(isResourcePage, isCollectionPage, fileName)
+    const { title, type: resourceType, date } = extractMetadataFromFilename(isResourcePage, isCollectionPage, fileName)
     const { backButtonLabel, backButtonUrl } = getBackButtonInfo(resourceName, collectionName, siteName)
     const {
       csp,
@@ -392,55 +392,65 @@ export default class EditPage extends Component {
             />
             )
           }
-          <div className={`${editorStyles.pageEditorSidebar} ${isLoadingPageContent ? editorStyles.pageEditorSidebarLoading : null}`} >
-            {
-              isLoadingPageContent
-              ? (
-                <div className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`} />
-              ) : ''
-            }
-            <SimpleMDE
-              id="simplemde-editor"
-              className="h-100"
-              onChange={this.onEditorChange}
-              ref={this.mdeRef}
-              value={editorValue}
-              options={{
-                toolbar: [
-                  headingButton,
-                  boldButton,
-                  italicButton,
-                  strikethroughButton,
-                  '|',
-                  codeButton,
-                  quoteButton,
-                  unorderedListButton,
-                  orderedListButton,
-                  '|',
-                  {
-                    name: 'image',
-                    action: async () => {
-                      this.setState({ isSelectingImage: true });
-                    },
-                    className: 'fa fa-picture-o',
-                    title: 'Insert Image',
-                    default: true,
-                  },
-                  {
-                    name: 'link',
-                    action: async () => { 
-                      this.onHyperlinkOpen() 
-                    },
-                    className: 'fa fa-link',
-                    title: 'Insert Link',
-                    default: true,
-                  },
-                  tableButton,
-                  guideButton,
-                ],
-              }}
-            />
-          </div>
+          {
+            resourceType !== 'file'
+            ?
+              <div className={`${editorStyles.pageEditorSidebar} ${isLoadingPageContent ? editorStyles.pageEditorSidebarLoading : null}`} >
+                {
+                  isLoadingPageContent
+                  ? (
+                    <div className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`} />
+                  ) : ''
+                }
+                <SimpleMDE
+                  id="simplemde-editor"
+                  className="h-100"
+                  onChange={this.onEditorChange}
+                  ref={this.mdeRef}
+                  value={editorValue}
+                  options={{
+                    toolbar: [
+                      headingButton,
+                      boldButton,
+                      italicButton,
+                      strikethroughButton,
+                      '|',
+                      codeButton,
+                      quoteButton,
+                      unorderedListButton,
+                      orderedListButton,
+                      '|',
+                      {
+                        name: 'image',
+                        action: async () => {
+                          this.setState({ isSelectingImage: true });
+                        },
+                        className: 'fa fa-picture-o',
+                        title: 'Insert Image',
+                        default: true,
+                      },
+                      {
+                        name: 'link',
+                        action: async () => { 
+                          this.onHyperlinkOpen() 
+                        },
+                        className: 'fa fa-link',
+                        title: 'Insert Link',
+                        default: true,
+                      },
+                      tableButton,
+                      guideButton,
+                    ],
+                  }}
+                />
+              </div>
+            :
+              <div className={`${editorStyles.pageEditorSidebar}`}>
+                <div className={`text-center`}>
+                  Editing is disabled for downloadable files.
+                </div>
+              </div>
+          }
           <div className={editorStyles.pageEditorMain}>
             {
               isCollectionPage && leftNavPages

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -393,63 +393,63 @@ export default class EditPage extends Component {
             )
           }
           {
-            resourceType !== 'file'
-            ?
-              <div className={`${editorStyles.pageEditorSidebar} ${isLoadingPageContent ? editorStyles.pageEditorSidebarLoading : null}`} >
-                {
-                  isLoadingPageContent
-                  ? (
-                    <div className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`} />
-                  ) : ''
-                }
-                <SimpleMDE
-                  id="simplemde-editor"
-                  className="h-100"
-                  onChange={this.onEditorChange}
-                  ref={this.mdeRef}
-                  value={editorValue}
-                  options={{
-                    toolbar: [
-                      headingButton,
-                      boldButton,
-                      italicButton,
-                      strikethroughButton,
-                      '|',
-                      codeButton,
-                      quoteButton,
-                      unorderedListButton,
-                      orderedListButton,
-                      '|',
-                      {
-                        name: 'image',
-                        action: async () => {
-                          this.setState({ isSelectingImage: true });
-                        },
-                        className: 'fa fa-picture-o',
-                        title: 'Insert Image',
-                        default: true,
+            <div className={`${editorStyles.pageEditorSidebar} ${isLoadingPageContent || resourceType === 'file' ? editorStyles.pageEditorSidebarLoading : null}`} >
+              {
+                resourceType === 'file'
+                ?
+                <>
+                  <div className={`text-center ${editorStyles.pageEditorSidebarDisabled}`}>
+                    Editing is disabled for downloadable files.
+                  </div>
+                </>
+                :
+                isLoadingPageContent
+                ? (
+                  <div className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`} />
+                ) : ''
+              }
+              <SimpleMDE
+                id="simplemde-editor"
+                className="h-100"
+                onChange={this.onEditorChange}
+                ref={this.mdeRef}
+                value={editorValue}
+                options={{
+                  toolbar: [
+                    headingButton,
+                    boldButton,
+                    italicButton,
+                    strikethroughButton,
+                    '|',
+                    codeButton,
+                    quoteButton,
+                    unorderedListButton,
+                    orderedListButton,
+                    '|',
+                    {
+                      name: 'image',
+                      action: async () => {
+                        this.setState({ isSelectingImage: true });
                       },
-                      {
-                        name: 'link',
-                        action: async () => { 
-                          this.onHyperlinkOpen() 
-                        },
-                        className: 'fa fa-link',
-                        title: 'Insert Link',
-                        default: true,
+                      className: 'fa fa-picture-o',
+                      title: 'Insert Image',
+                      default: true,
+                    },
+                    {
+                      name: 'link',
+                      action: async () => { 
+                        this.onHyperlinkOpen() 
                       },
-                      tableButton,
-                      guideButton,
-                    ],
-                  }}
-                />
-              </div>
-            :
-              <div className={`${editorStyles.pageEditorSidebar}`}>
-                <div className={`text-center`}>
-                  Editing is disabled for downloadable files.
-                </div>
-              </div>
+                      className: 'fa fa-link',
+                      title: 'Insert Link',
+                      default: true,
+                    },
+                    tableButton,
+                    guideButton,
+                  ],
+                }}
+              />
+            </div>
           }
           <div className={editorStyles.pageEditorMain}>
             {

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -21,6 +21,7 @@ import {
   prettifyPageFileName,
   prettifyCollectionPageFileName,
   retrieveResourceFileMetadata,
+  prettifyDate,
 } from '../utils';
 import {
   boldButton,
@@ -61,7 +62,11 @@ const getApiEndpoint = (isResourcePage, isCollectionPage, { collectionName, file
 
 const extractMetadataFromFilename = (isResourcePage, isCollectionPage, fileName) => {
   if (isResourcePage) {
-    return retrieveResourceFileMetadata(fileName)
+    const resourceMetadata = retrieveResourceFileMetadata(fileName)
+    return {
+      ...resourceMetadata,
+      date: prettifyDate(resourceMetadata.date)
+    }
   }
   if (isCollectionPage) {
     return { title: prettifyCollectionPageFileName(fileName), date: '' }

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -21,7 +21,7 @@ const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 const Workspace = ({ match, location }) => {
     const { siteName } = match.params;
 
-    const [collections, setCollections] = useState([])
+    const [collections, setCollections] = useState()
     const [unlinkedPages, setUnlinkedPages] = useState()
     const [contactUsCard, setContactUsCard] = useState(false)
 
@@ -128,8 +128,8 @@ const Workspace = ({ match, location }) => {
                     ))
                     : (
                         !collections
-                            ? 'There are no collections in this repository'
-                            : 'Loading Collections...'
+                            ? 'Loading Collections...'
+                            : 'There are no collections in this repository'
                     )
                   }
                 </div>

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -55,6 +55,17 @@
   }
 }
 
+.pageEditorSidebarDisabled{
+  width: 100%;
+  top: 50%;
+  pointer-events: none;
+  text-align: center;
+  position: absolute;
+  z-index: 2;
+  margin: -30px;
+  margin-bottom: -100px;
+}
+
 .pageEditorMain{
   transform: scale(0.95);
   transform-origin: center;


### PR DESCRIPTION
This PR re-implements resource file naming and identification of resource type through the file name, to resolve https://github.com/isomerpages/isomercms-frontend/issues/254. The major changes are as follows:
- The util functions for reading and writing resource file names have been changed to the new file name format `<YYYY-MM-DD>-<type>-<title>.md`
- Resource cards display the type of resource, either FILE (downloadable file) or POST (post). The card label has been modified to include file type.
- Resource pages of type FILE can no longer be clicked in CategoryPages.
- The EditPage layout disables input if the resource is of type FILE.

In addition, this PR also resolves https://github.com/isomerpages/isomercms-frontend/issues/272, by fixing a small bug involving collections.