### PR TITLE
fix: adds multiple header buttons to increase and decrease size of header text

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -28,7 +28,8 @@ import {
   boldButton,
   italicButton,
   strikethroughButton,
-  headingButton,
+  headingSmallerButton,
+  headingBiggerButton,
   codeButton,
   quoteButton,
   unorderedListButton,
@@ -454,7 +455,9 @@ export default class EditPage extends Component {
                 value={editorValue}
                 options={{
                   toolbar: [
-                    headingButton,
+                    headingSmallerButton,
+                    headingBiggerButton,
+                    '|',
                     boldButton,
                     italicButton,
                     strikethroughButton,

--- a/src/utils/markdownToolbar.jsx
+++ b/src/utils/markdownToolbar.jsx
@@ -59,7 +59,6 @@ export const headingBiggerButton = {
   title: 'Increase header size',
 };
 
-
 export const codeButton = {
   name: 'code',
   action: toggleCodeBlock,

--- a/src/utils/markdownToolbar.jsx
+++ b/src/utils/markdownToolbar.jsx
@@ -14,6 +14,7 @@ import {
   toggleItalic,
   toggleStrikethrough,
   toggleHeadingSmaller,
+  toggleHeadingBigger,
   toggleCodeBlock,
   toggleBlockquote,
   toggleUnorderedList,
@@ -44,13 +45,20 @@ export const strikethroughButton = {
   title: 'Strikethrough',
 };
 
-export const headingButton = {
-  name: 'heading',
+export const headingSmallerButton = {
+  name: 'headingSmaller',
   action: toggleHeadingSmaller,
   className: 'fa fa-header',
-  title: 'Heading',
-  default: true,
+  title: 'Decrease header size',
 };
+
+export const headingBiggerButton = {
+  name: 'headingBigger',
+  action: toggleHeadingBigger,
+  className: 'fa fa-lg fa-header',
+  title: 'Increase header size',
+};
+
 
 export const codeButton = {
   name: 'code',


### PR DESCRIPTION
Addresses #320 with addition of new header button to allow users to increase and decrease the size of header text.

<img width="645" alt="Screenshot 2020-12-30 at 12 04 52 PM" src="https://user-images.githubusercontent.com/39231249/103347410-3aaf0d80-4a97-11eb-91ab-408511f8aa58.png">

Note the initial click to create a large/small header is not very intuitive as clicking on the "large" header creates the smallest header that will increase in size as the user clicks it. Personally, I think this may not be so problematic as the contrast in the two buttons may encourage users to experiment, but please feedback if you have other ideas on the behavior!

