### PR TITLE
refactor: use react-query for EditNavBar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -149,6 +149,7 @@ function App() {
                     <ProtectedRouteWithProps path="/sites/:siteName/collections/:collectionName" component={CategoryPages} isResource={false}/>
                     <ProtectedRouteWithProps exact path="/sites/:siteName/folder/:folderName" component={Folders} />
                     <ProtectedRouteWithProps exact path="/sites/:siteName/folder/:folderName/subfolder/:subfolderName" component={Folders} />
+                    <ProtectedRouteWithProps exact path="/sites/:siteName/navbar" component={EditNavBar} />
                     <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
                     <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
                     <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,12 @@
+import React from 'react';
 import axios from 'axios';
+import { toast } from 'react-toastify';
+
+import Toast from './components/Toast';
+
+import { DEFAULT_ERROR_TOAST_MSG } from './utils';
+
+import elementStyles from './styles/isomer-cms/Elements.module.scss';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -67,9 +75,30 @@ const getEditNavBarData = async(siteName) => {
     }
 }
 
+const updateNavBarData = async (siteName, originalNav, links, sha) => {
+    try {
+        const params = {
+            content: {
+                ...originalNav,
+                links
+            },
+            sha: sha,
+        };
+        await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
+        window.location.reload();
+    } catch (err) {
+        toast(
+          <Toast notificationType='error' text={`There was a problem trying to save your nav bar. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+        );
+        throw err
+    }
+}
+
 export {
     getDirectoryFile,
     setDirectoryFile,
     getFolderContents,
     getEditNavBarData,
+    updateNavBarData,
 }

--- a/src/api.js
+++ b/src/api.js
@@ -33,8 +33,43 @@ const getFolderContents = async (siteName, folderName, subfolderName) => {
     return await axios.get(`${BACKEND_URL}/sites/${siteName}/folders?path=_${folderName}${subfolderName ? `/${subfolderName}` : ''}`);
 }
 
+// EditNavBar
+
+const getEditNavBarData = async(siteName) => {
+    let navContent, collectionContent, resourceContent, navSha
+      try {
+        const resp = await axios.get(`${BACKEND_URL}/sites/${siteName}/navigation`);
+        const { content, sha } = resp.data;
+        navContent = content
+        navSha = sha
+        const collectionResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`)
+        collectionContent = collectionResp.data
+        const resourceResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/resources`)
+        resourceContent = resourceResp.data
+
+        if (!navContent) return
+
+        return {
+            navContent,
+            navSha,
+            collectionContent,
+            resourceContent,
+        }
+      } catch (err) {
+        if (err.response && err.response.status === 404) {
+            throw {
+                status: 404,
+                message: err.response.data.message,
+            }
+        }
+
+        throw err
+    }
+}
+
 export {
     getDirectoryFile,
     setDirectoryFile,
     getFolderContents,
+    getEditNavBarData,
 }

--- a/src/components/LoadingButtonReactQuery.jsx
+++ b/src/components/LoadingButtonReactQuery.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function LoadingButton(props) {
+  // extract props
+  const {
+    label,
+    disabled,
+    disabledStyle,
+    className,
+    callback,
+    isLoading,
+    ...remainingProps
+  } = props;
+
+  return (
+    <button
+      type="button"
+      className={isLoading ? `${className} ${disabledStyle}` : className}
+      disabled={isLoading ? true : disabled}
+      onClick={() => callback()}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...remainingProps}
+    >
+      {isLoading
+        ? (
+          <div className="spinner-border text-primary" role="status" />
+        ) : label}
+    </button>
+  );
+}
+
+LoadingButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  disabledStyle: PropTypes.string.isRequired,
+  className: PropTypes.string.isRequired,
+  callback: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+};
+
+LoadingButton.defaultProps = {
+  disabled: false,
+};

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -3,9 +3,12 @@ import axios from 'axios';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
+import { useQuery } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 import { DragDropContext } from 'react-beautiful-dnd';
-import { Redirect } from 'react-router-dom'
+import { Redirect } from 'react-router-dom';
 import { toast } from 'react-toastify';
+
 
 import { DEFAULT_ERROR_TOAST_MSG, deslugifyDirectory, isEmpty } from '../utils';
 
@@ -99,6 +102,8 @@ const EditNavBar =  ({ match }) => {
         return;
     }
   };
+
+
 
   useEffect(() => {
     let _isMounted = true
@@ -643,6 +648,9 @@ const EditNavBar =  ({ match }) => {
               state: {siteName: siteName}
           }}
         />
+      }
+      {
+          process.env.REACT_APP_ENV === 'LOCAL_DEV' && <ReactQueryDevtools initialIsOpen={false} />
       }
     </>
   )

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -9,10 +9,13 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import { Redirect } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
-
 import { DEFAULT_ERROR_TOAST_MSG, deslugifyDirectory, isEmpty } from '../utils';
+import { validateLink } from '../utils/validators';
 
 import Toast from '../components/Toast';
+import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
+import DeleteWarningModal from '../components/DeleteWarningModal';
 import NavSection from '../components/navbar/NavSection'
 import TemplateNavBar from '../templates/NavBar'
 
@@ -20,13 +23,11 @@ import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 
-import Header from '../components/Header';
-import LoadingButton from '../components/LoadingButton';
-
-import DeleteWarningModal from '../components/DeleteWarningModal';
-import { validateLink } from '../utils/validators';
+// Import API
+import { getEditNavBarData } from '../api';
 
 const RADIX_PARSE_INT = 10
+const NAVIGATION_CONTENT_KEY = 'navigation-contents';
 
 const EditNavBar =  ({ match }) => {
   const { siteName } = match.params
@@ -103,35 +104,40 @@ const EditNavBar =  ({ match }) => {
     }
   };
 
-
+  const { data: navigationContents, error: queryError } = useQuery(
+    NAVIGATION_CONTENT_KEY,
+    () => getEditNavBarData(siteName),
+    { retry: false },
+  );
 
   useEffect(() => {
-    let _isMounted = true
-
-    const loadNavBarDetails = async () => {
-      let navContent, collectionContent, resourceContent, navSha
-      try {
-        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/navigation`);
-        const { content, sha } = resp.data;
-        navContent = content
-        navSha = sha
-        const collectionResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections`)
-        collectionContent = collectionResp.data
-        const resourceResp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources`)
-        resourceContent = resourceResp.data
-      } catch (error) {
-        if (error?.response?.status === 404) {
-          setShouldRedirectToNotFound(true)
-        } else {
-          toast(
-            <Toast notificationType='error' text={`There was a problem trying to load your data. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-          );
-        }
-        console.log(error)
+    let _isMounted = true;
+    if (queryError) {
+      if (queryError.status === 404) {
+        // redirect if one of the nav bar assets cannot be found
+        if (!shouldRedirectToNotFound && _isMounted) setShouldRedirectToNotFound(true)
+      } else {
+        toast(
+          <Toast notificationType='error' text={`There was a problem trying to load your data. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
+        );
       }
+    }
 
-      if (!navContent) return
+    return () => {
+      _isMounted = false;
+    }
+  }, [queryError])
+
+  useEffect(() => {
+    let _isMounted = true;
+    if (!_.isEmpty(navigationContents)) {
+      const {
+        navContent,
+        navSha,
+        collectionContent,
+        resourceContent,
+      } = navigationContents
 
       const { links: initialLinks } = navContent
 
@@ -176,12 +182,10 @@ const EditNavBar =  ({ match }) => {
       }
     }
 
-    loadNavBarDetails()
-
     return () => {
-      _isMounted = false
+      _isMounted = false;
     }
-  }, [])
+  }, [navigationContents])
 
   const onFieldChange = async (event) => {
     try {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -58,16 +58,21 @@ const Folders = ({ match, location }) => {
     )
 
     useEffect(() => {
+      let _isMounted = true;
       if (queryError) {
         if (queryError.status === 404) {
           // redirect if collection/folder cannot be found
-          if (!shouldRedirect) setShouldRedirect(true)
+          if (!shouldRedirect && _isMounted) setShouldRedirect(true)
         } else {
           toast(
             <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
             {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
           );
         }
+      }
+
+      return () => {
+        _isMounted = false
       }
     }, [queryError])
 


### PR DESCRIPTION
## Overview

This PR refactors the `EditNavBar` layout to use `react-query`, in line with our recent PRs (#350, #357). The GET and POST API calls are now defined as functions within the `api.js` file, and we replace them with `useQuery` and `useMutation` in the `EditNavBar` code.

This PR also creates a new, simplified `LoadingButton` component that is compatible with `react-query`. `react-query` provides us with the loading state of our api call - this means we don't need to handle it ourselves within our `LoadingButton` component. The new button component simply receives an `isLoading` prop and renders a loading spinner and loading styles when `isLoading` is true.
