### PR TITLE
Feat/drag drop new

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -20,11 +20,21 @@ const getDirectoryFile = async (siteName, folderName) => {
     }
 }
 
+const setDirectoryFile = async (siteName, folderName, payload) => {
+    try {
+        return await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+    } catch (err) {
+        // if need be, add custom error handling here
+        throw err
+    }
+}
+
 const getFolderContents = async (siteName, folderName, subfolderName) => {
     return await axios.get(`${BACKEND_URL}/sites/${siteName}/folders?path=_${folderName}${subfolderName ? `/${subfolderName}` : ''}`);
 }
 
 export {
     getDirectoryFile,
+    setDirectoryFile,
     getFolderContents,
 }

--- a/src/components/folders/FolderOptionButton.jsx
+++ b/src/components/folders/FolderOptionButton.jsx
@@ -12,7 +12,7 @@ const iconSelection = {
 
 
 
-const FolderOptionButton = ({ title, isSelected, onClick, option, isSubfolder }) => {
+const FolderOptionButton = ({ title, isSelected, onClick, option, isDisabled }) => {
     return (
         <button
             type="button"
@@ -20,13 +20,13 @@ const FolderOptionButton = ({ title, isSelected, onClick, option, isSubfolder })
                 ${elementStyles.card}
                 ${contentStyles.card}
                 ${isSelected ? elementStyles.folderOptionSelected : ''}
-                ${isSubfolder ? elementStyles.folderOptionDisabled : elementStyles.folderOption}
+                ${isDisabled ? elementStyles.folderOptionDisabled : elementStyles.folderOption}
             `}
-            disabled={isSubfolder}
+            disabled={isDisabled}
             onClick={onClick}
         >
             <div className={`${contentStyles.contentContainerFolderRow} justify-content-center`}>
-                <i className={`bx ${iconSelection[option]} ${elementStyles.folderOptionIcon} ${isSelected ? 'text-white' : ''} ${isSubfolder ? elementStyles.disabledIcon : ''} mr-2`} />
+                <i className={`bx ${iconSelection[option]} ${elementStyles.folderOptionIcon} ${isSelected ? 'text-white' : ''} ${isDisabled ? elementStyles.disabledIcon : ''} mr-2`} />
                 <span className={`${elementStyles.folderOptionText} ml-2`}>{title}</span>
             </div>
         </button>

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -102,7 +102,7 @@ const Folders = ({ match, location }) => {
 
     const toggleRearrange = () => { 
       // if no folder contents, do not enable reordering
-      if (folderOrderArray.length == 0 || !folderContents) return
+      if (folderOrderArray.length === 0 || !folderContents) return
 
       if (isRearrangeActive) { 
         // drag and drop complete, save new order 
@@ -112,7 +112,7 @@ const Folders = ({ match, location }) => {
         } else {
           newFolderOrder = convertArrayToFolderOrder(folderOrderArray)
         }
-        if (JSON.stringify(newFolderOrder)==JSON.stringify(parsedFolderContents)) { 
+        if (JSON.stringify(newFolderOrder) === JSON.stringify(parsedFolderContents)) { 
           // no change in file order
           setIsRearrangeActive((prevState) => !prevState)
           return

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -101,9 +101,6 @@ const Folders = ({ match, location }) => {
     }, [folderContents, subfolderName])
 
     const toggleRearrange = () => { 
-      // if no folder contents, do not enable reordering
-      if (folderOrderArray.length === 0 || !folderContents) return
-
       if (isRearrangeActive) { 
         // drag and drop complete, save new order 
         let newFolderOrder
@@ -183,9 +180,9 @@ const Folders = ({ match, location }) => {
               </div>
               {/* Options */}
               <div className={contentStyles.contentContainerFolderRowMargin}>
-                <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" />
+                <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" />
-                <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={subfolderName ? true : false} />
+                <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName ? true : false} />
               </div>
               {/* Collections content */}
               {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -112,11 +112,17 @@ const Folders = ({ match, location }) => {
         } else {
           newFolderOrder = convertArrayToFolderOrder(folderOrderArray)
         }
+        if (JSON.stringify(newFolderOrder)==JSON.stringify(parsedFolderContents)) { 
+          // no change in file order
+          console.log('hi')
+          setIsRearrangeActive((prevState) => !prevState)
+          return
+        }
         const updatedDirectoryFile = updateDirectoryFile(folderContents.data.content, newFolderOrder)
 
         const payload = {
           content: updatedDirectoryFile,
-          sha: directoryFileSha
+          sha: directoryFileSha,
         } 
         mutate(payload) // setIsRearrangeActive(false) handled by mutate
       } else {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useQuery } from 'react-query';
+import { useQuery, useMutation } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Link, Redirect } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -17,12 +17,15 @@ import Toast from '../components/Toast';
 import {
   DEFAULT_ERROR_TOAST_MSG,
   parseDirectoryFile,
+  updateDirectoryFile,
   convertFolderOrderToArray,
+  convertArrayToFolderOrder,
   retrieveSubfolderContents,
+  convertSubfolderArray,
 } from '../utils'
 
 // Import API
-import { getDirectoryFile } from '../api';
+import { getDirectoryFile, setDirectoryFile } from '../api';
 
 // Import styles
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -34,19 +37,29 @@ const FOLDER_CONTENTS_KEY = 'folder-contents'
 const Folders = ({ match, location }) => {
     const { siteName, folderName, subfolderName } = match.params;
 
-    const { data: folderContents, error } = useQuery(
-        FOLDER_CONTENTS_KEY,
-        () => getDirectoryFile(siteName, folderName),
-        { retry: false },
-    );
     const [isRearrangeActive, setIsRearrangeActive] = useState(false)
     const [directoryFileSha, setDirectoryFileSha] = useState('')
-    const [folderOrder, setFolderOrder] = useState([])
+    const [folderOrderArray, setFolderOrderArray] = useState([])
+    const [parsedFolderContents, setParsedFolderContents] = useState([])
     const [shouldRedirect, setShouldRedirect] = useState(false)
 
+    const { data: folderContents, error: queryError } = useQuery(
+      FOLDER_CONTENTS_KEY,
+      () => getDirectoryFile(siteName, folderName),
+      { 
+        retry: false,
+        enabled: !isRearrangeActive,
+      },
+    );
+
+    const { mutate, error: mutateError } = useMutation(
+      payload => setDirectoryFile(siteName, folderName, payload),
+      { onSettled: () => setIsRearrangeActive((prevState) => !prevState) }
+    )
+
     useEffect(() => {
-      if (error) {
-        if (error.status === 404) {
+      if (queryError) {
+        if (queryError.status === 404) {
           // redirect if collection/folder cannot be found
           if (!shouldRedirect) setShouldRedirect(true)
         } else {
@@ -56,28 +69,60 @@ const Folders = ({ match, location }) => {
           );
         }
       }
-    }, [error])
+    }, [queryError])
+
+    useEffect(() => {
+      if (mutateError) {
+        toast(
+          <Toast notificationType='error' text={`Your file reordering could not be saved. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+        );
+      }
+    }, [mutateError])
 
     useEffect(() => {
         if (folderContents && folderContents.data) {
           const parsedFolderContents = parseDirectoryFile(folderContents.data.content)
           setDirectoryFileSha(folderContents.data.sha)
+          setParsedFolderContents(parsedFolderContents)
 
           if (subfolderName) {
             const subfolderFiles = retrieveSubfolderContents(parsedFolderContents, subfolderName)
             if (subfolderFiles.length > 0) {
-              setFolderOrder(retrieveSubfolderContents(parsedFolderContents, subfolderName))
+              setFolderOrderArray(subfolderFiles)
             } else {
               // if subfolderName prop does not match directory file, it's not a valid subfolder
               if (!shouldRedirect) setShouldRedirect(true)
             }
           } else {
-            setFolderOrder(convertFolderOrderToArray(parsedFolderContents))
+            setFolderOrderArray(convertFolderOrderToArray(parsedFolderContents))
           }
         }
     }, [folderContents, subfolderName])
 
