### PR TITLE
Refactor: editHomepage to use hooks

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -351,8 +351,7 @@ const EditHomepage = ({ match, siteColors, setSiteColors }) => {
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType]['url'] = errorMessage
           } else {
-            newSectionError = _.cloneDeep(errors.sections[sectionIndex])
-            newSectionError = validateSections(errors.sections[sectionIndex], sectionType, field, value)
+            newSectionError = validateSections(_.cloneDeep(errors.sections[sectionIndex]), sectionType, field, value)
 
             if (field === 'button' && !value) {
               newSectionError[sectionType]['button'] = ''

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -198,36 +198,21 @@ const EditHomepage = ({ match, siteColors, setSiteColors }) => {
           // If this is the hero section, hide all highlights/dropdownelems by default
           if (section.hero) {
             const { dropdown, key_highlights: keyHighlights } = section.hero;
+            const hero = { title: '', subtitle: '', background: '', button: '', url: '' }
             if (dropdown) {
+              hero.dropdown = ''
               // Go through section.hero.dropdown.options
               displayDropdownElems = _.fill(Array(dropdown.options.length), false);
               // Fill in dropdown elem errors array
               dropdownElemsErrors = _.map(dropdown.options, () => DropdownElemConstructor(true));
-              // Fill in sectionErrors for hero with dropdown
-              sectionsErrors.push({
-                hero: {
-                  title: '', subtitle: '', background: '', button: '', url: '', dropdown: '',
-                },
-              });
             }
             if (keyHighlights) {
               displayHighlights = _.fill(Array(keyHighlights.length), false);
               // Fill in highlights errors array
               highlightsErrors = _.map(keyHighlights, () => KeyHighlightConstructor(true));
-              // Fill in sectionErrors for hero with key highlights
-              sectionsErrors.push({
-                hero: {
-                  title: '', subtitle: '', background: '', button: '', url: '',
-                },
-              });
             }
-            if (!dropdown && !keyHighlights) {
-              sectionsErrors.push({
-                hero: {
-                  title: '', subtitle: '', background: '', button: '', url: '',
-                },
-              });
-            }
+            // Fill in sectionErrors for hero
+            sectionsErrors.push({ hero })
           }
 
           // Check if there is already a resources section
@@ -366,6 +351,7 @@ const EditHomepage = ({ match, siteColors, setSiteColors }) => {
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType]['url'] = errorMessage
           } else {
+            newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError = validateSections(errors.sections[sectionIndex], sectionType, field, value)
 
             if (field === 'button' && !value) {

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -854,7 +854,7 @@ const EditHomepage = ({ match, siteColors, setSiteColors }) => {
 
   const toggleDropdown = async () => {
     try {
-      setDropdownIsActive(!dropdownIsActive)
+      setDropdownIsActive((prevState) => !prevState)
     } catch (err) {
       console.log(err);
     }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import { Base64 } from 'js-base64';
@@ -97,189 +97,222 @@ const enumSection = (type, isErrorConstructor) => {
   }
 };
 
-export default class EditHomepage extends Component {
-  _isMounted = false 
+const EditHomepage = ({ match, siteColors, setSiteColors }) => {
+  const { siteName } = match.params;
+  const [hasLoaded, setHasLoaded] = useState(false)
+  const scrollRefs = []
+  const [hasErrors, setHasErrors] = useState(false)
+  const [frontMatter, setFrontMatter] = useState(
+    {
+      title: '',
+      subtitle: '',
+      description: '',
+      image: '',
+      notification: '',
+      sections: [],
+    }
+  )
+  const [originalFrontMatter, setOriginalFrontMatter] = useState(
+    {
+      title: '',
+      subtitle: '',
+      description: '',
+      image: '',
+      notification: '',
+      sections: [],
+    }
+  )
+  const [sha, setSha] = useState(null)
+  const [hasResources, setHasResources] = useState(false)
+  const [dropdownIsActive, setDropdownIsActive] = useState(false)
+  const [displaySections, setDisplaySections] = useState([])
+  const [displayHighlights, setDisplayHighlights] = useState([])
+  const [displayDropdownElems, setDisplayDropdownElems] = useState([])
+  const [errors, setErrors] = useState(
+    {
+      sections: [],
+      highlights: [],
+      dropdownElems: [],
+    }
+  )
+  const [itemPendingForDelete, setItemPendingForDelete] = useState(
+    {
+      id: '',
+      type: '',
+    }
+  )
+  const [savedHeroElems, setSavedHeroElems] = useState('')
+  const [savedHeroErrors, setSavedHeroErrors] = useState('')
 
-  constructor(props) {
-    super(props);
-    this.scrollRefs = [];
-    this.state = {
-      frontMatter: {
-        title: '',
-        subtitle: '',
-        description: '',
-        image: '',
-        notification: '',
-        sections: [],
-      },
-      sha: null,
-      hasResources: false,
-      dropdownIsActive: false,
-      displaySections: [],
-      displayHighlights: [],
-      displayDropdownElems: [],
-      errors: {
-        sections: [],
-        highlights: [],
-        dropdownElems: [],
-      },
-      itemPendingForDelete: {
-        id: '',
-        type: '',
-      },
-      savedHeroElems: '',
-      savedHeroErrors: '',
-    };
-  }
+  useEffect(() => {
+    let _isMounted = true
+    const loadPageDetails = async () => {
+      // Set page colors
+      try {
+        let primaryColor
+        let secondaryColor
 
-  async componentDidMount() {
-    const { match, siteColors, setSiteColors } = this.props;
-    const { siteName } = match.params;
-    this._isMounted = true
+        if (!siteColors[siteName]) {
+          const {
+            primaryColor: sitePrimaryColor,
+            secondaryColor: siteSecondaryColor,
+          } = await getSiteColors(siteName)
 
-    // Set page colors
-    try {
-      let primaryColor
-      let secondaryColor
+          primaryColor = sitePrimaryColor
+          secondaryColor = siteSecondaryColor
 
-      if (!siteColors[siteName]) {
-        const {
-          primaryColor: sitePrimaryColor,
-          secondaryColor: siteSecondaryColor,
-        } = await getSiteColors(siteName)
+          if (_isMounted) setSiteColors((prevState) => ({
+            ...prevState,
+            [siteName]: {
+              primaryColor,
+              secondaryColor,
+            }
+          }))
+        } else {
+          primaryColor = siteColors[siteName].primaryColor
+          secondaryColor = siteColors[siteName].secondaryColor
+        }
 
-        primaryColor = sitePrimaryColor
-        secondaryColor = siteSecondaryColor
-
-        if (this._isMounted) setSiteColors((prevState) => ({
-          ...prevState,
-          [siteName]: {
-            primaryColor,
-            secondaryColor,
-          }
-        }))
-      } else {
-        primaryColor = siteColors[siteName].primaryColor
-        secondaryColor = siteColors[siteName].secondaryColor
+        createPageStyleSheet(siteName, primaryColor, secondaryColor)
+      
+      } catch (err) {
+        console.log(err);
       }
 
-      createPageStyleSheet(siteName, primaryColor, secondaryColor)
-    
-    } catch (err) {
-      console.log(err);
+      try {
+        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/homepage`, {
+          withCredentials: true,
+        });
+        const { content, sha } = resp.data;
+        const base64DecodedContent = Base64.decode(content);
+        const { frontMatter } = frontMatterParser(base64DecodedContent);
+        // Compute hasResources and set displaySections
+        let hasResources = false;
+        const displaySections = [];
+        let displayHighlights = [];
+        let displayDropdownElems = [];
+        const sectionsErrors = [];
+        let dropdownElemsErrors = [];
+        let highlightsErrors = [];
+        frontMatter.sections.forEach((section) => {
+          // If this is the hero section, hide all highlights/dropdownelems by default
+          if (section.hero) {
+            const { dropdown, key_highlights: keyHighlights } = section.hero;
+            if (dropdown) {
+              // Go through section.hero.dropdown.options
+              displayDropdownElems = _.fill(Array(dropdown.options.length), false);
+              // Fill in dropdown elem errors array
+              dropdownElemsErrors = _.map(dropdown.options, () => DropdownElemConstructor(true));
+              // Fill in sectionErrors for hero with dropdown
+              sectionsErrors.push({
+                hero: {
+                  title: '', subtitle: '', background: '', button: '', url: '', dropdown: '',
+                },
+              });
+            }
+            if (keyHighlights) {
+              displayHighlights = _.fill(Array(keyHighlights.length), false);
+              // Fill in highlights errors array
+              highlightsErrors = _.map(keyHighlights, () => KeyHighlightConstructor(true));
+              // Fill in sectionErrors for hero with key highlights
+              sectionsErrors.push({
+                hero: {
+                  title: '', subtitle: '', background: '', button: '', url: '',
+                },
+              });
+            }
+            if (!dropdown && !keyHighlights) {
+              sectionsErrors.push({
+                hero: {
+                  title: '', subtitle: '', background: '', button: '', url: '',
+                },
+              });
+            }
+          }
+
+          // Check if there is already a resources section
+          if (section.resources) {
+            sectionsErrors.push(ResourcesSectionConstructor(true));
+            hasResources = true;
+          }
+
+          if (section.infobar) {
+            sectionsErrors.push(InfobarSectionConstructor(true));
+          }
+
+          if (section.infopic) {
+            sectionsErrors.push(InfopicSectionConstructor(true));
+          }
+
+          // Minimize all sections by default
+          displaySections.push(false);
+        });
+
+        // Initialize errors object
+        const errors = {
+          sections: sectionsErrors,
+          highlights: highlightsErrors,
+          dropdownElems: dropdownElemsErrors,
+        };
+
+        if (_isMounted) {
+          setFrontMatter(frontMatter)
+          setOriginalFrontMatter(_.cloneDeep(frontMatter))
+          setSha(sha)
+          setHasResources(hasResources)
+          setDisplaySections(displaySections)
+          setDisplayDropdownElems(displayDropdownElems)
+          setDisplayHighlights(displayHighlights)
+          setErrors(errors)
+          setHasLoaded(true)
+        }
+      } catch (err) {
+        // Set frontMatter to be same to prevent warning message when navigating away
+        if (_isMounted) setFrontMatter(originalFrontMatter)
+        toast(
+          <Toast notificationType='error' text={`There was a problem trying to load your homepage. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+        );
+        console.log(err);
+      }
     }
 
+    loadPageDetails()
+    return () => {
+      _isMounted = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (scrollRefs.length > 0) {
+      scrollRefs[frontMatter.sections.length-1].scrollIntoView();
+    }
+  }, [frontMatter.sections.length])
+
+  useEffect(() => {
+    const hasSectionErrors = _.some(errors.sections, (section) => {
+      // Section is an object, e.g. { hero: {} }
+      // _.keys(section) produces an array with length 1
+      // The 0th element of the array contains the sectionType
+      const sectionType = _.keys(section)[0];
+      return _.some(section[sectionType], (errorMessage) => errorMessage.length > 0) === true;
+    })
+
+    const hasHighlightErrors = _.some(errors.highlights,
+      (highlight) => _.some(highlight,
+        (errorMessage) => errorMessage.length > 0) === true);
+
+    const hasDropdownElemErrors = _.some(errors.dropdownElems,
+      (dropdownElem) => _.some(dropdownElem,
+        (errorMessage) => errorMessage.length > 0) === true);
+
+    const hasErrors = hasSectionErrors || hasHighlightErrors || hasDropdownElemErrors;
+
+    setHasErrors(hasErrors)
+  }, [errors])
+
+  const onFieldChange = async (event) => {
     try {
-      const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/homepage`, {
-        withCredentials: true,
-      });
-      const { content, sha } = resp.data;
-      const base64DecodedContent = Base64.decode(content);
-      const { frontMatter } = frontMatterParser(base64DecodedContent);
-      // Compute hasResources and set displaySections
-      let hasResources = false;
-      const displaySections = [];
-      let displayHighlights = [];
-      let displayDropdownElems = [];
-      const sectionsErrors = [];
-      let dropdownElemsErrors = [];
-      let highlightsErrors = [];
-      frontMatter.sections.forEach((section) => {
-        // If this is the hero section, hide all highlights/dropdownelems by default
-        if (section.hero) {
-          const { dropdown, key_highlights: keyHighlights } = section.hero;
-          if (dropdown) {
-            // Go through section.hero.dropdown.options
-            displayDropdownElems = _.fill(Array(dropdown.options.length), false);
-            // Fill in dropdown elem errors array
-            dropdownElemsErrors = _.map(dropdown.options, () => DropdownElemConstructor(true));
-            // Fill in sectionErrors for hero with dropdown
-            sectionsErrors.push({
-              hero: {
-                title: '', subtitle: '', background: '', button: '', url: '', dropdown: '',
-              },
-            });
-          }
-          if (keyHighlights) {
-            displayHighlights = _.fill(Array(keyHighlights.length), false);
-            // Fill in highlights errors array
-            highlightsErrors = _.map(keyHighlights, () => KeyHighlightConstructor(true));
-            // Fill in sectionErrors for hero with key highlights
-            sectionsErrors.push({
-              hero: {
-                title: '', subtitle: '', background: '', button: '', url: '',
-              },
-            });
-          }
-          if (!dropdown && !keyHighlights) {
-            sectionsErrors.push({
-              hero: {
-                title: '', subtitle: '', background: '', button: '', url: '',
-              },
-            });
-          }
-        }
-
-        // Check if there is already a resources section
-        if (section.resources) {
-          sectionsErrors.push(ResourcesSectionConstructor(true));
-          hasResources = true;
-        }
-
-        if (section.infobar) {
-          sectionsErrors.push(InfobarSectionConstructor(true));
-        }
-
-        if (section.infopic) {
-          sectionsErrors.push(InfopicSectionConstructor(true));
-        }
-
-        // Minimize all sections by default
-        displaySections.push(false);
-      });
-
-      // Initialize errors object
-      const errors = {
-        sections: sectionsErrors,
-        highlights: highlightsErrors,
-        dropdownElems: dropdownElemsErrors,
-      };
-
-      if (this._isMounted) this.setState({
-        frontMatter,
-        originalFrontMatter: _.cloneDeep(frontMatter),
-        sha,
-        hasResources,
-        displaySections,
-        displayDropdownElems,
-        displayHighlights,
-        errors,
-      });
-    } catch (err) {
-      // Set frontMatter to be same to prevent warning message when navigating away
-      this.setState( {frontMatter: this.state.originalFrontMatter} )
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to load your homepage. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
-      console.log(err);
-    }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  componentDidUpdate(_, prevState) {
-    if (prevState.frontMatter.sections.length !== 0 && this.state.frontMatter.sections.length !== prevState.frontMatter.sections.length) {
-      // Occurs when a new section is created
-      this.scrollRefs[this.state.frontMatter.sections.length-1].scrollIntoView();
-    }
-  }
-  onFieldChange = async (event) => {
-    try {
-      const { state } = this;
-      const { errors } = state;
       const { id, value } = event.target;
       const idArray = id.split('-');
       const elemType = idArray[0];
@@ -289,18 +322,15 @@ export default class EditHomepage extends Component {
           // The field that changed belongs to a site-wide config
           const field = idArray[1]; // e.g. "title" or "subtitle"
 
-          this.setState((currState) => ({
-            ...currState,
-            frontMatter: {
-              ...currState.frontMatter,
-              [field]: value,
-            },
-          }));
+          setFrontMatter({
+            ...frontMatter,
+            [field]: value,
+          });
           break;
         }
         case 'section': {
           // The field that changed belongs to a homepage section config
-          const { sections } = state.frontMatter;
+          const { sections } = frontMatter;
 
           // sectionIndex is the index of the section array in the frontMatter
           const sectionIndex = parseInt(idArray[1], RADIX_PARSE_INT);
@@ -322,15 +352,15 @@ export default class EditHomepage extends Component {
           // Set special error message if hero button has text but hero url is empty
           // This needs to be done separately because it relies on the state of another field
           if (
-            field === 'url' && !value && this.state.frontMatter.sections[sectionIndex][sectionType].button
-            && (this.state.frontMatter.sections[sectionIndex][sectionType].button || value)
+            field === 'url' && !value && frontMatter.sections[sectionIndex][sectionType].button
+            && (frontMatter.sections[sectionIndex][sectionType].button || value)
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
             newSectionError[sectionType][field] = errorMessage
           } else if (
-            field === 'button' && !this.state.frontMatter.sections[sectionIndex][sectionType].url
-            && (value || this.state.frontMatter.sections[sectionIndex][sectionType].url) && sectionType !== 'resources'
+            field === 'button' && !frontMatter.sections[sectionIndex][sectionType].url
+            && (value || frontMatter.sections[sectionIndex][sectionType].url) && sectionType !== 'resources'
           ) {
             const errorMessage = 'Please specify a URL for your button'
             newSectionError = _.cloneDeep(errors.sections[sectionIndex])
@@ -352,21 +382,18 @@ export default class EditHomepage extends Component {
             },
           });
 
-          this.setState((currState) => ({
-            ...currState,
-            frontMatter: {
-              ...currState.frontMatter,
-              sections: newSections,
-            },
-            errors: newErrors,
-          }));
+          setFrontMatter({
+            ...frontMatter,
+            sections: newSections,
+          })
+          setErrors(newErrors)
 
-          this.scrollRefs[sectionIndex].scrollIntoView();
+          scrollRefs[sectionIndex].scrollIntoView();
           break;
         }
         case 'highlight': {
           // The field that changed belongs to a hero highlight
-          const { sections } = state.frontMatter;
+          const { sections } = frontMatter;
 
           // highlightsIndex is the index of the key_highlights array
           const highlightsIndex = parseInt(idArray[1], RADIX_PARSE_INT);
@@ -394,21 +421,18 @@ export default class EditHomepage extends Component {
             },
           });
 
-          this.setState((currState) => ({
-            ...currState,
-            frontMatter: {
-              ...currState.frontMatter,
-              sections: newSections,
-            },
-            errors: newErrors,
-          }));
+          setFrontMatter({
+            ...frontMatter,
+            sections: newSections,
+          })
+          setErrors(newErrors)
 
-          this.scrollRefs[0].scrollIntoView();
+          scrollRefs[0].scrollIntoView();
           break;
         }
         case 'dropdownelem': {
           // The field that changed is a dropdown element (i.e. dropdownelem)
-          const { sections } = state.frontMatter;
+          const { sections } = frontMatter;
 
           // dropdownsIndex is the index of the dropdown.options array
           const dropdownsIndex = parseInt(idArray[1], RADIX_PARSE_INT);
@@ -438,16 +462,13 @@ export default class EditHomepage extends Component {
             },
           });
 
-          this.setState((currState) => ({
-            ...currState,
-            frontMatter: {
-              ...currState.frontMatter,
-              sections: newSections,
-            },
-            errors: newErrors,
-          }));
+          setFrontMatter({
+            ...frontMatter,
+            sections: newSections
+          })
+          setErrors(newErrors)
 
-          this.scrollRefs[0].scrollIntoView();
+          scrollRefs[0].scrollIntoView();
           break;
         }
         default: {
@@ -461,26 +482,25 @@ export default class EditHomepage extends Component {
             },
           });
 
-          this.setState((currState) => ({
-            ...currState,
-            frontMatter: {
-              ...currState.frontMatter,
-              sections: update(currState.frontMatter.sections, {
-                0: {
-                  hero: {
-                    dropdown: {
-                      title: {
-                        $set: value,
-                      },
-                    },
+          const newSections = update(frontMatter.sections, {
+            0: {
+              hero: {
+                dropdown: {
+                  title: {
+                    $set: value,
                   },
                 },
-              }),
+              },
             },
-            errors: newErrors,
-          }));
+          })
 
-          this.scrollRefs[0].scrollIntoView();
+          setFrontMatter({
+            ...frontMatter,
+            sections: newSections
+          })
+          setErrors(newErrors)
+
+          scrollRefs[0].scrollIntoView();
         }
       }
     } catch (err) {
@@ -488,15 +508,12 @@ export default class EditHomepage extends Component {
     }
   }
 
-  createHandler = async (event) => {
+  const createHandler = async (event) => {
     try {
       const { id, value } = event.target;
       const idArray = id.split('-');
       const elemType = idArray[0];
 
-      const {
-        frontMatter, errors, displaySections, displayDropdownElems, displayHighlights,
-      } = this.state;
       let newSections = [];
       let newErrors = [];
 
@@ -505,7 +522,7 @@ export default class EditHomepage extends Component {
           // The Isomer site can only have 1 resources section in the homepage
           // Set hasResources to prevent the creation of more resources sections
           if (value === 'resources') {
-            this.setState({ hasResources: true });
+            setHasResources(true)
           }
 
           newSections = update(frontMatter.sections, {
@@ -522,9 +539,8 @@ export default class EditHomepage extends Component {
             $push: [true],
           });
 
-          this.setState({
-            displaySections: newDisplaySections,
-          });
+          setDisplaySections(newDisplaySections)
+
           break;
         }
         case 'dropdownelem': {
@@ -553,9 +569,8 @@ export default class EditHomepage extends Component {
             $splice: [[dropdownsIndex, 0, true]],
           });
 
-          this.setState({
-            displayDropdownElems: newDisplayDropdownElems,
-          });
+          setDisplayDropdownElems(newDisplayDropdownElems)
+
           break;
         }
         case 'highlight': {
@@ -584,11 +599,9 @@ export default class EditHomepage extends Component {
               $splice: [[highlightIndex, 0, true]],
             });
 
-            this.setState({
-              displayHighlights: newDisplayHighlights,
-            });
-          // If neither key highlights nor dropdown section exists, create new key highlights array
+            setDisplayHighlights(newDisplayHighlights)
           } else {
+            // If neither key highlights nor dropdown section exists, create new key highlights array
             newSections = _.cloneDeep(frontMatter.sections)
             newSections[0].hero.key_highlights = [KeyHighlightConstructor(false)];
 
@@ -597,36 +610,28 @@ export default class EditHomepage extends Component {
 
             const newDisplayHighlights = [true]
 
-            this.setState({
-              displayHighlights: newDisplayHighlights,
-            });
+            setDisplayHighlights(newDisplayHighlights)
           }
           break;
         }
         default:
           return;
       }
-      this.setState((currState) => ({
-        ...currState,
-        frontMatter: {
-          ...currState.frontMatter,
-          sections: newSections,
-        },
-        errors: newErrors,
-      }));
+      setFrontMatter({
+        ...frontMatter,
+        sections: newSections
+      })
+      setErrors(newErrors)
     } catch (err) {
       console.log(err);
     }
   }
 
-  deleteHandler = async (id) => {
+  const deleteHandler = async (id) => {
     try {
       const idArray = id.split('-');
       const elemType = idArray[0];
 
-      const {
-        frontMatter, errors, displaySections, displayDropdownElems, displayHighlights,
-      } = this.state;
       let newSections = [];
       let newErrors = {};
 
@@ -636,7 +641,7 @@ export default class EditHomepage extends Component {
 
           // Set hasResources to false to allow users to create a resources section
           if (frontMatter.sections[sectionIndex].resources) {
-            this.setState({ hasResources: false });
+            setHasResources(false)
           }
 
           newSections = update(frontMatter.sections, {
@@ -653,9 +658,7 @@ export default class EditHomepage extends Component {
             $splice: [[sectionIndex, 1]],
           });
 
-          this.setState({
-            displaySections: newDisplaySections,
-          });
+          setDisplaySections(newDisplaySections)
           break;
         }
         case 'dropdownelem': {
@@ -682,9 +685,7 @@ export default class EditHomepage extends Component {
             $splice: [[dropdownsIndex, 1]],
           });
 
-          this.setState({
-            displayDropdownElems: newDisplayDropdownElems,
-          });
+          setDisplayDropdownElems(newDisplayDropdownElems)
           break;
         }
         case 'highlight': {
@@ -709,44 +710,36 @@ export default class EditHomepage extends Component {
             $splice: [[highlightIndex, 1]],
           });
 
-          this.setState({
-            displayHighlights: newDisplayHighlights,
-          });
+          setDisplayHighlights(newDisplayHighlights)
           break;
         }
         default:
           return;
       }
-      this.setState((currState) => ({
-        ...currState,
-        frontMatter: {
-          ...currState.frontMatter,
-          sections: newSections,
-        },
-        errors: newErrors,
-      }));
+      setFrontMatter({
+        ...frontMatter,
+        sections: newSections
+      })
+      setErrors(newErrors)
     } catch (err) {
       console.log(err);
     }
   }
 
-  handleHighlightDropdownToggle = (event) => {
-    const {
-      frontMatter, errors,
-    } = this.state;
+  const handleHighlightDropdownToggle = (event) => {
     let newSections = [];
     let newErrors = {};
     const { target: { value } } = event;
     if (value === 'highlights') {
       if (!frontMatter.sections[0].hero.dropdown) return
       let highlightObj, highlightErrors, buttonObj, buttonErrors, urlObj, urlErrors
-      if (this.state.savedHeroElems) {
-        highlightObj = this.state.savedHeroElems.key_highlights || []
-        highlightErrors = this.state.savedHeroErrors.highlights || []
-        buttonObj = this.state.savedHeroElems.button || ''
-        buttonErrors = this.state.savedHeroErrors.button || ''
-        urlObj = this.state.savedHeroElems.url || ''
-        urlErrors = this.state.savedHeroErrors.url || ''
+      if (savedHeroElems) {
+        highlightObj = savedHeroElems.key_highlights || []
+        highlightErrors = savedHeroErrors.highlights || []
+        buttonObj = savedHeroElems.button || ''
+        buttonErrors = savedHeroErrors.button || ''
+        urlObj = savedHeroElems.url || ''
+        urlErrors = savedHeroErrors.url || ''
       } else {
         highlightObj = [];
         highlightErrors = [];
@@ -755,13 +748,11 @@ export default class EditHomepage extends Component {
         urlObj = ''
         urlErrors = ''
       }
-      this.setState({
-        savedHeroElems: this.state.frontMatter.sections[0].hero,
-        savedHeroErrors: {
-          dropdown: this.state.errors.sections[0].hero.dropdown,
-          dropdownElems: this.state.errors.dropdownElems
-        },
-      });
+      setSavedHeroElems(frontMatter.sections[0].hero)
+      setSavedHeroErrors({
+        dropdown: errors.sections[0].hero.dropdown,
+        dropdownElems: errors.dropdownElems
+      })
 
       newSections = update(frontMatter.sections, {
         0: {
@@ -808,24 +799,22 @@ export default class EditHomepage extends Component {
     } else {
       if (frontMatter.sections[0].hero.dropdown) return
       let dropdownObj, dropdownErrors, dropdownElemErrors
-      if (this.state.savedHeroElems) {
-        dropdownObj = this.state.savedHeroElems.dropdown || DropdownConstructor();
-        dropdownErrors = this.state.savedHeroErrors.dropdown || ''
-        dropdownElemErrors = this.state.savedHeroErrors.dropdownElems || ''
+      if (savedHeroElems) {
+        dropdownObj = savedHeroElems.dropdown || DropdownConstructor();
+        dropdownErrors = savedHeroErrors.dropdown || ''
+        dropdownElemErrors = savedHeroErrors.dropdownElems || ''
       } else {
         dropdownObj = DropdownConstructor();
         dropdownErrors = ''
         dropdownElemErrors = []
       }
 
-      this.setState({
-        savedHeroElems: this.state.frontMatter.sections[0].hero,
-        savedHeroErrors: {
-          highlights: this.state.errors.highlights,
-          button: this.state.errors.sections[0].hero.button,
-          url: this.state.errors.sections[0].hero.url,
-        },
-      });
+      setSavedHeroElems(frontMatter.sections[0].hero)
+      setSavedHeroErrors({
+        highlights: errors.highlights,
+        button: errors.sections[0].hero.button,
+        url: errors.sections[0].hero.url,
+      })
 
       newSections = update(frontMatter.sections, {
         0: {
@@ -870,34 +859,28 @@ export default class EditHomepage extends Component {
         }
       });
     }
-    this.setState((currState) => ({
-      ...currState,
-      frontMatter: {
-        ...currState.frontMatter,
-        sections: newSections,
-      },
-      errors: newErrors,
-    }));
+    setFrontMatter({
+      ...frontMatter,
+      sections: newSections
+    })
+    setErrors(newErrors)
   }
 
-  toggleDropdown = async () => {
+  const toggleDropdown = async () => {
     try {
-      this.setState((currState) => ({
-        dropdownIsActive: !currState.dropdownIsActive,
-      }));
+      setDropdownIsActive(!dropdownIsActive)
     } catch (err) {
       console.log(err);
     }
   }
 
-  displayHandler = async (event) => {
+  const displayHandler = async (event) => {
     try {
       const { id } = event.target;
       const idArray = id.split('-');
       const elemType = idArray[0];
       switch (elemType) {
         case 'section': {
-          const { displaySections } = this.state;
           const sectionId = idArray[1];
           let resetDisplaySections = _.fill(Array(displaySections.length), false)
           resetDisplaySections[sectionId] = !displaySections[sectionId]
@@ -905,14 +888,12 @@ export default class EditHomepage extends Component {
             $set: resetDisplaySections,
           });
 
-          this.setState({
-            displaySections: newDisplaySections,
-          });
-          this.scrollRefs[sectionId].scrollIntoView();
+          setDisplaySections(newDisplaySections)
+
+          scrollRefs[sectionId].scrollIntoView();
           break;
         }
         case 'highlight': {
-          const { displayHighlights } = this.state;
           const highlightIndex = idArray[1];
           let resetHighlightSections = _.fill(Array(displayHighlights.length), false)
           resetHighlightSections[highlightIndex] = !displayHighlights[highlightIndex]
@@ -920,13 +901,10 @@ export default class EditHomepage extends Component {
             $set: resetHighlightSections,
           });
 
-          this.setState({
-            displayHighlights: newDisplayHighlights,
-          });
+          setDisplayHighlights(newDisplayHighlights)
           break;
         }
         case 'dropdownelem': {
-          const { displayDropdownElems } = this.state;
           const dropdownsIndex = idArray[1];
           let resetDropdownSections = _.fill(Array(displayDropdownElems.length), false)
           resetDropdownSections[dropdownsIndex] = !displayDropdownElems[dropdownsIndex]
@@ -934,9 +912,7 @@ export default class EditHomepage extends Component {
             $set: resetDropdownSections,
           });
 
-          this.setState({
-            displayDropdownElems: newDisplayDropdownElems,
-          });
+          setDisplayDropdownElems(newDisplayDropdownElems)
           break;
         }
         default:
@@ -947,14 +923,12 @@ export default class EditHomepage extends Component {
     }
   }
 
-  savePage = async () => {
+  const savePage = async () => {
     try {
-      const { state } = this;
-      const { match } = this.props;
       const { siteName } = match.params;
-      let filteredFrontMatter = _.cloneDeep(state.frontMatter)
+      let filteredFrontMatter = _.cloneDeep(frontMatter)
       // Filter out components which have no input
-      filteredFrontMatter.sections = state.frontMatter.sections.map((section) => {
+      filteredFrontMatter.sections = frontMatter.sections.map((section) => {
         let newSection = {}
         for (const sectionName in section) {
           newSection[sectionName] = _.cloneDeep(_.omitBy(section[sectionName], _.isEmpty))
@@ -966,7 +940,7 @@ export default class EditHomepage extends Component {
 
       const params = {
         content: base64EncodedContent,
-        sha: state.sha,
+        sha: sha,
       };
 
       await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/homepage`, params, {
@@ -983,11 +957,8 @@ export default class EditHomepage extends Component {
     }
   }
 
-  onDragEnd = (result) => {
+  const onDragEnd = (result) => {
     const { source, destination, type } = result;
-    const {
-      frontMatter, errors, displaySections, displayDropdownElems, displayHighlights,
-    } = this.state;
 
     // If the user dropped the draggable to no known droppable
     if (!destination) return;
@@ -1029,9 +1000,7 @@ export default class EditHomepage extends Component {
           ],
         });
 
-        this.setState({
-          displaySections: newDisplaySections,
-        });
+        setDisplaySections(newDisplaySections)
         break;
       }
       case 'dropdownelem': {
@@ -1069,9 +1038,7 @@ export default class EditHomepage extends Component {
           ],
         });
 
-        this.setState({
-          displayDropdownElems: newDisplayDropdownElems,
-        });
+        setDisplayDropdownElems(newDisplayDropdownElems)
         break;
       }
       case 'highlight': {
@@ -1107,75 +1074,36 @@ export default class EditHomepage extends Component {
           ],
         });
 
-        this.setState({
-          displayHighlights: newDisplayHighlights,
-        });
+        setDisplayHighlights(newDisplayHighlights)
         break;
       }
       default:
         return;
     }
-    this.setState((currState) => ({
-      ...currState,
-      frontMatter: {
-        ...currState.frontMatter,
-        sections: newSections,
-      },
-      errors: newErrors,
-    }));
+    setFrontMatter({
+      ...frontMatter,
+      sections: newSections
+    })
+    setErrors(newErrors)
   }
 
-  render() {
-    const {
-      frontMatter,
-      originalFrontMatter,
-      hasResources,
-      dropdownIsActive,
-      displaySections,
-      displayHighlights,
-      displayDropdownElems,
-      errors,
-      itemPendingForDelete,
-      sha,
-    } = this.state;
-    const { match } = this.props;
-    const { siteName } = match.params;
+  const isLeftInfoPic = (sectionIndex) => {
+    // If the previous section in the list was not an infopic section
+    // or if the previous section was a right infopic section, return true
+    if (!frontMatter.sections[sectionIndex - 1].infopic
+      || !isLeftInfoPic(sectionIndex - 1)) return true;
 
-    const hasSectionErrors = _.some(errors.sections, (section) => {
-      // Section is an object, e.g. { hero: {} }
-      // _.keys(section) produces an array with length 1
-      // The 0th element of the array contains the sectionType
-      const sectionType = _.keys(section)[0];
-      return _.some(section[sectionType], (errorMessage) => errorMessage.length > 0) === true;
-    });
+    return false;
+  };
 
-    const hasHighlightErrors = _.some(errors.highlights,
-      (highlight) => _.some(highlight,
-        (errorMessage) => errorMessage.length > 0) === true);
-
-    const hasDropdownElemErrors = _.some(errors.dropdownElems,
-      (dropdownElem) => _.some(dropdownElem,
-        (errorMessage) => errorMessage.length > 0) === true);
-
-    const hasErrors = hasSectionErrors || hasHighlightErrors || hasDropdownElemErrors;
-
-    const isLeftInfoPic = (sectionIndex) => {
-      // If the previous section in the list was not an infopic section
-      // or if the previous section was a right infopic section, return true
-      if (!frontMatter.sections[sectionIndex - 1].infopic
-        || !isLeftInfoPic(sectionIndex - 1)) return true;
-
-      return false;
-    };
-
-    return (
-      <>
+  return (
+    <>
         {
           itemPendingForDelete.id
           && (
           <DeleteWarningModal
-            onCancel={() => this.setState({ itemPendingForDelete: { id: null, type: '' } })}
-            onDelete={() => { this.deleteHandler(itemPendingForDelete.id); this.setState({ itemPendingForDelete: { id: null, type: '' } }); }}
+            onCancel={() => setItemPendingForDelete({ id: null, type: '' })}
+            onDelete={() => { deleteHandler(itemPendingForDelete.id); setItemPendingForDelete({ id: null, type: '' })}}
             type={itemPendingForDelete.type}
           />
           )
@@ -1187,6 +1115,7 @@ export default class EditHomepage extends Component {
           backButtonText="Back to My Workspace"
           backButtonUrl={`/sites/${siteName}/workspace`}
         />
+        {hasLoaded && 
         <div className={elementStyles.wrapper}>
           <div className={editorStyles.homepageEditorSidebar}>
             <div>
@@ -1196,14 +1125,14 @@ export default class EditHomepage extends Component {
                   placeholder="Notification"
                   value={frontMatter.notification}
                   id="site-notification"
-                  onChange={this.onFieldChange} />
+                  onChange={onFieldChange} />
                 <span className={elementStyles.info}>
                   Note: Leave text field empty if you don’t need this notification bar
                 </span>
               </div>
 
               {/* Homepage section configurations */}
-              <DragDropContext onDragEnd={this.onDragEnd}>
+              <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="leftPane" type="editor">
                   {(droppableProvided) => (
                     <div
@@ -1225,17 +1154,17 @@ export default class EditHomepage extends Component {
                                 dropdown={section.hero.dropdown ? section.hero.dropdown : null}
                                 sectionIndex={sectionIndex}
                                 highlights={section.hero.key_highlights ? section.hero.key_highlights : []}
-                                onFieldChange={this.onFieldChange}
-                                createHandler={this.createHandler}
-                                deleteHandler={(event, type) => this.setState({ itemPendingForDelete: { id: event.target.id, type } })}
+                                onFieldChange={onFieldChange}
+                                createHandler={createHandler}
+                                deleteHandler={(event, type) => setItemPendingForDelete({ id: event.target.id, type })}
                                 shouldDisplay={displaySections[sectionIndex]}
                                 displayHighlights={displayHighlights}
                                 displayDropdownElems={displayDropdownElems}
-                                displayHandler={this.displayHandler}
-                                onDragEnd={this.onDragEnd}
+                                displayHandler={displayHandler}
+                                onDragEnd={onDragEnd}
                                 errors={errors}
                                 siteName={siteName}
-                                handleHighlightDropdownToggle={this.handleHighlightDropdownToggle}
+                                handleHighlightDropdownToggle={handleHighlightDropdownToggle}
                               />
                             </>
                           ) : (
@@ -1260,10 +1189,10 @@ export default class EditHomepage extends Component {
                                     subtitle={section.resources.subtitle}
                                     button={section.resources.button}
                                     sectionIndex={sectionIndex}
-                                    deleteHandler={(event) => this.setState({ itemPendingForDelete: { id: event.target.id, type: 'Resources Section' } })}
-                                    onFieldChange={this.onFieldChange}
+                                    deleteHandler={(event) => setItemPendingForDelete({ id: event.target.id, type: 'Resources Section' })}
+                                    onFieldChange={onFieldChange}
                                     shouldDisplay={displaySections[sectionIndex]}
-                                    displayHandler={this.displayHandler}
+                                    displayHandler={displayHandler}
                                     errors={errors.sections[sectionIndex].resources}
                                   />
                                 </div>
@@ -1293,10 +1222,10 @@ export default class EditHomepage extends Component {
                                     button={section.infobar.button}
                                     url={section.infobar.url}
                                     sectionIndex={sectionIndex}
-                                    deleteHandler={(event) => this.setState({ itemPendingForDelete: { id: event.target.id, type: 'Infobar Section' } })}
-                                    onFieldChange={this.onFieldChange}
+                                    deleteHandler={(event) => setItemPendingForDelete({ id: event.target.id, type: 'Infobar Section' })}
+                                    onFieldChange={onFieldChange}
                                     shouldDisplay={displaySections[sectionIndex]}
-                                    displayHandler={this.displayHandler}
+                                    displayHandler={displayHandler}
                                     errors={errors.sections[sectionIndex].infobar}
                                   />
                                 </div>
@@ -1328,10 +1257,10 @@ export default class EditHomepage extends Component {
                                     imageUrl={section.infopic.image}
                                     imageAlt={section.infopic.alt}
                                     sectionIndex={sectionIndex}
-                                    deleteHandler={(event) => this.setState({ itemPendingForDelete: { id: event.target.id, type: 'Infopic Section' } })}
-                                    onFieldChange={this.onFieldChange}
+                                    deleteHandler={(event) => setItemPendingForDelete({ id: event.target.id, type: 'Infopic Section' })}
+                                    onFieldChange={onFieldChange}
                                     shouldDisplay={displaySections[sectionIndex]}
-                                    displayHandler={this.displayHandler}
+                                    displayHandler={displayHandler}
                                     errors={errors.sections[sectionIndex].infopic}
                                     siteName={siteName}
                                   />
@@ -1356,7 +1285,7 @@ export default class EditHomepage extends Component {
               {/* Section creator */}
               <NewSectionCreator
                 hasResources={hasResources}
-                createHandler={this.createHandler}
+                createHandler={createHandler}
               />
             </div>
           </div>
@@ -1385,13 +1314,13 @@ export default class EditHomepage extends Component {
                 {/* Hero section */}
                 {section.hero
                   ? (
-                    <div ref={(ref) => { this.scrollRefs[sectionIndex] = ref; }}>
+                    <div ref={(ref) => { scrollRefs[sectionIndex] = ref }}>
                       <TemplateHeroSection
                         key={`section-${sectionIndex}`}
                         hero={section.hero}
                         siteName={siteName}
                         dropdownIsActive={dropdownIsActive}
-                        toggleDropdown={this.toggleDropdown}
+                        toggleDropdown={toggleDropdown}
                       />
                     </div>
                   )
@@ -1399,7 +1328,7 @@ export default class EditHomepage extends Component {
                 {/* Resources section */}
                 {section.resources
                   ? (
-                    <div ref={(ref) => { this.scrollRefs[sectionIndex] = ref; }}>
+                    <div ref={(ref) => { scrollRefs[sectionIndex] = ref }}>
                       <TemplateResourcesSection
                         key={`section-${sectionIndex}`}
                         title={section.resources.title}
@@ -1413,7 +1342,7 @@ export default class EditHomepage extends Component {
                 {/* Infobar section */}
                 {section.infobar
                   ? (
-                    <div ref={(ref) => { this.scrollRefs[sectionIndex] = ref; }}>
+                    <div ref={(ref) => { scrollRefs[sectionIndex] = ref }}>
                       <TemplateInfobarSection
                         key={`section-${sectionIndex}`}
                         title={section.infobar.title}
@@ -1428,7 +1357,7 @@ export default class EditHomepage extends Component {
                 {/* Infopic section */}
                 {section.infopic
                   ? (
-                    <div ref={(ref) => { this.scrollRefs[sectionIndex] = ref; }}>
+                    <div ref={(ref) => { scrollRefs[sectionIndex] = ref }}>
                       { isLeftInfoPic(sectionIndex)
                         ? (
                           <TemplateInfopicLeftSection
@@ -1468,14 +1397,15 @@ export default class EditHomepage extends Component {
               disabled={hasErrors}
               disabledStyle={elementStyles.disabled}
               className={(hasErrors || !sha) ? elementStyles.disabled : elementStyles.blue}
-              callback={this.savePage}
+              callback={savePage}
             />
           </div>
-        </div>
+        </div>}
       </>
-    );
-  }
+  )
 }
+
+export default EditHomepage
 
 EditHomepage.propTypes = {
   match: PropTypes.shape({

--- a/src/templates/homepage/HeroSection.jsx
+++ b/src/templates/homepage/HeroSection.jsx
@@ -100,13 +100,13 @@ const TemplateHeroSection = ({
   siteName,
   dropdownIsActive,
   toggleDropdown,
-}) => {
+}, ref) => {
   const heroStyle = {
     // See j08691's answer at https://stackoverflow.com/questions/21388712/background-size-doesnt-work
     background: `url(https://raw.githubusercontent.com/isomerpages/${siteName}/staging${hero.background}) no-repeat center center/cover`,
   };
   return (
-    <>
+    <div ref={ref}>
       {/* Main hero banner */}
       <section className="bp-hero bg-hero" style={heroStyle}>
         <div className="bp-hero-body">
@@ -145,11 +145,11 @@ const TemplateHeroSection = ({
       { (!hero.dropdown && hero.key_highlights)
         ? <KeyHighlights highlights={hero.key_highlights} />
         : null}
-    </>
+    </div>
   );
 };
 
-export default TemplateHeroSection;
+export default React.forwardRef(TemplateHeroSection);
 
 HeroButton.propTypes = {
   button: PropTypes.string,

--- a/src/templates/homepage/InfobarSection.jsx
+++ b/src/templates/homepage/InfobarSection.jsx
@@ -8,42 +8,44 @@ import PropTypes from 'prop-types';
 
 const TemplateInfobarSection = ({
   title, subtitle, description, button, sectionIndex,
-}) => (
-  <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
-    <div className="bp-container">
-      <div className="row">
-        <div className="col is-half is-offset-one-quarter has-text-centered padding--top--xl">
-          {/* Subtitle */}
-          {subtitle
-            ? <p className="padding--bottom eyebrow is-uppercase">{subtitle}</p>
-            : null}
-          {/* Title */}
-          {title
-            ? <h1 className="has-text-secondary padding--bottom"><b>{title}</b></h1>
-            : null}
-          {/* Description */}
-          { description
-            ? <p>{description}</p>
-            : null}
+}, ref) => (
+  <div ref={ref}>
+    <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
+      <div className="bp-container">
+        <div className="row">
+          <div className="col is-half is-offset-one-quarter has-text-centered padding--top--xl">
+            {/* Subtitle */}
+            {subtitle
+              ? <p className="padding--bottom eyebrow is-uppercase">{subtitle}</p>
+              : null}
+            {/* Title */}
+            {title
+              ? <h1 className="has-text-secondary padding--bottom"><b>{title}</b></h1>
+              : null}
+            {/* Description */}
+            { description
+              ? <p>{description}</p>
+              : null}
+          </div>
         </div>
       </div>
-    </div>
-    {/* Button */}
-    {button
-      ? (
-        <div className="row has-text-centered margin--top padding--bottom">
-          <div className="col is-offset-one-third is-one-third">
-            <div className="bp-sec-button">
-              <div>
-                <span>{button}</span>
-                <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+      {/* Button */}
+      {button
+        ? (
+          <div className="row has-text-centered margin--top padding--bottom">
+            <div className="col is-offset-one-third is-one-third">
+              <div className="bp-sec-button">
+                <div>
+                  <span>{button}</span>
+                  <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      )
-      : null}
-  </section>
+        )
+        : null}
+    </section>
+  </div>
 );
 
 TemplateInfobarSection.propTypes = {
@@ -61,4 +63,4 @@ TemplateInfobarSection.defaultProps = {
 };
 
 
-export default TemplateInfobarSection;
+export default React.forwardRef(TemplateInfobarSection);

--- a/src/templates/homepage/InfopicLeftSection.jsx
+++ b/src/templates/homepage/InfopicLeftSection.jsx
@@ -15,93 +15,95 @@ const TemplateInfopicLeftSection = ({
   imageUrl,
   imageAlt,
   siteName,
-}) => {
+}, ref) => {
   const addDefaultSrc = (e) => {
     e.target.src = '/placeholder_no_image.png'
   }
   return (
-    <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
-      <div className="bp-container">
-        {/* For mobile */}
-        <div className="row is-hidden-desktop is-hidden-tablet-only">
-          <div className="col is-half padding--bottom">
-            <p className="padding--bottom eyebrow is-uppercase">
-              { subtitle }
-            </p>
-            <h1 className="has-text-secondary padding--bottom">
-              <b>{ title }</b>
-            </h1>
-            <p>{ description }</p>
-            <div className="bp-sec-button margin--top padding--bottom">
-              {button
-                ? (
-                  <div>
-                    <span>{ button }</span>
-                    <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
-                  </div>
-                )
-                : null}
+    <div ref={ref}>
+      <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
+        <div className="bp-container">
+          {/* For mobile */}
+          <div className="row is-hidden-desktop is-hidden-tablet-only">
+            <div className="col is-half padding--bottom">
+              <p className="padding--bottom eyebrow is-uppercase">
+                { subtitle }
+              </p>
+              <h1 className="has-text-secondary padding--bottom">
+                <b>{ title }</b>
+              </h1>
+              <p>{ description }</p>
+              <div className="bp-sec-button margin--top padding--bottom">
+                {button
+                  ? (
+                    <div>
+                      <span>{ button }</span>
+                      <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                    </div>
+                  )
+                  : null}
+              </div>
+            </div>
+            <div className="col is-half">
+              <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
             </div>
           </div>
-          <div className="col is-half">
-            <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
-          </div>
-        </div>
-        {/* For tablet */}
-        <div className="row is-hidden-mobile is-hidden-desktop">
-          <div className="col is-half">
-            <p className="padding--bottom eyebrow is-uppercase">
-              { subtitle }
-            </p>
-            <h1 className="has-text-secondary padding--bottom">
-              <b>{ title }</b>
-            </h1>
-            <p>{ description }</p>
-            <div className="bp-sec-button margin--top padding--bottom">
-              { button
-                ? (
-                  <div>
-                    <span>{ button }</span>
-                    <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
-                  </div>
-                )
-                : null}
+          {/* For tablet */}
+          <div className="row is-hidden-mobile is-hidden-desktop">
+            <div className="col is-half">
+              <p className="padding--bottom eyebrow is-uppercase">
+                { subtitle }
+              </p>
+              <h1 className="has-text-secondary padding--bottom">
+                <b>{ title }</b>
+              </h1>
+              <p>{ description }</p>
+              <div className="bp-sec-button margin--top padding--bottom">
+                { button
+                  ? (
+                    <div>
+                      <span>{ button }</span>
+                      <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                    </div>
+                  )
+                  : null}
+              </div>
+            </div>
+            <div className="col is-half is-half padding--top--xl padding--bottom--xl">
+              <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
             </div>
           </div>
-          <div className="col is-half is-half padding--top--xl padding--bottom--xl">
-            <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
-          </div>
-        </div>
-        {/* For desktop */}
-        <div className="row is-hidden-mobile is-hidden-tablet-only">
-          <div className="col is-half padding--top--xl padding--bottom--xl padding--left--xl padding--right--xl">
-            <p className="padding--bottom eyebrow is-uppercase">
-              { subtitle }
-            </p>
-            <h1 className="has-text-secondary padding--bottom">
-              <b>{ title }</b>
-            </h1>
-            <p>{ description }</p>
-            <div className="bp-sec-button margin--top padding--bottom">
-              { button
-                ? (
-                  <div>
-                    <span>{ button }</span>
-                    <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
-                  </div>
-                )
-                : null }
+          {/* For desktop */}
+          <div className="row is-hidden-mobile is-hidden-tablet-only">
+            <div className="col is-half padding--top--xl padding--bottom--xl padding--left--xl padding--right--xl">
+              <p className="padding--bottom eyebrow is-uppercase">
+                { subtitle }
+              </p>
+              <h1 className="has-text-secondary padding--bottom">
+                <b>{ title }</b>
+              </h1>
+              <p>{ description }</p>
+              <div className="bp-sec-button margin--top padding--bottom">
+                { button
+                  ? (
+                    <div>
+                      <span>{ button }</span>
+                      <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                    </div>
+                  )
+                  : null }
+              </div>
+            </div>
+            <div className="col is-half is-half padding--top--xl padding--bottom--xl">
+              <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
             </div>
           </div>
-          <div className="col is-half is-half padding--top--xl padding--bottom--xl">
-            <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
-          </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
 )};
 
-export default TemplateInfopicLeftSection;
+export default React.forwardRef(TemplateInfopicLeftSection);
 
 TemplateInfopicLeftSection.propTypes = {
   title: PropTypes.string,

--- a/src/templates/homepage/InfopicRightSection.jsx
+++ b/src/templates/homepage/InfopicRightSection.jsx
@@ -15,93 +15,95 @@ const TemplateInfopicRightSection = ({
   imageUrl,
   imageAlt,
   siteName,
-}) => {
+}, ref) => {
   const addDefaultSrc = (e) => {
     e.target.src = '/placeholder_no_image.png'
   }
   return (
-    <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
-      <div className="bp-container">
-        {/* For mobile */}
-        <div className="row is-hidden-desktop is-hidden-tablet-only">
-          <div className="col is-half padding--bottom">
-            <p className="padding--bottom eyebrow is-uppercase">
-              { subtitle }
-            </p>
-            <h1 className="has-text-secondary padding--bottom">
-              <b>{ title }</b>
-            </h1>
-            <p>{ description }</p>
-            <div className="bp-sec-button margin--top padding--bottom">
-              {button
-                ? (
-                  <div>
-                    <span>{ button }</span>
-                    <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
-                  </div>
-                )
-                : null}
+    <div ref={ref}>
+      <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
+        <div className="bp-container">
+          {/* For mobile */}
+          <div className="row is-hidden-desktop is-hidden-tablet-only">
+            <div className="col is-half padding--bottom">
+              <p className="padding--bottom eyebrow is-uppercase">
+                { subtitle }
+              </p>
+              <h1 className="has-text-secondary padding--bottom">
+                <b>{ title }</b>
+              </h1>
+              <p>{ description }</p>
+              <div className="bp-sec-button margin--top padding--bottom">
+                {button
+                  ? (
+                    <div>
+                      <span>{ button }</span>
+                      <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                    </div>
+                  )
+                  : null}
+              </div>
+            </div>
+            <div className="col is-half">
+              <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
             </div>
           </div>
-          <div className="col is-half">
-            <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
+          {/* For tablet */}
+          <div className="row is-hidden-mobile is-hidden-desktop">
+            <div className="col is-half is-half padding--top--xl padding--bottom--xl">
+              <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
+            </div>
+            <div className="col is-half">
+              <p className="padding--bottom eyebrow is-uppercase">
+                { subtitle }
+              </p>
+              <h1 className="has-text-secondary padding--bottom">
+                <b>{ title }</b>
+              </h1>
+              <p>{ description }</p>
+              <div className="bp-sec-button margin--top padding--bottom">
+                { button
+                  ? (
+                    <div>
+                      <span>{ button }</span>
+                      <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                    </div>
+                  )
+                  : null}
+              </div>
+            </div>
           </div>
-        </div>
-        {/* For tablet */}
-        <div className="row is-hidden-mobile is-hidden-desktop">
-          <div className="col is-half is-half padding--top--xl padding--bottom--xl">
-            <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
-          </div>
-          <div className="col is-half">
-            <p className="padding--bottom eyebrow is-uppercase">
-              { subtitle }
-            </p>
-            <h1 className="has-text-secondary padding--bottom">
-              <b>{ title }</b>
-            </h1>
-            <p>{ description }</p>
-            <div className="bp-sec-button margin--top padding--bottom">
-              { button
-                ? (
-                  <div>
-                    <span>{ button }</span>
-                    <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
-                  </div>
-                )
-                : null}
+          {/* For desktop */}
+          <div className="row is-hidden-mobile is-hidden-tablet-only">
+            <div className="col is-half is-half padding--top--xl padding--bottom--xl">
+              <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
+            </div>
+            <div className="col is-half padding--top--xl padding--bottom--xl padding--left--xl padding--right--xl">
+              <p className="padding--bottom eyebrow is-uppercase">
+                { subtitle }
+              </p>
+              <h1 className="has-text-secondary padding--bottom">
+                <b>{ title }</b>
+              </h1>
+              <p>{ description }</p>
+              <div className="bp-sec-button margin--top padding--bottom">
+                { button
+                  ? (
+                    <div>
+                      <span>{ button }</span>
+                      <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+                    </div>
+                  )
+                  : null }
+              </div>
             </div>
           </div>
         </div>
-        {/* For desktop */}
-        <div className="row is-hidden-mobile is-hidden-tablet-only">
-          <div className="col is-half is-half padding--top--xl padding--bottom--xl">
-            <img onError={addDefaultSrc} src={`https://raw.githubusercontent.com/isomerpages/${siteName}/staging${imageUrl}`} alt={imageAlt} />
-          </div>
-          <div className="col is-half padding--top--xl padding--bottom--xl padding--left--xl padding--right--xl">
-            <p className="padding--bottom eyebrow is-uppercase">
-              { subtitle }
-            </p>
-            <h1 className="has-text-secondary padding--bottom">
-              <b>{ title }</b>
-            </h1>
-            <p>{ description }</p>
-            <div className="bp-sec-button margin--top padding--bottom">
-              { button
-                ? (
-                  <div>
-                    <span>{ button }</span>
-                    <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
-                  </div>
-                )
-                : null }
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+      </section>
+    </div>
 )};
 
-export default TemplateInfopicRightSection;
+export default React.forwardRef(TemplateInfopicRightSection);
 
 TemplateInfopicRightSection.propTypes = {
   title: PropTypes.string,

--- a/src/templates/homepage/ResourcesSection.jsx
+++ b/src/templates/homepage/ResourcesSection.jsx
@@ -26,57 +26,59 @@ const ResourcePost = () => (
 
 const TemplateResourceSection = ({
   title, subtitle, button, sectionIndex,
-}) => (
-  <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
-    <div className="bp-container">
-      <div className="row">
-        <div className="col is-half is-offset-one-quarter has-text-centered padding--top--lg">
-          {/* Subtitle */}
-          {subtitle
-            ? (
-              <p className="padding--bottom eyebrow is-uppercase">
-                {subtitle}
-              </p>
-            )
-            : null}
-          {/* Title */}
-          {title
-            ? (
-              <h1 className="has-text-secondary padding--bottom">
-                <b>
-                  {title}
-                </b>
-              </h1>
-            )
-            : null}
+}, ref) => (
+  <div ref={ref}>
+    <section className={`bp-section ${(sectionIndex % 2 === 1) ? 'bg-newssection' : null}`}>
+      <div className="bp-container">
+        <div className="row">
+          <div className="col is-half is-offset-one-quarter has-text-centered padding--top--lg">
+            {/* Subtitle */}
+            {subtitle
+              ? (
+                <p className="padding--bottom eyebrow is-uppercase">
+                  {subtitle}
+                </p>
+              )
+              : null}
+            {/* Title */}
+            {title
+              ? (
+                <h1 className="has-text-secondary padding--bottom">
+                  <b>
+                    {title}
+                  </b>
+                </h1>
+              )
+              : null}
+          </div>
         </div>
-      </div>
-      <div className="watermark-container">
-        <div className="row padding--bottom resource-sample-mask">
-          <ResourcePost />
-          <ResourcePost />
-          <ResourcePost />
+        <div className="watermark-container">
+          <div className="row padding--bottom resource-sample-mask">
+            <ResourcePost />
+            <ResourcePost />
+            <ResourcePost />
+          </div>
+          <div className="d-flex flex-column watermark-text">
+            <span className="watermark-text-title">PLACEHOLDER MEDIA</span>
+            <span className="watermark-text-content">Your 3 latest resources will be displayed here.</span>
+            <span className="watermark-text-content">You may change the resources displayed by changing the date of the resource in the resources section.</span>
+          </div>
         </div>
-        <div className="d-flex flex-column watermark-text">
-          <span className="watermark-text-title">PLACEHOLDER MEDIA</span>
-          <span className="watermark-text-content">Your 3 latest resources will be displayed here.</span>
-          <span className="watermark-text-content">You may change the resources displayed by changing the date of the resource in the resources section.</span>
-        </div>
-      </div>
-      <div className="row has-text-centered margin--top padding--bottom--lg">
-        <div className="col is-offset-one-third is-one-third">
-          <div className="bp-sec-button">
-            <div className="d-flex align-items-center justify-content-center">
-              <span>
-                {button || 'MORE'}
-              </span>
-              <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+        <div className="row has-text-centered margin--top padding--bottom--lg">
+          <div className="col is-offset-one-third is-one-third">
+            <div className="bp-sec-button">
+              <div className="d-flex align-items-center justify-content-center">
+                <span>
+                  {button || 'MORE'}
+                </span>
+                <i className="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true" />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </div>
 );
 
 TemplateResourceSection.propTypes = {
@@ -92,4 +94,4 @@ TemplateResourceSection.defaultProps = {
   button: undefined,
 };
 
-export default TemplateResourceSection;
+export default React.forwardRef(TemplateResourceSection);


### PR DESCRIPTION
This PR refactors the existing EditHomepage to use hooks instead of a class component. The reason for this is twofold:

- We want to implement a similar page to editHomepage for navigation
- We would like to use context to set site colours instead of how it's being done currently, however, we have a mix of class components and functional components currently, which prevents us from using the useContext hook

Of particular note is the change in rendering behaviour while loading the page data. Previously, we would display a blank version of the editHomepage.

**Previous**

<img width="1075" alt="Screenshot 2021-02-04 at 4 24 26 PM" src="https://user-images.githubusercontent.com/22111124/106865093-ad01b600-6705-11eb-8636-0933dd617688.png">

However, I ran into some issues replicating this behaviour. Instead, this PR displays the following while loading the page info.

**After**

<img width="1073" alt="Screenshot 2021-02-04 at 4 27 28 PM" src="https://user-images.githubusercontent.com/22111124/106865413-1e416900-6706-11eb-9423-b472c645bde8.png">

Also, this PR refactors the scrollRefs to be a state variable to be more consistent with the behaviour in editContactUs.