### PR TITLE
fix: modify editpage error class css to underline spelling errors

### DIFF
--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12147,3 +12147,8 @@ a.navbar-item {
 .resource-sample-mask{
     opacity: 0.1;
 }
+
+.CodeMirror .cm-spell-error:not(.cm-url):not(.cm-comment):not(.cm-tag):not(.cm-word) {
+    background-color: #ffffff !important;
+    border-bottom: 1px dotted #ff0000;
+}


### PR DESCRIPTION
## Overview

Currently, the markdown editor highlights spelling errors in red, which can be distracting. This commit overwrites the default red highlights with a less distracting dotted red line instead. 

This PR fixes #304.

**Before**
<img width="595" alt="Screenshot 2020-12-24 at 4 11 52 PM" src="https://user-images.githubusercontent.com/31984694/103073564-cf7eba80-4602-11eb-8aa2-6174c3cdae31.png">

**After**
<img width="601" alt="Screenshot 2020-12-24 at 4 11 44 PM" src="https://user-images.githubusercontent.com/31984694/103073584-d9a0b900-4602-11eb-90be-452d6fe72aaf.png">
