### PR TITLE
Fix/double auto logout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,7 +113,7 @@ function App() {
   const ProtectedRouteWithProps = (props) => {
     return (
       <Sentry.ErrorBoundary fallback={FallbackComponent}>
-        <ProtectedRoute {...props} isLoggedIn={isLoggedIn} siteColors={siteColors} setSiteColors={setSiteColors} />
+        <ProtectedRoute {...props} siteColors={siteColors} setSiteColors={setSiteColors} />
       </Sentry.ErrorBoundary>
     )
   }
@@ -129,9 +129,9 @@ function App() {
             you have multiple routes, but you want only one
             of them to render at a time
           */}
-            <LoginContext.Provider value={setLogoutState}>
+            <LoginContext.Provider value={{isLoggedIn, setLogin, setLogoutState}}>
               <Switch>
-                  <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} setLogin={setLogin} />
+                  <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} />
                   <ProtectedRouteWithProps exact path="/" component={Home} />
                   <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName/:fileName" component={EditPage} isCollectionPage={true} isResourcePage={false} />
                   <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName" component={CategoryPages} isResource={false}/>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,13 +104,6 @@ function App() {
     }
   }
 
-  // useEffect(() => {
-  //   if (isLoggedIn && axiosErrCount === 1) {
-  //     setShouldBlockNavigation(true)
-  //     console.log('User token has expired or does not exist')
-  //   }
-  // }, [axiosErrCount])
-
   useEffect(() => {
     if (shouldBlockNavigation) {
       alert('Warning: your token has expired. Isomer will log you out now.')
@@ -122,12 +115,6 @@ function App() {
       logout()
     }
   }, [shouldBlockNavigation])
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      setShouldBlockNavigation(false)
-    }
-  }, [isLoggedIn])
 
   const ProtectedRouteWithProps = (props) => {
     return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,14 +88,16 @@ function App() {
   )
 
   const setLogin = () => {
-    setIsLoggedIn(true)
+    if (!isLoggedIn) setIsLoggedIn(true)
     localStorage.setItem(LOCAL_STORAGE_AUTH_STATE, true)
   }
 
   const setLogoutState = () => {
     localStorage.removeItem(LOCAL_STORAGE_AUTH_STATE)
-    setIsLoggedIn(false)
-    setShouldBlockNavigation(false)
+    if (isLoggedIn) {
+      setIsLoggedIn(false)
+      setShouldBlockNavigation(false)
+    }
   }
 
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,13 +69,16 @@ function App() {
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
   const [siteColors, setSiteColors] = useState({})
 
+  let axiosErrCount = 0
+
   axios.interceptors.response.use(
     function (response) {
       return response
     },
     async function (error) {
       if (error.response && error.response.status === 401) {
-        if (isLoggedIn) {
+        axiosErrCount += 1
+        if (isLoggedIn && axiosErrCount === 1) {
           setShouldBlockNavigation(true)
           console.log('User token has expired or does not exist')
         }
@@ -97,8 +100,16 @@ function App() {
     if (isLoggedIn) {
       setIsLoggedIn(false)
       setShouldBlockNavigation(false)
+      axiosErrCount = 0
     }
   }
+
+  // useEffect(() => {
+  //   if (isLoggedIn && axiosErrCount === 1) {
+  //     setShouldBlockNavigation(true)
+  //     console.log('User token has expired or does not exist')
+  //   }
+  // }, [axiosErrCount])
 
   useEffect(() => {
     if (shouldBlockNavigation) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,19 +69,14 @@ function App() {
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
   const [siteColors, setSiteColors] = useState({})
 
-  let axiosErrCount = 0
-
   axios.interceptors.response.use(
     function (response) {
       return response
     },
     async function (error) {
       if (error.response && error.response.status === 401) {
-        axiosErrCount += 1
-        if (isLoggedIn && axiosErrCount === 1) {
-          setShouldBlockNavigation(true)
-          console.log('User token has expired or does not exist')
-        }
+        setShouldBlockNavigation(true)
+        console.log('User token has expired or does not exist')
       } else {
         console.log('An unknown error occurred: ')
         console.error(error)
@@ -100,7 +95,6 @@ function App() {
     if (isLoggedIn) {
       setIsLoggedIn(false)
       setShouldBlockNavigation(false)
-      axiosErrCount = 0
     }
   }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,8 +75,10 @@ function App() {
     },
     async function (error) {
       if (error.response && error.response.status === 401) {
-        setShouldBlockNavigation(true)
-        console.log('User token has expired or does not exist')
+        if (isLoggedIn && !shouldBlockNavigation) {
+          setShouldBlockNavigation(true)
+          console.log('User token has expired or does not exist')
+        }
       } else {
         console.log('An unknown error occurred: ')
         console.error(error)
@@ -92,14 +94,14 @@ function App() {
 
   const setLogoutState = () => {
     localStorage.removeItem(LOCAL_STORAGE_AUTH_STATE)
-    if (isLoggedIn) {
+    if (isLoggedIn && shouldBlockNavigation) {
       setIsLoggedIn(false)
       setShouldBlockNavigation(false)
     }
   }
 
   useEffect(() => {
-    if (shouldBlockNavigation) {
+    if (isLoggedIn && shouldBlockNavigation) {
       alert('Warning: your token has expired. Isomer will log you out now.')
       const logout = async () =>  {
         console.log('Logging out...')

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -30,19 +30,22 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     const [allCategories, setAllCategories] = useState()
 
     useEffect(() => {
+        let _isMounted = true
         const fetchData = async () => {
           // Retrieve the list of all page/resource categories for use in the dropdown options.
           if (isResource) {
             const resourcesResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`);
             const { resources: allCategories } = resourcesResp.data;
-            setAllCategories(allCategories.map((category) => category.dirName))
+            if (_isMounted) setAllCategories(allCategories.map((category) => category.dirName))
           } else {
             const collectionsResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections`);
             const { collections: collectionCategories } = collectionsResp.data;
-            setAllCategories(collectionCategories)
+            if (_isMounted) setAllCategories(collectionCategories)
           }
         }
         fetchData()
+
+        return () => { _isMounted = false }
       }, [])
 
     const loadThirdNavOptions = async () => {

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -16,19 +16,22 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
     const { siteName } = rest.computedMatch?.params
     
     useEffect(() => {
+        let _isMounted = true
         const fetchData = async () => {
             try {
                 await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}`)
-                setPageNotFound(false)
+                if (_isMounted) setPageNotFound(false)
             } catch (e) {
-                setPageNotFound(true)
+                if (_isMounted) setPageNotFound(true)
             }
         }
         if (siteName) {
             fetchData()
         } else {
-            setPageNotFound(false)
+            if (_isMounted) setPageNotFound(false)
         }
+
+        return () => { _isMounted = false } 
     }, [siteName])
 
     return (

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,9 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { Redirect, Route } from 'react-router-dom'
 import axios from 'axios'
 
 // Import layouts
 import Home from '../layouts/Home';
+
+// Import contexts
+const { LoginContext } = require('../contexts/LoginContext')
 
 // Constants
 const authContextString = '#isomercms'
@@ -11,7 +14,8 @@ const authContextString = '#isomercms'
 // axios settings
 axios.defaults.withCredentials = true
 
-const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) => {
+const ProtectedRoute = ({ component: WrappedComponent, ...rest }) => {
+    const { isLoggedIn } = useContext(LoginContext)
     const [pageNotFound, setPageNotFound] = useState()
     const { siteName } = rest.computedMatch?.params
     
@@ -73,7 +77,13 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
                 }
 
                 console.log('User is not logged in at', rest.location.pathname)
-                return <Home {...rest} {...props} />
+                // Render login component if not logged in
+                if (rest.location.pathname === '/') {
+                    return <Home {...rest} {...props} />
+                }
+
+                // Redirect all URLs to Login component when not logged in	
+                return <Redirect to={{ pathname: '/' }} />
             }
         } />
     )

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -73,13 +73,7 @@ const ProtectedRoute = ({ component: WrappedComponent, isLoggedIn, ...rest }) =>
                 }
 
                 console.log('User is not logged in at', rest.location.pathname)
-                // Render login component if not logged in
-                if (rest.location.pathname === '/') {
-                    return <Home {...rest} {...props} />
-                }
-
-                // Redirect all URLs to Login component when not logged in
-                return <Redirect to={{ pathname: '/' }} />
+                return <Home {...rest} {...props} />
             }
         } />
     )

--- a/src/layouts/AuthCallback.jsx
+++ b/src/layouts/AuthCallback.jsx
@@ -1,7 +1,12 @@
-import React, { useEffect } from 'react'
+import React, { useContext, useEffect } from 'react'
 import { Redirect } from 'react-router-dom';
 
-const AuthCallback = ({ setLogin, isLoggedIn }) => {
+// Import contexts
+const { LoginContext } = require('../contexts/LoginContext')
+
+const AuthCallback = () => {
+    const { setLogin, isLoggedIn } = useContext(LoginContext)
+
     useEffect(() => {
         if (!isLoggedIn) setLogin()
     }, [isLoggedIn])

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -50,7 +50,7 @@ const Resources = ({ match, location }) => {
         }
         if (_isMounted) setIsLoading(false)
       } catch (err) {
-        setIsLoading(false)
+        if (_isMounted) setIsLoading(false)
         console.log(err)
       }
     }

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -21,6 +21,8 @@ import {
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
+const CancelToken = axios.CancelToken;
+const source = CancelToken.source();
 
 const Workspace = ({ match, location, siteColors, setSiteColors }) => {
     const { siteName } = match.params;
@@ -52,16 +54,16 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
 
         try { 
-          await axios.get(`${BACKEND_URL}/sites/${siteName}/pages/contact-us.md`);
+          await axios.get(`${BACKEND_URL}/sites/${siteName}/pages/contact-us.md`, { cancelToken: source.token });
           if (_isMounted) setContactUsCard(true) 
         } catch (e) {
-          if (e.response.status === 500) {
+          if (e.response?.status === 500) {
             // create option for contact-us page
           }
         }
 
         try { 
-          const collectionsResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`);
+          const collectionsResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`, { cancelToken: source.token });
           if (_isMounted) setCollections(collectionsResp.data?.collections)
         } catch (e) {
           setCollections(undefined)
@@ -69,7 +71,7 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
         
         try { 
-          const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/unlinkedPages`);
+          const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/unlinkedPages`, { cancelToken: source.token });
           if (_isMounted) {
             console.log(unlinkedPagesResp.data?.pages)
             setUnlinkedPages(unlinkedPagesResp.data?.pages.filter(page => page.fileName !== 'contact-us.md'))
@@ -79,7 +81,10 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
       }
       fetchData()
-      return () => { _isMounted = false }
+      return () => {
+        source.cancel('Page was unmounted')
+        _isMounted = false
+      }
     }, [])
 
     return (

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -21,8 +21,6 @@ import {
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
-const CancelToken = axios.CancelToken;
-const source = CancelToken.source();
 
 const Workspace = ({ match, location, siteColors, setSiteColors }) => {
     const { siteName } = match.params;
@@ -54,7 +52,7 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
 
         try { 
-          await axios.get(`${BACKEND_URL}/sites/${siteName}/pages/contact-us.md`, { cancelToken: source.token });
+          await axios.get(`${BACKEND_URL}/sites/${siteName}/pages/contact-us.md`);
           if (_isMounted) setContactUsCard(true) 
         } catch (e) {
           if (e.response?.status === 500) {
@@ -63,7 +61,7 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
 
         try { 
-          const collectionsResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`, { cancelToken: source.token });
+          const collectionsResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`);
           if (_isMounted) setCollections(collectionsResp.data?.collections)
         } catch (e) {
           setCollections(undefined)
@@ -71,7 +69,7 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
         
         try { 
-          const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/unlinkedPages`, { cancelToken: source.token });
+          const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/unlinkedPages`);
           if (_isMounted) {
             console.log(unlinkedPagesResp.data?.pages)
             setUnlinkedPages(unlinkedPagesResp.data?.pages.filter(page => page.fileName !== 'contact-us.md'))
@@ -81,10 +79,7 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
         }
       }
       fetchData()
-      return () => {
-        source.cancel('Page was unmounted')
-        _isMounted = false
-      }
+      return () => { _isMounted = false }
     }, [])
 
     return (


### PR DESCRIPTION
## Overview

Currently, when we automatically log users out of the CMS, we trigger a browser window alert which warns users that they are being logged out. However, the browser alert is sometimes displayed multiple times, which is a bad user experience. This PR aims to fix this bug by ensuring that the browser alert is only triggered once upon auto-logout.

An example of the multiple auto-logout warnings:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/31984694/106904103-b99e0280-6735-11eb-8635-3ef768fc9844.gif)

This PR also accomplishes the following:
- Store login information (the `isLoggedIn` state variable) in the `LoginContext` instead of passing it as a prop to minimize re-renders
- Clean up possible memory leaks by preventing state updates upon component dismount in couple of components (namely, `ProtectedRoute`, `Resources`, `CollectionPagesSection`)

### Cause of multiple alerts

After inspecting the auto-logout flow with printed log statements, we realized that the `useEffect` blocks that we use in our auto-logout flow were being triggered more than once. This goes against the explicit designed intention of the auto-logout flow, which is to run each of the `useEffect` blocks once to log the user out and return the app to its initial state. The logout browser alert was being triggered multiple times because the conditional logic which was used in the auto-logout flow was flawed and triggered subsequent state updates in the wrong order.

For example, the initial condition in the `useEffect` to trigger the logout alert was dependent only on the `shouldBlockNavigation` variable:
```
  useEffect(() => {
    if (shouldBlockNavigation) {
      alert('Warning: your token has expired. Isomer will log you out now.')
      const logout = async () =>  {
        console.log('Logging out...')
        await axios.get(`${BACKEND_URL}/auth/logout`)
        setLogoutState()
      }
      logout()
    }
  }, [shouldBlockNavigation])
```
where `setLogoutState` sets both the `isLoggedIn` and `shouldBlockNavigation` states to be `false`. However, with just a check on the `shouldBlockNavigation` variable, it's possible for the `shouldBlockNavigation` variable to change and trigger this `useEffect` block even if `isLoggedIn` is `false`. This does not make sense, since we should only be displaying the alert and logging people out if they are not already logged out! Updating the condition to check for `(shouldBlockNavigation && isLoggedIn)` helps to eliminate this possibility.

More stringent checks were also applied to other sections of the auto-logout flow. This also works to prevent unnecessary re-renders since we limit access to blocks of code which are changing the state of the app and ensuring they are run only once. Thus, we eliminate a large source of unnecessary state updates, and subsequently, re-renders.
