### PR TITLE
Feat/update site colors without re-render

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,8 @@ import elementStyles from './styles/isomer-cms/Elements.module.scss';
 import { defaultSiteColors } from './utils/siteColorUtils';
 
 // Import contexts
-const { LoginContext } = require('./contexts/LoginContext')
+const { LoginContext } = require('./contexts/LoginContext');
+const { SiteColorsContext } = require('./contexts/SiteColorsContext');
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -67,7 +68,7 @@ function App() {
     return false
   })
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
-  const [siteColors, setSiteColors] = useState({})
+  const [siteColors, setSiteColors] = useState(defaultSiteColors)
 
   axios.interceptors.response.use(
     function (response) {
@@ -131,33 +132,35 @@ function App() {
             you have multiple routes, but you want only one
             of them to render at a time
           */}
-            <LoginContext.Provider value={{isLoggedIn, setLogin, setLogoutState}}>
-              <Switch>
-                  <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} />
-                  <ProtectedRouteWithProps exact path="/" component={Home} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName/:fileName" component={EditPage} isCollectionPage={true} isResourcePage={false} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName" component={CategoryPages} isResource={false}/>
-                  <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/images" component={Images} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/pages/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={false} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/workspace" component={Workspace} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/homepage" component={EditHomepage} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/contact-us" component={EditContactUs} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/resources/:resourceName/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={true} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
-                  <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />
-                  <ProtectedRouteWithProps exact path="/sites" component={Sites} />
-                  <ProtectedRouteWithProps path="/" component={NotFoundPage}/>
-                  <Route>
-                    <Redirect to={ isLoggedIn ? '/sites' : '/' } />
-                  </Route>
-              </Switch>
-            </LoginContext.Provider>
+            <SiteColorsContext.Provider value={{siteColors, setSiteColors}}>
+              <LoginContext.Provider value={{isLoggedIn, setLogin, setLogoutState}}>
+                <Switch>
+                    <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} />
+                    <ProtectedRouteWithProps exact path="/" component={Home} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName/:fileName" component={EditPage} isCollectionPage={true} isResourcePage={false} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName" component={CategoryPages} isResource={false}/>
+                    <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/images" component={Images} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/pages/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={false} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/workspace" component={Workspace} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/homepage" component={EditHomepage} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/contact-us" component={EditContactUs} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/resources/:resourceName/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={true} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
+                    <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />
+                    <ProtectedRouteWithProps exact path="/sites" component={Sites} />
+                    <ProtectedRouteWithProps path="/" component={NotFoundPage}/>
+                    <Route>
+                      <Redirect to={ isLoggedIn ? '/sites' : '/' } />
+                    </Route>
+                </Switch>
+              </LoginContext.Provider>
+            </SiteColorsContext.Provider>
         </div>
     </Router>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,8 +34,8 @@ import FallbackComponent from './components/FallbackComponent'
 // Styles
 import elementStyles from './styles/isomer-cms/Elements.module.scss';
 
-// Utils
-import { defaultSiteColors } from './utils/siteColorUtils';
+// Import hooks
+import useSiteColorsHook from './hooks/useSiteColorsHook';
 
 // Import contexts
 const { LoginContext } = require('./contexts/LoginContext');
