### PR TITLE
Feat/error handling when media payload is rejected by nginx

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -442,6 +442,7 @@ const ComponentSettingsModal = ({
                     isRequired={true}
                     onFieldChange={changeHandler}
                   />
+                  {errors.title && <br/>}
                   {/* Third Nav */}
                   { 
                     ((type === "page" && originalCategory) || (type === 'page' && !originalCategory && category)) &&

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -416,10 +416,14 @@ const ComponentSettingsModal = ({
                       className="w-100"
                       onChange={categoryDropdownHandler}
                       isDisabled={isCategoryDisabled}
-                      defaultValue={{
+                      placeholder={"Select a category or create a new category..."}
+                      defaultValue={originalCategory ? 
+                        {
                           value: originalCategory,
                           label: generateInitialCategoryLabel(originalCategory, isCategoryDisabled),
-                        }}
+                        }
+                        : null
+                      }
                       options={allCategories}
                     />
                   </div>
@@ -445,10 +449,14 @@ const ComponentSettingsModal = ({
                               defaultOptions
                               className="w-100"
                               onChange={thirdNavDropdownHandler}
-                              value={{
+                              placeholder={"Select a third nav or create a new third nav section..."}
+                              value={thirdNavTitle ?
+                                {
                                   value: thirdNavTitle,
                                   label: generateInitialThirdNavLabel(thirdNavTitle, originalCategory),
-                              }}
+                                }
+                                : null
+                              }
                               // When displaying third nav from workspace, use backupLoadThirdNavOptions
                               loadOptions={(!originalCategory && category) ? backupLoadThirdNavOptions : loadThirdNavOptions}
                               filterOption={createFilter()}

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -408,7 +408,7 @@ const ComponentSettingsModal = ({
               <div className={elementStyles.modalContent}>
                 <div className={elementStyles.modalFormFields}>
                   {/* Category */}
-                  <p className={elementStyles.formLabel}>{`${type === 'resource' ? `Resource Category Name` : `Collection Name`} (optional)`}</p>
+                  <p className={elementStyles.formLabel}>{`Add to ${type === 'resource' ? `Resource Category` : `Collection`} (optional)`}</p>
                   <div className="d-flex text-nowrap">
                     <CreatableSelect
                       isClearable
@@ -446,7 +446,7 @@ const ComponentSettingsModal = ({
                   { 
                     ((type === "page" && originalCategory) || (type === 'page' && !originalCategory && category)) &&
                     <>
-                        <p className={elementStyles.formLabel}>Third Nav Section (optional)</p>
+                        <p className={elementStyles.formLabel}>Add to Third Nav Section (optional)</p>
                         <div className="d-flex text-nowrap">
                             <AsyncCreatableSelect
                               key={category}

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -427,7 +427,12 @@ const ComponentSettingsModal = ({
                       options={allCategories}
                     />
                   </div>
-                  <span className={elementStyles.error}>{errors.category}</span>
+                  { errors.category &&
+                  <>
+                    <span className={elementStyles.error}>{errors.category}</span>
+                    <br/>
+                  </>
+                  }
                   {/* Title */}
                   <FormField
                     title="Title"

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -143,11 +143,10 @@ const ComponentSettingsModal = ({
           } else if (type === 'page') {
               const collectionsResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections`);
               const { collections } = collectionsResp.data;
-              const collectionCategories = [''].concat(collections) // allow for selection of "Unlinked Page" category
-              if (_isMounted) setAllCategories(collectionCategories.map((category) => (
+              if (_isMounted) setAllCategories(collections.map((category) => (
                   {
                     value:category,
-                    label:category ? category : 'Unlinked Page'
+                    label:category,
                   }
               )))
           }
@@ -409,7 +408,7 @@ const ComponentSettingsModal = ({
               <div className={elementStyles.modalContent}>
                 <div className={elementStyles.modalFormFields}>
                   {/* Category */}
-                  <p className={elementStyles.formLabel}>Category Folder Name</p>
+                  <p className={elementStyles.formLabel}>{`${type === 'resource' ? `Resource Category Name` : `Collection Name`} (optional)`}</p>
                   <div className="d-flex text-nowrap">
                     <CreatableSelect
                       isClearable
@@ -447,7 +446,7 @@ const ComponentSettingsModal = ({
                   { 
                     ((type === "page" && originalCategory) || (type === 'page' && !originalCategory && category)) &&
                     <>
-                        <p className={elementStyles.formLabel}>Third Nav Section</p>
+                        <p className={elementStyles.formLabel}>Third Nav Section (optional)</p>
                         <div className="d-flex text-nowrap">
                             <AsyncCreatableSelect
                               key={category}

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -296,7 +296,7 @@ const OverviewCard = ({
                 <i className="bx bx-sm bx-folder-plus" />
                 <input
                   type="text"
-                  placeholder={'Create new category'}
+                  placeholder={`Create new ${isResource ? 'category' : 'collection'}`}
                   value={newCategory}
                   id={'categoryName'}
                   className={errorMessage ? `${elementStyles.error}` : null}

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -97,7 +97,7 @@ export default class MediaSettingsModal extends Component {
       } else if (err?.response?.status === 413 || err?.response === undefined) {
         // Error due to file size too large - we receive 413 if nginx accepts the payload but it is blocked by our express settings, and undefined if it is blocked by nginx
         toast(
-          <Toast notificationType='error' text={`The ${type === 'image' ? 'image' : 'file'} is too large. Please choose a smaller ${type === 'image' ? 'image' : 'file'}.`}/>, 
+          <Toast notificationType='error' text={`Unable to upload as ${type === 'image' ? 'image' : 'file'} size is too large. Please reduce your ${type === 'image' ? 'image' : 'file'} size and try again.`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
       } else {

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -97,7 +97,7 @@ export default class MediaSettingsModal extends Component {
       } else if (err?.response?.status === 413 || err?.response === undefined) {
         // Error due to file size too large - we receive 413 if nginx accepts the payload but it is blocked by our express settings, and undefined if it is blocked by nginx
         toast(
-          <Toast notificationType='error' text={`Unable to upload as ${type === 'image' ? 'image' : 'file'} size is too large. Please reduce your ${type === 'image' ? 'image' : 'file'} size and try again.`}/>, 
+          <Toast notificationType='error' text={`Unable to upload as the ${type === 'image' ? 'image' : 'file'} size exceeds 5MB. Please reduce your ${type === 'image' ? 'image' : 'file'} size and try again.`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
       } else {

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -94,8 +94,8 @@ export default class MediaSettingsModal extends Component {
           <Toast notificationType='error' text={`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
         );
-      } else if (err?.response?.status === 413) {
-        // Error due to file size too large
+      } else if (err?.response?.status === 413 || err?.response === undefined) {
+        // Error due to file size too large - we receive 413 if nginx accepts the payload but it is blocked by our express settings, and undefined if it is blocked by nginx
         toast(
           <Toast notificationType='error' text={`The ${type === 'image' ? 'image' : 'file'} is too large. Please choose a smaller ${type === 'image' ? 'image' : 'file'}.`}/>, 
           {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}

--- a/src/utils/dropdownUtils.js
+++ b/src/utils/dropdownUtils.js
@@ -17,7 +17,7 @@ export const retrieveThirdNavOptions = async (siteName, collectionName, isExisti
             thirdNavArr = collectionPages.filter((elem) => elem.type === 'third-nav')
             allCollectionPages = collectionPages
         }
-        const thirdNavOptions = [''].concat(thirdNavArr).map((thirdNav) => (
+        const thirdNavOptions = thirdNavArr.map((thirdNav) => (
             {
                 value:thirdNav.title,
                 label:thirdNav.title ? thirdNav.title : 'None',


### PR DESCRIPTION
This PR attempts to handle the case where payloads are rejected by nginx. Currently, if a payload is too large, the request is immediately rejected by nginx, preventing our backend error handling from catching and throwing the correct 413 error. To account for this, we check for an empty response, which would indicate that our request did not make it to our backend server. I have simulated this locally by moving our cors initialization after the express limit has been set on the backend to force a network error for large files, since it's not possible to test this properly on local dev, but we should still ensure this is working on staging after merging.

This PR also adds some miscellaneous fixes. The list of these are:
- Change the placeholder text from categories to collections for pages in the page moving modal
- Set the placeholders correctly for the selects in ComponentSettingsModal so they have placeholder styling
- Fixed the error message of category from appearing on the same line as title in the ComponentSettingsModal
- Update the error message for large file size and the field titles for ComponentSettingsModal, to resolve https://github.com/isomerpages/isomercms-frontend/issues/295. Also partially addresses https://github.com/isomerpages/isomercms-frontend/issues/301