### PR TITLE
Fix: restriction of image files that can be uploaded

### DIFF
--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -100,7 +100,7 @@ export default class MediaModal extends Component {
                   type="file"
                   id="file-upload"
                   accept={type === 'file' ? `application/msword, application/vnd.ms-excel, application/vnd.ms-powerpoint,
-                  text/plain, application/pdf` : 'image*'}
+                  text/plain, application/pdf` : 'image/*'}
                   hidden
                 />
                 {/* Render medias */}

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -108,7 +108,7 @@ export default class Images extends Component {
                     }}
                     type="file"
                     id="file-upload"
-                    accept="image/png, image/jpeg, image/gif"
+                    accept="image/*"
                     hidden
                   />
                   {/* Images */}


### PR DESCRIPTION
This PR fixes 2 minor bugs involving the uploading of images.

- In the image tab, we placed a restriction on uploadable files to only a certain subset of images. This caused issues for users who wanted to upload a new favicon.
- In places which used `FormFieldMedia` to deal with image uploads, we only restrict the uploadable file to be of any image type. However, due to a typo (`image*` instead of `image/*`), there were no restrictions being placed on files uploaded in this way.

The two places where this could occur have both been changed to allow any type of image (`image/*`).