@@ -68,7 +68,7 @@ function App() {
     return false
   })
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
-  const [siteColors, setSiteColors] = useState(defaultSiteColors)
+  const [siteColors, retrieveSiteColors, generatePageStyleSheet] = useSiteColorsHook()
 
   axios.interceptors.response.use(
     function (response) {
@@ -116,7 +116,7 @@ function App() {
   const ProtectedRouteWithProps = (props) => {
     return (
       <Sentry.ErrorBoundary fallback={FallbackComponent}>
-        <ProtectedRoute {...props} siteColors={siteColors} setSiteColors={setSiteColors} />
+        <ProtectedRoute {...props} />
       </Sentry.ErrorBoundary>
     )
   }
@@ -132,7 +132,7 @@ function App() {
             you have multiple routes, but you want only one
             of them to render at a time
           */}
-            <SiteColorsContext.Provider value={{siteColors, setSiteColors}}>
+            <SiteColorsContext.Provider value={{siteColors, retrieveSiteColors, generatePageStyleSheet}}>
               <LoginContext.Provider value={{isLoggedIn, setLogin, setLogoutState}}>
                 <Switch>
                     <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ axios.defaults.withCredentials = true
 // Constants
 const { REACT_APP_BACKEND_URL: BACKEND_URL } = process.env
 const LOCAL_STORAGE_AUTH_STATE = 'isomercms_auth'
+const LOCAL_STORAGE_SITE_COLORS = 'isomercms_colors'
 
 const ToastCloseButton = ({ closeToast }) => (
   <span style={{
@@ -95,6 +96,10 @@ function App() {
       setShouldBlockNavigation(false)
     }
   }
+
+  useEffect(() => {
+    localStorage.removeItem(LOCAL_STORAGE_SITE_COLORS)
+  }, [])
 
   useEffect(() => {
     if (isLoggedIn && shouldBlockNavigation) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,12 +34,8 @@ import FallbackComponent from './components/FallbackComponent'
 // Styles
 import elementStyles from './styles/isomer-cms/Elements.module.scss';
 
-// Import hooks
-import useSiteColorsHook from './hooks/useSiteColorsHook';
-
 // Import contexts
 const { LoginContext } = require('./contexts/LoginContext');
-const { SiteColorsContext } = require('./contexts/SiteColorsContext');
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -68,7 +64,6 @@ function App() {
     return false
   })
   const [shouldBlockNavigation, setShouldBlockNavigation] = useState(false)
-  const [siteColors, retrieveSiteColors, generatePageStyleSheet] = useSiteColorsHook()
 
   axios.interceptors.response.use(
     function (response) {
@@ -132,35 +127,33 @@ function App() {
             you have multiple routes, but you want only one
             of them to render at a time
           */}
-            <SiteColorsContext.Provider value={{siteColors, retrieveSiteColors, generatePageStyleSheet}}>
-              <LoginContext.Provider value={{isLoggedIn, setLogin, setLogoutState}}>
-                <Switch>
-                    <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} />
-                    <ProtectedRouteWithProps exact path="/" component={Home} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName/:fileName" component={EditPage} isCollectionPage={true} isResourcePage={false} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName" component={CategoryPages} isResource={false}/>
-                    <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/images" component={Images} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/pages/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={false} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/workspace" component={Workspace} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/homepage" component={EditHomepage} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/contact-us" component={EditContactUs} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/resources/:resourceName/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={true} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
-                    <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />
-                    <ProtectedRouteWithProps exact path="/sites" component={Sites} />
-                    <ProtectedRouteWithProps path="/" component={NotFoundPage}/>
-                    <Route>
-                      <Redirect to={ isLoggedIn ? '/sites' : '/' } />
-                    </Route>
-                </Switch>
-              </LoginContext.Provider>
-            </SiteColorsContext.Provider>
+            <LoginContext.Provider value={{isLoggedIn, setLogin, setLogoutState}}>
+              <Switch>
+                  <ProtectedRouteWithProps exact path='/auth' component={AuthCallback} />
+                  <ProtectedRouteWithProps exact path="/" component={Home} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName/:fileName" component={EditPage} isCollectionPage={true} isResourcePage={false} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName" component={CategoryPages} isResource={false}/>
+                  <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/images" component={Images} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/pages/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={false} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/workspace" component={Workspace} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/homepage" component={EditHomepage} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/contact-us" component={EditContactUs} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/resources/:resourceName/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={true} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
+                  <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />
+                  <ProtectedRouteWithProps exact path="/sites" component={Sites} />
+                  <ProtectedRouteWithProps path="/" component={NotFoundPage}/>
+                  <Route>
+                    <Redirect to={ isLoggedIn ? '/sites' : '/' } />
+                  </Route>
+              </Switch>
+            </LoginContext.Provider>
         </div>
     </Router>
   );

--- a/src/contexts/SiteColorsContext.js
+++ b/src/contexts/SiteColorsContext.js
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+// Utils
+import { defaultSiteColors } from '../utils/siteColorUtils';
+
+export const SiteColorsContext = createContext({
+    siteColors: defaultSiteColors,
+    setSiteColors: () => {},
+});

--- a/src/contexts/SiteColorsContext.js
+++ b/src/contexts/SiteColorsContext.js
@@ -1,6 +1,0 @@
-import { createContext } from 'react';
-
-// Utils
-import { defaultSiteColors } from '../utils/siteColorUtils';
-
-export const SiteColorsContext = createContext(null);

--- a/src/contexts/SiteColorsContext.js
+++ b/src/contexts/SiteColorsContext.js
@@ -3,7 +3,4 @@ import { createContext } from 'react';
 // Utils
 import { defaultSiteColors } from '../utils/siteColorUtils';
 
-export const SiteColorsContext = createContext({
-    siteColors: defaultSiteColors,
-    setSiteColors: () => {},
-});
+export const SiteColorsContext = createContext(null);

--- a/src/hooks/useSiteColorsHook.jsx
+++ b/src/hooks/useSiteColorsHook.jsx
@@ -1,29 +1,44 @@
-import React, { useState } from 'react';
-
 // Utils
 import { defaultSiteColors, getSiteColors, createPageStyleSheet } from '../utils/siteColorUtils';
 
+// Constants
+const LOCAL_STORAGE_SITE_COLORS = 'isomercms_colors'
+
 const useSiteColorsHook = () => {
-    const [siteColors, setSiteColors] = useState(defaultSiteColors)
+    const getLocalStorageSiteColors = () => {
+        const localStorageSiteColors = JSON.parse(localStorage.getItem(LOCAL_STORAGE_SITE_COLORS))
+        return localStorageSiteColors
+    }
+
+    const setLocalStorageSiteColors = (newSiteColors) => {
+        localStorage.setItem(LOCAL_STORAGE_SITE_COLORS, JSON.stringify(newSiteColors))
+    }
 
     const retrieveSiteColors = async (siteName) => {
-        if (!siteColors[siteName]) {
+        const siteColors = getLocalStorageSiteColors()
+        console.log(siteColors, 'test')
+        // if (!siteColors[siteName]) {
+        if (!siteColors || !siteColors[siteName]) {
+
             const {
                 primaryColor,
                 secondaryColor,
             } = await getSiteColors(siteName)
     
-            setSiteColors((prevState) => ({
-                ...prevState,
+            setLocalStorageSiteColors({
+                ...siteColors,
                 [siteName]: {
                     primaryColor,
                     secondaryColor,
-                }
-            }))
+                },
+            })
         }
     }
 
     const generatePageStyleSheet = (siteName) => {
+        const siteColors = getLocalStorageSiteColors()
+        console.log(siteColors)
+
         let primaryColor = defaultSiteColors.default.primaryColor
         let secondaryColor = defaultSiteColors.default.secondaryColor
 
@@ -39,11 +54,10 @@ const useSiteColorsHook = () => {
         createPageStyleSheet(siteName, primaryColor, secondaryColor)
     }
 
-    return [
-        siteColors,
+    return {
         retrieveSiteColors,
         generatePageStyleSheet,
-    ]
+    }
 }
 
 export default useSiteColorsHook;

--- a/src/hooks/useSiteColorsHook.jsx
+++ b/src/hooks/useSiteColorsHook.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+
+// Utils
+import { defaultSiteColors, getSiteColors, createPageStyleSheet } from '../utils/siteColorUtils';
+
+const useSiteColorsHook = () => {
+    const [siteColors, setSiteColors] = useState(defaultSiteColors)
+
+    const retrieveSiteColors = async (siteName) => {
+        if (!siteColors[siteName]) {
+            const {
+                primaryColor,
+                secondaryColor,
+            } = await getSiteColors(siteName)
+    
+            setSiteColors((prevState) => ({
+                ...prevState,
+                [siteName]: {
+                    primaryColor,
+                    secondaryColor,
+                }
+            }))
+        }
+    }
+
+    const generatePageStyleSheet = (siteName) => {
+        let primaryColor = defaultSiteColors.default.primaryColor
+        let secondaryColor = defaultSiteColors.default.secondaryColor
+
+        if (siteColors[siteName]) {
+            const {
+                primaryColor: sitePrimaryColor,
+                secondaryColor: siteSecondaryColor,
+            } = siteColors[siteName]
+            primaryColor = sitePrimaryColor
+            secondaryColor = siteSecondaryColor
+        }
+
+        createPageStyleSheet(siteName, primaryColor, secondaryColor)
+    }
+
+    return [
+        siteColors,
+        retrieveSiteColors,
+        generatePageStyleSheet,
+    ]
+}
+
+export default useSiteColorsHook;

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -1,5 +1,5 @@
 // TODO: Clean up formatting, semi-colons, PropTypes etc
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import { Base64 } from 'js-base64';
@@ -37,6 +37,9 @@ import TemplateFeedbackSection from '../templates/contact-us/FeedbackSection';
 
 import DeleteWarningModal from '../components/DeleteWarningModal';
 import GenericWarningModal from '../components/GenericWarningModal';
+
+// Import contexts
+const { SiteColorsContext } = require('../contexts/SiteColorsContext');
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-array-index-key */
@@ -111,7 +114,9 @@ const displayDeletedFrontMatter = (deletedFrontMatter) => {
   return displayText
 }
 
-const EditContactUs =  ({ match, siteColors, setSiteColors }) => {
+const EditContactUs =  ({ match }) => {
+  const { retrieveSiteColors, generatePageStyleSheet } = useContext(SiteColorsContext)
+
   const { siteName } = match.params;
   const [hasLoaded, setHasLoaded] = useState(false)
   const [scrollRefs, setScrollRefs] = useState({
@@ -159,32 +164,8 @@ const EditContactUs =  ({ match, siteColors, setSiteColors }) => {
     const loadContactUsDetails = async () => {
       // Set page colors
       try {
-        let primaryColor
-        let secondaryColor
-
-        if (!siteColors[siteName]) {
-          const {
-            primaryColor: sitePrimaryColor,
-            secondaryColor: siteSecondaryColor,
-          } = await getSiteColors(siteName)
-
-          primaryColor = sitePrimaryColor
-          secondaryColor = siteSecondaryColor
-
-          if (_isMounted) setSiteColors((prevState) => ({
-            ...prevState,
-            [siteName]: {
-              primaryColor,
-              secondaryColor,
-            }
-          }))
-        } else {
-          primaryColor = siteColors[siteName].primaryColor
-          secondaryColor = siteColors[siteName].secondaryColor
-        }
-
-        createPageStyleSheet(siteName, primaryColor, secondaryColor)
-      
+        await retrieveSiteColors(siteName)
+        generatePageStyleSheet(siteName)
       } catch (err) {
         console.log(err);
       }

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -1,5 +1,5 @@
 // TODO: Clean up formatting, semi-colons, PropTypes etc
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import { Base64 } from 'js-base64';
@@ -13,11 +13,6 @@ import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody, is
 import { sanitiseFrontMatter } from '../utils/contact-us/dataSanitisers';
 import { validateFrontMatter } from '../utils/contact-us/validators';
 import { validateContactType, validateLocationType } from '../utils/validators';
-import {
-  createPageStyleSheet,
-  getSiteColors,
-} from '../utils/siteColorUtils';
-
 
 import EditorSection from '../components/contact-us/Section';
 import Toast from '../components/Toast';
@@ -38,8 +33,8 @@ import TemplateFeedbackSection from '../templates/contact-us/FeedbackSection';
 import DeleteWarningModal from '../components/DeleteWarningModal';
 import GenericWarningModal from '../components/GenericWarningModal';
 
-// Import contexts
-const { SiteColorsContext } = require('../contexts/SiteColorsContext');
+// Import hooks
+import useSiteColorsHook from '../hooks/useSiteColorsHook';
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-array-index-key */
@@ -115,7 +110,7 @@ const displayDeletedFrontMatter = (deletedFrontMatter) => {
 }
 
 const EditContactUs =  ({ match }) => {
-  const { retrieveSiteColors, generatePageStyleSheet } = useContext(SiteColorsContext)
+  const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
 
   const { siteName } = match.params;
   const [hasLoaded, setHasLoaded] = useState(false)

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, createRef, useState } from 'react';
+import React, { useContext, useEffect, createRef, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import { Base64 } from 'js-base64';
@@ -12,10 +12,6 @@ import TemplateInfopicLeftSection from '../templates/homepage/InfopicLeftSection
 import TemplateInfopicRightSection from '../templates/homepage/InfopicRightSection';
 import TemplateResourcesSection from '../templates/homepage/ResourcesSection';
 import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody } from '../utils';
-import {
-  createPageStyleSheet,
-  getSiteColors,
-} from '../utils/siteColorUtils';
 import EditorInfobarSection from '../components/homepage/InfobarSection';
 import EditorInfopicSection from '../components/homepage/InfopicSection';
 import EditorResourcesSection from '../components/homepage/ResourcesSection';
@@ -29,6 +25,9 @@ import { validateSections, validateHighlights, validateDropdownElems } from '../
 import DeleteWarningModal from '../components/DeleteWarningModal';
 import { toast } from 'react-toastify';
 import Toast from '../components/Toast';
+
+// Import contexts
+const { SiteColorsContext } = require('../contexts/SiteColorsContext');
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-array-index-key */
@@ -97,7 +96,9 @@ const enumSection = (type, isErrorConstructor) => {
   }
 };
 
-const EditHomepage = ({ match, siteColors, setSiteColors }) => {
+const EditHomepage = ({ match }) => {
+  const { retrieveSiteColors, generatePageStyleSheet } = useContext(SiteColorsContext)
+
   const { siteName } = match.params;
   const [hasLoaded, setHasLoaded] = useState(false)
   const [scrollRefs, setScrollRefs] = useState([])
@@ -149,32 +150,8 @@ const EditHomepage = ({ match, siteColors, setSiteColors }) => {
     const loadPageDetails = async () => {
       // Set page colors
       try {
-        let primaryColor
-        let secondaryColor
-
-        if (!siteColors[siteName]) {
-          const {
-            primaryColor: sitePrimaryColor,
-            secondaryColor: siteSecondaryColor,
-          } = await getSiteColors(siteName)
-
-          primaryColor = sitePrimaryColor
-          secondaryColor = siteSecondaryColor
-
-          if (_isMounted) setSiteColors((prevState) => ({
-            ...prevState,
-            [siteName]: {
-              primaryColor,
-              secondaryColor,
-            }
-          }))
-        } else {
-          primaryColor = siteColors[siteName].primaryColor
-          secondaryColor = siteColors[siteName].secondaryColor
-        }
-
-        createPageStyleSheet(siteName, primaryColor, secondaryColor)
-      
+        await retrieveSiteColors(siteName)
+        generatePageStyleSheet(siteName)
       } catch (err) {
         console.log(err);
       }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, createRef, useState } from 'react';
+import React, { useEffect, createRef, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import { Base64 } from 'js-base64';
@@ -26,8 +26,8 @@ import DeleteWarningModal from '../components/DeleteWarningModal';
 import { toast } from 'react-toastify';
 import Toast from '../components/Toast';
 
-// Import contexts
-const { SiteColorsContext } = require('../contexts/SiteColorsContext');
+// Import hooks
+import useSiteColorsHook from '../hooks/useSiteColorsHook';
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-array-index-key */
@@ -97,7 +97,7 @@ const enumSection = (type, isErrorConstructor) => {
 };
 
 const EditHomepage = ({ match }) => {
-  const { retrieveSiteColors, generatePageStyleSheet } = useContext(SiteColorsContext)
+  const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
 
   const { siteName } = match.params;
   const [hasLoaded, setHasLoaded] = useState(false)
@@ -148,7 +148,7 @@ const EditHomepage = ({ match }) => {
   useEffect(() => {
     let _isMounted = true
     const loadPageDetails = async () => {
-      // Set page colors
+      // // Set page colors
       try {
         await retrieveSiteColors(siteName)
         generatePageStyleSheet(siteName)

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Redirect } from "react-router-dom";
 import axios from 'axios';
 import Bluebird from 'bluebird';
@@ -47,8 +47,8 @@ import HyperlinkModal from '../components/HyperlinkModal';
 import MediaModal from '../components/media/MediaModal';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
-// Import contexts
-const { SiteColorsContext } = require('../contexts/SiteColorsContext');
+// Import hooks
+import useSiteColorsHook from '../hooks/useSiteColorsHook';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -99,7 +99,7 @@ const getBackButtonInfo = (resourceCategory, collectionName, siteName) => {
 }
 
 const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) => {
-  const { retrieveSiteColors, generatePageStyleSheet } = useContext(SiteColorsContext)
+  const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
 
   const { collectionName, fileName, siteName, resourceName } = match.params;
   const apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { Redirect } from "react-router-dom";
 import axios from 'axios';
 import Bluebird from 'bluebird';
@@ -36,10 +36,6 @@ import {
   tableButton,
   guideButton,
 } from '../utils/markdownToolbar';
-import {
-  createPageStyleSheet,
-  getSiteColors,
-} from '../utils/siteColorUtils';
 import 'easymde/dist/easymde.min.css';
 import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -50,6 +46,9 @@ import LoadingButton from '../components/LoadingButton';
 import HyperlinkModal from '../components/HyperlinkModal';
 import MediaModal from '../components/media/MediaModal';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
+
+// Import contexts
+const { SiteColorsContext } = require('../contexts/SiteColorsContext');
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -99,7 +98,9 @@ const getBackButtonInfo = (resourceCategory, collectionName, siteName) => {
   }
 }
 
-const EditPage = ({ match, isResourcePage, isCollectionPage, siteColors, setSiteColors, history, type }) => {
+const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) => {
+  const { retrieveSiteColors, generatePageStyleSheet } = useContext(SiteColorsContext)
+
   const { collectionName, fileName, siteName, resourceName } = match.params;
   const apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })
   const { title, type: resourceType, date } = extractMetadataFromFilename(isResourcePage, isCollectionPage, fileName)
@@ -132,32 +133,8 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, siteColors, setSite
     const loadPageDetails = async () => {
       // Set page colors
       try {
-        let primaryColor
-        let secondaryColor
-
-        if (!siteColors[siteName]) {
-          const {
-            primaryColor: sitePrimaryColor,
-            secondaryColor: siteSecondaryColor,
-          } = await getSiteColors(siteName)
-
-          primaryColor = sitePrimaryColor
-          secondaryColor = siteSecondaryColor
-
-          if (_isMounted) setSiteColors((prevState) => ({
-            ...prevState,
-            [siteName]: {
-              primaryColor,
-              secondaryColor,
-            }
-          }))
-        } else {
-          primaryColor = siteColors[siteName].primaryColor
-          secondaryColor = siteColors[siteName].secondaryColor
-        }
-
-        createPageStyleSheet(siteName, primaryColor, secondaryColor)
-
+        await retrieveSiteColors(siteName)
+        generatePageStyleSheet(siteName)
       } catch (err) {
         console.log(err);
       }

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 
@@ -14,15 +14,16 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 // Import utils
 import { prettifyPageFileName } from '../utils';
-import {
-  getSiteColors,
-} from '../utils/siteColorUtils';
 
+// Import contexts
+const { SiteColorsContext } = require('../contexts/SiteColorsContext');
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
-const Workspace = ({ match, location, siteColors, setSiteColors }) => {
+const Workspace = ({ match, location }) => {
+    const { retrieveSiteColors } = useContext(SiteColorsContext)
+
     const { siteName } = match.params;
 
     const [collections, setCollections] = useState()
@@ -33,20 +34,7 @@ const Workspace = ({ match, location, siteColors, setSiteColors }) => {
       let _isMounted = true
       const fetchData = async () => {
         try {
-          if (!siteColors[siteName]) {
-            const {
-              primaryColor,
-              secondaryColor,
-            } = await getSiteColors(siteName)
-    
-            if (_isMounted) setSiteColors((prevState) => ({
-              ...prevState,
-              [siteName]: {
-                primaryColor,
-                secondaryColor,
-              }
-            }))
-          }
+          await retrieveSiteColors(siteName)
         } catch (e) {
           console.log(e)
         }

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -15,14 +15,14 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 // Import utils
 import { prettifyPageFileName } from '../utils';
 
-// Import contexts
-const { SiteColorsContext } = require('../contexts/SiteColorsContext');
+// Import hooks
+import useSiteColorsHook from '../hooks/useSiteColorsHook';
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
 const Workspace = ({ match, location }) => {
-    const { retrieveSiteColors } = useContext(SiteColorsContext)
+    const { retrieveSiteColors } = useSiteColorsHook()
 
     const { siteName } = match.params;
 

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -7,7 +7,7 @@ const DEFAULT_ISOMER_PRIMARY_COLOR = '#6031b6';
 const DEFAULT_ISOMER_SECONDARY_COLOR = '#4372d6';
 
 const defaultSiteColors = {
-    defult: {
+    default: {
         primaryColor: DEFAULT_ISOMER_PRIMARY_COLOR,
         secondaryColor: DEFAULT_ISOMER_SECONDARY_COLOR,
     }


### PR DESCRIPTION
## Overview

Currently, our app re-renders with a distracting flash when we retrieve an update a repo's site colors. 

_Gif demonstrating the problem_
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/31984694/107332471-2f67ec80-6aef-11eb-8d74-2af5960bdf75.gif)
_Upon reload of the page, it displays the default color palette and then flashes to the new color palette_

This is probably* because of a couple of reasons:
- site colors was stored as a state variable at the root app level, which causes a re-render of the root app
- even if we do not pass site colors as a prop, we use the `render` prop in our `ProtectedRoute` HOC, which causes a re-render of the layout component being passed to the HOC

This PR solves this problem by storing site colors in local storage instead. The site color reading and writing processes are abstracted into a custom hook, which greatly reduces the number of lines of code needed to implement it for each component.

*I say probably because I am not 100% sure that these are the exact causes