### PR TITLE
Fix: add check for PayloadTooLargeError for media

### DIFF
--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -94,6 +94,12 @@ export default class MediaSettingsModal extends Component {
           <Toast notificationType='error' text={`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
+      } else if (err?.response?.status === 413) {
+        // Error due to file size too large
+        toast(
+          <Toast notificationType='error' text={`The ${type === 'image' ? 'image' : 'file'} is too large. Please choose a smaller ${type === 'image' ? 'image' : 'file'}.`}/>, 
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+        );
       } else {
         toast(
           <Toast notificationType='error' text={`There was a problem trying to save this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 


### PR DESCRIPTION
This PR adds handling for the PayloadTooLargeError in the MediaSettingsModal. To be reviewed with PR#[94](https://github.com/isomerpages/isomercms-backend/pull/94) on the isomercms-backend repo. This PR attempts to resolve https://github.com/isomerpages/isomercms-frontend/issues/226.