### PR TITLE
Feat/edit nav bar page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import EditContactUs from './layouts/EditContactUs';
 import Resources from './layouts/Resources';
 import Menus from './layouts/Menus';
 import EditNav from './layouts/EditNav';
+import EditNavBar from './layouts/EditNavBar'
 import Settings from './layouts/Settings';
 import NotFoundPage from './components/NotFoundPage'
 import ProtectedRoute from './components/ProtectedRoute'
@@ -152,6 +153,7 @@ function App() {
                   <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
                   <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
                   <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/menu" component={EditNavBar} />
                   <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
                   <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />
                   <ProtectedRouteWithProps exact path="/sites" component={Sites} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,7 +153,7 @@ function App() {
                   <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
                   <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
                   <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
-                  <ProtectedRouteWithProps path="/sites/:siteName/menu" component={EditNavBar} />
+                  <ProtectedRouteWithProps path="/sites/:siteName/navbar" component={EditNavBar} />
                   <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
                   <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />
                   <ProtectedRouteWithProps exact path="/sites" component={Sites} />

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -130,7 +130,7 @@ const FolderCard = ({
           <i className={`bx bx-md text-dark ${generateImage(pageType)} ${contentStyles.componentIcon}`} />
           <span className={`${contentStyles.componentFolderName} align-self-center ml-4 mr-auto`}>{displayText}</span>
           {
-            pageType === 'homepage' || pageType === 'contact-us'
+            pageType === 'homepage' || pageType === 'contact-us' || pageType === 'nav'
             ? ''
             : (
               <div className={`position-relative`}>

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -54,6 +54,8 @@ const FolderCard = ({
         return `/sites/${siteName}/resources/${category}`
       case 'contact-us':
         return `/sites/${siteName}/contact-us`
+      case 'nav':
+        return `/sites/${siteName}/navbar`
       default:
         return ''
     }
@@ -65,6 +67,8 @@ const FolderCard = ({
         return 'bxs-home-circle'
       case 'contact-us':
         return 'bxs-phone'
+      case 'nav':
+        return 'bxs-compass'
       default: 
         return 'bxs-folder'
     }

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -56,7 +56,7 @@ const NavElem = ({
 
   const generateTitle = () => {
     if (collection) {
-      return `Collection: ${title}`
+      return `Folder: ${title}`
     }
     if (sublinks) {
       return `Sublinks: ${title}`
@@ -92,11 +92,11 @@ const NavElem = ({
               {
                 collection &&
                 <>
-                  <p className={elementStyles.formLabel}>Collection</p>
+                  <p className={elementStyles.formLabel}>Folder</p>
                   <Select
                     className="w-100"
                     onChange={collectionDropdownHandler}
-                    placeholder={"Select a collection..."}
+                    placeholder={"Select a folder..."}
                     defaultValue={{
                       value: collection,
                       label: collection,
@@ -167,7 +167,7 @@ const NavSection = ({
     ... options.length > 0 
       ? [{
         value: 'collectionLink',
-        label: 'Collection',
+        label: 'Folder',
       }]
       : [],
     ... !hasResources 
@@ -251,7 +251,7 @@ const NavSection = ({
         <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Link</button>
       </div>
       <span className={elementStyles.info}>
-        Note: you can specify a collection or resource room to automatically populate its links. Only one resource room link is allowed. Select "Sublinks" if you want to specify your own links.
+        Note: you can specify a folder or resource room to automatically populate its links. Only one resource room link is allowed. Select "Sublinks" if you want to specify your own links.
       </span>
     </>
   )

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -251,7 +251,7 @@ const NavSection = ({
         <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Link</button>
       </div>
       <span className={elementStyles.info}>
-        Note: you can specify a collection or resource room to automatically populate its links. Select "Sublinks" if you want to specify your own links.
+        Note: you can specify a collection or resource room to automatically populate its links. Only one resource room link is allowed. Select "Sublinks" if you want to specify your own links.
       </span>
     </>
   )

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -6,6 +6,7 @@ import styles from '../../styles/App.module.scss';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import FormField from '../FormField';
 import NavSublinkSection from './NavSublinkSection'
+import { isEmpty } from '../../utils';
 
 /* eslint
   react/no-array-index-key: 0
@@ -20,12 +21,15 @@ const NavElem = ({
   url,
   linkIndex,
   sublinks,
+  isResource,
   onFieldChange,
   createHandler,
   deleteHandler,
   displayHandler,
   shouldDisplay,
   displaySublinks,
+  linkErrors,
+  sublinkErrors,
 }) => {
   const collectionDropdownHandler = (newValue) => {
     let event;
@@ -57,14 +61,14 @@ const NavElem = ({
     if (sublinks) {
       return `Sublinks: ${title}`
     }
-    if (url) {
-      return `Page: ${title}`
+    if (isResource) {
+      return `Resource: ${title}`
     }
-    return `Resource: ${title}`
+    return `Page: ${title}`
   }
 
   return (
-    <div className={elementStyles.card}>
+    <div className={`${elementStyles.card} ${!shouldDisplay && (!isEmpty(linkErrors) || !isEmpty(sublinkErrors)) ? elementStyles.error : ''}`}>
       <div className={elementStyles.cardHeader}>
         <h2>
           {generateTitle()}
@@ -83,6 +87,7 @@ const NavElem = ({
                 value={title}
                 isRequired
                 onFieldChange={onFieldChange}
+                errorMessage={linkErrors.title}
               />
               {
                 collection &&
@@ -101,12 +106,13 @@ const NavElem = ({
                 </>
               }
               {
-                (url || sublinks) &&
+                (!collection && !isResource) &&
                 <FormField
                   title="Permalink"
                   id={`link-${linkIndex}-url`}
                   value={url}
                   onFieldChange={onFieldChange}
+                  errorMessage={linkErrors.url}
                 />
               }
               {
@@ -119,6 +125,7 @@ const NavElem = ({
                   onFieldChange={onFieldChange}
                   displayHandler={displayHandler}
                   displaySublinks={displaySublinks}
+                  errors={sublinkErrors}
                 />
               }
             </div>
@@ -142,6 +149,7 @@ const NavSection = ({
   displayLinks,
   displaySublinks,
   hasResources,
+  errors,
 }) => {
   const [newSectionType, setNewSectionType] = useState()
   const selectInputRef = useRef()
@@ -209,6 +217,7 @@ const NavSection = ({
                             collection={link.collection}
                             sublinks={link.sublinks}
                             url={link.url}
+                            isResource={link.resource_room}
                             linkIndex={linkIndex}
                             onFieldChange={onFieldChange}
                             createHandler={createHandler}
@@ -216,6 +225,8 @@ const NavSection = ({
                             displayHandler={displayHandler}
                             shouldDisplay={displayLinks[linkIndex]}
                             displaySublinks={displaySublinks[linkIndex]}
+                            linkErrors={errors.links[linkIndex]}
+                            sublinkErrors={errors.sublinks[linkIndex]}
                           />
                         </div>
                       )}
@@ -262,6 +273,7 @@ NavElem.propTypes = {
       label: PropTypes.string.isRequired,
     }),
   ).isRequired,
+  isResource: PropTypes.bool,
   linkIndex: PropTypes.number.isRequired,
   onFieldChange: PropTypes.func.isRequired,
   createHandler: PropTypes.func.isRequired,
@@ -269,6 +281,16 @@ NavElem.propTypes = {
   displayHandler: PropTypes.func.isRequired,
   shouldDisplay: PropTypes.bool,
   displaySublinks: PropTypes.arrayOf(PropTypes.bool),
+  linkErrors: PropTypes.shape({
+    title: PropTypes.string,
+    url: PropTypes.string,
+  }),
+  sublinkErrors: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+    }),
+  )
 };
 
 NavSection.propTypes = {
@@ -299,4 +321,21 @@ NavSection.propTypes = {
   displayLinks: PropTypes.arrayOf(PropTypes.bool).isRequired,
   displaySublinks: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.bool)).isRequired,
   hasResources: PropTypes.bool.isRequired,
+  errors: PropTypes.shape({
+    links: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ),
+    sublinks: PropTypes.arrayOf(
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          title: PropTypes.string,
+          url: PropTypes.string,
+        }),
+      )
+    ),
+  })
+  
 };

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Droppable, Draggable } from 'react-beautiful-dnd';
+import styles from '../../styles/App.module.scss';
+import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
+import FormField from '../FormField';
+import Dropdown from '../Dropdown'
+import NavSublinkSection from './NavSublinkSection'
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const defaultText = '--Choose a collection--'
+
+const NavElem = ({
+  title,
+  options,
+  collection,
+  isResourceRoom,
+  linkIndex,
+  sublinks,
+  onFieldChange,
+  createHandler,
+  deleteHandler,
+  displayHandler,
+  shouldDisplay,
+  displaySublinks,
+}) => (
+  <div className={elementStyles.card}>
+    <div className={elementStyles.cardHeader}>
+      <h2>
+        {title}
+      </h2>
+      <button type="button" id={`link-${linkIndex}-toggle`} onClick={displayHandler}>
+        <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`link-${linkIndex}-icon`} />
+      </button>
+    </div>
+    { shouldDisplay
+      ? (
+        <>
+          <div className={elementStyles.cardContent}>
+            <FormField
+              title="Nav title"
+              id={`link-${linkIndex}-title`}
+              value={title}
+              isRequired
+              onFieldChange={onFieldChange}
+            />
+            <h2>
+              Choose a collection
+            </h2>
+            <span className={elementStyles.info}>
+              Note: you can specify a collection or resource room to automatically populate its links. Select "Create Sublinks" if you want to specify your own links.
+            </span>
+            <Dropdown 
+              options={options}
+              defaultOption={defaultText}
+              emptyDefault={true}
+              name='newSection'
+              id='section-new'
+              onFieldChange={onFieldChange}
+            />
+            {
+              collection === '' && !isResourceRoom &&
+              <NavSublinkSection
+                linkIndex={linkIndex}
+                sublinks={sublinks}
+                createHandler={createHandler}
+                deleteHandler={deleteHandler}
+                onFieldChange={onFieldChange}
+                displayHandler={displayHandler}
+                displaySublinks={displaySublinks[linkIndex]}
+              />
+            }
+          </div>
+          <div className={elementStyles.inputGroup}>
+            <button type="button" id={`link-${linkIndex}-delete`} className={`ml-auto ${elementStyles.warning}`} onClick={deleteHandler}>Delete link</button>
+          </div>
+        </>
+      )
+      : null}
+  </div>
+);
+
+const NavSection = ({
+  links,
+  options,
+  createHandler,
+  deleteHandler,
+  onFieldChange,
+  displayHandler,
+  displayLinks,
+  displaySublinks,
+}) => (
+  <>
+    <Droppable droppableId="link" type="link">
+      {(droppableProvided) => (
+        /* eslint-disable react/jsx-props-no-spreading */
+        <div
+          className={styles.card}
+          ref={droppableProvided.innerRef}
+          {...droppableProvided.droppableProps}
+        >
+          { (links && links.length > 0)
+            ? <>
+                <b>Links</b>
+                {links.map((link, linkIndex) => (
+                  <Draggable
+                    draggableId={`link-${linkIndex}-draggable`}
+                    index={linkIndex}
+                  >
+                    {(draggableProvided) => (
+                      <div
+                        className={styles.card}
+                        key={linkIndex}
+                        {...draggableProvided.draggableProps}
+                        {...draggableProvided.dragHandleProps}
+                        ref={draggableProvided.innerRef}
+                      >
+                        <NavElem
+                          key={`link-${linkIndex}`}
+                          title={links[linkIndex].title}
+                          options={options}
+                          collection={link.collection}
+                          isResourceRoom={link.resource_room}
+                          sublinks={link.sublinks}
+                          linkIndex={linkIndex}
+                          onFieldChange={onFieldChange}
+                          deleteHandler={deleteHandler}
+                          displayHandler={displayHandler}
+                          shouldDisplay={displayLinks[linkIndex]}
+                          displaySublinks={displaySublinks[linkIndex]}
+                        />
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+              </>
+            : null}
+          {droppableProvided.placeholder}
+        </div>
+      )}
+    </Droppable>
+    <button type="button" id={`link-${links.length}-create`} className={`ml-auto ${elementStyles.blue}`} onClick={createHandler}>Create New Link</button>
+  </>
+);
+
+export default NavSection;

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -141,7 +141,6 @@ const NavSection = ({
   displayHandler,
   displayLinks,
   displaySublinks,
-  resourceRoomName,
 }) => {
   const [newSectionType, setNewSectionType] = useState()
   const sectionCreationHandler = () => {
@@ -203,7 +202,6 @@ const NavSection = ({
                             options={options}
                             collection={link.collection}
                             isResourceRoom={link.resource_room}
-                            resourceRoomName={resourceRoomName}
                             sublinks={link.sublinks}
                             url={link.url}
                             linkIndex={linkIndex}

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -186,6 +186,7 @@ const NavSection = ({
                   {links.map((link, linkIndex) => (
                     <Draggable
                       draggableId={`link-${linkIndex}-draggable`}
+                      key={`link-${linkIndex}-draggable`}
                       index={linkIndex}
                     >
                       {(draggableProvided) => (

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -198,10 +198,9 @@ const NavSection = ({
                         >
                           <NavElem
                             key={`link-${linkIndex}`}
-                            title={links[linkIndex].title}
+                            title={link.title}
                             options={options}
                             collection={link.collection}
-                            isResourceRoom={link.resource_room}
                             sublinks={link.sublinks}
                             url={link.url}
                             linkIndex={linkIndex}
@@ -239,3 +238,57 @@ const NavSection = ({
 };
 
 export default NavSection;
+
+NavElem.propTypes = {
+  title: PropTypes.string,
+  url: PropTypes.string,
+  collection: PropTypes.string,
+  sublinks: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+    }),
+  ),
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  linkIndex: PropTypes.number.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  createHandler: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool,
+  displaySublinks: PropTypes.arrayOf(PropTypes.bool),
+};
+
+NavSection.propTypes = {
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+      collection: PropTypes.string,
+      resource_room: PropTypes.bool,
+      sublinks: PropTypes.arrayOf(
+        PropTypes.shape({
+          title: PropTypes.string,
+          url: PropTypes.string,
+        }),
+      )
+    }),
+  ).isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  createHandler: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  displayLinks: PropTypes.arrayOf(PropTypes.bool).isRequired,
+  displaySublinks: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.bool)).isRequired,
+};

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -223,13 +223,13 @@ const NavSection = ({
         )}
       </Droppable>
       <div className='d-flex justify-content-between'>
-      <Select
-        className='w-50'
-        onChange={(option) => setNewSectionType(option ? option.value : '')}
-        placeholder={"Select link type..."}
-        options={sectionCreationOptions}
-      />
-      <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Link</button>
+        <Select
+          className='w-50'
+          onChange={(option) => setNewSectionType(option ? option.value : '')}
+          placeholder={"Select link type..."}
+          options={sectionCreationOptions}
+        />
+        <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Link</button>
       </div>
       <span className={elementStyles.info}>
         Note: you can specify a collection or resource room to automatically populate its links. Select "Sublinks" if you want to specify your own links.

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -99,10 +99,7 @@ const NavElem = ({
                 isRequired
                 onFieldChange={onFieldChange}
               />
-              <p className={elementStyles.formLabel}>Choose a label</p>
-              <span className={elementStyles.info}>
-                Note: you can specify a collection or resource room to automatically populate its links. Select "Create Sublinks" if you want to specify your own links.
-              </span>
+              <p className={elementStyles.formLabel}>Collection</p>
               <Select
                 isClearable
                 className="w-100"
@@ -111,6 +108,9 @@ const NavElem = ({
                 defaultValue={generateDefaultValue()}
                 options={options}
               />
+              <span className={elementStyles.info}>
+                Note: you can specify a collection or resource room to automatically populate its links. Select "Create Sublinks" if you want to specify your own links.
+              </span>
               {
                 sublinks &&
                 <NavSublinkSection
@@ -181,6 +181,7 @@ const NavSection = ({
                           url={link.url}
                           linkIndex={linkIndex}
                           onFieldChange={onFieldChange}
+                          createHandler={createHandler}
                           deleteHandler={deleteHandler}
                           displayHandler={displayHandler}
                           shouldDisplay={displayLinks[linkIndex]}

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -164,10 +164,12 @@ const NavSection = ({
     createHandler(event)
   }
   const sectionCreationOptions = [
-    {
-      value: 'collectionLink',
-      label: 'Collection',
-    },
+    ... options.length > 0 
+      ? [{
+        value: 'collectionLink',
+        label: 'Collection',
+      }]
+      : [],
     ... !hasResources 
       ? [{
         value: 'resourceLink',

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 import Select from 'react-select';
@@ -141,9 +141,12 @@ const NavSection = ({
   displayHandler,
   displayLinks,
   displaySublinks,
+  hasResources,
 }) => {
   const [newSectionType, setNewSectionType] = useState()
+  const selectInputRef = useRef()
   const sectionCreationHandler = () => {
+    selectInputRef.current.select.clearValue()
     const event = {
       target: {
         id: `link-create`,
@@ -157,10 +160,12 @@ const NavSection = ({
       value: 'collectionLink',
       label: 'Collection',
     },
-    {
-      value: 'resourceLink',
-      label: 'Resource Room',
-    },
+    ... !hasResources 
+      ? [{
+        value: 'resourceLink',
+        label: 'Resource Room',
+      }]
+      : [],
     {
       value: 'pageLink',
       label: 'Single Page',
@@ -224,6 +229,7 @@ const NavSection = ({
       </Droppable>
       <div className='d-flex justify-content-between'>
         <Select
+          ref={selectInputRef}
           className='w-50'
           onChange={(option) => setNewSectionType(option ? option.value : '')}
           placeholder={"Select link type..."}
@@ -292,4 +298,5 @@ NavSection.propTypes = {
   displayHandler: PropTypes.func.isRequired,
   displayLinks: PropTypes.arrayOf(PropTypes.bool).isRequired,
   displaySublinks: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.bool)).isRequired,
+  hasResources: PropTypes.bool.isRequired,
 };

--- a/src/components/navbar/NavSublinkSection.jsx
+++ b/src/components/navbar/NavSublinkSection.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Droppable, Draggable } from 'react-beautiful-dnd';
+import styles from '../../styles/App.module.scss';
+import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
+import FormField from '../FormField';
+
+const SublinkElem = ({
+  title,
+  url,
+  linkIndex,
+  sublinkIndex,
+  onFieldChange,
+  deleteHandler,
+  shouldDisplay,
+  displayHandler,
+}) => (
+  <div className={elementStyles.card}>
+    <div className={elementStyles.cardHeader}>
+      <h2>
+        {title}
+      </h2>
+      <button type="button" id={`sublink-${linkIndex}-${sublinkIndex}-toggle`} onClick={displayHandler}>
+        <i className={`bx ${shouldDisplay ? 'bx-chevron-down' : 'bx-chevron-right'}`} id={`sublink-${linkIndex}-${sublinkIndex}-icon`} />
+      </button>
+    </div>
+    { shouldDisplay
+      ? (
+        <>
+          <div className={elementStyles.cardContent}>
+            <FormField
+              title="Sublink title"
+              id={`sublink-${linkIndex}-${sublinkIndex}-title`}
+              value={title}
+              isRequired
+              onFieldChange={onFieldChange}
+            />
+            <FormField
+              title="Sublink URL"
+              id={`sublink-${linkIndex}-${sublinkIndex}-url`}
+              value={url}
+              isRequired
+              onFieldChange={onFieldChange}
+            />
+          </div>
+          <div className={elementStyles.inputGroup}>
+            <button type="button" id={`sublink-${linkIndex}-${sublinkIndex}-delete`} className={`ml-auto ${elementStyles.warning}`} onClick={deleteHandler}>Delete sublink</button>
+          </div>
+        </>
+      )
+      : null}
+  </div>
+);
+
+const NavSublinkSection = ({
+  linkIndex,
+  sublinks,
+  createHandler,
+  deleteHandler,
+  onFieldChange,
+  displayHandler,
+  displaySublinks
+}) => (
+  <Droppable droppableId="sublink" type="sublink">
+    {(droppableProvided) => (
+      /* eslint-disable react/jsx-props-no-spreading */
+      <div
+        className={styles.card}
+        ref={droppableProvided.innerRef}
+        {...droppableProvided.droppableProps}
+      >
+        { (sublinks && sublinks.length > 0)
+          ? <>
+              <b>Sublinks</b>
+              {sublinks.map((sublink, sublinkIndex) => (
+                <Draggable
+                  draggableId={`sublink-${linkIndex}-${sublinkIndex}-draggable`}
+                  index={sublinkIndex}
+                >
+                  {(draggableProvided) => (
+                    <div
+                      className={styles.card}
+                      key={sublinkIndex}
+                      {...draggableProvided.draggableProps}
+                      {...draggableProvided.dragHandleProps}
+                      ref={draggableProvided.innerRef}
+                    >
+                      <SublinkElem
+                        key={`sublink-${linkIndex}-${sublinkIndex}`}
+                        title={sublinks[sublinkIndex].title}
+                        url={sublinks[sublinkIndex].url}
+                        linkIndex={linkIndex}
+                        sublinkIndex={sublinkIndex}
+                        onFieldChange={onFieldChange}
+                        deleteHandler={deleteHandler}
+                        displayHandler={displayHandler}
+                        shouldDisplay={displaySublinks[sublinkIndex]}
+                      />
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+            </>
+          : null}
+        {droppableProvided.placeholder}
+        <button type="button" id={`sublink-${linkIndex}-${sublinks.length}-create`} className={`ml-auto ${elementStyles.blue}`} onClick={createHandler}>Create Sublink</button>
+      </div>
+    )}
+  </Droppable>
+)
+
+export default NavSublinkSection

--- a/src/components/navbar/NavSublinkSection.jsx
+++ b/src/components/navbar/NavSublinkSection.jsx
@@ -87,8 +87,8 @@ const NavSublinkSection = ({
                     >
                       <SublinkElem
                         key={`sublink-${linkIndex}-${sublinkIndex}`}
-                        title={sublinks[sublinkIndex].title}
-                        url={sublinks[sublinkIndex].url}
+                        title={sublink.title}
+                        url={sublink.url}
                         linkIndex={linkIndex}
                         sublinkIndex={sublinkIndex}
                         onFieldChange={onFieldChange}
@@ -110,3 +110,29 @@ const NavSublinkSection = ({
 )
 
 export default NavSublinkSection
+
+SublinkElem.propTypes = {
+  title: PropTypes.string,
+  url: PropTypes.string,
+  linkIndex: PropTypes.number.isRequired,
+  sublinkIndex: PropTypes.number.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool,
+  displayHandler: PropTypes.func.isRequired,
+};
+
+NavSublinkSection.propTypes = {
+  linkIndex: PropTypes.number,
+  sublinks: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+    }),
+  ),
+  createHandler: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  displaySublinks: PropTypes.arrayOf(PropTypes.bool),
+};

--- a/src/components/navbar/NavSublinkSection.jsx
+++ b/src/components/navbar/NavSublinkSection.jsx
@@ -4,6 +4,7 @@ import { Droppable, Draggable } from 'react-beautiful-dnd';
 import styles from '../../styles/App.module.scss';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import FormField from '../FormField';
+import { isEmpty } from '../../utils';
 
 const SublinkElem = ({
   title,
@@ -14,8 +15,9 @@ const SublinkElem = ({
   deleteHandler,
   shouldDisplay,
   displayHandler,
+  errors,
 }) => (
-  <div className={elementStyles.card}>
+  <div className={`${elementStyles.card} ${!shouldDisplay && !isEmpty(errors) ? elementStyles.error : ''}`}>
     <div className={elementStyles.cardHeader}>
       <h2>
         {title}
@@ -34,6 +36,7 @@ const SublinkElem = ({
               value={title}
               isRequired
               onFieldChange={onFieldChange}
+              errorMessage={errors.title}
             />
             <FormField
               title="Sublink URL"
@@ -41,6 +44,7 @@ const SublinkElem = ({
               value={url}
               isRequired
               onFieldChange={onFieldChange}
+              errorMessage={errors.url}
             />
           </div>
           <div className={elementStyles.inputGroup}>
@@ -59,7 +63,8 @@ const NavSublinkSection = ({
   deleteHandler,
   onFieldChange,
   displayHandler,
-  displaySublinks
+  displaySublinks,
+  errors,
 }) => (
   <Droppable droppableId={`sublink-${linkIndex}`} type="sublink">
     {(droppableProvided) => (
@@ -96,6 +101,7 @@ const NavSublinkSection = ({
                         deleteHandler={deleteHandler}
                         displayHandler={displayHandler}
                         shouldDisplay={displaySublinks[sublinkIndex]}
+                        errors={errors[sublinkIndex]}
                       />
                     </div>
                   )}
@@ -121,6 +127,10 @@ SublinkElem.propTypes = {
   deleteHandler: PropTypes.func.isRequired,
   shouldDisplay: PropTypes.bool,
   displayHandler: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    title: PropTypes.string,
+    url: PropTypes.string,
+  }),
 };
 
 NavSublinkSection.propTypes = {
@@ -136,4 +146,10 @@ NavSublinkSection.propTypes = {
   onFieldChange: PropTypes.func.isRequired,
   displayHandler: PropTypes.func.isRequired,
   displaySublinks: PropTypes.arrayOf(PropTypes.bool),
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+    }),
+  )
 };

--- a/src/components/navbar/NavSublinkSection.jsx
+++ b/src/components/navbar/NavSublinkSection.jsx
@@ -61,7 +61,7 @@ const NavSublinkSection = ({
   displayHandler,
   displaySublinks
 }) => (
-  <Droppable droppableId="sublink" type="sublink">
+  <Droppable droppableId={`sublink-${linkIndex}`} type="sublink">
     {(droppableProvided) => (
       /* eslint-disable react/jsx-props-no-spreading */
       <div

--- a/src/components/navbar/NavSublinkSection.jsx
+++ b/src/components/navbar/NavSublinkSection.jsx
@@ -75,6 +75,7 @@ const NavSublinkSection = ({
               {sublinks.map((sublink, sublinkIndex) => (
                 <Draggable
                   draggableId={`sublink-${linkIndex}-${sublinkIndex}-draggable`}
+                  key={`sublink-${linkIndex}-${sublinkIndex}-draggable`}
                   index={sublinkIndex}
                 >
                   {(draggableProvided) => (

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -1,0 +1,485 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import update from 'immutability-helper';
+import { DragDropContext } from 'react-beautiful-dnd';
+import { Redirect } from 'react-router-dom'
+import { toast } from 'react-toastify';
+
+import { DEFAULT_ERROR_TOAST_MSG } from '../utils';
+
+import Toast from '../components/Toast';
+import NavSection from '../components/navbar/NavSection'
+
+import '../styles/isomer-template.scss';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
+
+import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
+
+import DeleteWarningModal from '../components/DeleteWarningModal';
+
+const RADIX_PARSE_INT = 10
+
+const EditNavBar =  ({ match }) => {
+  const { siteName } = match.params
+
+  const [links, setLinks] = useState([])
+  const [collections, setCollections] = useState([])
+  const [options, setOptions] = useState([])
+  const [displayLinks, setDisplayLinks] = useState([])
+  const [displaySublinks, setDisplaySublinks] = useState([])
+  const [shouldRedirectToNotFound, setShouldRedirectToNotFound] = useState(false)
+  const [hasLoaded, setHasLoaded] = useState(false)
+  const [itemPendingForDelete, setItemPendingForDelete] = useState(
+    {
+      id: '',
+      type: '',
+    }
+  )
+
+
+  const LinkSectionConstructor = () => ({
+    title: 'Link Title',
+    collection: collections[0],
+  });
+  
+  const SublinkSectionConstructor = () => ({
+    title: 'Sublink Title',
+    url: ''
+  });
+  
+  const enumSection = (type) => {
+    switch (type) {
+      case 'link':
+        return LinkSectionConstructor();
+      case 'sublink':
+        return SublinkSectionConstructor();
+      default:
+        return;
+    }
+  };
+
+  useEffect(() => {
+    let _isMounted = true
+
+    const loadNavBarDetails = async () => {
+      let content
+      try {
+        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/navigation`);
+        content = resp.data;
+      } catch (error) {
+        if (error?.response?.status === 404) {
+          setShouldRedirectToNotFound(true)
+        } else {
+          toast(
+            <Toast notificationType='error' text={`There was a problem trying to load your navigation bar. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
+            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+          );
+        }
+        console.log(error)
+      }
+
+      if (!content) return
+
+      const { links } = content
+
+      // TODO: Load list of all collections
+
+      // TODO: add options for resource room and no collection
+
+      // Add booleans for displaying links and sublinks
+      const displayLinks = _.fill(Array(links.length), false)
+      const displaySublinks = []
+      links.forEach(link => {
+        let numSublinks = 0
+        if ("sublink" in link) {
+          numSublinks = link.sublink.length
+        }
+        displaySublinks.push(_.fill(Array(numSublinks), false))
+      })
+
+      if (_isMounted) {
+        setLinks(links)
+        setHasLoaded(true)
+        setDisplayLinks(displayLinks)
+        setDisplaySublinks(displaySublinks)
+      }
+    }
+
+    loadNavBarDetails()
+
+    return () => {
+      _isMounted = false
+    }
+  }, [])
+
+  const onFieldChange = async (event) => {
+    try {
+      const { id, value } = event.target;
+      const idArray = id.split('-');
+      const elemType = idArray[0];
+
+      switch (elemType) {
+        case 'link': {
+          const linkIndex = parseInt(idArray[1], RADIX_PARSE_INT)
+          const field = idArray[2]
+          const newLinks = update(links, {
+            [linkIndex]: {
+              [field]: {
+                $set: value,
+              },
+            },
+          });
+          setLinks(newLinks)
+          break;
+        }
+        case 'sublink': {
+          const linkIndex = parseInt(idArray[1], RADIX_PARSE_INT)
+          const sublinkIndex = parseInt(idArray[2], RADIX_PARSE_INT)
+          const field = idArray[3]
+          const newLinks = update(links, {
+            [linkIndex]: {
+              sublinks: {
+                [sublinkIndex] : {
+                  [field]: {
+                    $set: value,
+                  },
+                },
+              },
+            },
+          });
+          setLinks(newLinks)
+          break;
+        }
+        default: {
+          return
+        }
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  const createHandler = async (event) => {
+    try {
+      const { id, value } = event.target;
+      const idArray = id.split('-');
+      const elemType = idArray[0];
+
+      switch (elemType) {
+        case 'link': {
+          const newLinks = update(links, {
+            $push: [enumSection(elemType)]
+          })
+          const resetDisplayLinks = _.fill(Array(links.length), false)
+          const resetDisplaySublinks = []
+          links.forEach(link => {
+            let numSublinks = 0
+            if ("sublink" in link) {
+              numSublinks = link.sublink.length
+            }
+            resetDisplaySublinks.push(_.fill(Array(numSublinks), false))
+          })
+          const newDisplayLinks = update(resetDisplayLinks, {
+            $push: [true],
+          });
+          setLinks(newLinks)
+          setDisplayLinks(newDisplayLinks)
+          setDisplaySublinks(resetDisplaySublinks)
+          break
+        }
+        case 'sublink': {
+          const linkIndex = parseInt(idArray[1], RADIX_PARSE_INT)
+          const sublinkIndex = parseInt(idArray[2], RADIX_PARSE_INT)
+          const newLinks = update(links, {
+            [linkIndex]: {
+              sublinks: {
+                [sublinkIndex] : {
+                  $push: [enumSection(elemType)],
+                },
+              },
+            },
+          })
+          const resetDisplaySublinks = []
+          links.forEach(link => {
+            let numSublinks = 0
+            if ("sublink" in link) {
+              numSublinks = link.sublink.length
+            }
+            resetDisplaySublinks.push(_.fill(Array(numSublinks), false))
+          })
+          const newDisplaySublinks = update(resetDisplaySublinks, {
+            [linkIndex]: {
+              $push: [true],
+            },
+          });
+          setLinks(newLinks)
+          setDisplaySublinks(newDisplaySublinks)
+          break
+        }
+        default:
+          return;
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  const deleteHandler = async (id) => {
+    try {
+      const idArray = id.split('-');
+      const elemType = idArray[0];
+
+      switch (elemType) {
+        case 'link': {
+          const linkIndex = parseInt(idArray[1], RADIX_PARSE_INT)
+          const newLinks = update(links, {
+            $splice: [[linkIndex, 1]]
+          })
+          const newDisplayLinks = update(displayLinks, {
+            $splice: [[linkIndex, 1]],
+          })
+          const newDisplaySublinks = update(displaySublinks, {
+            $splice: [[linkIndex, 1]],
+          })
+          setLinks(newLinks)
+          setDisplayLinks(newDisplayLinks)
+          setDisplaySublinks(newDisplaySublinks)
+          break
+        }
+        case 'sublink': {
+          const linkIndex = parseInt(idArray[1], RADIX_PARSE_INT)
+          const sublinkIndex = parseInt(idArray[2], RADIX_PARSE_INT)
+          const newLinks = update(links, {
+            [linkIndex]: {
+              sublinks: {
+                [sublinkIndex] : {
+                  $splice: [[sublinkIndex, 1]]
+                },
+              },
+            },
+          })
+          const newDisplaySublinks = update(displaySublinks, {
+            [linkIndex]: {
+              $splice: [[sublinkIndex, 1]],
+            },
+          })
+          setLinks(newLinks)
+          setDisplaySublinks(newDisplaySublinks)
+          break
+        }
+        default:
+          return;
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  const displayHandler = async (event) => {
+    try {
+      const { id } = event.target;
+      const idArray = id.split('-');
+      const elemType = idArray[0];
+      switch (elemType) {
+        case 'link': {
+          const linkId = idArray[1];
+          let resetDisplayLinks = _.fill(Array(links.length), false)
+          resetDisplayLinks[linkId] = !displayLinks[linkId]
+          const newDisplayLinks = update(displayLinks, {
+            $set: resetDisplayLinks,
+          });
+
+          setDisplayLinks(newDisplayLinks)
+          break;
+        }
+        case 'sublink': {
+          const linkId = idArray[1];
+          const sublinkId = idArray[2]
+          let resetSublinkSections = _.fill(Array(displaySublinks[linkId].length), false)
+          resetSublinkSections[sublinkId] = !displaySublinks[sublinkId]
+          const newDisplaySublinks = update(displaySublinks, {
+            [linkId]: {
+              $set: resetSublinkSections,
+            },
+          });
+
+          setDisplaySublinks(newDisplaySublinks)
+          break;
+        }
+        default:
+          return;
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  const saveNav = async () => {
+    // TODO
+  }
+
+  const onDragEnd = (result) => {
+    const { source, destination, type } = result;
+    console.log(source)
+    console.log(destination)
+    console.log(type)
+
+    // If the user dropped the draggable to no known droppable
+    if (!destination) return;
+
+    // The draggable elem was returned to its original position
+    if (
+      destination.droppableId === source.droppableId
+      && destination.index === source.index
+    ) return;
+
+    let newSections = [];
+    let newErrors = [];
+
+    switch (type) {
+      case 'link': {
+        const draggedLink = links[source.index]
+        const newLinks = update(links, {
+          $splice: [
+            [source.index, 1], // Remove elem from its original position
+            [destination.index, 0, draggedLink], // Splice elem into its new position
+          ],
+        })
+        const displayLinkBool = displayLinks[source.index];
+        const displaySublinkBools = displaySublinks[source.index]
+        const newDisplayLinks = update(displayLinks, {
+          $splice: [
+            [source.index, 1],
+            [destination.index, 0, displayLinkBool],
+          ],
+        })
+        const newDisplaySublinks = update(displaySublinks, {
+          $splice: [
+            [source.index, 1],
+            [destination.index, 0, displaySublinkBools],
+          ],
+        })
+        setLinks(newLinks)
+        setDisplayLinks(newDisplayLinks)
+        setDisplaySublinks(newDisplaySublinks)
+        break
+      } case 'sublink': {
+        const idArray = source.droppableId.split('-');
+        const linkIndex = idArray[1]
+        const draggedSublink = links[linkIndex][source.index]
+        const newLinks = update(links, {
+          [linkIndex]: {
+            sublinks: {
+              $splice: [
+                [source.index, 1],
+                [destination.index, 0, draggedSublink],
+              ],
+            },
+          },
+        })
+        const displaySublinkBool = displaySublinks[linkIndex][source.index]
+        const newDisplaySublinks = update(displaySublinks, {
+          [linkIndex]: {
+            $splice: [
+              [source.index, 1],
+              [destination.index, 0, displaySublinkBool],
+            ],
+          },
+        })
+        setLinks(newLinks)
+        setDisplaySublinks(newDisplaySublinks)
+        break
+      }
+      default:
+        return;
+    }
+  }
+
+  const hasChanges = () => {
+    // TODO
+    // return JSON.stringify(sanitisedOriginalFrontMatter) === JSON.stringify(frontMatter) && JSON.stringify(footerContent) === JSON.stringify(originalFooterContent)
+    return false
+  }
+
+  return (
+    <>
+      {
+        itemPendingForDelete.id
+        && (
+        <DeleteWarningModal
+          onCancel={() => setItemPendingForDelete({ id: null, type: '' })}
+          onDelete={() => { deleteHandler(itemPendingForDelete.id); setItemPendingForDelete({ id: null, type: '' }); }}
+          type={itemPendingForDelete.type}
+        />
+        )
+      }
+      <Header
+        title={"Nav Bar"}
+        shouldAllowEditPageBackNav={hasChanges()}
+        isEditPage="true"
+        backButtonText="Back to My Workspace"
+        backButtonUrl={`/sites/${siteName}/workspace`}
+      />
+      { hasLoaded &&
+        <div className={elementStyles.wrapper}>
+          <div className={editorStyles.homepageEditorSidebar}>
+            <div>
+              <DragDropContext onDragEnd={onDragEnd}>
+                <NavSection
+                  links={links}
+                  options={options}
+                  createHandler={createHandler}
+                  deleteHandler={(event) => setItemPendingForDelete({ id: event.target.id, type: 'Resources Section' })}
+                  onFieldChange={onFieldChange}
+                  displayHandler={displayHandler}
+                  displayLinks={displayLinks}
+                  displaySublinks={displaySublinks}
+                />
+              </DragDropContext>
+            </div>
+          </div>
+          <div className={`${editorStyles.contactUsEditorMain} ` }>
+            {/* navbar content */}
+            <section className="bp-section is-small padding--bottom--lg">
+              <div className="bp-container">
+                <div className="row">
+                  <div className="col is-8 is-offset-2">
+                    {/* TODO: display menu */}
+                    MENU
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+          <div className={editorStyles.pageEditorFooter}>
+            {/* TODO: save button */}
+            SAVE
+          </div>
+        </div>
+      }
+      {
+        shouldRedirectToNotFound &&
+        <Redirect
+          to={{
+              pathname: '/not-found',
+              state: {siteName: siteName}
+          }}
+        />
+      }
+    </>
+  )
+}
+
+export default EditNavBar
+
+EditNavBar.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      siteName: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -209,7 +209,6 @@ const EditNavBar =  ({ match }) => {
               },
             });
           }
-          console.log(newLinks)
           setLinks(newLinks)
           break;
         }
@@ -274,9 +273,7 @@ const EditNavBar =  ({ match }) => {
           const newLinks = update(links, {
             [linkIndex]: {
               sublinks: {
-                [sublinkIndex] : {
-                  $push: [enumSection(elemType)],
-                },
+                $push: [enumSection(elemType)],
               },
             },
           })
@@ -333,9 +330,7 @@ const EditNavBar =  ({ match }) => {
           const newLinks = update(links, {
             [linkIndex]: {
               sublinks: {
-                [sublinkIndex] : {
-                  $splice: [[sublinkIndex, 1]]
-                },
+                $splice: [[sublinkIndex, 1]]
               },
             },
           })
@@ -377,7 +372,7 @@ const EditNavBar =  ({ match }) => {
           const linkId = idArray[1];
           const sublinkId = idArray[2]
           let resetSublinkSections = _.fill(Array(displaySublinks[linkId].length), false)
-          resetSublinkSections[sublinkId] = !displaySublinks[sublinkId]
+          resetSublinkSections[sublinkId] = !displaySublinks[linkId][sublinkId]
           const newDisplaySublinks = update(displaySublinks, {
             [linkId]: {
               $set: resetSublinkSections,
@@ -401,9 +396,6 @@ const EditNavBar =  ({ match }) => {
 
   const onDragEnd = (result) => {
     const { source, destination, type } = result;
-    console.log(source)
-    console.log(destination)
-    console.log(type)
 
     // If the user dropped the draggable to no known droppable
     if (!destination) return;
@@ -413,9 +405,6 @@ const EditNavBar =  ({ match }) => {
       destination.droppableId === source.droppableId
       && destination.index === source.index
     ) return;
-
-    let newSections = [];
-    let newErrors = [];
 
     switch (type) {
       case 'link': {
@@ -447,7 +436,7 @@ const EditNavBar =  ({ match }) => {
       } case 'sublink': {
         const idArray = source.droppableId.split('-');
         const linkIndex = idArray[1]
-        const draggedSublink = links[linkIndex][source.index]
+        const draggedSublink = links[linkIndex].sublinks[source.index]
         const newLinks = update(links, {
           [linkIndex]: {
             sublinks: {

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -128,46 +128,46 @@ const EditNavBar =  ({ match }) => {
 
       if (!navContent) return
 
-      const { links } = navContent
+      const { links: initialLinks } = navContent
 
-      let hasResources = false
+      let navHasResources = false
       // Add booleans for displaying links and sublinks
-      const displayLinks = _.fill(Array(links.length), false)
-      const displaySublinks = []
-      const errors = {
-        links: _.fill(Array(links.length), enumSection('error')),
+      const initialDisplayLinks = _.fill(Array(initialLinks.length), false)
+      const initialDisplaySublinks = []
+      const initialErrors = {
+        links: _.fill(Array(initialLinks.length), enumSection('error')),
         sublinks: [],
       }
-      links.forEach(link => {
+      initialLinks.forEach(link => {
         let numSublinks = 0
         if ("sublinks" in link) {
           numSublinks = link.sublinks.length
         }
-        if ('resource_room' in link) hasResources = true
-        displaySublinks.push(_.fill(Array(numSublinks), false))
-        errors.sublinks.push(_.fill(Array(numSublinks), enumSection('error')))
+        if ('resource_room' in link) navHasResources = true
+        initialDisplaySublinks.push(_.fill(Array(numSublinks), false))
+        initialErrors.sublinks.push(_.fill(Array(numSublinks), enumSection('error')))
       })
 
-      const { collections } = collectionContent
-      const { resources } = resourceContent
+      const { collections: initialCollections } = collectionContent
+      const { resources: initialResource } = resourceContent
 
-      const options = collections.map((collection) => ({
+      const initialOptions = initialCollections.map((collection) => ({
         value: collection,
         label: collection,
       }))
 
       if (_isMounted) {
-        setLinks(links)
+        setLinks(initialLinks)
         setHasLoaded(true)
-        setDisplayLinks(displayLinks)
-        setDisplaySublinks(displaySublinks)
-        setCollections(collections)
-        setOptions(options)
-        setResources(resources.map(resource => deslugifyDirectory(resource.dirName)))
+        setDisplayLinks(initialDisplayLinks)
+        setDisplaySublinks(initialDisplaySublinks)
+        setCollections(initialCollections)
+        setOptions(initialOptions)
+        setResources(initialResource.map(resource => deslugifyDirectory(resource.dirName)))
         setOriginalNav(navContent)
         setSha(navSha)
-        setHasResources(hasResources)
-        setErrors(errors)
+        setHasResources(navHasResources)
+        setErrors(initialErrors)
       }
     }
 

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -28,6 +28,7 @@ const EditNavBar =  ({ match }) => {
   const { siteName } = match.params
 
   const [links, setLinks] = useState([])
+  const [originalNav, setOriginalNav] = useState()
   const [collections, setCollections] = useState([])
   const [options, setOptions] = useState([])
   const [displayLinks, setDisplayLinks] = useState([])
@@ -141,6 +142,7 @@ const EditNavBar =  ({ match }) => {
         setCollections(collections)
         setOptions(options)
         setResources(resources.map(resource => deslugifyDirectory(resource.dirName)))
+        setOriginalNav(content)
       }
     }
 
@@ -424,9 +426,10 @@ const EditNavBar =  ({ match }) => {
   }
 
   const hasChanges = () => {
-    // TODO
-    // return JSON.stringify(sanitisedOriginalFrontMatter) === JSON.stringify(frontMatter) && JSON.stringify(footerContent) === JSON.stringify(originalFooterContent)
-    return false
+    return JSON.stringify(originalNav) === JSON.stringify({
+      ...originalNav,
+      links: links
+    })
   }
 
   return (

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -7,10 +7,11 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import { Redirect } from 'react-router-dom'
 import { toast } from 'react-toastify';
 
-import { DEFAULT_ERROR_TOAST_MSG } from '../utils';
+import { DEFAULT_ERROR_TOAST_MSG, deslugifyDirectory } from '../utils';
 
 import Toast from '../components/Toast';
 import NavSection from '../components/navbar/NavSection'
+import TemplateNavBar from '../templates/NavBar'
 
 import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -39,7 +40,7 @@ const EditNavBar =  ({ match }) => {
       type: '',
     }
   )
-  const [resourceRoomName, setResourceRoomName] = useState('')
+  const [resources, setResources] = useState()
 
 
   const LinkCollectionSectionConstructor = () => ({
@@ -65,7 +66,7 @@ const EditNavBar =  ({ match }) => {
 
   const SublinkSectionConstructor = () => ({
     title: 'Sublink Title',
-    url: ''
+    url: '/permalink'
   });
   
   const enumSection = (type) => {
@@ -89,14 +90,14 @@ const EditNavBar =  ({ match }) => {
     let _isMounted = true
 
     const loadNavBarDetails = async () => {
-      let content, collectionContent, resourceRoomContent
+      let content, collectionContent, resourceContent
       try {
         const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/navigation`);
         content = resp.data;
         const collectionResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections`)
         collectionContent = collectionResp.data
-        const resourceRoomResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resource-room`)
-        resourceRoomContent = resourceRoomResp.data
+        const resourceResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`)
+        resourceContent = resourceResp.data
       } catch (error) {
         if (error?.response?.status === 404) {
           setShouldRedirectToNotFound(true)
@@ -125,7 +126,7 @@ const EditNavBar =  ({ match }) => {
       })
 
       const { collections } = collectionContent
-      const { resourceRoom } = resourceRoomContent
+      const { resources } = resourceContent
 
       const options = collections.map((collection) => ({
         value: collection,
@@ -139,7 +140,7 @@ const EditNavBar =  ({ match }) => {
         setDisplaySublinks(displaySublinks)
         setCollections(collections)
         setOptions(options)
-        setResourceRoomName(resourceRoom)
+        setResources(resources.map(resource => deslugifyDirectory(resource.dirName)))
       }
     }
 
@@ -461,23 +462,19 @@ const EditNavBar =  ({ match }) => {
                   displayHandler={displayHandler}
                   displayLinks={displayLinks}
                   displaySublinks={displaySublinks}
-                  resourceRoomName={resourceRoomName}
                 />
               </DragDropContext>
             </div>
           </div>
+          {/* need to change the css here */}
           <div className={`${editorStyles.contactUsEditorMain} ` }>
             {/* navbar content */}
-            <section className="bp-section is-small padding--bottom--lg">
-              <div className="bp-container">
-                <div className="row">
-                  <div className="col is-8 is-offset-2">
-                    {/* TODO: display menu */}
-                    MENU
-                  </div>
-                </div>
-              </div>
-            </section>
+            {/* TODO: update collectionInfo */}
+            <TemplateNavBar
+              links={links}
+              collectionInfo={null}
+              resources={resources}
+            />
           </div>
           <div className={editorStyles.pageEditorFooter}>
             {/* TODO: save button */}

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -43,7 +43,7 @@ const EditNavBar =  ({ match }) => {
     }
   )
   const [resources, setResources] = useState()
-
+  const [hasResources, setHasResources] = useState(false)
 
   const LinkCollectionSectionConstructor = () => ({
     title: 'Link Title',
@@ -118,6 +118,7 @@ const EditNavBar =  ({ match }) => {
 
       const { links } = navContent
 
+      let hasResources = false
       // Add booleans for displaying links and sublinks
       const displayLinks = _.fill(Array(links.length), false)
       const displaySublinks = []
@@ -126,6 +127,7 @@ const EditNavBar =  ({ match }) => {
         if ("sublinks" in link) {
           numSublinks = link.sublinks.length
         }
+        if ('resource_room' in link) hasResources = true
         displaySublinks.push(_.fill(Array(numSublinks), false))
       })
 
@@ -147,6 +149,7 @@ const EditNavBar =  ({ match }) => {
         setResources(resources.map(resource => deslugifyDirectory(resource.dirName)))
         setOriginalNav(navContent)
         setSha(navSha)
+        setHasResources(hasResources)
       }
     }
 
@@ -215,6 +218,7 @@ const EditNavBar =  ({ match }) => {
           const newLinks = update(links, {
             $push: [enumSection(value)]
           })
+          if (value === 'resourceLink') setHasResources(true)
           const resetDisplayLinks = _.fill(Array(links.length), false)
           const resetDisplaySublinks = []
           links.forEach(link => {
@@ -274,6 +278,7 @@ const EditNavBar =  ({ match }) => {
       switch (elemType) {
         case 'link': {
           const linkIndex = parseInt(idArray[1], RADIX_PARSE_INT)
+          if ('resource_room' in links[linkIndex]) setHasResources(false)
           const newLinks = update(links, {
             $splice: [[linkIndex, 1]]
           })
@@ -489,6 +494,7 @@ const EditNavBar =  ({ match }) => {
                   displayHandler={displayHandler}
                   displayLinks={displayLinks}
                   displaySublinks={displaySublinks}
+                  hasResources={hasResources}
                 />
               </DragDropContext>
             </div>

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -86,7 +86,7 @@ const Workspace = ({ match, location }) => {
                 <i className="bx bx-sm bx-bulb text-dark" />
                 <span><strong className="ml-1">Pro tip:</strong> Organise this workspace by moving pages into folders</span>
               </div>
-              {/* Homepage and Contact Us */}
+              {/* Homepage, Nav bar and Contact Us */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
                   <FolderCard
@@ -94,6 +94,13 @@ const Workspace = ({ match, location }) => {
                     settingsToggle={() => {}}
                     key={"homepage"}
                     pageType={"homepage"}
+                    siteName={siteName}
+                  />
+                  <FolderCard
+                    displayText={"Navigation Bar"}
+                    settingsToggle={() => {}}
+                    key={"nav"}
+                    pageType={"nav"}
                     siteName={siteName}
                   />
                   { contactUsCard && 

--- a/src/templates/NavBar.jsx
+++ b/src/templates/NavBar.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const TemplateNavBar = ({ links, collectionInfo, resources }) => (
   <nav className="navbar is-transparent flex-fill">
     <div className="bp-container">
-      <div id="navbarExampleTransparentExample" className="bp-container is-fluid margin--none navbar-menu h-100">
+      <div className="bp-container is-fluid margin--none navbar-menu h-100">
         <div className="navbar-start">
           {
             links.map((link, linkIndex) => {

--- a/src/templates/NavBar.jsx
+++ b/src/templates/NavBar.jsx
@@ -6,16 +6,16 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
       <div id="navbarExampleTransparentExample" className="bp-container is-fluid margin--none navbar-menu h-100">
         <div className="navbar-start">
           {
-            links.map((link) => {
+            links.map((link, linkIndex) => {
               if (link.collection) {
                 return (
-                  <div className="navbar-item has-dropdown is-hoverable">
+                  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
                     <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
                       { link.title }
                     </a>
                     <div className="navbar-dropdown">
-                      {collectionInfo && collectionInfo[link.collection].map((collection) => (
-                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
+                      {collectionInfo && collectionInfo[link.collection].map((collection, collectionIndex) => (
+                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`collection-${collectionIndex}`}>
                           { collection }
                         </a>
                       ))}
@@ -25,13 +25,13 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
               }
               if (link.resource_room) {
                 return (
-                  <div className="navbar-item has-dropdown is-hoverable">
+                  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
                     <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
                       { link.title }
                     </a>
                     <div className="navbar-dropdown">
-                      {resources && resources.map((resource) => (
-                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
+                      {resources && resources.map((resource, resourceIndex) => (
+                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`resource-${resourceIndex}`}>
                           { resource }
                         </a>
                       ))}
@@ -41,13 +41,13 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
               }
               if (link.sublinks) {
                 return (
-                  <div className="navbar-item has-dropdown is-hoverable">
+                  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
                     <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
                       { link.title }
                     </a>
                     <div className="navbar-dropdown">
-                      {link.sublinks && link.sublinks.map((sublink) => (
-                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
+                      {link.sublinks && link.sublinks.map((sublink, sublinkIndex) => (
+                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`sublink-${sublinkIndex}`}>
                           { sublink.title }
                         </a>
                       ))}
@@ -57,7 +57,7 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
               }
               if (link.url) {
                 return (
-                  <li className="navbar-item">
+                  <li className="navbar-item" key={`link-${linkIndex}`}>
                     <a className="navbar-item is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
                       { link.title }
                     </a>

--- a/src/templates/NavBar.jsx
+++ b/src/templates/NavBar.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+const TemplateNavBar = ({ links, collectionInfo, resources }) => (
+  <nav className="navbar is-transparent flex-fill">
+    <div className="bp-container">
+      <div id="navbarExampleTransparentExample" className="bp-container is-fluid margin--none navbar-menu h-100">
+        <div className="navbar-start">
+          {
+            links.map((link) => {
+              if (link.collection) {
+                return (
+                  <div className="navbar-item has-dropdown is-hoverable">
+                    <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
+                      { link.title }
+                    </a>
+                    <div className="navbar-dropdown">
+                      {collectionInfo && collectionInfo[link.collection].map((collection) => (
+                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
+                          { collection }
+                        </a>
+                      ))}
+                    </div>
+                  </div>
+                );
+              }
+              if (link.resource_room) {
+                return (
+                  <div className="navbar-item has-dropdown is-hoverable">
+                    <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
+                      { link.title }
+                    </a>
+                    <div className="navbar-dropdown">
+                      {resources && resources.map((resource) => (
+                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
+                          { resource }
+                        </a>
+                      ))}
+                    </div>
+                  </div>
+                )
+              }
+              if (link.sublinks) {
+                return (
+                  <div className="navbar-item has-dropdown is-hoverable">
+                    <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
+                      { link.title }
+                    </a>
+                    <div className="navbar-dropdown">
+                      {link.sublinks && link.sublinks.map((sublink) => (
+                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()}>
+                          { sublink.title }
+                        </a>
+                      ))}
+                    </div>
+                  </div>
+                )
+              }
+              if (link.url) {
+                return (
+                  <li className="navbar-item">
+                    <a className="navbar-item is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
+                      { link.title }
+                    </a>
+                  </li>
+                );
+              }
+              return (
+                <p>
+                  Unaccounted for
+                </p>
+              );
+            })
+          }
+        </div>
+      </div>
+    </div>
+  </nav>
+);
+
+export default TemplateNavBar;

--- a/src/templates/NavBar.jsx
+++ b/src/templates/NavBar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const NavDropdownSection = ({ children, link, linkIndex }) => (
   <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
@@ -74,3 +75,40 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
 );
 
 export default TemplateNavBar;
+
+NavDropdownSection.propTypes = {
+  link: PropTypes.shape({
+    title: PropTypes.string,
+    url: PropTypes.string,
+    collection: PropTypes.string,
+    resource_room: PropTypes.bool,
+    sublinks: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    )
+  }).isRequired,
+  linkIndex: PropTypes.number.isRequired,
+};
+
+TemplateNavBar.propTypes = {
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+      collection: PropTypes.string,
+      resource_room: PropTypes.bool,
+      sublinks: PropTypes.arrayOf(
+        PropTypes.shape({
+          title: PropTypes.string,
+          url: PropTypes.string,
+        }),
+      )
+    }),
+  ).isRequired,
+  collectionInfo: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ),
+  resources: PropTypes.arrayOf(PropTypes.string),
+};

--- a/src/templates/NavBar.jsx
+++ b/src/templates/NavBar.jsx
@@ -52,19 +52,13 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
                   </NavDropdownSection>
                 )
               }
-              if (link.url) {
-                return (
-                  <li className="navbar-item" key={`link-${linkIndex}`}>
-                    <a className="navbar-item is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
-                      { link.title }
-                    </a>
-                  </li>
-                );
-              }
+              // Single Page
               return (
-                <p>
-                  Unaccounted for
-                </p>
+                <li className="navbar-item" key={`link-${linkIndex}`}>
+                  <a className="navbar-item is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
+                    { link.title }
+                  </a>
+                </li>
               );
             })
           }

--- a/src/templates/NavBar.jsx
+++ b/src/templates/NavBar.jsx
@@ -1,5 +1,16 @@
 import React from 'react';
 
+const NavDropdownSection = ({ children, link, linkIndex }) => (
+  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
+      <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
+          { link.title }
+      </a>
+       <div className="navbar-dropdown">
+          { children }
+      </div>
+  </div>
+)
+
 const TemplateNavBar = ({ links, collectionInfo, resources }) => (
   <nav className="navbar is-transparent flex-fill">
     <div className="bp-container">
@@ -9,50 +20,35 @@ const TemplateNavBar = ({ links, collectionInfo, resources }) => (
             links.map((link, linkIndex) => {
               if (link.collection) {
                 return (
-                  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
-                    <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
-                      { link.title }
-                    </a>
-                    <div className="navbar-dropdown">
-                      {collectionInfo && collectionInfo[link.collection].map((collection, collectionIndex) => (
-                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`collection-${collectionIndex}`}>
-                          { collection }
-                        </a>
-                      ))}
-                    </div>
-                  </div>
+                  <NavDropdownSection link={link} linkIndex={linkIndex}>
+                    {collectionInfo && collectionInfo[link.collection].map((collection, collectionIndex) => (
+                      <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`collection-${collectionIndex}`}>
+                        { collection }
+                      </a>
+                    ))}
+                  </NavDropdownSection>
                 );
               }
               if (link.resource_room) {
                 return (
-                  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
-                    <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
-                      { link.title }
-                    </a>
-                    <div className="navbar-dropdown">
-                      {resources && resources.map((resource, resourceIndex) => (
-                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`resource-${resourceIndex}`}>
-                          { resource }
-                        </a>
-                      ))}
-                    </div>
-                  </div>
+                  <NavDropdownSection link={link} linkIndex={linkIndex}>
+                    {resources && resources.map((resource, resourceIndex) => (
+                      <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`resource-${resourceIndex}`}>
+                        { resource }
+                      </a>
+                    ))}
+                  </NavDropdownSection>
                 )
               }
               if (link.sublinks) {
                 return (
-                  <div className="navbar-item has-dropdown is-hoverable" key={`link-${linkIndex}`}>
-                    <a className="navbar-link is-uppercase" href="/" onClick={(event) => event.preventDefault()}>
-                      { link.title }
-                    </a>
-                    <div className="navbar-dropdown">
-                      {link.sublinks && link.sublinks.map((sublink, sublinkIndex) => (
-                        <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`sublink-${sublinkIndex}`}>
-                          { sublink.title }
-                        </a>
-                      ))}
-                    </div>
-                  </div>
+                  <NavDropdownSection link={link} linkIndex={linkIndex}>
+                    {link.sublinks && link.sublinks.map((sublink, sublinkIndex) => (
+                      <a className="navbar-item sub-link" href="/" onClick={(event) => event.preventDefault()} key={`sublink-${sublinkIndex}`}>
+                        { sublink.title }
+                      </a>
+                    ))}
+                  </NavDropdownSection>
                 )
               }
               if (link.url) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,9 @@ const ALPHANUM_REGEX = /^[0-9]+[a-z]*$/ // at least one number, followed by 0 or
 const NUM_REGEX = /^[0-9]+$/
 const NUM_IDENTIFIER_REGEX = /^[0-9]+/
 export const DEFAULT_ERROR_TOAST_MSG = 'Please try again or check your internet connection.' 
+export const SINGLE_PAGE_IDENTIFIER = '_SINGLE_PAGE'
+export const SUBLINK_IDENTIFIER = '_SUBLINK'
+export const RESOURCE_ROOM_IDENTIFIER = '_RESOURCE_ROOM'
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,6 +44,15 @@ export function deslugifyCollectionPage(collectionPageName) {
     .join(' '); // join it back together
 }
 
+// this function converts directories into readable form
+// for example, '0-this-is-a-file.md' -> 'This Is A File'
+export function deslugifyDirectory(dirName) {
+  return dirName
+    .split('-')
+    .map(string => _.upperFirst(string)) // capitalize first letter
+    .join(' '); // join it back together
+}
+
 // takes a string URL and returns true if the link is an internal link
 // only works on browser side
 export function isLinkInternal(url) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,7 @@ export function deslugifyCollectionPage(collectionPageName) {
 }
 
 // this function converts directories into readable form
-// for example, '0-this-is-a-file.md' -> 'This Is A File'
+// for example, 'this-is-a-directory' -> 'This Is A Directory'
 export function deslugifyDirectory(dirName) {
   return dirName
     .split('-')

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,10 +13,7 @@ axios.defaults.withCredentials = true
 const ALPHANUM_REGEX = /^[0-9]+[a-z]*$/ // at least one number, followed by 0 or more lower-cased alphabets
 const NUM_REGEX = /^[0-9]+$/
 const NUM_IDENTIFIER_REGEX = /^[0-9]+/
-export const DEFAULT_ERROR_TOAST_MSG = 'Please try again or check your internet connection.' 
-export const SINGLE_PAGE_IDENTIFIER = '_SINGLE_PAGE'
-export const SUBLINK_IDENTIFIER = '_SUBLINK'
-export const RESOURCE_ROOM_IDENTIFIER = '_RESOURCE_ROOM'
+export const DEFAULT_ERROR_TOAST_MSG = 'Please try again or check your internet connection.'
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -91,6 +91,12 @@ const LOCATION_OPERATING_HOURS_MIN_LENGTH = 2;
 const LOCATION_OPERATING_HOURS_MAX_LENGTH = 30;
 const LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH = 100;
 
+// Nav Bar Editor
+// ===============
+const LINK_TITLE_MIN_LENGTH = 1;
+const LINK_TITLE_MAX_LENGTH = 30;
+const LINK_URL_MIN_LENGTH = 1;
+
 // Page Settings Modal
 // ===================
 const PAGE_SETTINGS_PERMALINK_MIN_LENGTH = 4;
@@ -575,6 +581,29 @@ const validateLocationType = (locationType, value) => {
   return errorMessage
 }
 
+// Nav Bar Editor
+const validateLink = (linkType, value) => {
+  let errorMessage = '';
+  switch (linkType) {
+    case 'title':
+      if (value.length < LINK_TITLE_MIN_LENGTH) {
+        errorMessage = `Title cannot be empty.`;
+      };
+      if (value.length > LINK_TITLE_MAX_LENGTH) {
+        errorMessage = `Title should be shorter than ${LINK_TITLE_MAX_LENGTH} characters.`;
+      };
+      break;
+    case 'url':
+      if (value.length < LINK_URL_MIN_LENGTH) {
+        errorMessage = `Permalink cannot be empty.`;
+      };
+      break;
+    default:
+      break;
+  }
+  return errorMessage
+}
+
 
 // Page Settings Modal
 // ===================
@@ -790,6 +819,7 @@ const validateFileName = (value) => {
 export {
   validateContactType,
   validateLocationType,
+  validateLink,
   validateHighlights,
   validateDropdownElems,
   validateSections,


### PR DESCRIPTION
This PR adds in an edit nav bar page ~(currently accessible through sites/{sitename}/menu)~ accessible through workspace. To be reviewed in conjunction with PR#[122](https://github.com/isomerpages/isomercms-backend/pull/112) on the isomercms-backend repo.

Miscellaneous items to clean up:
- ~Proptypes for nav and sublink sections~
- ~Link to editNav from workspace~
- Error handling?

Points for discussion:
- Currently the display for the nav bar doesn't exactly match the one on the actual site - it is missing the logo, and the nav bar on the cms is scrollable while the actual one is not. I don't see a good way for the two to match, since half the page on the cms is dedicated to the editable portion
- Errors - what kind of errors (if any) should we look out for? Currently no error checking has been implemented since only 2 fields can take in any user input (title and url), and these can take on any values if editing the file through github. Should we enforce something like maximum/minimum length?