### PR TITLE
Feat/media modal search bar

### DIFF
--- a/src/components/FormFieldMedia.jsx
+++ b/src/components/FormFieldMedia.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { toast } from 'react-toastify';
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import MediasModal from './media/MediaModal';
+import MediaModal from './media/MediaModal';
 import MediaSettingsModal from './media/MediaSettingsModal';
 import Toast from './Toast';
 
@@ -25,6 +25,7 @@ const FormFieldMedia = ({
   const [isSelectingItem, setIsSelectingItem] = useState(false)
   const [isFileStagedForUpload, setIsFileStagedForUpload] = useState(false)
   const [stagedFileDetails, setStagedFileDetails] = useState()
+  const [imageSearchTerm, setImageSearchTerm] = useState('')
 
   const onItemClick = (path) => {
     setIsSelectingItem(false)
@@ -45,7 +46,8 @@ const FormFieldMedia = ({
     setIsSelectingItem(!isSelectingItem)
   }
   
-  const toggleItemAndSettingsModal = () => {
+  const toggleItemAndSettingsModal = (searchTerm) => {
+    setImageSearchTerm(searchTerm)
     setIsSelectingItem(!isSelectingItem)
     setIsFileStagedForUpload(!isFileStagedForUpload)
   }
@@ -107,13 +109,15 @@ const FormFieldMedia = ({
         }
         {
           isSelectingItem && (
-            <MediasModal
+            <MediaModal
               type={type}
               siteName={siteName}
               onMediaSelect={onItemClick}
               toggleItemModal={toggleItemModal}
               readFileToStageUpload={readFileToStageUpload}
               onClose={() => setIsSelectingItem(false)}
+              imageSearchTerm={imageSearchTerm}
+              setImageSearchTerm={setImageSearchTerm}
             />
           )
         }

--- a/src/components/FormFieldMedia.jsx
+++ b/src/components/FormFieldMedia.jsx
@@ -25,7 +25,7 @@ const FormFieldMedia = ({
   const [isSelectingItem, setIsSelectingItem] = useState(false)
   const [isFileStagedForUpload, setIsFileStagedForUpload] = useState(false)
   const [stagedFileDetails, setStagedFileDetails] = useState()
-  const [imageSearchTerm, setImageSearchTerm] = useState('')
+  const [mediaSearchTerm, setMediaSearchTerm] = useState('')
   const [selectedFile, setSelectedFile] = useState({})
 
   const onItemClick = (path) => {
@@ -116,8 +116,8 @@ const FormFieldMedia = ({
               toggleItemModal={toggleItemModal}
               readFileToStageUpload={readFileToStageUpload}
               onClose={() => setIsSelectingItem(false)}
-              imageSearchTerm={imageSearchTerm}
-              setImageSearchTerm={setImageSearchTerm}
+              mediaSearchTerm={mediaSearchTerm}
+              setMediaSearchTerm={setMediaSearchTerm}
               selectedFile={selectedFile}
               setSelectedFile={setSelectedFile}
             />

--- a/src/components/FormFieldMedia.jsx
+++ b/src/components/FormFieldMedia.jsx
@@ -26,6 +26,7 @@ const FormFieldMedia = ({
   const [isFileStagedForUpload, setIsFileStagedForUpload] = useState(false)
   const [stagedFileDetails, setStagedFileDetails] = useState()
   const [imageSearchTerm, setImageSearchTerm] = useState('')
+  const [selectedFile, setSelectedFile] = useState({})
 
   const onItemClick = (path) => {
     setIsSelectingItem(false)
@@ -46,8 +47,9 @@ const FormFieldMedia = ({
     setIsSelectingItem(!isSelectingItem)
   }
   
-  const toggleItemAndSettingsModal = () => {
+  const toggleItemAndSettingsModal = (newFileName) => {
     setIsFileStagedForUpload(!isFileStagedForUpload)
+    onItemClick(`/images/${newFileName}`)
   }
 
   const stageFileForUpload = (fileName, fileData) => {
@@ -116,6 +118,8 @@ const FormFieldMedia = ({
               onClose={() => setIsSelectingItem(false)}
               imageSearchTerm={imageSearchTerm}
               setImageSearchTerm={setImageSearchTerm}
+              selectedFile={selectedFile}
+              setSelectedFile={setSelectedFile}
             />
           )
         }

--- a/src/components/FormFieldMedia.jsx
+++ b/src/components/FormFieldMedia.jsx
@@ -46,9 +46,7 @@ const FormFieldMedia = ({
     setIsSelectingItem(!isSelectingItem)
   }
   
-  const toggleItemAndSettingsModal = (searchTerm) => {
-    setImageSearchTerm(searchTerm)
-    setIsSelectingItem(!isSelectingItem)
+  const toggleItemAndSettingsModal = () => {
     setIsFileStagedForUpload(!isFileStagedForUpload)
   }
 

--- a/src/components/FormFieldMedia.jsx
+++ b/src/components/FormFieldMedia.jsx
@@ -125,7 +125,7 @@ const FormFieldMedia = ({
               onClose={() => setIsFileStagedForUpload(false)}
               onSave={toggleItemAndSettingsModal}
               media={stagedFileDetails}
-              isPendingUpload="true"
+              isPendingUpload
             />
           )
         }

--- a/src/components/SaveDeleteButtons.jsx
+++ b/src/components/SaveDeleteButtons.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import LoadingButton from './LoadingButton'
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
-const SaveDeleteButtons = ({ isDisabled, hasDeleteButton, saveCallback, deleteCallback }) => {
+const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, hasDeleteButton, saveCallback, deleteCallback }) => {
   return (
     <div className={elementStyles.modalButtons}>
       { hasDeleteButton
         ? (
           <LoadingButton
-            label="Delete"
+            label={deleteLabel || 'Delete'}
             disabled={isDisabled}
             disabledStyle={elementStyles.disabled}
             className={`ml-auto ${isDisabled ? elementStyles.disabled : elementStyles.warning}`}
@@ -16,7 +17,7 @@ const SaveDeleteButtons = ({ isDisabled, hasDeleteButton, saveCallback, deleteCa
           />
         ) : null}
       <LoadingButton
-        label="Save"
+        label={saveLabel || 'Save'}
         disabled={isDisabled}
         disabledStyle={elementStyles.disabled}
         className={`${hasDeleteButton ? null : `ml-auto`} ${isDisabled ? elementStyles.disabled : elementStyles.blue}`}
@@ -26,5 +27,14 @@ const SaveDeleteButtons = ({ isDisabled, hasDeleteButton, saveCallback, deleteCa
     </div>
   )
 }
+
+SaveDeleteButtons.propTypes = {
+  saveLabel: PropTypes.string,
+  deleteLabel: PropTypes.string,
+  isDisabled: PropTypes.bool,
+  hasDeleteButton: PropTypes.bool.isRequired,
+  saveCallback: PropTypes.func.isRequired,
+  deleteCallback: PropTypes.func.isRequired,
+};
 
 export default SaveDeleteButtons

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -20,23 +20,23 @@ export default class MediaModal extends Component {
   }
 
   async componentDidMount() {
-    const { siteName, type, imageSearchTerm } = this.props;
+    const { siteName, type, mediaSearchTerm } = this.props;
     const mediaRoute = type === 'file' ? 'documents' : 'images';
     try {
       const { data: { documents, images } } = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${mediaRoute}`, {
         withCredentials: true,
       });
       if (_.isEmpty(documents || images)) {
-        this.setState({ medias: [], filteredMedias: [], searchTerm: imageSearchTerm });
+        this.setState({ medias: [], filteredMedias: [], searchTerm: mediaSearchTerm });
       } else {
         let filteredMedias
         if (type === 'file') {
-          filteredMedias = this.filterMediaByFileName(documents, imageSearchTerm)
+          filteredMedias = this.filterMediaByFileName(documents, mediaSearchTerm)
         } else {
-          filteredMedias = this.filterMediaByFileName(images, imageSearchTerm)
+          filteredMedias = this.filterMediaByFileName(images, mediaSearchTerm)
         }
 
-        this.setState({ medias: documents || images, filteredMedias, searchTerm: imageSearchTerm });
+        this.setState({ medias: documents || images, filteredMedias, searchTerm: mediaSearchTerm });
       }
     } catch (err) {
       console.error(err);
@@ -53,11 +53,11 @@ export default class MediaModal extends Component {
   }
 
   searchChangeHandler = (event) => {
-    const { setImageSearchTerm } = this.props
+    const { setMediaSearchTerm } = this.props
     const { medias } = this.state
     const { target: { value } } = event
     const filteredMedias = this.filterMediaByFileName(medias, value)
-    setImageSearchTerm(value)
+    setMediaSearchTerm(value)
     this.setState({ filteredMedias })
   }
 
@@ -68,7 +68,7 @@ export default class MediaModal extends Component {
       onMediaSelect,
       type,
       readFileToStageUpload,
-      imageSearchTerm,
+      mediaSearchTerm,
       selectedFile,
       setSelectedFile,
     } = this.props;
@@ -80,7 +80,7 @@ export default class MediaModal extends Component {
             <div className={mediaStyles.mediaModal}>
               <div className={elementStyles.modalHeader}>
                 <h1 className="pl-5 mr-auto">{`Select ${type === 'file' ? 'File' : 'Image'}`}</h1>
-                <MediaSearchBar value={imageSearchTerm} onSearchChange={this.searchChangeHandler} />
+                <MediaSearchBar value={mediaSearchTerm} onSearchChange={this.searchChangeHandler} />
                 <button type="button" onClick={onClose}>
                   <i className="bx bx-x" />
                 </button>
@@ -143,5 +143,5 @@ MediaModal.propTypes = {
   siteName: PropTypes.string.isRequired,
   onMediaSelect: PropTypes.func.isRequired,
   type: PropTypes.oneOf(['file', 'image']).isRequired,
-  setImageSearchTerm: PropTypes.func.isRequired,
+  setMediaSearchTerm: PropTypes.func.isRequired,
 };

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -69,8 +69,10 @@ export default class MediaModal extends Component {
       type,
       readFileToStageUpload,
       imageSearchTerm,
+      selectedFile,
+      setSelectedFile,
     } = this.props;
-    const { filteredMedias, selectedFile } = this.state;
+    const { filteredMedias } = this.state;
     return (filteredMedias
       && (
         <>
@@ -107,7 +109,7 @@ export default class MediaModal extends Component {
                     type={type}
                     media={media}
                     siteName={siteName}
-                    onClick={() => this.setState({ selectedFile: media })}
+                    onClick={() => setSelectedFile(media)}
                     key={media.path}
                     isSelected={media.path === selectedFile?.path}
                   />

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -9,7 +9,7 @@ import MediaUploadCard from './MediaUploadCard';
 import { MediaSearchBar } from './MediaSearchBar';
 import LoadingButton from '../LoadingButton';
 
-export default class MediasModal extends Component {
+export default class MediaModal extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -136,7 +136,7 @@ export default class MediasModal extends Component {
   }
 }
 
-MediasModal.propTypes = {
+MediaModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   siteName: PropTypes.string.isRequired,
   onMediaSelect: PropTypes.func.isRequired,

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -6,6 +6,7 @@ import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import MediaCard from './MediaCard';
 import MediaUploadCard from './MediaUploadCard';
+import { MediaSearchBar } from './MediaSearchBar';
 import LoadingButton from '../LoadingButton';
 
 export default class MediasModal extends Component {
@@ -13,7 +14,9 @@ export default class MediasModal extends Component {
     super(props);
     this.state = {
       medias: '',
+      filteredMedias: '',
       selectedFile: null,
+      searchTerm: '',
     };
   }
 
@@ -25,13 +28,23 @@ export default class MediasModal extends Component {
         withCredentials: true,
       });
       if (_.isEmpty(documents || images)) {
-        this.setState({ medias: [] });
+        this.setState({ medias: [], filteredMedias: [] });
       } else {
-        this.setState({ medias: documents || images });
+        this.setState({ medias: documents || images, filteredMedias: documents || images });
       }
     } catch (err) {
       console.error(err);
     }
+  }
+
+  searchChangeHandler = (event) => {
+    const { medias } = this.state
+    const { target: { value } } = event
+    const filteredMedias = medias.filter((media) => {
+      if (media.fileName.toLowerCase().includes(value)) return true
+      return false
+    })
+    this.setState({ searchTerm: value, filteredMedias, })
   }
 
   render() {
@@ -42,14 +55,15 @@ export default class MediasModal extends Component {
       type,
       readFileToStageUpload,
     } = this.props;
-    const { medias, selectedFile } = this.state;
-    return (medias 
+    const { filteredMedias, selectedFile, searchTerm } = this.state;
+    return (filteredMedias
       && (
         <>
           <div className={elementStyles.overlay}>
             <div className={mediaStyles.mediaModal}>
               <div className={elementStyles.modalHeader}>
-                <h1 className="pl-5" style={{ flexGrow: 1 }}>{`Select ${type === 'file' ? 'File' : 'Image'}`}</h1>
+                <h1 className="pl-5 mr-auto">{`Select ${type === 'file' ? 'File' : 'Image'}`}</h1>
+                <MediaSearchBar value={searchTerm} onSearchChange={this.searchChangeHandler} />
                 <button type="button" onClick={onClose}>
                   <i className="bx bx-x" />
                 </button>
@@ -73,7 +87,7 @@ export default class MediasModal extends Component {
                   hidden
                 />
                 {/* Render medias */}
-                {medias.map((media) => (
+                {filteredMedias.map((media) => (
                   <MediaCard
                     type={type}
                     media={media}

--- a/src/components/media/MediaSearchBar.jsx
+++ b/src/components/media/MediaSearchBar.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
+
+
+export const MediaSearchBar = ({
+    value,
+    onSearchChange,
+}) => {
+    return (
+        <div className={elementStyles.mediaSearchBarContainer}>
+            <input
+                type="text"
+                placeholder="Search by file name"
+                value={value}
+                autoComplete="off"
+                onChange={onSearchChange}
+            />
+        </div>
+    )
+}
+
+MediaSearchBar.propTypes = {
+    value: PropTypes.string,
+    onSearchChange: PropTypes.func.isRequired,
+  };

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -188,7 +188,8 @@ export default class MediaSettingsModal extends Component {
                 onFieldChange={this.setFileName}
               />
             </div>
-            <SaveDeleteButtons 
+            <SaveDeleteButtons
+              saveLabel="Upload"
               isDisabled={isPendingUpload ? false : (errorMessage || !sha)}
               hasDeleteButton={!isPendingUpload}
               saveCallback={this.saveFile}

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -86,7 +86,7 @@ export default class MediaSettingsModal extends Component {
           withCredentials: true,
         });
       }
-      onSave()
+      onSave(newFileName)
     } catch (err) {
       if (err?.response?.status === 409) {
         // Error due to conflict in name

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -123,7 +123,7 @@ export default class EditPage extends Component {
       stagedFileDetails: {},
       isLoadingPageContent: true,
       shouldRedirectToNotFound: false,
-      imageSearchTerm: '',
+      mediaSearchTerm: '',
       selectedFile: '',
     };
     this.mdeRef = React.createRef();
@@ -321,8 +321,8 @@ export default class EditPage extends Component {
     });
   }
 
-  setImageSearchTerm = (searchTerm) => {
-    this.setState({ imageSearchTerm: searchTerm })
+  setMediaSearchTerm = (searchTerm) => {
+    this.setState({ mediaSearchTerm: searchTerm })
   }
 
   onHyperlinkOpen = () => {
@@ -407,7 +407,7 @@ export default class EditPage extends Component {
       leftNavPages,
       selectionText,
       isLoadingPageContent,
-      imageSearchTerm,
+      mediaSearchTerm,
       selectedFile,
     } = this.state;
 
@@ -434,8 +434,8 @@ export default class EditPage extends Component {
               toggleImageModal={this.toggleImageModal}
               readFileToStageUpload={this.readFileToStageUpload}
               onClose={() => this.setState({ isSelectingImage: false })}
-              imageSearchTerm={imageSearchTerm}
-              setImageSearchTerm={this.setImageSearchTerm}
+              mediaSearchTerm={mediaSearchTerm}
+              setMediaSearchTerm={this.setMediaSearchTerm}
               selectedFile={selectedFile}
               setSelectedFile={this.setSelectedFile}
             />

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -118,13 +118,13 @@ export default class EditPage extends Component {
       isSelectingImage: false,
       isInsertingHyperlink: false,
       pendingImageUpload: null,
-      selectedImage: '',
       selectionText: '',
       isFileStagedForUpload: false,
       stagedFileDetails: {},
       isLoadingPageContent: true,
       shouldRedirectToNotFound: false,
       imageSearchTerm: '',
+      selectedFile: '',
     };
     this.mdeRef = React.createRef();
     this.apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })
@@ -237,6 +237,10 @@ export default class EditPage extends Component {
     this._isMounted = false;
   }
 
+  setSelectedFile = (selectedFile) => {
+    this.setState({ selectedFile })
+  }
+
   updatePage = async () => {
     try {
       const { state } = this;
@@ -293,10 +297,28 @@ export default class EditPage extends Component {
     }));
   }
 
-  toggleImageAndSettingsModal = (searchTerm) => {
-    this.setState((currState) => ({
-      isFileStagedForUpload: !currState.isFileStagedForUpload,
-    }));
+  toggleImageAndSettingsModal = (newFileName) => {
+    // insert image into editor
+    let editorValue
+    if (newFileName) {
+      const cm = this.mdeRef.current.simpleMde.codemirror;
+      cm.replaceSelection(`![](/images/${newFileName})`);
+
+      // set state so that rerender is triggered and image is shown
+      editorValue = this.mdeRef.current.simpleMde.codemirror.getValue()
+    }
+
+    this.setState((currState) => {
+      const updatedState = {
+        isFileStagedForUpload: !currState.isFileStagedForUpload,
+      }
+
+      if (editorValue) {
+        updatedState.editorValue = editorValue
+      }
+
+      return updatedState
+    });
   }
 
   setImageSearchTerm = (searchTerm) => {
@@ -386,6 +408,7 @@ export default class EditPage extends Component {
       selectionText,
       isLoadingPageContent,
       imageSearchTerm,
+      selectedFile,
     } = this.state;
 
     const html = marked(editorValue)
@@ -413,6 +436,8 @@ export default class EditPage extends Component {
               onClose={() => this.setState({ isSelectingImage: false })}
               imageSearchTerm={imageSearchTerm}
               setImageSearchTerm={this.setImageSearchTerm}
+              selectedFile={selectedFile}
+              setSelectedFile={this.setSelectedFile}
             />
             )
           }

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -417,7 +417,7 @@ export default class EditPage extends Component {
                 onClose={() => this.setState({ isFileStagedForUpload: false })}
                 onSave={this.toggleImageAndSettingsModal}
                 media={stagedFileDetails}
-                isPendingUpload="true"
+                isPendingUpload
               />
             )
           }

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -49,7 +49,7 @@ import Header from '../components/Header';
 import DeleteWarningModal from '../components/DeleteWarningModal';
 import LoadingButton from '../components/LoadingButton';
 import HyperlinkModal from '../components/HyperlinkModal';
-import MediasModal from '../components/media/MediaModal';
+import MediaModal from '../components/media/MediaModal';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
 // axios settings
@@ -404,7 +404,7 @@ export default class EditPage extends Component {
         <div className={elementStyles.wrapper}>
           {
             isSelectingImage && (
-            <MediasModal
+            <MediaModal
               type="image"
               siteName={siteName}
               onMediaSelect={this.onImageClick}

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -124,6 +124,7 @@ export default class EditPage extends Component {
       stagedFileDetails: {},
       isLoadingPageContent: true,
       shouldRedirectToNotFound: false,
+      imageSearchTerm: '',
     };
     this.mdeRef = React.createRef();
     this.apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })
@@ -292,11 +293,16 @@ export default class EditPage extends Component {
     }));
   }
 
-  toggleImageAndSettingsModal = () => {
+  toggleImageAndSettingsModal = (searchTerm) => {
     this.setState((currState) => ({
       isSelectingImage: !currState.isSelectingImage,
       isFileStagedForUpload: !currState.isFileStagedForUpload,
+      imageSearchTerm: searchTerm,
     }));
+  }
+
+  setImageSearchTerm = (searchTerm) => {
+    this.setState({ imageSearchTerm: searchTerm })
   }
 
   onHyperlinkOpen = () => {
@@ -365,7 +371,7 @@ export default class EditPage extends Component {
   }
 
   render() {
-    const { match, isCollectionPage, isResourcePage, primaryColors, secondaryColors } = this.props;
+    const { match, isCollectionPage, isResourcePage } = this.props;
     const { siteName, fileName, collectionName, resourceName } = match.params;
     const { title, type: resourceType, date } = extractMetadataFromFilename(isResourcePage, isCollectionPage, fileName)
     const { backButtonLabel, backButtonUrl } = getBackButtonInfo(resourceName, collectionName, siteName)
@@ -381,6 +387,7 @@ export default class EditPage extends Component {
       leftNavPages,
       selectionText,
       isLoadingPageContent,
+      imageSearchTerm,
     } = this.state;
 
     const html = marked(editorValue)
@@ -406,6 +413,8 @@ export default class EditPage extends Component {
               toggleImageModal={this.toggleImageModal}
               readFileToStageUpload={this.readFileToStageUpload}
               onClose={() => this.setState({ isSelectingImage: false })}
+              imageSearchTerm={imageSearchTerm}
+              setImageSearchTerm={this.setImageSearchTerm}
             />
             )
           }

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -295,9 +295,7 @@ export default class EditPage extends Component {
 
   toggleImageAndSettingsModal = (searchTerm) => {
     this.setState((currState) => ({
-      isSelectingImage: !currState.isSelectingImage,
       isFileStagedForUpload: !currState.isFileStagedForUpload,
-      imageSearchTerm: searchTerm,
     }));
   }
 

--- a/src/layouts/Files.jsx
+++ b/src/layouts/Files.jsx
@@ -43,23 +43,25 @@ export default class Files extends Component {
 
   onFileSelect = async (event) => {
     const fileReader = new FileReader();
-    const fileName = event.target.files[0].name;
-    fileReader.onload = (() => {
-      /** Github only requires the content of the file
-       * fileReader returns  `data:application/*;base64, {fileContent}`
-       * hence the split
-       */
+    const file = event.target?.files[0] || '';
+    if (file.name) {
+      fileReader.onload = (() => {
+        /** Github only requires the content of the file
+         * fileReader returns  `data:application/*;base64, {fileContent}`
+         * hence the split
+         */
 
-      const fileContent = fileReader.result.split(',')[1];
-      // For modal to pop up
-      this.setState({
-        pendingFileUpload: {
-          fileName,
-          content: fileContent,
-        },
+        const fileContent = fileReader.result.split(',')[1];
+        // For modal to pop up
+        this.setState({
+          pendingFileUpload: {
+            fileName: file.name,
+            content: fileContent,
+          },
+        });
       });
-    });
-    fileReader.readAsDataURL(event.target.files[0]);
+      fileReader.readAsDataURL(file);
+    }
   }
 
   uploadFile = async (fileName, fileContent) => {

--- a/src/layouts/Files.jsx
+++ b/src/layouts/Files.jsx
@@ -43,6 +43,7 @@ export default class Files extends Component {
 
   onFileSelect = async (event) => {
     const fileReader = new FileReader();
+    console.log(event.target.files)
     const file = event.target?.files[0] || '';
     if (file.name) {
       fileReader.onload = (() => {
@@ -61,6 +62,7 @@ export default class Files extends Component {
         });
       });
       fileReader.readAsDataURL(file);
+      event.target.value = '';
     }
   }
 

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -149,7 +149,7 @@ export default class Images extends Component {
             media={pendingImageUpload}
             siteName={siteName}
             // eslint-disable-next-line react/jsx-boolean-value
-            isPendingUpload={true}
+            isPendingUpload
             onClose={() => this.setState({ pendingImageUpload: null })}
             onSave={() => window.location.reload()}
           />

--- a/src/styles/isomer-cms/Elements.module.scss
+++ b/src/styles/isomer-cms/Elements.module.scss
@@ -9,3 +9,4 @@
 @import 'elements/login';
 @import 'elements/dropdown';
 @import 'elements/toast';
+@import 'elements/searchBar';

--- a/src/styles/isomer-cms/elements/searchBar.scss
+++ b/src/styles/isomer-cms/elements/searchBar.scss
@@ -1,0 +1,5 @@
+.mediaSearchBarContainer {
+    width: 33%;
+    padding-left: 1rem;
+    padding-right: 1rem;
+}

--- a/src/styles/isomer-cms/pages/Content.module.scss
+++ b/src/styles/isomer-cms/pages/Content.module.scss
@@ -122,7 +122,6 @@
     
     .card{
       box-sizing: border-box;
-      height: 200px;
     }
   }
 }

--- a/src/styles/isomer-cms/pages/Media.module.scss
+++ b/src/styles/isomer-cms/pages/Media.module.scss
@@ -40,6 +40,7 @@
   flex-wrap: wrap;
   overflow-y: scroll;
   padding-bottom: 50px;
+  width: 100%;
 
     &:after {
       content: '';


### PR DESCRIPTION
## Overview

This PR addresses issue #303. 

This PR does two main things:
1. It adds a search bar for the `MediaModal` component (including the corresponding styles). The search bar filters images in the `MediaModal` by file name for images/files which contain the search term as a substring.
2. ~When a user uploads an image/file and they are redirected back from the `MediaSettingsModal` to the `MediaModal`, we pre-fill the search bar so that the image they just uploaded is displayed in the `MediaModal`.~ We automatically insert an image into the editor (in the case of `EditPage`) / automatically select an image (in the case of a `FormFieldMedia`) upon upload of an image

This PR also fixes miscellaneous bugs associated with the file reader:
- unable to retrieve file for upload if an upload operation was previously cancelled ([7a6a550](https://github.com/isomerpages/isomercms-frontend/commit/7a6a55092cc9afb09928a2e5877bf344ed2f278b))
- unable to select the same file twice consecutively for upload ([4a2c745](https://github.com/isomerpages/isomercms-frontend/commit/4a2c745446e97e410326fffcad93ed469a69e2f6))
- fix component prop definitions and misc. style changes