### PR TITLE
Fix/double auto logout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,13 +104,6 @@ function App() {
     }
   }
 
-  // useEffect(() => {
-  //   if (isLoggedIn && axiosErrCount === 1) {
-  //     setShouldBlockNavigation(true)
-  //     console.log('User token has expired or does not exist')
-  //   }
-  // }, [axiosErrCount])
-
   useEffect(() => {
     if (shouldBlockNavigation) {
       alert('Warning: your token has expired. Isomer will log you out now.')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,14 +88,16 @@ function App() {
   )
 
   const setLogin = () => {
-    setIsLoggedIn(true)
+    if (!isLoggedIn) setIsLoggedIn(true)
     localStorage.setItem(LOCAL_STORAGE_AUTH_STATE, true)
   }
 
   const setLogoutState = () => {
     localStorage.removeItem(LOCAL_STORAGE_AUTH_STATE)
-    setIsLoggedIn(false)
-    setShouldBlockNavigation(false)
+    if (isLoggedIn) {
+      setIsLoggedIn(false)
+      setShouldBlockNavigation(false)
+    }
   }
 
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,13 +69,16 @@ function App() {
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
   const [siteColors, setSiteColors] = useState({})
 
+  let axiosErrCount = 0
+
   axios.interceptors.response.use(
     function (response) {
       return response
     },
     async function (error) {
       if (error.response && error.response.status === 401) {
-        if (isLoggedIn) {
+        axiosErrCount += 1
+        if (isLoggedIn && axiosErrCount === 1) {
           setShouldBlockNavigation(true)
           console.log('User token has expired or does not exist')
         }
@@ -97,8 +100,16 @@ function App() {
     if (isLoggedIn) {
       setIsLoggedIn(false)
       setShouldBlockNavigation(false)
+      axiosErrCount = 0
     }
   }
+
+  // useEffect(() => {
+  //   if (isLoggedIn && axiosErrCount === 1) {
+  //     setShouldBlockNavigation(true)
+  //     console.log('User token has expired or does not exist')
+  //   }
+  // }, [axiosErrCount])
 
   useEffect(() => {
     if (shouldBlockNavigation) {

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -16,19 +16,22 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
     const { siteName } = rest.computedMatch?.params
     
     useEffect(() => {
+        let _isMounted = true
         const fetchData = async () => {
             try {
                 await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}`)
-                setPageNotFound(false)
+                if (_isMounted) setPageNotFound(false)
             } catch (e) {
-                setPageNotFound(true)
+                if (_isMounted) setPageNotFound(true)
             }
         }
         if (siteName) {
             fetchData()
         } else {
-            setPageNotFound(false)
+            if (_isMounted) setPageNotFound(false)
         }
+
+        return () => { _isMounted = false } 
     }, [siteName])
 
     return (

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -73,13 +73,7 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
                 }
 
                 console.log('User is not logged in at', rest.location.pathname)
-                // Render login component if not logged in
-                if (rest.location.pathname === '/') {
-                    return <Home {...rest} {...props} />
-                }
-
-                // Redirect all URLs to Login component when not logged in
-                return <Redirect to={{ pathname: '/' }} />
+                return <Home {...rest} {...props} />
             }
         } />
     )

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -50,7 +50,7 @@ const Resources = ({ match, location }) => {
         }
         if (_isMounted) setIsLoading(false)
       } catch (err) {
-        setIsLoading(false)
+        if (_isMounted) setIsLoading(false)
         console.log(err)
       }
     }


### PR DESCRIPTION
## Overview

Currently, when we automatically log users out of the CMS, we trigger a browser window alert which warns users that they are being logged out. However, for several reasons, the browser alert is triggered multiple times, which is a bad user experience. This PR aims to fix this bug by ensuring that the browser alert is only triggered once upon auto-logout.

This PR also cleans up possible memory leaks by preventing state updates upon component dismount in couple of components (namely, `ProtectedRoute` and `Resources`).

### Cause of multiple alerts

The main cause of the multiple alerts is due to the synchronous nature of the axios interceptor, and our dependence on React state variables which are updated asynchronously. The way the auto-logout flow works currently is that we have configured an axios error interceptor function which, upon receipt of a `401` error, triggers the auto-logout flow. 

The high-level explanation is as follows. There are several places in the CMS code where we make multiple network requests at the same time. If the user's token has expired, then we will receive multiple `401` errors at once.  This leads to the error interceptor being triggered multiple times almost simultaneously, thus causing the auto-logout flow to be run multiple times. Although we attempt to enforce the auto-logout flow to be run only once using some conditional logic, the conditional logic is dependent on React state variables, which are often not updated in time, resulting in the auto-logout flow being run multiple times.

### Solution

Our goal is to limit the axios `401` error interceptor to be run only once, and now we know that we cannot use conditional logic which uses React state variables since we cannot predict when they will be updated. The solution is thus to use synchronous variables to keep track of how many times the `401` error interceptor has been run. 