### PR TITLE
Fix/slugify collection and resource category name automatically

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -245,7 +245,7 @@ export async function saveFileAndRetrieveUrl(fileInfo) {
   else slugifiedCategory = category
 
   const baseApiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${originalCategory ? type === "resource" ? `/resources/${originalCategory}` : `/collections/${originalCategory}` : ''}`
-  const newBaseApiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${category ? type === "resource" ? `/resources/${category}` : `/collections/${category}` : ''}`
+  const newBaseApiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${category ? type === "resource" ? `/resources/${slugifiedCategory}` : `/collections/${slugifiedCategory}` : ''}`
   let newFileName, frontMatter
   if (type === "resource") {
     newFileName = generateResourceFileName(title.toLowerCase(), date, resourceType);

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -20,7 +20,7 @@ const alphabetsRegexTest = RegExp(ALPHABETS_ONLY_REGEX);
 const alphanumericRegexTest = RegExp(ALPHANUMERICS_ONLY_REGEX);
 const fileNameRegexTest = /^[a-zA-Z0-9" "_-]+$/;
 const fileNameExtensionRegexTest = /^[a-zA-z]{3,4}$/;
-const RESOURCE_CATEGORY_REGEX = '^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$';
+const RESOURCE_CATEGORY_REGEX = '^([a-zA-Z0-9]+[- ])*[a-zA-Z0-9]+$';
 const resourceRoomNameRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX);
 
@@ -748,7 +748,7 @@ const validateCategoryName = (value, componentName) => {
   }
   // Resource category fails regex
   else if (!resourceCategoryRegexTest.test(value)) {
-    errorMessage = `The ${componentName} category should only have alphanumeric characters separated by hypens.`;
+    errorMessage = `The ${componentName} category should only have alphanumeric characters separated by hypens or spaces.`;
   }
 
   return errorMessage;


### PR DESCRIPTION
This PR changes the flow of adding new collections/resource categories, to resolve https://github.com/isomerpages/isomercms-frontend/issues/323. Previously, we would enforce that users slugified their category names when generating them, however, this was not a great user experience. Instead, this PR changes it to allow users to include spaces inside their collection/resource category name, but slugify it under the hood instead. 

In addition, this PR fixes a related bug where the slugified category was not being used to generate the base api url for the file.