-    const toggleRearrange = () => { setIsRearrangeActive((prevState) => !prevState) }
+    const toggleRearrange = () => { 
+      // if no folder contents, do not enable reordering
+      if (folderOrderArray.length == 0 || !folderContents) return
+
+      if (isRearrangeActive) { 
+        // drag and drop complete, save new order 
+        let newFolderOrder
+        if (subfolderName) {
+          newFolderOrder = convertSubfolderArray(folderOrderArray, parsedFolderContents, subfolderName)
+        } else {
+          newFolderOrder = convertArrayToFolderOrder(folderOrderArray)
+        }
+        const updatedDirectoryFile = updateDirectoryFile(folderContents.data.content, newFolderOrder)
+
+        const payload = {
+          content: updatedDirectoryFile,
+          sha: directoryFileSha
+        } 
+        mutate(payload) // setIsRearrangeActive(false) handled by mutate
+      } else {
+        setIsRearrangeActive((prevState) => !prevState) 
+      }
+    }
 
     return (
         <>
@@ -137,10 +182,18 @@ const Folders = ({ match, location }) => {
               </div>
               {/* Collections content */}
               {
-                  error && <span>There was an error retrieving your content. Please refresh the page.</span>
+                  queryError && <span>There was an error retrieving your content. Please refresh the page.</span>
               }
               {
-                  !error && folderContents && <FolderContent data={folderOrder} siteName={siteName} folderName={folderName} />
+                !queryError
+                && folderContents 
+                && <FolderContent 
+                    folderOrderArray={folderOrderArray} 
+                    setFolderOrderArray={setFolderOrderArray} 
+                    siteName={siteName} 
+                    folderName={folderName} 
+                    enableDragDrop={isRearrangeActive}
+                  />
               }
             </div>
             {/* main section ends here */}

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -133,6 +133,8 @@ const Folders = ({ match, location }) => {
           <Header
             backButtonText={`Back to ${subfolderName ? folderName : 'Workspace'}`}
             backButtonUrl={`/sites/${siteName}/${subfolderName ? `folder/${folderName}` : 'workspace'}`}
+            shouldAllowEditPageBackNav={!isRearrangeActive}
+            isEditPage="true"
           />
           {/* main bottom section */}
           <div className={elementStyles.wrapper}>

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -114,7 +114,6 @@ const Folders = ({ match, location }) => {
         }
         if (JSON.stringify(newFolderOrder)==JSON.stringify(parsedFolderContents)) { 
           // no change in file order
-          console.log('hi')
           setIsRearrangeActive((prevState) => !prevState)
           return
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -603,8 +603,8 @@ export const convertFolderOrderToArray = (folderOrder) => {
 
 export const convertArrayToFolderOrder = (array) => {
   const updatedFolderOrder = array.map(({ type, children, path }) => {
-    if (type == 'dir') return children
-    if (type == 'file') return path
+    if (type === 'dir') return children
+    if (type === 'file') return path
   })
   return _.flatten(updatedFolderOrder)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -552,6 +552,13 @@ export const parseDirectoryFile = (folderContent) => {
   return decodedContent.collections[collectionKey].order
 }
 
+export const updateDirectoryFile = (folderContent, folderOrder) => {
+  const decodedContent = yaml.safeLoad(Base64.decode(folderContent))
+  const collectionKey = Object.keys(decodedContent.collections)[0]
+  decodedContent.collections[collectionKey].order = folderOrder
+  return Base64.encode(yaml.safeDump(decodedContent))
+}
+
 export const convertFolderOrderToArray = (folderOrder) => {
   let currFolderEntry = {}
   return folderOrder.reduce((acc, curr, currIdx) => {
@@ -594,6 +601,14 @@ export const convertFolderOrderToArray = (folderOrder) => {
   }, [])
 }
 
+export const convertArrayToFolderOrder = (array) => {
+  const updatedFolderOrder = array.map(({ type, children, path }) => {
+    if (type == 'dir') return children
+    if (type == 'file') return path
+  })
+  return _.flatten(updatedFolderOrder)
+}
+
 export const retrieveSubfolderContents = (folderOrder, subfolderName) => {
   return folderOrder.reduce((acc, curr) => {
     const folderPathArr = curr.split('/')
@@ -610,3 +625,16 @@ export const retrieveSubfolderContents = (folderOrder, subfolderName) => {
     return acc
   }, [])
 }
+
+export const convertSubfolderArray = (folderOrderArray, rawFolderContents, subfolderName) => {
+  const arrayCopy = _.cloneDeep(folderOrderArray)
+  return rawFolderContents.map((curr) => {
+    const folderPathArr = curr.split('/')
+    const subfolderTitle = folderPathArr[0]
+    if (folderPathArr.length === 2 && subfolderTitle === subfolderName) {
+      const { path } = arrayCopy.shift()
+      return path
+    }
+    return curr
+  })
+} 


### PR DESCRIPTION
This PR adds drag-drop functionality to 1) reorder files and folders in a collection, 2) reorder files in a subfolder. This PR addresses #344, and is a follow-up to #350. The contents of this PR are identical to that on #353 with the exception of the latest commit c25644a, and just applies the changes on the latest staging.

This PR does not support dragging a file into a subfolder. To simplify the saving logic, the backend is only updated after a user completes the "Rearrange Items" button. The Header backnav will display a warning if a user has not saved their reordered pages. 