### PR TITLE
Fix: disable check for url for resources section

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -324,7 +324,7 @@ export default class EditHomepage extends Component {
             newSectionError[sectionType][field] = errorMessage
           } else if (
             field === 'button' && !this.state.frontMatter.sections[sectionIndex][sectionType].url
-            && (value || this.state.frontMatter.sections[sectionIndex][sectionType].url)
+            && (value || this.state.frontMatter.sections[sectionIndex][sectionType].url) && sectionType !== 'resources'
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])


### PR DESCRIPTION
This PR fixes a bug introduced by https://github.com/isomerpages/isomercms-frontend/pull/309/. Currently, the resources section cannot be saved when the button name is present, as the url for that section is always missing and hence results in an error. This PR fixes that by adding an additional check to ensure the section is not of type resources.