### PR TITLE
Feat/drag drop folders

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -20,11 +20,16 @@ const getDirectoryFile = async (siteName, folderName) => {
     }
 }
 
+const setDirectoryFile = async (siteName, folderName, payload) => {
+    return await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+}
+
 const getFolderContents = async (siteName, folderName, subfolderName) => {
     return await axios.get(`${BACKEND_URL}/sites/${siteName}/folders?path=_${folderName}${subfolderName ? `/${subfolderName}` : ''}`);
 }
 
 export {
     getDirectoryFile,
+    setDirectoryFile,
     getFolderContents,
 }

--- a/src/api.js
+++ b/src/api.js
@@ -21,7 +21,12 @@ const getDirectoryFile = async (siteName, folderName) => {
 }
 
 const setDirectoryFile = async (siteName, folderName, payload) => {
-    return await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+    try {
+        return await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+    } catch (err) {
+        // any future custom error handling
+        throw err
+    }
 }
 
 const getFolderContents = async (siteName, folderName, subfolderName) => {

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Droppable, Draggable } from 'react-beautiful-dnd';
+import { DragDropContext } from 'react-beautiful-dnd';
+import update from 'immutability-helper';
 
 import { deslugifyPage } from '../../utils'
 
@@ -35,21 +38,74 @@ const FolderContentItem = ({ title, isFile, numItems, link }) => {
     )
 }
 
