### PR TITLE
Feat/add settings fields

### DIFF
--- a/src/components/FormFieldDropdown.jsx
+++ b/src/components/FormFieldDropdown.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CreatableSelect from 'react-select/creatable';
+import Select from 'react-select';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 const calculateBoolean = (booleanVal) => {
@@ -30,7 +30,7 @@ const FormFieldDropdown = ({
         <div className={`d-flex align-items-center ${elementStyles.formDropdownLabel}`}>
             <span>{`${title}:`}</span>
         </div>
-        <CreatableSelect
+        <Select
             className={elementStyles.formDropdownInput}
             onChange={(event) => creatableSelectHandler(onFieldChange, event, id)}
             value={{
@@ -54,13 +54,7 @@ export default FormFieldDropdown;
   
 FormFieldDropdown.propTypes = {
     title: PropTypes.string.isRequired,
-    defaultValue: PropTypes.string,
     value: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     onFieldChange: PropTypes.func.isRequired,
-};
-  
-FormFieldDropdown.defaultProps = {
-    defaultValue: 'false',
-    style: undefined,
 };

--- a/src/components/FormFieldDropdown.jsx
+++ b/src/components/FormFieldDropdown.jsx
@@ -21,13 +21,9 @@ const creatableSelectHandler = (callback, dropdownEvent, id) => {
 
 const FormFieldDropdown = ({
     title,
-    defaultValue,
     value,
     id,
-    errorMessage,
     onFieldChange,
-    isRequired,
-    style,
 }) => (
     <>
       <div className={elementStyles.formDropdown}>
@@ -35,7 +31,6 @@ const FormFieldDropdown = ({
             <span>{`${title}:`}</span>
         </div>
         <CreatableSelect
-            isClearable
             className={elementStyles.formDropdownInput}
             onChange={(event) => creatableSelectHandler(onFieldChange, event, id)}
             value={{
@@ -62,10 +57,7 @@ FormFieldDropdown.propTypes = {
     defaultValue: PropTypes.string,
     value: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
-    errorMessage: PropTypes.string.isRequired,
     onFieldChange: PropTypes.func.isRequired,
-    isRequired: PropTypes.bool.isRequired,
-    style: PropTypes.string,
 };
   
 FormFieldDropdown.defaultProps = {

--- a/src/components/FormFieldDropdown.jsx
+++ b/src/components/FormFieldDropdown.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CreatableSelect from 'react-select/creatable';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+
+const calculateBoolean = (booleanVal) => {
+    if (booleanVal && booleanVal !== 'false') {
+        return 'true'
+    }
+    return 'false'
+}
+
+const creatableSelectHandler = (callback, dropdownEvent, id) => {
+    callback({
+        target: {
+            id,
+            value: dropdownEvent.value,
+        },
+    })
+}
+
+const FormFieldDropdown = ({
+    title,
+    defaultValue,
+    value,
+    id,
+    errorMessage,
+    onFieldChange,
+    isRequired,
+    style,
+}) => (
+    <>
+      <div className={elementStyles.formDropdown}>
+        <div className={`d-flex align-items-center ${elementStyles.formDropdownLabel}`}>
+            <span>{`${title}:`}</span>
+        </div>
+        <CreatableSelect
+            isClearable
+            className={elementStyles.formDropdownInput}
+            onChange={(event) => creatableSelectHandler(onFieldChange, event, id)}
+            value={{
+                value: calculateBoolean(value),
+                label: calculateBoolean(value),
+            }}
+            options={[{
+                value: 'true',
+                label: 'true',
+             }, {
+                value: 'false',
+                label: 'false',
+             },
+            ]}
+        />
+      </div>
+    </>
+);
+  
+export default FormFieldDropdown;
+  
+FormFieldDropdown.propTypes = {
+    title: PropTypes.string.isRequired,
+    defaultValue: PropTypes.string,
+    value: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    errorMessage: PropTypes.string.isRequired,
+    onFieldChange: PropTypes.func.isRequired,
+    isRequired: PropTypes.bool.isRequired,
+    style: PropTypes.string,
+};
+  
+FormFieldDropdown.defaultProps = {
+    defaultValue: 'false',
+    style: undefined,
+};

--- a/src/components/FormFieldHorizontal.jsx
+++ b/src/components/FormFieldHorizontal.jsx
@@ -5,6 +5,7 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 const FormFieldHorizontal = ({
   title,
   defaultValue,
+  placeholder,
   value,
   id,
   errorMessage,
@@ -17,7 +18,7 @@ const FormFieldHorizontal = ({
       <p className={elementStyles.formHorizontalLabel}>{`${title}:`}</p>
       <input
         type="text"
-        placeholder={title}
+        placeholder={placeholder ? placeholder : title}
         value={value}
         defaultValue={defaultValue}
         id={id}
@@ -36,6 +37,7 @@ export default FormFieldHorizontal;
 
 FormFieldHorizontal.propTypes = {
   title: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
   defaultValue: PropTypes.string,
   value: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -433,6 +433,14 @@ export default class Settings extends Component {
             {/* container for settings fields */}
             <div className={contentStyles.contentContainerCards}>
               <div className={contentStyles.cardContainer}>
+                <FormFieldHorizontal
+                  title="Title"
+                  id="title"
+                  value={title}
+                  errorMessage={errors.title}
+                  isRequired={false}
+                  onFieldChange={this.changeHandler}
+                />
                 {/* Logo fields */}
                 <FormFieldMedia
                   title="Agency logo"

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -510,6 +510,7 @@ export default class Settings extends Component {
                   <p className={elementStyles.formSectionHeader}>Analytics</p>
                   <FormFieldHorizontal
                     title="Facebook Pixel"
+                    placeholder="Facebook Pixel ID"
                     id="facebook_pixel"
                     value={facebook_pixel}
                     errorMessage={errors.facebook_pixel}
@@ -518,6 +519,7 @@ export default class Settings extends Component {
                   />
                   <FormFieldHorizontal
                     title="Google Analytics"
+                    placeholder="Google Analytics ID"
                     id="google_analytics"
                     value={google_analytics}
                     errorMessage={errors.google_analytics}

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -6,7 +6,7 @@ import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import LoadingButton from '../components/LoadingButton';
 import ColorPicker from '../components/ColorPicker';
-import FormField from '../components/FormField';
+import FormFieldDropdown from '../components/FormFieldDropdown';
 import FormFieldMedia from '../components/FormFieldMedia';
 import FormFieldColor from '../components/FormFieldColor';
 import FormFieldHorizontal from '../components/FormFieldHorizontal';
@@ -166,7 +166,17 @@ export default class Settings extends Component {
     const grandparentElementId = parentElement?.parentElement?.id
     // const errorMessage = validateSettings(id, value);
 
-    if (grandparentElementId === 'footer-fields') {
+    // although show_reach is a part of footer-fields, the CreatableSelect dropdown handler does not
+    // return a normal event, so we need to handle the case separately
+    if (id === 'show_reach') {
+      this.setState((currState) => ({
+        ...currState,
+        otherFooterSettings: {
+          ...currState.otherFooterSettings,
+          [id]: value,
+        },
+      }));
+    } else if (grandparentElementId === 'footer-fields') {
       this.setState((currState) => ({
         ...currState,
         otherFooterSettings: {
@@ -448,7 +458,7 @@ export default class Settings extends Component {
                     isRequired={false}
                     onFieldChange={this.changeHandler}
                   />
-                  <FormFieldHorizontal
+                  <FormFieldDropdown
                     title="Display government masthead"
                     id="is_government"
                     value={is_government}
@@ -571,9 +581,26 @@ export default class Settings extends Component {
                 {/* Footer fields */}
                 <div id="footer-fields">
                   <p className={elementStyles.formSectionHeader}>Footer</p>
-                  {Object.keys(otherFooterSettings).map((footerSetting) => (
-                    <FormFieldHorizontal
-                      title={footerSetting.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                  {Object.keys(otherFooterSettings).map((footerSetting) => {
+                    const title = footerSetting.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+
+                    if (footerSetting === 'show_reach') {
+                      return (
+                        <FormFieldDropdown
+                          title={title}
+                          id={footerSetting}
+                          value={otherFooterSettings[footerSetting]}
+                          key={`${footerSetting}-form`}
+                          errorMessage={errors.otherFooterSettings[footerSetting]}
+                          isRequired={false}
+                          onFieldChange={this.changeHandler}
+                        />
+                      )
+                    }
+
+                    return (
+                      <FormFieldHorizontal
+                      title={title}
                       id={footerSetting}
                       value={otherFooterSettings[footerSetting]}
                       key={`${footerSetting}-form`}
@@ -581,7 +608,8 @@ export default class Settings extends Component {
                       isRequired={false}
                       onFieldChange={this.changeHandler}
                     />
-                  ))}
+                    )
+                  })}
                 </div>
                 <br />
                 <br />

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -52,6 +52,9 @@ const stateFields = {
     feedback: '',
     faq: '',
   },
+  navigationSettings: {
+    logo: '',
+  },
   socialMediaContent: {
     facebook: '',
     linkedin: '',
@@ -94,6 +97,7 @@ export default class Settings extends Component {
       const {
         configFieldsRequired,
         footerContent,
+        navigationContent,
         footerSha,
       } = settings;
 
@@ -112,6 +116,10 @@ export default class Settings extends Component {
         socialMediaContent: {
           ...currState.socialMediaContent,
           ...footerContent.social_media,
+        },
+        navigationSettings: {
+          ...currState.navigationSettings,
+          ...navigationContent,
         },
         footerSha,
       }));
@@ -206,10 +214,20 @@ export default class Settings extends Component {
         },
       }));
     } else {
-      this.setState((currState) => ({
-        ...currState,
-        [id]: value,
-      }));
+      if (id === 'logo') {
+        this.setState((currState) => ({
+          ...currState,
+          navigationSettings: {
+            ...currState.navigationSettings,
+            [id]: value,
+          },
+        }));
+      } else {
+        this.setState((currState) => ({
+          ...currState,
+          [id]: value,
+        }));
+      }
     }
   };
 
@@ -231,6 +249,7 @@ export default class Settings extends Component {
         facebook_pixel,
         google_analytics,
         colors,
+        navigationSettings,
       } = this.state;
       const configSettings = {
         title,
@@ -250,6 +269,7 @@ export default class Settings extends Component {
           social_media: socialMediaSettings,
         },
         configSettings,
+        navigationSettings,
         footerSha,
       };
 
@@ -367,6 +387,7 @@ export default class Settings extends Component {
       colors,
       socialMediaContent,
       otherFooterSettings,
+      navigationSettings: { logo },
       footerSha,
       errors,
     } = this.state;
@@ -380,10 +401,11 @@ export default class Settings extends Component {
 
     // retrieve errors
     const hasConfigErrors = _.some([errors.favicon, errors.shareicon, errors.facebook_pixel, errors.google_analytics]);
+    const hasNavigationErrors = _.some([errors.navigationSettings.logo])
     const hasColorErrors = _.some([errors.colors.primaryColor, errors.colors.secondaryColor]);
     const hasMediaColorErrors = _.some(errors.colors['media-colors'].map((mediaColor) => mediaColor.color));
     const hasSocialMediaErrors = _.some(Object.values(errors.socialMediaContent));
-    const hasErrors = hasConfigErrors || hasColorErrors || hasMediaColorErrors || hasSocialMediaErrors;
+    const hasErrors = hasConfigErrors || hasNavigationErrors || hasColorErrors || hasMediaColorErrors || hasSocialMediaErrors;
     return (
       <>
         <Header />
@@ -411,7 +433,19 @@ export default class Settings extends Component {
             {/* container for settings fields */}
             <div className={contentStyles.contentContainerCards}>
               <div className={contentStyles.cardContainer}>
-                {/* Favicon field */}
+                {/* Logo fields */}
+                <FormFieldMedia
+                  title="Agency logo"
+                  id="logo"
+                  value={logo}
+                  errorMessage={errors.navigationSettings.logo}
+                  isRequired
+                  onFieldChange={this.changeHandler}
+                  inlineButtonText={"Choose Image"}
+                  siteName={siteName}
+                  placeholder=" "
+                  type="image"
+                />
                 <FormFieldMedia
                   title="Favicon"
                   id="favicon"

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -462,8 +462,6 @@ export default class Settings extends Component {
                     title="Display government masthead"
                     id="is_government"
                     value={is_government}
-                    errorMessage={errors.is_government}
-                    isRequired={false}
                     onFieldChange={this.changeHandler}
                   />
                 </div>

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -17,6 +17,9 @@ import { validateSocialMedia } from '../utils/validators';
 const stateFields = {
   title: '',
   favicon: '',
+  shareicon: '',
+  facebook_pixel: '',
+  google_analytics: '',
   colors: {
     'primary-color': '',
     'secondary-color': '',
@@ -224,11 +227,17 @@ export default class Settings extends Component {
       const {
         title,
         favicon,
+        shareicon,
+        facebook_pixel,
+        google_analytics,
         colors,
       } = this.state;
       const configSettings = {
         title,
         favicon,
+        shareicon,
+        'facebook-pixel': facebook_pixel, // rename due to quirks on isomer template
+        google_analytics,
         colors,
       };
 
@@ -352,6 +361,9 @@ export default class Settings extends Component {
       siteName,
       title,
       favicon,
+      shareicon,
+      facebook_pixel,
+      google_analytics,
       colors,
       socialMediaContent,
       otherFooterSettings,
@@ -367,7 +379,7 @@ export default class Settings extends Component {
     const { location } = this.props;
 
     // retrieve errors
-    const hasConfigErrors = _.some([errors.favicon]);
+    const hasConfigErrors = _.some([errors.favicon, errors.shareicon, errors.facebook_pixel, errors.google_analytics]);
     const hasColorErrors = _.some([errors.colors.primaryColor, errors.colors.secondaryColor]);
     const hasMediaColorErrors = _.some(errors.colors['media-colors'].map((mediaColor) => mediaColor.color));
     const hasSocialMediaErrors = _.some(Object.values(errors.socialMediaContent));
@@ -412,6 +424,38 @@ export default class Settings extends Component {
                   placeholder=" "
                   type="image"
                 />
+                <FormFieldMedia
+                  title="Shareicon"
+                  id="shareicon"
+                  value={shareicon}
+                  errorMessage={errors.shareicon}
+                  isRequired
+                  onFieldChange={this.changeHandler}
+                  inlineButtonText={"Choose Image"}
+                  siteName={siteName}
+                  placeholder=" "
+                  type="image"
+                />
+                {/* Analytics fields */}
+                <div id="analytics-fields">
+                  <p className={elementStyles.formSectionHeader}>Analytics</p>
+                  <FormFieldHorizontal
+                    title="Facebook Pixel"
+                    id="facebook_pixel"
+                    value={facebook_pixel}
+                    errorMessage={errors.facebook_pixel}
+                    isRequired={false}
+                    onFieldChange={this.changeHandler}
+                  />
+                  <FormFieldHorizontal
+                    title="Google Analytics"
+                    id="google_analytics"
+                    value={google_analytics}
+                    errorMessage={errors.google_analytics}
+                    isRequired={false}
+                    onFieldChange={this.changeHandler}
+                  />
+                </div>
                 {/* Color fields */}
                 <div id="color-fields">
                   <p className={elementStyles.formSectionHeader}>Colors</p>

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -20,6 +20,7 @@ const stateFields = {
   shareicon: '',
   facebook_pixel: '',
   google_analytics: '',
+  is_government: '',
   colors: {
     'primary-color': '',
     'secondary-color': '',
@@ -248,6 +249,7 @@ export default class Settings extends Component {
         shareicon,
         facebook_pixel,
         google_analytics,
+        is_government,
         colors,
         navigationSettings,
       } = this.state;
@@ -257,6 +259,7 @@ export default class Settings extends Component {
         shareicon,
         'facebook-pixel': facebook_pixel, // rename due to quirks on isomer template
         google_analytics,
+        is_government,
         colors,
       };
 
@@ -384,6 +387,7 @@ export default class Settings extends Component {
       shareicon,
       facebook_pixel,
       google_analytics,
+      is_government,
       colors,
       socialMediaContent,
       otherFooterSettings,
@@ -400,7 +404,7 @@ export default class Settings extends Component {
     const { location } = this.props;
 
     // retrieve errors
-    const hasConfigErrors = _.some([errors.favicon, errors.shareicon, errors.facebook_pixel, errors.google_analytics]);
+    const hasConfigErrors = _.some([errors.favicon, errors.shareicon, errors.is_government, errors.facebook_pixel, errors.google_analytics]);
     const hasNavigationErrors = _.some([errors.navigationSettings.logo])
     const hasColorErrors = _.some([errors.colors.primaryColor, errors.colors.secondaryColor]);
     const hasMediaColorErrors = _.some(errors.colors['media-colors'].map((mediaColor) => mediaColor.color));
@@ -433,51 +437,66 @@ export default class Settings extends Component {
             {/* container for settings fields */}
             <div className={contentStyles.contentContainerCards}>
               <div className={contentStyles.cardContainer}>
-                <FormFieldHorizontal
-                  title="Title"
-                  id="title"
-                  value={title}
-                  errorMessage={errors.title}
-                  isRequired={false}
-                  onFieldChange={this.changeHandler}
-                />
+                {/* General fields */}
+                <div id="general-fields">
+                  <p className={elementStyles.formSectionHeader}>General</p>
+                  <FormFieldHorizontal
+                    title="Title"
+                    id="title"
+                    value={title}
+                    errorMessage={errors.title}
+                    isRequired={false}
+                    onFieldChange={this.changeHandler}
+                  />
+                  <FormFieldHorizontal
+                    title="Display government masthead"
+                    id="is_government"
+                    value={is_government}
+                    errorMessage={errors.is_government}
+                    isRequired={false}
+                    onFieldChange={this.changeHandler}
+                  />
+                </div>
                 {/* Logo fields */}
-                <FormFieldMedia
-                  title="Agency logo"
-                  id="logo"
-                  value={logo}
-                  errorMessage={errors.navigationSettings.logo}
-                  isRequired
-                  onFieldChange={this.changeHandler}
-                  inlineButtonText={"Choose Image"}
-                  siteName={siteName}
-                  placeholder=" "
-                  type="image"
-                />
-                <FormFieldMedia
-                  title="Favicon"
-                  id="favicon"
-                  value={favicon}
-                  errorMessage={errors.favicon}
-                  isRequired
-                  onFieldChange={this.changeHandler}
-                  inlineButtonText={"Choose Image"}
-                  siteName={siteName}
-                  placeholder=" "
-                  type="image"
-                />
-                <FormFieldMedia
-                  title="Shareicon"
-                  id="shareicon"
-                  value={shareicon}
-                  errorMessage={errors.shareicon}
-                  isRequired
-                  onFieldChange={this.changeHandler}
-                  inlineButtonText={"Choose Image"}
-                  siteName={siteName}
-                  placeholder=" "
-                  type="image"
-                />
+                <div id="logo-fields">
+                  <p className={elementStyles.formSectionHeader}>Logos</p>
+                  <FormFieldMedia
+                    title="Agency logo"
+                    id="logo"
+                    value={logo}
+                    errorMessage={errors.navigationSettings.logo}
+                    isRequired
+                    onFieldChange={this.changeHandler}
+                    inlineButtonText={"Choose Image"}
+                    siteName={siteName}
+                    placeholder=" "
+                    type="image"
+                  />
+                  <FormFieldMedia
+                    title="Favicon"
+                    id="favicon"
+                    value={favicon}
+                    errorMessage={errors.favicon}
+                    isRequired
+                    onFieldChange={this.changeHandler}
+                    inlineButtonText={"Choose Image"}
+                    siteName={siteName}
+                    placeholder=" "
+                    type="image"
+                  />
+                  <FormFieldMedia
+                    title="Shareicon"
+                    id="shareicon"
+                    value={shareicon}
+                    errorMessage={errors.shareicon}
+                    isRequired
+                    onFieldChange={this.changeHandler}
+                    inlineButtonText={"Choose Image"}
+                    siteName={siteName}
+                    placeholder=" "
+                    type="image"
+                  />
+                </div>
                 {/* Analytics fields */}
                 <div id="analytics-fields">
                   <p className={elementStyles.formSectionHeader}>Analytics</p>

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -47,6 +47,21 @@ p {
   }
 }
 
+.formDropdown{
+  @extend .formHorizontal;
+
+  .formDropdownLabel{
+    @extend .formLabel;
+    width: 25%;
+    margin: 0px;
+    padding: 0px;
+  }
+
+  .formDropdownInput{
+    width: 75%;
+  }
+}
+
 .formColor{
   display: flex;
   width: 50%;


### PR DESCRIPTION
Note: This is to be reviewed with PR #[85](https://github.com/isomerpages/isomercms-backend/pull/85) in the backend.

## Overview
This PR adds new fields and logic to the `Settings` layout, resolving issues #269, #270, and #271 in the process.

Firstly, it adds the following fields to the `Settings` layout:
- `shareicon`
- `facebook_pixel`
- `google_analytics`
- `is_government` (whether government masthead should be displayed)
- `logo` (agency logo)

It also reintroduces the `title` field, which was previously removed in PR #197. The reason for reintroduction is explained in more detail in issue #269.

Note that these changes need to be accompanied by changes in the backend, since we need to retrieve and update the agency logo from a new file (`_data/navigation.yml`), and also because the reintroduced `title` field now represents both the browser tab title (found in `index.md`) as well as the footer title (found in `_data/footer.yml`).

## Style changes for dropdown fields

There are certain fields in `Settings`, such as `show_reach` or `is_government`, which should only accept `true` or `false` values. In such cases, we should limit the user's options instead of allowing them to enter plain text. This PR introduces a `FormFieldDropdown` component which does just that.

<img width="690" alt="Screenshot 2020-12-02 at 11 58 35 AM" src="https://user-images.githubusercontent.com/31984694/100826719-f0397180-3495-11eb-95a5-5a47fc991243.png">