### PR TITLE
Fix/highlight errors on edit homepage

### DIFF
--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -8,6 +8,7 @@ import FormFieldMedia from '../FormFieldMedia';
 import HeroButton from './HeroButton';
 import HeroDropdown from './HeroDropdown';
 import KeyHighlight from './KeyHighlight';
+import { isEmpty } from '../../utils';
 
 /* eslint
   react/no-array-index-key: 0
@@ -36,7 +37,7 @@ const EditorHeroSection = ({
   siteName,
   handleHighlightDropdownToggle,
 }) => (
-  <div className={elementStyles.card}>
+  <div className={`${elementStyles.card} ${!shouldDisplay && !isEmpty(errors.sections[0].hero) ? elementStyles.error : ''}`}>
     <div className={elementStyles.cardHeader}>
       <h2>Hero section</h2>
       <button className="pl-3" type="button" id={`section-${sectionIndex}`} onClick={displayHandler}>

--- a/src/components/homepage/InfobarSection.jsx
+++ b/src/components/homepage/InfobarSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import FormField from '../FormField';
+import { isEmpty } from '../../utils';
 
 /* eslint
   react/no-array-index-key: 0
@@ -20,7 +21,7 @@ const EditorInfobarSection = ({
   displayHandler,
   errors,
 }) => (
-  <div className={`${elementStyles.card} move`}>
+  <div className={`${elementStyles.card} ${!shouldDisplay && !isEmpty(errors) ? elementStyles.error : ''} move`}>
     <div className={elementStyles.cardHeader}>
       <h2>
         Infobar section: {title}

--- a/src/components/homepage/InfopicSection.jsx
+++ b/src/components/homepage/InfopicSection.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import FormField from '../FormField';
 import FormFieldMedia from '../FormFieldMedia';
+import { isEmpty } from '../../utils';
 
 /* eslint
   react/no-array-index-key: 0
@@ -24,7 +25,7 @@ const EditorInfopicSection = ({
   errors,
   siteName,
 }) => (
-  <div className={`${elementStyles.card} move`}>
+  <div className={`${elementStyles.card} ${!shouldDisplay && !isEmpty(errors) ? elementStyles.error : ''} move`}>
     <div className={elementStyles.cardHeader}>
       <h2>
         Infopic section: {title}

--- a/src/components/homepage/ResourcesSection.jsx
+++ b/src/components/homepage/ResourcesSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import FormField from '../FormField';
+import { isEmpty } from '../../utils';
 
 /* eslint
   react/no-array-index-key: 0
@@ -18,7 +19,7 @@ const EditorResourcesSection = ({
   displayHandler,
   errors,
 }) => (
-  <div className={`${elementStyles.card} move`}>
+  <div className={`${elementStyles.card} ${!shouldDisplay && !isEmpty(errors) ? elementStyles.error : ''} move`}>
     <div className={elementStyles.cardHeader}>
       <h2>
         Resources section: {title}

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -270,6 +270,12 @@ export default class EditHomepage extends Component {
     this._isMounted = false;
   }
 
+  componentDidUpdate(_, prevState) {
+    if (prevState.frontMatter.sections.length !== 0 && this.state.frontMatter.sections.length !== prevState.frontMatter.sections.length) {
+      // Occurs when a new section is created
+      this.scrollRefs[this.state.frontMatter.sections.length-1].scrollIntoView();
+    }
+  }
   onFieldChange = async (event) => {
     try {
       const { state } = this;
@@ -902,6 +908,7 @@ export default class EditHomepage extends Component {
           this.setState({
             displaySections: newDisplaySections,
           });
+          this.scrollRefs[sectionId].scrollIntoView();
           break;
         }
         case 'highlight': {

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -327,7 +327,7 @@ export default class EditPage extends Component {
 
   onImageClick = (path) => {
     const cm = this.mdeRef.current.simpleMde.codemirror;
-    cm.replaceSelection(`![](${path})`);
+    cm.replaceSelection(`![](${path.replaceAll(' ', '%20')})`);
     // set state so that rerender is triggered and image is shown
     this.setState({
       editorValue: this.mdeRef.current.simpleMde.codemirror.getValue(),

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 // ==============
 const PERMALINK_REGEX = '^((\/([a-z0-9]+-)*[a-z0-9]+)+)\/?$';
 const URL_REGEX_PART_1 = '^(https://)?(www.)?(';
-const URL_REGEX_PART_2 = '.com/)([a-zA-Z0-9_-]+(/)?)+$';
+const URL_REGEX_PART_2 = '.com/)([a-zA-Z0-9_-]+([/.])?)+$';
 const PHONE_REGEX = '^\\+65(6|8|9)[0-9]{7}$'
 const EMAIL_REGEX = '^(([^<>()\\[\\]\\.,;:\\s@\\"]+(\\.[^<>()\\[\\]\\.,;:\\s@\\"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z-0-9]+\\.)+[a-zA-Z]{2,}))$'
 const DATE_REGEX = '^([0-9]{4}-[0-9]{2}-[0-9]{2})$';


### PR DESCRIPTION
This PR fixes several issues raised during the usability test conducted on 29 Dec. The issues fixed in this PR are:
- Implemented error highlighting, similar to what EditContactUs currently has for minimised sections.
- Loosened social media url regex to allow for periods - facebook and instagram links both allow the use of periods.
- Fixed an issue where images with spaces in their name could not be displayed in EditPage
- Implemented automatic scrolling within EditHomepage. Previously, users were having issues with editing and creating new sections because they were not sure of which section they were editing until they changed a value. This PR changes the snapping to occur when the box is expanded, and also when a new section is created.