### PR TITLE
Fix/url check for button and category field title

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -413,7 +413,13 @@ const ComponentSettingsModal = ({
               <div className={elementStyles.modalContent}>
                 <div className={elementStyles.modalFormFields}>
                   {/* Category */}
-                  <p className={elementStyles.formLabel}>{`Add to ${type === 'resource' ? `Resource Category` : `Collection`} (optional)`}</p>
+                  <p className={elementStyles.formLabel}>
+                    {`Add to ${type === 'resource' ? `Resource Category` : `Collection (optional)`}`}
+                    {
+                      type === 'resource' &&
+                      <b> (required)</b>
+                    }
+                  </p>
                   <div className="d-flex text-nowrap">
                     <CreatableSelect
                       isClearable

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -280,14 +280,14 @@ export default class EditHomepage extends Component {
           // This needs to be done separately because it relies on the state of another field
           if (
             field === 'url' && !value && this.state.frontMatter.sections[sectionIndex][sectionType].button
-            && (this.state.frontMatter.sections[sectionIndex][sectionType].button || this.state.frontMatter.sections[sectionIndex][sectionType].url)
+            && (this.state.frontMatter.sections[sectionIndex][sectionType].button || value)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType][field] = errorMessage
           } else if (
             field === 'button' && !this.state.frontMatter.sections[sectionIndex][sectionType].url
-            && (this.state.frontMatter.sections[sectionIndex][sectionType].button || this.state.frontMatter.sections[sectionIndex][sectionType].url)
+            && (value || this.state.frontMatter.sections[sectionIndex][sectionType].url)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
@@ -295,7 +295,7 @@ export default class EditHomepage extends Component {
           } else {
             newSectionError = validateSections(errors.sections[sectionIndex], sectionType, field, value)
 
-            if (!this.state.frontMatter.sections[sectionIndex][sectionType].button && !this.state.frontMatter.sections[sectionIndex][sectionType].url) {
+            if (field === 'button' && !value) {
               newSectionError[sectionType]['button'] = ''
               newSectionError[sectionType]['url'] = ''
             }


### PR DESCRIPTION
This PR fixes some issues which surfaced during a usability test conducted. The main bugs fixed are:
- Currently, we have an issue where if the button url is left blank, then the button text is deleted, the error message still persists. This was due to us using state for value before the state actually updated, resulting the error message not being cleared. This PR fixes this issue.
- The field name for resource category in the ComponentSettingsModal has also been updated to reflect that this field is compulsory.