### PR TITLE
fix: remove use of enquote string

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -143,13 +143,6 @@ export function isEmpty(obj) {
   return isEmptyVal
 }
 
-export function enquoteString(str) {
-  let enquotedString = str;
-  if (str[0] !== '"') enquotedString = `"${enquotedString}`;
-  if (str[str.length - 1] !== '"') enquotedString += '"';
-  return enquotedString;
-}
-
 export function dequoteString(str) {
   let dequotedString = str;
   if (str[0] === '"') dequotedString = dequotedString.slice(1);
@@ -256,7 +249,7 @@ export async function saveFileAndRetrieveUrl(fileInfo) {
   let newFileName, frontMatter
   if (type === "resource") {
     newFileName = generateResourceFileName(title.toLowerCase(), date, resourceType);
-    frontMatter = { title: enquoteString(title), date };
+    frontMatter = { title, date };
   } else if (type === "page") {
     frontMatter = thirdNavTitle
       ? { title, permalink, third_nav_title: thirdNavTitle }


### PR DESCRIPTION
Currently, when saving data for resource pages, we enquote the title in anticipation of special characters in the title. However, this turns out to be unnecessary, and in fact, detrimental because our yaml library automatically enquotes strings which contains special characters. This manual enquoting results in a title string with two double quotes.

**Example**
<img width="1349" alt="Screenshot 2020-12-23 at 10 39 33 AM" src="https://user-images.githubusercontent.com/31984694/102978940-4c952b80-4540-11eb-8567-a488ffe92117.png">

This PR fixes that by removing the use of enquote string and letting the library do its work.