### PR TITLE
fix: button handler is not called after blur event in Firefox

### DIFF
--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -74,7 +74,7 @@ const FolderCard = ({
     return (
       <div
         id={id}
-        onClick={(e) => {
+        onMouseDown={(e) => {
           e.stopPropagation();
           e.preventDefault(); 
           if (handler) handler(e);

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -148,7 +148,7 @@ const OverviewCard = ({
     return (
       <div
         id={id}
-        onClick={(e) => {
+        onMouseDown={(e) => {
           e.stopPropagation();
           e.preventDefault(); 
           if (handler) handler(e);


### PR DESCRIPTION
Currently, when the CMS is run on a Firefox browser, the dropdown buttons for the `OverviewCard` and `FolderCard` are unresponsive - meaning, nothing happens when you click on them. @alexanderleegs  found that this was due to the differences in order in which event handlers are called on different browsers. In the case of Firefox, the `onClick` event is only called after the `blur` event is fired, which means that our buttons do not work, since we define our event handlers `onClick`. For reference: https://stackoverflow.com/questions/24635536/different-behavior-of-blur-event-in-different-browsers

The solution to this is to use the `onMouseDown` event instead of an `onClick` event, since the `onMouseDown` is fired before the `blur` event. For reference: https://stackoverflow.com/questions/9335325/blur-event-stops-click-event-from-working