### PR TITLE
Feat/use site colors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,8 +8,8 @@ import {
 import axios from 'axios';
 import * as Sentry from "@sentry/react";
 import { ToastContainer } from 'react-toastify';
-
 import 'react-toastify/dist/ReactToastify.css';
+
 // Layouts
 import AuthCallback from './layouts/AuthCallback'
 import Home from './layouts/Home';
@@ -31,7 +31,11 @@ import NotFoundPage from './components/NotFoundPage'
 import ProtectedRoute from './components/ProtectedRoute'
 import FallbackComponent from './components/FallbackComponent'
 
+// Styles
 import elementStyles from './styles/isomer-cms/Elements.module.scss';
+
+// Utils
+import { defaultSiteColors } from './utils/siteColorUtils';
 
 // Import contexts
 const { LoginContext } = require('./contexts/LoginContext')
@@ -63,9 +67,7 @@ function App() {
     return false
   })
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
-  const [primaryColors, setPrimaryColors] = useState({})
-  const [secondaryColors, setSecondaryColors] = useState({})
-
+  const [siteColors, setSiteColors] = useState({})
 
   axios.interceptors.response.use(
     function (response) {
@@ -117,7 +119,7 @@ function App() {
   const ProtectedRouteWithProps = (props) => {
     return (
       <Sentry.ErrorBoundary fallback={FallbackComponent}>
-        <ProtectedRoute {...props} isLoggedIn={isLoggedIn} />
+        <ProtectedRoute {...props} isLoggedIn={isLoggedIn} siteColors={siteColors} setSiteColors={setSiteColors} />
       </Sentry.ErrorBoundary>
     )
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,6 +63,9 @@ function App() {
     return false
   })
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
+  const [primaryColors, setPrimaryColors] = useState({})
+  const [secondaryColors, setSecondaryColors] = useState({})
+
 
   axios.interceptors.response.use(
     function (response) {

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -12,6 +12,11 @@ import { toast } from 'react-toastify';
 import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody, isEmpty, retrieveResourceFileMetadata } from '../utils';
 import { sanitiseFrontMatter } from '../utils/dataSanitisers';
 import { validateContact, validateLocation } from '../utils/validators';
+import {
+  createPageStyleSheet,
+  getSiteColors,
+} from '../utils/siteColorUtils';
+
 
 import EditorSection from '../components/contact-us/Section';
 import Toast from '../components/Toast';
@@ -118,12 +123,45 @@ export default class EditContactUs extends Component {
     };
   }
 
-  async componentDidMount() {  
-    const { match } = this.props;
+  async componentDidMount() {
+    const { match, siteColors, setSiteColors } = this.props;
     const { siteName } = match.params;
     this._isMounted = true
 
     let content, sha, footerContent, footerSha
+
+    // Set page colors
+    try {
+      let primaryColor
+      let secondaryColor
+
+      if (!siteColors[siteName]) {
+        const {
+          primaryColor: sitePrimaryColor,
+          secondaryColor: siteSecondaryColor,
+        } = await getSiteColors(siteName)
+
+        primaryColor = sitePrimaryColor
+        secondaryColor = siteSecondaryColor
+
+        if (this._isMounted) setSiteColors((prevState) => ({
+          ...prevState,
+          [siteName]: {
+            primaryColor,
+            secondaryColor,
+          }
+        }))
+      } else {
+        primaryColor = siteColors[siteName].primaryColor
+        secondaryColor = siteColors[siteName].secondaryColor
+      }
+
+      createPageStyleSheet(siteName, primaryColor, secondaryColor)
+    
+    } catch (err) {
+      console.log(err);
+    }
+
     try {
       const contactUsResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/contact-us.md`);
       const { content:pageContent , sha:pageSha } = contactUsResp.data;

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -77,6 +77,8 @@ const enumSection = (type, args) => {
 };
 
 export default class EditContactUs extends Component {
+  _isMounted = false
+
   constructor(props) {
     super(props);
     this.scrollRefs = {
@@ -119,6 +121,7 @@ export default class EditContactUs extends Component {
   async componentDidMount() {  
     const { match } = this.props;
     const { siteName } = match.params;
+    this._isMounted = true
 
     let content, sha, footerContent, footerSha
     try {
@@ -197,7 +200,7 @@ export default class EditContactUs extends Component {
       locations: locationsScrollRefs,
     }
 
-    this.setState({
+    if (this._isMounted) this.setState({
       originalFooterContent: _.cloneDeep(footerContent),
       footerContent,
       footerSha,
@@ -214,6 +217,10 @@ export default class EditContactUs extends Component {
         locations: locationsErrors,
       },
     });
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   onDragEnd = (result) => {

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -12,6 +12,10 @@ import TemplateInfopicLeftSection from '../templates/homepage/InfopicLeftSection
 import TemplateInfopicRightSection from '../templates/homepage/InfopicRightSection';
 import TemplateResourcesSection from '../templates/homepage/ResourcesSection';
 import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody } from '../utils';
+import {
+  createPageStyleSheet,
+  getSiteColors,
+} from '../utils/siteColorUtils';
 import EditorInfobarSection from '../components/homepage/InfobarSection';
 import EditorInfopicSection from '../components/homepage/InfopicSection';
 import EditorResourcesSection from '../components/homepage/ResourcesSection';
@@ -129,10 +133,43 @@ export default class EditHomepage extends Component {
   }
 
   async componentDidMount() {
+    const { match, siteColors, setSiteColors } = this.props;
+    const { siteName } = match.params;
     this._isMounted = true
+
+    // Set page colors
     try {
-      const { match } = this.props;
-      const { siteName } = match.params;
+      let primaryColor
+      let secondaryColor
+
+      if (!siteColors[siteName]) {
+        const {
+          primaryColor: sitePrimaryColor,
+          secondaryColor: siteSecondaryColor,
+        } = await getSiteColors(siteName)
+
+        primaryColor = sitePrimaryColor
+        secondaryColor = siteSecondaryColor
+
+        if (this._isMounted) setSiteColors((prevState) => ({
+          ...prevState,
+          [siteName]: {
+            primaryColor,
+            secondaryColor,
+          }
+        }))
+      } else {
+        primaryColor = siteColors[siteName].primaryColor
+        secondaryColor = siteColors[siteName].secondaryColor
+      }
+
+      createPageStyleSheet(siteName, primaryColor, secondaryColor)
+    
+    } catch (err) {
+      console.log(err);
+    }
+
+    try {
       const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/homepage`, {
         withCredentials: true,
       });

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -94,6 +94,37 @@ const getBackButtonInfo = (resourceCategory, collectionName, siteName) => {
     backButtonUrl: `/sites/${siteName}/workspace`,
   }
 }
+const defaultIsomerPrimaryColor = '#6031b6';
+const defaultIsomerSecondaryColor = '#4372d6';
+
+function getStyleSheet(unique_title) {
+  for(let i=0; i<document.styleSheets.length; i++) {
+    const sheet = document.styleSheets[i];
+    if(sheet.title == unique_title) {
+      return sheet;
+    }
+  }
+}
+const createPageStyleSheet = (repoName) => {
+  const styleElement = document.createElement('style')
+  const styleTitle = `${repoName}-style`
+  styleElement.setAttribute('id', styleTitle)
+  styleElement.setAttribute('title', styleTitle)
+  document.head.appendChild(styleElement);
+
+  const customStyleSheet = getStyleSheet(styleTitle)
+  customStyleSheet.insertRule(".bp-section.bp-section-pagetitle { background-color: red !important;}", 0);
+  customStyleSheet.insertRule(".content h1 strong { color: red !important;}", 0);
+  customStyleSheet.insertRule(".content h2 strong { color: red !important;}", 0);
+  customStyleSheet.insertRule(".content h3 strong { color: red !important;}", 0);
+  customStyleSheet.insertRule(".content h4 strong { color: red !important;}", 0);
+  customStyleSheet.insertRule(".content h5 strong { color: red !important;}", 0);
+  customStyleSheet.insertRule(".has-text-secondary { color: red !important;}", 0);
+  customStyleSheet.insertRule(".bp-menu-list a.is-active { color: red !important;}", 0);
+  customStyleSheet.insertRule(".sgds-icon-chevron-up:before { color: red !important;}", 0);
+  customStyleSheet.insertRule(".sgds-icon-chevron-down:before { color: red !important;}", 0);
+
+}
 
 export default class EditPage extends Component {
   _isMounted = true 
@@ -125,6 +156,45 @@ export default class EditPage extends Component {
   }
 
   async componentDidMount() {
+    const {
+      primaryColors,
+      secondaryColors,
+      setPrimaryColors,
+      setSecondaryColors,
+    } = this.props;
+
+    const { match } = this.props;
+    const { siteName } = match.params;
+
+    // Set page colors
+    const primaryColor = defaultIsomerPrimaryColor
+    const secondaryColor = defaultIsomerSecondaryColor
+    createPageStyleSheet(siteName)
+
+    // // If no color data, retrieve color data
+    // if (!primaryColors[this.siteName]) {
+    //   try {
+    //     // get settings data from backend
+    //     const settingsResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${this.siteName}/settings`, {
+    //       withCredentials: true,
+    //     });
+    //     const { settings } = settingsResp.data;
+    //     const { configFieldsRequired: { colors } } = settings;
+
+    //     console.log(colors)
+    //     setPrimaryColors({
+    //       ...primaryColors,
+    //       [this.siteName]: colors?.['primary-color'],
+    //     });
+    //     setSecondaryColors({
+    //       ...secondaryColors,
+    //       [this.siteName]: colors?.['secondary-color'],
+    //     });
+    //   } catch (err) {
+    //     console.log(err);
+    //   }
+    // }
+
     this._isMounted = true
     let content, sha
     try {
@@ -149,9 +219,6 @@ export default class EditPage extends Component {
     try {
       // split the markdown into front matter and content
       const { frontMatter, mdBody } = frontMatterParser(Base64.decode(content));
-      
-      const { match } = this.props;
-      const { siteName } = match.params;
       
       // retrieve CSP
       const cspResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/netlify-toml`);
@@ -327,7 +394,7 @@ export default class EditPage extends Component {
   }
 
   render() {
-    const { match, isCollectionPage, isResourcePage } = this.props;
+    const { match, isCollectionPage, isResourcePage, primaryColors, secondaryColors } = this.props;
     const { siteName, fileName, collectionName, resourceName } = match.params;
     const { title, type: resourceType, date } = extractMetadataFromFilename(isResourcePage, isCollectionPage, fileName)
     const { backButtonLabel, backButtonUrl } = getBackButtonInfo(resourceName, collectionName, siteName)

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -14,11 +14,15 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 // Import utils
 import { prettifyPageFileName } from '../utils';
+import {
+  getSiteColors,
+} from '../utils/siteColorUtils';
+
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
-const Workspace = ({ match, location }) => {
+const Workspace = ({ match, location, siteColors, setSiteColors }) => {
     const { siteName } = match.params;
 
     const [collections, setCollections] = useState()
@@ -28,6 +32,25 @@ const Workspace = ({ match, location }) => {
     useEffect(() => {
       let _isMounted = true
       const fetchData = async () => {
+        try {
+          if (!siteColors[siteName]) {
+            const {
+              primaryColor,
+              secondaryColor,
+            } = await getSiteColors(siteName)
+    
+            if (_isMounted) setSiteColors((prevState) => ({
+              ...prevState,
+              [siteName]: {
+                primaryColor,
+                secondaryColor,
+              }
+            }))
+          }
+        } catch (e) {
+          console.log(e)
+        }
+
         try { 
           await axios.get(`${BACKEND_URL}/sites/${siteName}/pages/contact-us.md`);
           if (_isMounted) setContactUsCard(true) 

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12130,6 +12130,7 @@ a.navbar-item {
         font-family: Lato,sans-serif;
         line-height: 4.8rem;
         margin: 1rem;
+        text-align: center;
     }
 
     .watermark-text-content {
@@ -12139,6 +12140,7 @@ a.navbar-item {
         font-style: italic;
         font-family: Lato,sans-serif;
         line-height: 2rem;
+        text-align: center;
     }
 }
 

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12118,12 +12118,30 @@ a.navbar-item {
     right:0;
     width: 100%;
     height: 100%;
-    color: #ffffff;
-    font-weight: 700;
-    display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 0.6;
+    opacity: 0.9;
     font-size: 5vw;
-    transform: rotate(-30deg);
+
+    .watermark-text-title {
+        color: #303754;
+        font-weight: 700;
+        font-size: 4rem;
+        font-family: Lato,sans-serif;
+        line-height: 4.8rem;
+        margin: 1rem;
+    }
+
+    .watermark-text-content {
+        color: #303754;
+        font-weight: 400;
+        font-size: 1.2rem;
+        font-style: italic;
+        font-family: Lato,sans-serif;
+        line-height: 2rem;
+    }
+}
+
+.resource-sample-mask{
+    opacity: 0.1;
 }

--- a/src/templates/homepage/ResourcesSection.jsx
+++ b/src/templates/homepage/ResourcesSection.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import contentStyles from '../../styles/isomer-cms/pages/Content.module.scss';
+
 
 /* eslint
   react/no-array-index-key: 0
@@ -50,12 +52,16 @@ const TemplateResourceSection = ({
         </div>
       </div>
       <div className="watermark-container">
-        <div className="row padding--bottom">
+        <div className="row padding--bottom resource-sample-mask">
           <ResourcePost />
           <ResourcePost />
           <ResourcePost />
         </div>
-        <p className="watermark-text">Placeholder Media</p>
+        <div className="d-flex flex-column watermark-text">
+          <span className="watermark-text-title">PLACEHOLDER MEDIA</span>
+          <span className="watermark-text-content">Your 3 latest resources will be displayed here.</span>
+          <span className="watermark-text-content">You may change the resources displayed by changing the date of the resource in the resources section.</span>
+        </div>
       </div>
       <div className="row has-text-centered margin--top padding--bottom--lg">
         <div className="col is-offset-one-third is-one-third">

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -33,8 +33,23 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
   
     // breadcrumb - primary color
     customStyleSheet.insertRule(`.bp-section.bp-section-pagetitle { background-color: ${primaryColor} !important;}`, 0);
+
+    // EditHomepage: key highlights - primary color
+    customStyleSheet.insertRule(`#key-highlights { background-color: ${primaryColor} !important;}`, 0);
+
+    // EditHomepage: site notifications - secondary color
+    customStyleSheet.insertRule(`.bg-secondary { background-color: ${secondaryColor} !important;}`, 0);
+
+    // EditHomepage: hero button - secondary color
+    customStyleSheet.insertRule(`.is-secondary { background-color: ${secondaryColor} !important;}`, 0);
+
+    // EditHomepage: info section button text - secondary color
+    customStyleSheet.insertRule(`.bp-sec-button span { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
+    customStyleSheet.insertRule(`.bp-sec-button:hover span { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
+    customStyleSheet.insertRule(`.bp-sec-button .sgds-icon { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.bp-sec-button .sgds-icon:before { color: ${secondaryColor} !important;}`, 0);
   
-    // headings
+    // EditPage: headings - secondary color
     customStyleSheet.insertRule(`.content h1 strong { color: ${secondaryColor} !important;}`, 0);
     customStyleSheet.insertRule(`.content h2 strong { color: ${secondaryColor} !important;}`, 0);
     customStyleSheet.insertRule(`.content h3 strong { color: ${secondaryColor} !important;}`, 0);
@@ -42,7 +57,7 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
     customStyleSheet.insertRule(`.content h5 strong { color: ${secondaryColor} !important;}`, 0);
     customStyleSheet.insertRule(`.has-text-secondary { color: ${secondaryColor} !important;}`, 0);
   
-    // left nav
+    // EditPage: left nav - secondary color
     customStyleSheet.insertRule(`.bp-menu-list a.is-active { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
     customStyleSheet.insertRule(`.bp-menu-list a.is-active:hover { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
     customStyleSheet.insertRule(`.bp-menu-list a:hover { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -36,6 +36,7 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
 
     // EditHomepage: key highlights - primary color
     customStyleSheet.insertRule(`#key-highlights { background-color: ${primaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`#key-highlights .col { background-color: ${primaryColor} !important;}`, 0);
 
     // EditHomepage: site notifications - secondary color
     customStyleSheet.insertRule(`.bg-secondary { background-color: ${secondaryColor} !important;}`, 0);

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -1,0 +1,74 @@
+import axios from 'axios';
+
+// axios settings
+axios.defaults.withCredentials = true
+
+const DEFAULT_ISOMER_PRIMARY_COLOR = '#6031b6';
+const DEFAULT_ISOMER_SECONDARY_COLOR = '#4372d6';
+
+const defaultSiteColors = {
+    defult: {
+        primaryColor: DEFAULT_ISOMER_PRIMARY_COLOR,
+        secondaryColor: DEFAULT_ISOMER_SECONDARY_COLOR,
+    }
+}
+
+const getStyleSheet = (unique_title) => {
+    for(let i=0; i<document.styleSheets.length; i++) {
+      const sheet = document.styleSheets[i];
+      if(sheet.title == unique_title) {
+        return sheet;
+      }
+    }
+}
+
+const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
+    const styleElement = document.createElement('style')
+    const styleTitle = `${repoName}-style`
+    styleElement.setAttribute('id', styleTitle)
+    styleElement.setAttribute('title', styleTitle)
+    document.head.appendChild(styleElement);
+  
+    const customStyleSheet = getStyleSheet(styleTitle)
+  
+    // breadcrumb - primary color
+    customStyleSheet.insertRule(`.bp-section.bp-section-pagetitle { background-color: ${primaryColor} !important;}`, 0);
+  
+    // headings
+    customStyleSheet.insertRule(`.content h1 strong { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.content h2 strong { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.content h3 strong { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.content h4 strong { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.content h5 strong { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.has-text-secondary { color: ${secondaryColor} !important;}`, 0);
+  
+    // left nav
+    customStyleSheet.insertRule(`.bp-menu-list a.is-active { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
+    customStyleSheet.insertRule(`.bp-menu-list a.is-active:hover { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
+    customStyleSheet.insertRule(`.bp-menu-list a:hover { color: ${secondaryColor} !important; border-bottom: 2px solid ${secondaryColor} !important}`, 0);
+    customStyleSheet.insertRule(`.sgds-icon-chevron-up:before { color: ${secondaryColor} !important;}`, 0);
+    customStyleSheet.insertRule(`.sgds-icon-chevron-down:before { color: ${secondaryColor} !important;}`, 0);
+}
+
+const getSiteColors = async (siteName) => {
+    try {
+        // get settings data from backend
+        const settingsResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`);
+        const { settings } = settingsResp.data;
+        const { configFieldsRequired: { colors } } = settings;
+
+        return {
+            primaryColor: colors?.['primary-color'] || DEFAULT_ISOMER_PRIMARY_COLOR,
+            secondaryColor: colors?.['secondary-color'] || DEFAULT_ISOMER_SECONDARY_COLOR,
+        }
+    } catch (err) {
+        console.log(err);
+        throw err
+    }
+}
+
+export {
+    defaultSiteColors,
+    createPageStyleSheet,
+    getSiteColors,
+}

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -16,7 +16,7 @@ const defaultSiteColors = {
 const getStyleSheet = (unique_title) => {
     for(let i=0; i<document.styleSheets.length; i++) {
       const sheet = document.styleSheets[i];
-      if(sheet.title == unique_title) {
+      if(sheet.title === unique_title) {
         return sheet;
       }
     }


### PR DESCRIPTION
## Overview

This PR resolves issue #149. It implements custom style sheets for each Isomer repo so that live previews resemble the actual web page even more. Refer to #149, specifically this comment ([link](https://github.com/isomerpages/isomercms-frontend/issues/149#issuecomment-718134200)), for more details on the rationale behind the implementation. This implements custom colors for the following layouts:
- `EditPage`
- `EditHomepage`
- `EditContactUs`

This PR also updates the resources section of the `EditHomepage` layout so that the watermark now includes a more informative message on the resource tiles, which might or might not be the color expected.

Samples:

**EditHomepage**

Before:
<img width="1677" alt="Screenshot 2020-12-17 at 6 36 38 AM" src="https://user-images.githubusercontent.com/31984694/102414939-4c71c900-4032-11eb-8e3e-b7ab649b6e52.png">

After:
<img width="1680" alt="Screenshot 2020-12-17 at 6 19 23 AM" src="https://user-images.githubusercontent.com/31984694/102414165-00725480-4031-11eb-876a-967314aab806.png">

**EditPage**
Before:
<img width="1675" alt="Screenshot 2020-12-17 at 6 36 45 AM" src="https://user-images.githubusercontent.com/31984694/102414987-5b587b80-4032-11eb-8669-62b28491e877.png">

After:
<img width="1678" alt="Screenshot 2020-12-17 at 6 25 42 AM" src="https://user-images.githubusercontent.com/31984694/102414198-0bc58000-4031-11eb-9c4b-dee1bc953b4f.png">

**Resources section in `EditHomepage**

Before:
<img width="1192" alt="Screenshot 2020-12-22 at 11 42 23 PM" src="https://user-images.githubusercontent.com/31984694/102906278-5de22780-44af-11eb-9556-c29619859c81.png">

After:
<img width="1194" alt="Screenshot 2020-12-22 at 11 38 46 PM" src="https://user-images.githubusercontent.com/31984694/102906234-4c991b00-44af-11eb-9d38-df905ebd5d42.png">


### Implementation

The implementation can be broken down into a few simple steps:
1. If color settings for the target repo already exist, skip this step. Otherwise, retrieve color settings from `_config.yml` file for the target repo. Extract the primary and secondary colors of the site
2. Create a custom style sheet when the `EditPage`/`EditHomepage`/`EditContactUs` layout mounts, and insert rules for specific HTML elements whose colors need to be modified.

### Notes on implementation

Ideally, I would have liked to use a React context to store the `siteColors` instead of a state hook at the App level. However, since the preview layouts (`EditPage`, `EditHomepage`, `EditContactUs`) are class components, we are not able to use the React Context API unless we refactor these class components into hooks, which would take significant engineering effort.

To mitigate this, I set up the code so that site colors are retrieved when one accesses the repo's `Workspace`. Any page navigated to from the `Workspace` will now have the site colors and will no longer need to retrieve them. However, if a user navigates directly to a preview layout (such as `EditPage`) and the site colors do not exist, then we will still retrieve them.

**The downside to this approach is that because `siteColors` is passed as a prop to all layouts, when we update the `siteColors` hook, the page jumps and re-renders.** This is something I'm not too happy about, and would welcome any technical solutions or workarounds which can prevent this re-render / jump.