### PR TITLE
Feat/toast notification errors

### DIFF
--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -115,6 +115,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                         }
                         collectionPageData={collectionPageData}
                         loadThirdNavOptions={loadThirdNavOptions}
+                        setIsComponentSettingsActive={setIsComponentSettingsActive}
                     />
                 )
             }

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -9,6 +9,7 @@ import * as _ from 'lodash';
 import { Redirect } from 'react-router-dom';
 import FormField from './FormField';
 import {
+  DEFAULT_ERROR_TOAST_MSG,
   frontMatterParser,
   dequoteString,
   generatePageFileName,
@@ -190,7 +191,7 @@ const ComponentSettingsModal = ({
       fetchData().catch((err) => {
         setIsComponentSettingsActive((prevState) => !prevState)
         toast(
-          <Toast notificationType='error' text={`There was a problem retrieving data from your repo. Please reload the page or check your internet connection.`}/>,
+          <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
         );
         console.log(err)
@@ -267,7 +268,7 @@ const ComponentSettingsModal = ({
                 );
             } else {
               toast(
-                <Toast notificationType='error' text={`There was a problem saving your page settings. Please reload the page or check your internet connection.`}/>,
+                <Toast notificationType='error' text={`There was a problem saving your page settings. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
                 {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
               );
             }
@@ -286,7 +287,7 @@ const ComponentSettingsModal = ({
             window.location.reload();
         } catch (err) {
           toast(
-            <Toast notificationType='error' text={`There was a problem trying to delete this file. Please reload the page or check your internet connection.`}/>,
+            <Toast notificationType='error' text={`There was a problem trying to delete this file. ${DEFAULT_ERROR_TOAST_MSG}.`}/>,
             {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
           );
           console.log(err);

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -255,7 +255,7 @@ const ComponentSettingsModal = ({
             setNewPageUrl(redirectUrl)
             setRedirectToNewPage(true)
         } catch (err) {
-            if (err.response.status === 409) {
+            if (err?.response?.status === 409) {
                 // Error due to conflict in name
                 setErrors((prevState) => ({
                     ...prevState,

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -21,6 +21,8 @@ import { validatePageSettings, validateResourceSettings } from '../utils/validat
 import DeleteWarningModal from './DeleteWarningModal';
 import ResourceFormFields from './ResourceFormFields';
 import SaveDeleteButtons from './SaveDeleteButtons';
+import { toast } from 'react-toastify';
+import Toast from './Toast';
 
 // Import utils
 import { retrieveThirdNavOptions } from '../utils/dropdownUtils'
@@ -56,6 +58,7 @@ const ComponentSettingsModal = ({
     siteName,
     type,
     loadThirdNavOptions,
+    setIsComponentSettingsActive,
 }) => {
     // Errors
     const [errors, setErrors] = useState({
@@ -184,7 +187,14 @@ const ComponentSettingsModal = ({
           }
       }
 
-      fetchData().catch((err) => console.log(err))
+      fetchData().catch((err) => {
+        setIsComponentSettingsActive((prevState) => !prevState)
+        toast(
+          <Toast notificationType='error' text={`There was a problem retrieving data from your repo. Please reload the page or check your internet connection.`}/>,
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+        );
+        console.log(err)
+      })
       return () => { _isMounted = false }
     }, [])
 
@@ -251,6 +261,15 @@ const ComponentSettingsModal = ({
                     ...prevState,
                     title: 'This title is already in use. Please choose a different one.',
                 }));
+                toast(
+                  <Toast notificationType='error' text={`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`}/>,
+                  {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+                );
+            } else {
+              toast(
+                <Toast notificationType='error' text={`There was a problem retrieving data from your repo. Please reload the page or check your internet connection.`}/>,
+                {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+              );
             }
             console.log(err);
         }
@@ -266,7 +285,11 @@ const ComponentSettingsModal = ({
             // Refresh page
             window.location.reload();
         } catch (err) {
-            console.log(err);
+          toast(
+            <Toast notificationType='error' text={`There was a problem trying to delete this file. Please reload the page or check your internet connection.`}/>,
+            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+          );
+          console.log(err);
         }
     }
 

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -267,7 +267,7 @@ const ComponentSettingsModal = ({
                 );
             } else {
               toast(
-                <Toast notificationType='error' text={`There was a problem retrieving data from your repo. Please reload the page or check your internet connection.`}/>,
+                <Toast notificationType='error' text={`There was a problem saving your page settings. Please reload the page or check your internet connection.`}/>,
                 {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
               );
             }

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -12,6 +12,7 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 import {
+  DEFAULT_ERROR_TOAST_MSG,
   checkIsOutOfViewport,
 } from '../utils'
 
@@ -75,7 +76,7 @@ const FolderCard = ({
       window.location.reload();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text="There was a problem trying to delete this folder. Please try again or check your internet connection."/>, 
+        <Toast notificationType='error' text={`There was a problem trying to delete this folder. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -5,6 +5,8 @@ import axios from 'axios';
 
 import FolderModal from './FolderModal';
 import DeleteWarningModal from './DeleteWarningModal'
+import { toast } from 'react-toastify';
+import Toast from './Toast';
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
@@ -72,6 +74,10 @@ const FolderCard = ({
       // Refresh page
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text="There was a problem trying to delete this folder. Please try again or check your internet connection."/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import SaveDeleteButtons from './SaveDeleteButtons';
 import FormField from './FormField';
+import { toast } from 'react-toastify';
+import Toast from './Toast';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -22,6 +24,10 @@ const FolderModal = ({ displayTitle, displayText, onClose, category, siteName, i
       // Refresh page
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text="There was a problem trying to rename this folder. Please try again or check your internet connection."/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -6,6 +6,9 @@ import SaveDeleteButtons from './SaveDeleteButtons';
 import FormField from './FormField';
 import { toast } from 'react-toastify';
 import Toast from './Toast';
+import {
+  DEFAULT_ERROR_TOAST_MSG,
+} from '../utils'
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -25,7 +28,7 @@ const FolderModal = ({ displayTitle, displayText, onClose, category, siteName, i
       window.location.reload();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text="There was a problem trying to rename this folder. Please try again or check your internet connection."/>, 
+        <Toast notificationType='error' text={`There was a problem trying to rename this folder. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -5,6 +5,7 @@ import GenericWarningModal from './GenericWarningModal'
 import LoadingButton from './LoadingButton'
 import Toast from './Toast';
 import {
+  DEFAULT_ERROR_TOAST_MSG,
   frontMatterParser,
   saveFileAndRetrieveUrl,
   checkIsOutOfViewport,
@@ -108,7 +109,7 @@ const OverviewCard = ({
         );
       } else {
         toast(
-          <Toast notificationType='error' text="There was a problem trying to move this file. Please try again or check your internet connection."/>, 
+          <Toast notificationType='error' text={`There was a problem trying to move this file. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
       }

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -106,6 +106,11 @@ const OverviewCard = ({
           <Toast notificationType='error' text='This file name already exists in the category you are trying to move to. Please rename the file before proceeding.'/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
+      } else {
+        toast(
+          <Toast notificationType='error' text="There was a problem trying to move this file. Please try again or check your internet connection."/>, 
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+        );
       }
       setCanShowGenericWarningModal(false)
       console.log(err);
@@ -126,6 +131,10 @@ const OverviewCard = ({
       // Refresh page
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text="There was a problem trying to delete this file. Please try again or check your internet connection."/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -100,7 +100,7 @@ const OverviewCard = ({
       // Refresh page
       window.location.reload();
     } catch (err) {
-      if (err.response.status === 409) {
+      if (err?.response?.status === 409) {
         // Error due to conflict in name
         toast(
           <Toast notificationType='error' text='This file name already exists in the category you are trying to move to. Please rename the file before proceeding.'/>, 

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -91,14 +91,19 @@ export default class MediaSettingsModal extends Component {
           <Toast notificationType='error' text={`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
+      } else {
+        toast(
+          <Toast notificationType='error' text={`There was a problem trying to save this ${type === 'image' ? 'image' : 'file'}. Please try again or check your internet connection.`}/>, 
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+        );
       }
       console.log(err);
     }
   }
 
   deleteFile = async () => {
+    const { siteName, media: { fileName }, type } = this.props;
     try {
-      const { siteName, media: { fileName }, type } = this.props;
       const { sha } = this.state;
       const params = {
         sha,
@@ -111,6 +116,10 @@ export default class MediaSettingsModal extends Component {
 
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text={`There was a problem trying to delete this ${type === 'image' ? 'image' : 'file'}. Please try again or check your internet connection.`}/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -85,7 +85,7 @@ export default class MediaSettingsModal extends Component {
       }
       onSave()
     } catch (err) {
-      if (err.response.status === 409) {
+      if (err?.response?.status === 409) {
         // Error due to conflict in name
         toast(
           <Toast notificationType='error' text={`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`}/>, 

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -9,6 +9,9 @@ import SaveDeleteButtons from '../SaveDeleteButtons';
 import { validateFileName } from '../../utils/validators';
 import { toast } from 'react-toastify';
 import Toast from '../Toast';
+import {
+  DEFAULT_ERROR_TOAST_MSG,
+} from '../../utils'
 
 export default class MediaSettingsModal extends Component {
   constructor(props) {
@@ -93,7 +96,7 @@ export default class MediaSettingsModal extends Component {
         );
       } else {
         toast(
-          <Toast notificationType='error' text={`There was a problem trying to save this ${type === 'image' ? 'image' : 'file'}. Please try again or check your internet connection.`}/>, 
+          <Toast notificationType='error' text={`There was a problem trying to save this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
       }
@@ -117,7 +120,7 @@ export default class MediaSettingsModal extends Component {
       window.location.reload();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text={`There was a problem trying to delete this ${type === 'image' ? 'image' : 'file'}. Please try again or check your internet connection.`}/>, 
+        <Toast notificationType='error' text={`There was a problem trying to delete this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -24,6 +24,8 @@ import Header from '../components/Header';
 import LoadingButton from '../components/LoadingButton';
 import { validateSections, validateHighlights, validateDropdownElems } from '../utils/validators';
 import DeleteWarningModal from '../components/DeleteWarningModal';
+import { toast } from 'react-toastify';
+import Toast from '../components/Toast';
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-array-index-key */
@@ -921,6 +923,10 @@ export default class EditHomepage extends Component {
 
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text={`There was a problem trying to save your homepage. Please try again or check your internet connection.`}/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -12,7 +12,7 @@ import TemplateInfobarSection from '../templates/homepage/InfobarSection';
 import TemplateInfopicLeftSection from '../templates/homepage/InfopicLeftSection';
 import TemplateInfopicRightSection from '../templates/homepage/InfopicRightSection';
 import TemplateResourcesSection from '../templates/homepage/ResourcesSection';
-import { frontMatterParser, concatFrontMatterMdBody } from '../utils';
+import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody } from '../utils';
 import EditorInfobarSection from '../components/homepage/InfobarSection';
 import EditorInfopicSection from '../components/homepage/InfopicSection';
 import EditorResourcesSection from '../components/homepage/ResourcesSection';
@@ -924,7 +924,7 @@ export default class EditHomepage extends Component {
       window.location.reload();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text={`There was a problem trying to save your homepage. Please try again or check your internet connection.`}/>, 
+        <Toast notificationType='error' text={`There was a problem trying to save your homepage. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -10,6 +10,8 @@ import SimplePage from '../templates/SimplePage';
 import LeftNavPage from '../templates/LeftNavPage';
 import { checkCSP } from '../utils/cspUtils';
 import Policy from 'csp-parse';
+import { toast } from 'react-toastify';
+import Toast from '../components/Toast';
 
 import {
   frontMatterParser,
@@ -188,6 +190,10 @@ export default class EditPage extends Component {
 
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text={`There was a problem saving your page. Please try again or check your internet connection.`}/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }
@@ -202,6 +208,10 @@ export default class EditPage extends Component {
       });
       history.goBack();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text={`There was a problem deleting your page. Please try again or check your internet connection.`}/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -14,6 +14,7 @@ import { toast } from 'react-toastify';
 import Toast from '../components/Toast';
 
 import {
+  DEFAULT_ERROR_TOAST_MSG,
   frontMatterParser,
   concatFrontMatterMdBody,
   prependImageSrc,
@@ -191,7 +192,7 @@ export default class EditPage extends Component {
       window.location.reload();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text={`There was a problem saving your page. Please try again or check your internet connection.`}/>, 
+        <Toast notificationType='error' text={`There was a problem saving your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);
@@ -209,7 +210,7 @@ export default class EditPage extends Component {
       history.goBack();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text={`There was a problem deleting your page. Please try again or check your internet connection.`}/>, 
+        <Toast notificationType='error' text={`There was a problem deleting your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -15,6 +15,9 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 import { validateSocialMedia } from '../utils/validators';
 import { toast } from 'react-toastify';
 import Toast from '../components/Toast';
+import {
+  DEFAULT_ERROR_TOAST_MSG,
+} from '../utils'
 
 const stateFields = {
   title: '',
@@ -295,7 +298,7 @@ export default class Settings extends Component {
       window.location.reload();
     } catch (err) {
       toast(
-        <Toast notificationType='error' text="There was a problem trying to save your settings. Please try again or check your internet connection."/>, 
+        <Toast notificationType='error' text={`There was a problem trying to save your settings. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
         {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
       );
       console.log(err);

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -13,6 +13,8 @@ import FormFieldHorizontal from '../components/FormFieldHorizontal';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 import { validateSocialMedia } from '../utils/validators';
+import { toast } from 'react-toastify';
+import Toast from '../components/Toast';
 
 const stateFields = {
   title: '',
@@ -292,6 +294,10 @@ export default class Settings extends Component {
 
       window.location.reload();
     } catch (err) {
+      toast(
+        <Toast notificationType='error' text="There was a problem trying to save your settings. Please try again or check your internet connection."/>, 
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+      );
       console.log(err);
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,7 @@ axios.defaults.withCredentials = true
 const ALPHANUM_REGEX = /^[0-9]+[a-z]*$/ // at least one number, followed by 0 or more lower-cased alphabets
 const NUM_REGEX = /^[0-9]+$/
 const NUM_IDENTIFIER_REGEX = /^[0-9]+/
+export const DEFAULT_ERROR_TOAST_MSG = 'Please try again or check your internet connection.' 
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {

--- a/src/utils/dropdownUtils.js
+++ b/src/utils/dropdownUtils.js
@@ -3,6 +3,7 @@ import React from 'react';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import { toast } from 'react-toastify';
 import Toast from '../components/Toast';
+import { DEFAULT_ERROR_TOAST_MSG } from '../utils'
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -28,7 +29,7 @@ export const retrieveThirdNavOptions = async (siteName, collectionName, isExisti
         }
     } catch (err) {
         toast(
-            <Toast notificationType='error' text={`There was a problem trying to retrieve data from your repo. Please try again or check your internet connection.`}/>,
+            <Toast notificationType='error' text={`There was a problem trying to retrieve data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
             {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
           );
         console.log(err);

--- a/src/utils/dropdownUtils.js
+++ b/src/utils/dropdownUtils.js
@@ -1,24 +1,36 @@
 import axios from 'axios';
+import React from 'react';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import { toast } from 'react-toastify';
+import Toast from '../components/Toast';
 
 // axios settings
 axios.defaults.withCredentials = true
 
 export const retrieveThirdNavOptions = async (siteName, collectionName, isExistingCollection) => {
-    let thirdNavArr = [], allCollectionPages = []
-    if (isExistingCollection) {
-        const endpoint = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages`
-        const { data : { collectionPages } } = await axios.get(endpoint)
-        thirdNavArr = collectionPages.filter((elem) => elem.type === 'third-nav')
-        allCollectionPages = collectionPages
-    }
-    const thirdNavOptions = [''].concat(thirdNavArr).map((thirdNav) => (
-        {
-            value:thirdNav.title,
-            label:thirdNav.title ? thirdNav.title : 'None',
+    try {
+        let thirdNavArr = [], allCollectionPages = []
+        if (isExistingCollection) {
+            const endpoint = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${collectionName}/pages`
+            const { data : { collectionPages } } = await axios.get(endpoint)
+            thirdNavArr = collectionPages.filter((elem) => elem.type === 'third-nav')
+            allCollectionPages = collectionPages
         }
-    ))
-    return {
-        collectionPages: allCollectionPages,
-        thirdNavOptions,
+        const thirdNavOptions = [''].concat(thirdNavArr).map((thirdNav) => (
+            {
+                value:thirdNav.title,
+                label:thirdNav.title ? thirdNav.title : 'None',
+            }
+        ))
+        return {
+            collectionPages: allCollectionPages,
+            thirdNavOptions,
+        }
+    } catch (err) {
+        toast(
+            <Toast notificationType='error' text={`There was a problem trying to retrieve data from your repo. Please try again or check your internet connection.`}/>,
+            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+          );
+        console.log(err);
     }
 }


### PR DESCRIPTION
## Overview

This PR resolves issue #279 by rendering error toast notifications, which first appeared in #247, when a user-triggered API call fails. The error toasts serve as a form of feedback to let the user know that their action has failed and informs them of other possible actions they could take (reload the page, check internet connection etc.).

Previously, we displayed error toasts when a user attempted to create/save a file but there already existed another file with the same file name (PR #247). This PR expands on that to display error toasts for **all** errors, not just for the cases where there is a file name conflict.

This PR also performs a minor bug fix where we attempt to access the `status` attribute of an error (`err.response.status`) in an attempt to display an error toast. This `status` attribute might not exist if the error object is not an HTTP error, which leads to an undefined attribute exception. This is resolved by using optional chaining.

The following list identifies the components and operations where the error toast notification gets displayed.

### Components
**ComponentSettingsModal**
- When a user changes the category dropdown (this triggers an API call to retrieve third nav options)
- When a user attempts to save page settings
- When a user attempts to delete the page

**FolderCard**
- When a user attempts to delete a folder

**FolderModal**
- When a user attempts to rename a folder

**MediaSettingsModal**
- When a user attempts to save media (image/file)
- When a user attempts to delete media

**OverviewCard**
- When a user attempts to move a file
- When a user attempts to delete a file

### Layouts

**EditHomepage**
- When a user attempts to save their homepage data

**EditPage**
- When a user attempts to save page content
- When a user attempts to delete page

**Settings**
- When a user attempts to save their settings