### PR TITLE
Fix/update resource name display and fix misc bugs

### DIFF
--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -88,7 +88,7 @@ const FolderCard = ({
 
   const deleteHandler = async () => {
     try {
-      const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${pageType === 'collection' ? `/collections/${category}` : `/resources/${category}`}`
+      const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${pageType === 'collection' ? `/collections/${category}` : `/resources/${category}`}`
       await axios.delete(apiUrl);
 
       // Refresh page

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -47,6 +47,7 @@ const OverviewCard = ({
   const [canShowGenericWarningModal, setCanShowGenericWarningModal] = useState(false)
   const [chosenCategory, setChosenCategory] = useState()
   const [isOutOfViewport, setIsOutOfViewport] = useState()
+  const [isNewCollection, setIsNewCollection] = useState(false)
   const baseApiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${category ? isResource ? `/resources/${category}` : `/collections/${category}` : ''}`
 
   useEffect(() => {
@@ -74,7 +75,7 @@ const OverviewCard = ({
       } = frontMatter;
 
       let collectionPageData
-      if (!isResource && chosenCategory) {
+      if (!isResource && !isNewCollection) {
         // User selected an existing page collection
         const { collectionPages } = await retrieveThirdNavOptions(siteName, chosenCategory, true)
         collectionPageData = collectionPages
@@ -94,7 +95,7 @@ const OverviewCard = ({
         isNewFile: false,
         siteName,
         collectionPageData,
-        isNewCollection: !chosenCategory,
+        isNewCollection,
       }
       await saveFileAndRetrieveUrl(fileInfo)
 
@@ -113,6 +114,7 @@ const OverviewCard = ({
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
       }
+      setIsNewCollection(false)
       setCanShowGenericWarningModal(false)
       console.log(err);
     }
@@ -221,6 +223,7 @@ const OverviewCard = ({
         onProceed={moveFile}
         onCancel={() => {
           setChosenCategory()
+          setIsNewCollection(false)
           setCanShowGenericWarningModal(false)
         }}
         proceedText="Continue"
@@ -320,6 +323,7 @@ const OverviewCard = ({
                   disabledStyle={elementStyles.disabled}
                   className={(!!errorMessage || !newCategory) ? elementStyles.disabled : elementStyles.blue}
                   callback={() => {
+                    setIsNewCollection(true)
                     setChosenCategory(newCategory)
                     fileMoveDropdownRef.current.blur()
                     setCanShowGenericWarningModal(true)

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -345,7 +345,7 @@ const OverviewCard = ({
         <DeleteWarningModal
           onCancel={() => setCanShowDeleteWarningModal(false)}
           onDelete={deleteHandler}
-          type="resource"
+          type={isResource ? "resource" : "page"}
         />
       )
     }

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -75,7 +75,7 @@ const OverviewCard = ({
       } = frontMatter;
 
       let collectionPageData
-      if (!isResource && !isNewCollection) {
+      if (!isResource && !isNewCollection && chosenCategory) {
         // User selected an existing page collection
         const { collectionPages } = await retrieveThirdNavOptions(siteName, chosenCategory, true)
         collectionPageData = collectionPages

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,14 +109,13 @@ export function retrieveResourceFileMetadata(fileName) {
 
   const titleTokenArray = tokenArray.slice(3);
   const prettifiedTitleTokenArray = titleTokenArray.map((token) => {
-    if (token.length < 2) return token.toUpperCase()
-    return token.slice(0,1).toUpperCase() + token.slice(1)
+    // We search for special characters which were converted to text
+    // Convert dollar back to $ if it is followed by any alphanumeric character
+    const convertedToken = token.replaceAll(/dollar(?=([0-9]))/g, '$')
+    if (convertedToken.length < 2) return convertedToken.toUpperCase()
+    return convertedToken.slice(0,1).toUpperCase() + convertedToken.slice(1)
   });
-  const prettifiedTitle = prettifiedTitleTokenArray.join(' ')
-
-  // We search for special characters which were converted to text
-  // Convert dollar back to $ if it is followed by any alphanumeric character
-  const title = prettifiedTitle.replaceAll(/dollar(?=([a-zA-Z0-9]))/gi, '$')
+  const title = prettifiedTitleTokenArray.join(' ')
 
   return { date, title };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,7 +107,16 @@ export function retrieveResourceFileMetadata(fileName) {
   const year = tokenArray[0];
   const date = `${day} ${month} ${year}`;
 
-  const title = tokenArray.slice(3).join(' ');
+  const titleTokenArray = tokenArray.slice(3);
+  const prettifiedTitleTokenArray = titleTokenArray.map((token) => {
+    if (token.length < 2) return token.toUpperCase()
+    return token.slice(0,1).toUpperCase() + token.slice(1)
+  });
+  const prettifiedTitle = prettifiedTitleTokenArray.join(' ')
+
+  // We search for special characters which were converted to text
+  // Convert dollar back to $ if it is followed by any alphanumeric character
+  const title = prettifiedTitle.replaceAll(/dollar(?=([a-zA-Z0-9]))/gi, '$')
 
   return { date, title };
 }


### PR DESCRIPTION
This PR resolves https://github.com/isomerpages/isomercms-frontend/issues/292. It updates our resource name display in preparation for the resource name migration to rename existing resource files. The title of resources are now prettified, similarly to what is being done for pages. Additionally, we check for the existence of the special string "dollar" followed by any alphanumeric character, as this indicates that the title of the file contains a $ sign. The reason we require this is due to the generation and prettifying of resource file names - the filename will still contain the dollar string, but we would like the display the title on the cms as the user first inputted it.

In addition, the following bugs have been fixed:
- A typo in the endpoint being called when deleting folders has been corrected.
- Previously, we were not distinguishing correctly between new and existing collections, causing an error when we attempted to retrieve collection data for a new collection. A new variable to check for new collections has been added to OverviewCard.
- The title of the delete warning modal when deleting pages has been corrected.