### PR TITLE
Fix: show different messages for field for new pages and existing pages

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -45,6 +45,14 @@ const generateInitialThirdNavLabel = (thirdNavTitle, originalCategory) => {
     return "Select a third nav section..."
 }
 
+const generateCategoryFieldTitle = (type, isCategoryDisabled) => {
+  if (isCategoryDisabled) {
+    return `${type === 'resource' ? `Resource Category` : `Collection`}`
+  } else {
+    return `Add to ${type === 'resource' ? `Resource Category` : `Collection (optional)`}`
+  }
+}
+
 // Global state
 let thirdNavData = {}
 
@@ -414,9 +422,9 @@ const ComponentSettingsModal = ({
                 <div className={elementStyles.modalFormFields}>
                   {/* Category */}
                   <p className={elementStyles.formLabel}>
-                    {`Add to ${type === 'resource' ? `Resource Category` : `Collection (optional)`}`}
+                    {generateCategoryFieldTitle(type, isCategoryDisabled)}
                     {
-                      type === 'resource' &&
+                      type === 'resource' && !isCategoryDisabled &&
                       <b> (required)</b>
                     }
                   </p>
@@ -426,7 +434,7 @@ const ComponentSettingsModal = ({
                       className="w-100"
                       onChange={categoryDropdownHandler}
                       isDisabled={isCategoryDisabled}
-                      placeholder={"Select a category or create a new category..."}
+                      placeholder={isCategoryDisabled && type==='page' ? "Unlinked Page" : "Select a category or create a new category..."}
                       defaultValue={originalCategory ? 
                         {
                           value: originalCategory,


### PR DESCRIPTION
This PR fixes a minor issue with the field title of the category field of the component settings modal.

Previously, we updated the title to reflect to users more clearly that they should be choosing categories to add to - however, this also resulted in the field title changing when editing details, which is a source of confusion. This PR introduces separate field titles depending on whether the user can select a field.

In addition, the placeholder text for the collection name when editing the details of unlinked pages has been changed to `Unlinked Page` instead of the previous `Select a category or create a new category...` to make it clearer to the user that the category cannot be edited from this modal.