### PR TITLE
fix: creates div to wrap formfield

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -437,12 +437,7 @@ const ComponentSettingsModal = ({
                       options={allCategories}
                     />
                   </div>
-                  { errors.category &&
-                  <>
-                    <span className={elementStyles.error}>{errors.category}</span>
-                    <br/>
-                  </>
-                  }
+                  { errors.category && <span className={elementStyles.error}>{errors.category}</span> }
                   {/* Title */}
                   <FormField
                     title="Title"
@@ -452,7 +447,6 @@ const ComponentSettingsModal = ({
                     isRequired={true}
                     onFieldChange={changeHandler}
                   />
-                  {errors.title && <br/>}
                   {/* Third Nav */}
                   { 
                     ((type === "page" && originalCategory) || (type === 'page' && !originalCategory && category)) &&

--- a/src/components/FormField.jsx
+++ b/src/components/FormField.jsx
@@ -17,7 +17,7 @@ const FormField = ({
   fixedMessage,
   maxWidth,
 }) => (
-  <>
+  <div>
     { title && <label className={elementStyles.formLabel}>{title}</label> }
     <div className={`d-flex text-nowrap ${maxWidth ? 'w-100' : ''}`}>
       { fixedMessage && <p className={elementStyles.formFixedText}>{fixedMessage}</p> }
@@ -36,7 +36,7 @@ const FormField = ({
       />
     </div>
     { errorMessage && <span className={elementStyles.error}>{errorMessage}</span> }
-  </>
+  </div>
 );
 
 export default FormField;


### PR DESCRIPTION
This PR contains a small fix for the bug shown below where the error message runs onto the next form field, by creating a `<div></div>` tag to wrap the form fields. 

Before:
<img width="341" alt="Screenshot 2020-12-29 at 12 28 09 PM" src="https://user-images.githubusercontent.com/39231249/103280696-518b2c80-49d1-11eb-9c3a-fbd53d1e3926.png">

Fixed:
<img width="338" alt="Screenshot 2020-12-29 at 12 29 50 PM" src="https://user-images.githubusercontent.com/39231249/103280794-8e572380-49d1-11eb-8883-3bac783faece.png">