-const FolderContent = ({ data, siteName, folderName }) => {
+const FolderContent = ({ folderOrderArray, setFolderOrderArray, siteName, folderName, enableDragDrop }) => {
+    const onDragEnd = (result) => {
+        const { source, destination } = result;
+        
+        // If the user dropped the draggable to no known droppable
+        if (!destination) return;
+    
+        // The draggable elem was returned to its original position
+        if (
+            destination.droppableId === source.droppableId
+            && destination.index === source.index
+        ) return;
+    
+        const elem = folderOrderArray[source.index]
+        const newFolderOrderArray = update(folderOrderArray, {
+            $splice: [
+                [source.index, 1], // Remove elem from its original position
+                [destination.index, 0, elem], // Splice elem into its new position
+            ],
+        });
+        setFolderOrderArray(newFolderOrderArray)
+    }
+    
     return (
-        <div className={`${contentStyles.contentContainerFolderColumn} mb-5`}>
-            {
-                data.map((folderContentItem) => (
-                    <FolderContentItem
-                        key={folderContentItem.title}
-                        title={deslugifyPage(folderContentItem.title)}
-                        numItems={folderContentItem.type === 'dir' ? folderContentItem.children.length : null}
-                        isFile={folderContentItem.type === 'dir' ? false: true}
-                        link={folderContentItem.type === 'dir' ? `/sites/${siteName}/folder/${folderName}/subfolder/${folderContentItem.title}` : `/sites/${siteName}/collections/${folderName}/${folderContentItem.path}`}
-                    />
-                ))
-            }
-        </div>
+        <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable 
+                droppableId="folder" 
+                type="folder" 
+                isDropDisabled={!enableDragDrop}
+            >
+                {(droppableProvided) => (        
+                    <div 
+                        className={`${contentStyles.contentContainerFolderColumn} mb-5`}
+                        ref={droppableProvided.innerRef}
+                        {...droppableProvided.droppableProps}
+                    >
+                        {
+                            folderOrderArray.map((folderContentItem, folderContentIndex) => (
+                                <Draggable
+                                    draggableId={`folder-${folderContentIndex}-draggable`}
+                                    index={folderContentIndex}
+                                    isDragDisabled={!enableDragDrop}
+                                >
+                                    {(draggableProvided) => (
+                                        <div
+                                            key={folderContentIndex}
+                                            {...draggableProvided.draggableProps}
+                                            {...draggableProvided.dragHandleProps}
+                                            ref={draggableProvided.innerRef}
+                                        >        
+                                            <FolderContentItem
+                                                key={folderContentItem.title}
+                                                title={deslugifyPage(folderContentItem.title)}
+                                                numItems={folderContentItem.type === 'dir' ? folderContentItem.children.length : null}
+                                                isFile={folderContentItem.type === 'dir' ? false: true}
+                                                link={folderContentItem.type === 'dir' ? `/sites/${siteName}/folder/${folderName}/subfolder/${folderContentItem.title}` : `/sites/${siteName}/collections/${folderName}/${folderContentItem.path}`}
+                                                itemIndex={folderContentIndex}
+                                            />
+                                        </div>
+                                    )}
+                                </Draggable>
+                            ))
+                        }
+                        {droppableProvided.placeholder}
+                    </div>
+                )}
+            </Droppable>
+        </DragDropContext>
     )
 }
 

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -67,7 +67,8 @@ const Folders = ({ match, location }) => {
     }, [error])
 
     const { mutate } = useMutation(
-        payload => setDirectoryFile(siteName, folderName, payload)
+        payload => setDirectoryFile(siteName, folderName, payload),
+        { onSettled: () => setIsRearrangeActive((prevState) => !prevState) }
     )
 
     useEffect(() => {
@@ -91,7 +92,10 @@ const Folders = ({ match, location }) => {
     }, [folderContents, subfolderName])
 
     const toggleRearrange = () => { 
-        if (isRearrangeActive && folderOrderArray && folderContents) { 
+        // if no folder contents, do not enable reordering
+        if (folderOrderArray.length == 0 || !folderContents) return
+        
+        if (isRearrangeActive) { 
             // drag and drop complete, save new order 
             let newFolderOrder
             if (subfolderName) {
@@ -105,9 +109,10 @@ const Folders = ({ match, location }) => {
                 content: updatedDirectoryFile,
                 sha: directoryFileSha
             } 
-            mutate(payload)
+            mutate(payload) // setIsRearrangeActive(false) handled by mutate
+        } else {
+          setIsRearrangeActive((prevState) => !prevState) 
         }
-        setIsRearrangeActive((prevState) => !prevState) 
     }
 
     return (

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -91,11 +91,9 @@ const Folders = ({ match, location }) => {
     }, [folderContents, subfolderName])
 
     const toggleRearrange = () => { 
-        
         if (isRearrangeActive && folderOrderArray && folderContents) { 
             // drag and drop complete, save new order 
             let newFolderOrder
-            
             if (subfolderName) {
                 newFolderOrder = convertSubfolderArray(folderOrderArray, parsedFolderContents, subfolderName)
             } else {
@@ -110,7 +108,6 @@ const Folders = ({ match, location }) => {
             mutate(payload)
         }
         setIsRearrangeActive((prevState) => !prevState) 
-        
     }
 
     return (

--- a/src/utils.js
+++ b/src/utils.js
@@ -552,6 +552,13 @@ export const parseDirectoryFile = (folderContent) => {
   return decodedContent.collections[collectionKey].order
 }
 
+export const updateDirectoryFile = (folderContent, folderOrder) => {
+  const decodedContent = yaml.safeLoad(Base64.decode(folderContent))
+  const collectionKey = Object.keys(decodedContent.collections)[0]
+  decodedContent.collections[collectionKey].order = folderOrder
+  return Base64.encode(yaml.safeDump(decodedContent))
+}
+
 export const convertFolderOrderToArray = (folderOrder) => {
   let currFolderEntry = {}
   return folderOrder.reduce((acc, curr, currIdx) => {
@@ -594,6 +601,14 @@ export const convertFolderOrderToArray = (folderOrder) => {
   }, [])
 }
 
+export const convertArrayToFolderOrder = (array) => {
+  const updatedFolderOrder = array.map(({ type, children, path }) => {
+    if (type == 'dir') return children
+    if (type == 'file') return path
+  })
+  return _.flatten(updatedFolderOrder)
+}
+
 export const retrieveSubfolderContents = (folderOrder, subfolderName) => {
   return folderOrder.reduce((acc, curr) => {
     const folderPathArr = curr.split('/')
@@ -609,4 +624,19 @@ export const retrieveSubfolderContents = (folderOrder, subfolderName) => {
     }
     return acc
   }, [])
+}
+
+export const convertSubfolderArray = (folderOrderArray, rawFolderContents, subfolderName) => {
+  const arrayCopy = _.cloneDeep(folderOrderArray)
+  return rawFolderContents.map((curr) => {
+    const folderPathArr = curr.split('/')
+    if (folderPathArr.length === 2) {
+      const [subfolderTitle, subfolderFileName] = folderPathArr
+      if (subfolderTitle === subfolderName) {
+        const { path } = arrayCopy.shift()
+        return path
+      }
+    }
+    return curr
+  })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -630,12 +630,10 @@ export const convertSubfolderArray = (folderOrderArray, rawFolderContents, subfo
   const arrayCopy = _.cloneDeep(folderOrderArray)
   return rawFolderContents.map((curr) => {
     const folderPathArr = curr.split('/')
-    if (folderPathArr.length === 2) {
-      const [subfolderTitle, subfolderFileName] = folderPathArr
-      if (subfolderTitle === subfolderName) {
-        const { path } = arrayCopy.shift()
-        return path
-      }
+    const subfolderTitle = folderPathArr[0]
+    if (folderPathArr.length === 2 && subfolderTitle === subfolderName) {
+      const { path } = arrayCopy.shift()
+      return path
     }
     return curr
   })


### PR DESCRIPTION
This PR adds drag-drop functionality to 1) reorder files and folders in a collection, 2) reorder files in a subfolder. This PR addresses #344, and is a follow-up to #350.

To simplify the logic for now, we have decided to implement the non-live version of reordering, where the backend is only updated after a user completes the "Rearrange Items" button. This PR does not support dragging a file into a subfolder.

#### Bugs: 
~~1. useQuery is disabled while a user reorders a collection, which is ideal behavior because we do not want to be querying and rerendering while the user reorders files. Once the user completes reorder and sends the mutation to modify the file on the backend, useQuery is enabled again. However, currently, it seems that useQuery does not show the updated order immediately, but instead renders the a cached version of the old order for a few seconds.  This may be either to do with 1) some useQuery parameter setting that we can adjust for removing the cache 2) Github taking some time to update the file. Update on bug, seems like 2) is more plausible. I have tried invalidating the query upon mutation success via `queryClient.invalidateQueries()`, but it does not resolve this issue.~~ resolved with e337f4b
~~2. This PR inherits a small bug from `feat/new-folder-layout` where the files belonging to a subfolder is not properly added to the children array; currently all subfolders have a children array length of 1. Once this is resolved, the `convertArrayToFolderOrder functionality` should work as expected. For now, users can test the reordering in subfolders as `convertSubfolderArray` should work as expected without facing the same bugs.~~ resolved with 67ea5d2 
