### PR TITLE
Feat/folder creation modal layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,6 +161,7 @@ function App() {
                     <ProtectedRouteWithProps path="/sites/:siteName/resources/:resourceName/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={true} />
                     <ProtectedRouteWithProps path="/sites/:siteName/resources/:collectionName" component={CategoryPages} isResource={true}/>
                     <ProtectedRouteWithProps path="/sites/:siteName/resources" component={Resources} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/navbar" component={EditNavBar} />
                     <ProtectedRouteWithProps path="/sites/:siteName/menus/main-menu" component={EditNav} />
                     <ProtectedRouteWithProps path="/sites/:siteName/menus" component={Menus} />
                     <ProtectedRouteWithProps path="/sites/:siteName/settings" component={Settings} />

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -72,7 +72,7 @@ const ComponentSettingsModal = ({
     loadThirdNavOptions,
     setIsComponentSettingsActive,
 }) => {
-    const { setShouldRedirect, setRedirectUrl } = useRedirectHook()
+    const { setRedirectToPage } = useRedirectHook()
     // Errors
     const [errors, setErrors] = useState({
         title: '',
@@ -267,8 +267,7 @@ const ComponentSettingsModal = ({
               if (type === 'resource' && !isPost && originalCategory) {
                 window.location.reload();
               } else {
-                setRedirectUrl(redirectUrl)
-                setShouldRedirect(true)
+                setRedirectToPage(redirectUrl)
               }  
             }
                       

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -26,6 +26,8 @@ const FolderCard = ({
   pageType,
   siteName,
   category,
+  folderStyle,
+  onClick,
 }) => {
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
   const [canShowDropdown, setCanShowDropdown] = useState(false)
@@ -69,6 +71,8 @@ const FolderCard = ({
         return 'bxs-phone'
       case 'nav':
         return 'bxs-compass'
+      case 'file':
+        return 'bxs-file-blank'
       default: 
         return 'bxs-folder'
     }
@@ -106,6 +110,48 @@ const FolderCard = ({
     }
   }
 
+  const FolderCardContent = () =>
+    <div id={itemIndex} className={`${contentStyles.folderInfo}`}>
+      <i className={`bx bx-md text-dark ${generateImage(pageType)} ${contentStyles.componentIcon}`} />
+      <span className={`${contentStyles.componentFolderName} align-self-center ml-4 mr-auto`}>{displayText}</span>
+      {
+        pageType === 'homepage' || pageType === 'contact-us' || pageType === 'nav' || pageType === 'file'
+        ? ''
+        : (
+          <div className={`position-relative`}>
+            <button
+              className={contentStyles.componentIcon}
+              type="button"
+              id={`settings-folder-${itemIndex}`}
+              onClick={(e) => {
+                e.preventDefault();
+                settingsToggle(e);
+                setCanShowDropdown(true)
+              }}
+            >
+              <i id={`settingsIcon-${itemIndex}`} className="bx bx-dots-vertical-rounded" />
+            </button>
+          { canShowDropdown &&
+            <div className={`${elementStyles.dropdown} ${isOutOfViewport && elementStyles.right}`} ref={dropdownRef} tabIndex={2} onBlur={()=>setCanShowDropdown(false)}>
+              { isOutOfViewport !== undefined && 
+                <>
+                  <MenuItem handler={(e) => {dropdownRef.current.blur(); setIsFolderModalOpen(true)}} id={`folderSettings-${itemIndex}`}>
+                    <i id={`settingsIcon-${itemIndex}`} className="bx bx-sm bx-edit"/>
+                    <div className={elementStyles.dropdownText}>Rename</div>
+                  </MenuItem>
+                  <MenuItem handler={() => {dropdownRef.current.blur(); setCanShowDeleteWarningModal(true)}} id={`folderDelete-${itemIndex}`}>
+                    <i className="bx bx-sm bx-trash text-danger"/>
+                    <div className={elementStyles.dropdownText}>Delete folder</div>
+                  </MenuItem>
+                </>
+              }
+            </div>
+          }
+          </div>
+        )
+      }
+    </div>
+
   return (
     <>
       { isFolderModalOpen &&
@@ -125,48 +171,16 @@ const FolderCard = ({
           type="folder"
         />
       }
-      <Link className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard}`} to={generateLink()}>
-        <div id={itemIndex} className={`${contentStyles.folderInfo}`}>
-          <i className={`bx bx-md text-dark ${generateImage(pageType)} ${contentStyles.componentIcon}`} />
-          <span className={`${contentStyles.componentFolderName} align-self-center ml-4 mr-auto`}>{displayText}</span>
-          {
-            pageType === 'homepage' || pageType === 'contact-us' || pageType === 'nav'
-            ? ''
-            : (
-              <div className={`position-relative`}>
-                <button
-                  className={contentStyles.componentIcon}
-                  type="button"
-                  id={`settings-folder-${itemIndex}`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    settingsToggle(e);
-                    setCanShowDropdown(true)
-                  }}
-                >
-                  <i id={`settingsIcon-${itemIndex}`} className="bx bx-dots-vertical-rounded" />
-                </button>
-              { canShowDropdown &&
-                <div className={`${elementStyles.dropdown} ${isOutOfViewport && elementStyles.right}`} ref={dropdownRef} tabIndex={2} onBlur={()=>setCanShowDropdown(false)}>
-                  { isOutOfViewport !== undefined && 
-                    <>
-                      <MenuItem handler={(e) => {dropdownRef.current.blur(); setIsFolderModalOpen(true)}} id={`folderSettings-${itemIndex}`}>
-                        <i id={`settingsIcon-${itemIndex}`} className="bx bx-sm bx-edit"/>
-                        <div className={elementStyles.dropdownText}>Rename</div>
-                      </MenuItem>
-                      <MenuItem handler={() => {dropdownRef.current.blur(); setCanShowDeleteWarningModal(true)}} id={`folderDelete-${itemIndex}`}>
-                        <i className="bx bx-sm bx-trash text-danger"/>
-                        <div className={elementStyles.dropdownText}>Delete folder</div>
-                      </MenuItem>
-                    </>
-                  }
-                </div>
-              }
-              </div>
-            )
-          }
+      {generateLink() 
+        ? 
+          <Link className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard} ${folderStyle}`} to={generateLink()}>
+            {FolderCardContent()}
+          </Link>
+        :
+        <div className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard} ${folderStyle}`} onClick={onClick}>
+          {FolderCardContent()}
         </div>
-      </Link>
+      }
     </>
   )
 }

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -146,7 +146,11 @@ const FolderCreationModal = ({
               </div>
               <div className={`d-flex justify-content-between w-100`}>
                 <span>Pages</span>
-                <span className={`w-25`}>{`Sort by`}
+                <span className={`w-25 ${contentStyles.segment}`}>
+                  <span className={elementStyles.sortLabel}>
+                    {`Sort by `}
+                  </span>
+                  
                   <Select
                     onChange={sortOrderChangeHandler}
                     className={'w-100'}

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -26,20 +26,18 @@ const FolderCreationModal = ({
   pagesData,
   siteName,
   setIsFolderCreationActive,
+  setRedirectToNewPage,
+  setNewPageUrl,
 }) => {
   // Errors
   const [errors, setErrors] = useState('')
 
-  const [folderName, setFolderName] = useState('');
   const [title, setTitle] = useState('')
   const [selectedFiles, setSelectedFiles] = useState(new Set())
   //retrieve only when necessary, i.e. after user has chosen to move this page
   // const [sha, setSha] = useState('')
 
   const [isSelectingTitle, setIsSelectingTitle] = useState(true)
-  // Page redirection and modals
-  const [newPageUrl, setNewPageUrl] = useState('')
-  const [redirectToNewPage, setRedirectToNewPage] = useState(false)
   const [sortedPagesData, setSortedPagesData] = useState(pagesData)
 
   const sortOptions = [
@@ -191,16 +189,6 @@ const FolderCreationModal = ({
           </div>
         }
       </div>
-      {
-        redirectToNewPage
-        && (
-          <Redirect
-            to={{
-              pathname: newPageUrl
-            }}
-          />
-        )
-      }
     </>
   );
 }
@@ -213,4 +201,6 @@ FolderCreationModal.propTypes = {
   // pagesData, TODO
   siteName: PropTypes.string.isRequired,
   setIsFolderCreationActive: PropTypes.func.isRequired,
+  setRedirectToNewPage: PropTypes.func.isRequired,
+  setNewPageUrl: PropTypes.func.isRequired,
 };

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -13,6 +13,7 @@ import FolderNamingModal from './FolderNamingModal';
 import useRedirectHook from '../hooks/useRedirectHook';
 
 import { validateCategoryName } from '../utils/validators';
+import { deslugifyPage } from '../utils'
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
@@ -150,7 +151,7 @@ const FolderCreationModal = ({
                     sortedPagesData && sortedPagesData.length > 0
                     ? sortedPagesData.map((pageData, pageIdx) => (
                           <FolderCard
-                              displayText={pageData.title}
+                              displayText={deslugifyPage(pageData.title)}
                               settingsToggle={() => {}}
                               key={pageData.title}
                               pageType={"file"}

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -15,6 +15,7 @@ import adminStyles from '../styles/isomer-cms/pages/Admin.module.scss';
 import { validateCategoryName } from '../utils/validators';
 import { toast } from 'react-toastify';
 import Toast from './Toast';
+import FolderNamingModal from './FolderNamingModal';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -102,39 +103,13 @@ const FolderCreationModal = ({
     <>
       <div className={elementStyles.overlay}>
         { isSelectingTitle &&
-          <div className={elementStyles['modal-newfolder']}>
-            <div className={elementStyles.modalHeader}>
-              <h1>{`Create new sub folder`}</h1>
-              <button id="settings-CLOSE" type="button" onClick={() => setIsFolderCreationActive(false)}>
-                <i id="settingsIcon-CLOSE" className="bx bx-x" />
-              </button>
-            </div>
-            <div className={elementStyles.modalContent}>
-              <div>
-                
-              You may edit folder name anytime. <br/>Choose the pages you would like to group.</div>
-              <div className={elementStyles.modalFormFields}>
-                {/* Title */}
-                <FormField
-                  title="Sub folder name"
-                  id="subfolder"
-                  value={title}
-                  errorMessage={errors}
-                  isRequired={true}
-                  onFieldChange={folderNameChangeHandler}
-                />
-              </div>
-              <div className={elementStyles.modalButtons}>
-                <LoadingButton
-                  label="Select Pages"
-                  disabled={(errors || !title) ? true : false}
-                  disabledStyle={elementStyles.disabled}
-                  className={(errors || !title) ? elementStyles.disabled : elementStyles.blue}
-                  callback={() => setIsSelectingTitle(false)}
-                />
-              </div>
-            </div>
-          </div>
+          <FolderNamingModal 
+            onClose={() => setIsFolderCreationActive(false)}
+            onProceed={() => setIsSelectingTitle(false)}
+            folderNameChangeHandler={folderNameChangeHandler}
+            title={title}
+            errors={errors}
+          />
         }
         { !isSelectingTitle &&
           <div className={`${elementStyles.fullscreenWrapper}`}>

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -138,8 +138,8 @@ const FolderCreationModal = ({
         }
         { !isSelectingTitle &&
           <div className={`${elementStyles.fullscreenWrapper}`}>
-            <div className={`${adminStyles.adminSidebar} bg-transparent`} />
-            <div className={`${contentStyles.mainSection} bg-light`}>
+            <div className={`${adminStyles.adminSidebar} ${elementStyles.wrappedContent} bg-transparent`} />
+            <div className={`${contentStyles.mainSection} ${elementStyles.wrappedContent} bg-light`}>
               {/* Page title */}
               <div className={contentStyles.sectionHeader}>
                 <h1 className={contentStyles.sectionTitle}>{`Select pages to add into '${title}'`}</h1>

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -1,0 +1,195 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { Base64 } from 'js-base64';
+import PropTypes from 'prop-types';
+import * as _ from 'lodash';
+import { Redirect } from 'react-router-dom';
+import update from 'immutability-helper';
+import Select from 'react-select';
+import FormField from './FormField';
+import FolderCard from './FolderCard';
+import LoadingButton from './LoadingButton';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+import adminStyles from '../styles/isomer-cms/pages/Admin.module.scss';
+import { validateCategoryName } from '../utils/validators';
+import { toast } from 'react-toastify';
+import Toast from './Toast';
+
+// axios settings
+axios.defaults.withCredentials = true
+
+const FolderCreationModal = ({
+  parentFolder,
+  existingSubfolders,
+  pagesData,
+  siteName,
+  setIsFolderCreationActive,
+}) => {
+  // Errors
+  const [errors, setErrors] = useState('')
+
+  const [folderName, setFolderName] = useState('');
+  const [title, setTitle] = useState('')
+  const [selectedFiles, setSelectedFiles] = useState(new Set())
+  //retrieve only when necessary, i.e. after user has chosen to move this page
+  // const [sha, setSha] = useState('')
+
+  const [isSelectingTitle, setIsSelectingTitle] = useState(true)
+  // Page redirection and modals
+  const [newPageUrl, setNewPageUrl] = useState('')
+  const [redirectToNewPage, setRedirectToNewPage] = useState(false)
+  const [sortedPagesData, setSortedPagesData] = useState(pagesData)
+
+  const baseApiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${parentFolder ? `/collections/${parentFolder}` : ''}`
+
+  const saveHandler = async () => {
+    // TODO
+    console.log('saving')
+  }
+
+  const folderNameChangeHandler = (event) => {
+    const { id, value } = event.target;
+    let errorMessage = validateCategoryName(value, 'page')
+    if (existingSubfolders.includes(value)) errorMessage = `Another folder with the same name exists. Please choose a different name.`
+    setTitle(value)
+    setErrors(errorMessage)
+  }
+
+  const fileSelectChangeHandler = (name) => {
+    let newSelectedFiles
+    if (selectedFiles.has(name)) {
+      newSelectedFiles = update(selectedFiles, {
+        $remove: [name]
+      })
+    } else {
+      newSelectedFiles = update(selectedFiles, {
+        $add: [name]
+      })
+    }
+    setSelectedFiles(newSelectedFiles)
+  }
+
+  return (
+    <>
+      <div className={elementStyles.overlay}>
+        { isSelectingTitle &&
+          <div className={elementStyles['modal-newfolder']}>
+            <div className={elementStyles.modalHeader}>
+              <h1>{`Create new sub folder`}</h1>
+              <button id="settings-CLOSE" type="button" onClick={() => setIsFolderCreationActive(false)}>
+                <i id="settingsIcon-CLOSE" className="bx bx-x" />
+              </button>
+            </div>
+            <div className={elementStyles.modalContent}>
+              <div>
+                
+              You may edit folder name anytime. <br/>Choose the pages you would like to group.</div>
+              <div className={elementStyles.modalFormFields}>
+                {/* Title */}
+                <FormField
+                  title="Sub folder name"
+                  id="subfolder"
+                  value={title}
+                  errorMessage={errors}
+                  isRequired={true}
+                  onFieldChange={folderNameChangeHandler}
+                />
+              </div>
+              <div className={elementStyles.modalButtons}>
+                <LoadingButton
+                  label="Select Pages"
+                  disabled={(errors || !title) ? true : false}
+                  disabledStyle={elementStyles.disabled}
+                  className={(errors || !title) ? elementStyles.disabled : elementStyles.blue}
+                  callback={() => setIsSelectingTitle(false)}
+                />
+              </div>
+            </div>
+          </div>
+        }
+        { !isSelectingTitle &&
+          <div className={`${elementStyles.fullscreenWrapper}`}>
+            <div className={`${adminStyles.adminSidebar} bg-transparent`} />
+            <div className={`${contentStyles.mainSection} bg-light`}>
+              {/* Page title */}
+              <div className={contentStyles.sectionHeader}>
+                <h1 className={contentStyles.sectionTitle}>{`Select pages to add into '${title}'`}</h1>
+              </div>
+              <div className={`d-flex justify-content-between w-100`}>
+                <span>Pages</span>
+                <div className={`d-flex`}>
+                  <p>{`Sort by`}</p>
+                  <Select
+
+                  />
+                </div>
+              </div>
+              {/* Pages */}
+              <div className={contentStyles.folderContainerBoxes}>
+                <div className={contentStyles.boxesContainer}>
+                  {
+                    sortedPagesData && sortedPagesData.length > 0
+                    ? sortedPagesData.map((pageData, pageIdx) => (
+                          <FolderCard
+                              displayText={pageData.title}
+                              settingsToggle={() => {}}
+                              key={pageData.title}
+                              pageType={"file"}
+                              siteName={siteName}
+                              itemIndex={pageIdx}
+                              folderStyle={selectedFiles.has(pageData.title) ? `border border-primary` : ''}
+                              onClick={() => {
+                                  fileSelectChangeHandler(pageData.title)
+                              }}
+                          />
+                    ))
+                    : (
+                        !sortedPagesData
+                            ? 'Loading Pages...'
+                            : 'There are no pages in this folder'
+                    )
+                  }
+                </div>
+              </div>
+            </div>
+            <div className={contentStyles.sectionFooter}>
+                <LoadingButton
+                  label={`Cancel`}
+                  disabledStyle={elementStyles.disabled}
+                  className={`${elementStyles.warning}`}
+                  callback={() => setIsFolderCreationActive(false)}
+                />
+                <LoadingButton
+                  label={`Done`}
+                  disabledStyle={elementStyles.disabled}
+                  className={`${elementStyles.blue}`}
+                  callback={saveHandler}
+                />
+              </div>
+          </div>
+        }
+      </div>
+      {
+        redirectToNewPage
+        && (
+          <Redirect
+            to={{
+              pathname: newPageUrl
+            }}
+          />
+        )
+      }
+    </>
+  );
+}
+
+export default FolderCreationModal
+
+FolderCreationModal.propTypes = {
+  parentFolder: PropTypes.string.isRequired,
+  existingSubfolders: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // pagesData, TODO
+  siteName: PropTypes.string.isRequired,
+  setIsFolderCreationActive: PropTypes.func.isRequired,
+};

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -44,8 +44,8 @@ const FolderCreationModal = ({
   const sortOptions = [
     ... parentFolder 
       ? [{
-        value: 'collection',
-        label: 'Collection',
+        value: 'folder',
+        label: 'Original order',
       }]
       : [],
     {
@@ -90,8 +90,8 @@ const FolderCreationModal = ({
   }
 
   const sortOrderChangeHandler = (option) => {
-    // Reset to original order in collection
-    if (option.value === 'collection') setSortedPagesData(pagesData)
+    // Reset to original order in folder
+    if (option.value === 'folder') setSortedPagesData(pagesData)
     else {
       const sortedOrder = sortedPagesData.concat().sort(sortFuncs[option.value])
       setSortedPagesData(sortedOrder)
@@ -153,8 +153,8 @@ const FolderCreationModal = ({
                     defaultValue={
                       parentFolder 
                       ? {
-                          value: 'collection',
-                          label: 'Collection',
+                          value: 'folder',
+                          label: 'Original order',
                         }
                       : {
                           value: 'title',

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -201,6 +201,4 @@ FolderCreationModal.propTypes = {
   // pagesData, TODO
   siteName: PropTypes.string.isRequired,
   setIsFolderCreationActive: PropTypes.func.isRequired,
-  setRedirectToNewPage: PropTypes.func.isRequired,
-  setNewPageUrl: PropTypes.func.isRequired,
 };

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -1,21 +1,22 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import axios from 'axios';
-import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import * as _ from 'lodash';
-import { Redirect } from 'react-router-dom';
 import update from 'immutability-helper';
 import Select from 'react-select';
-import FormField from './FormField';
+import { toast } from 'react-toastify';
+
 import FolderCard from './FolderCard';
 import LoadingButton from './LoadingButton';
+import Toast from './Toast';
+import FolderNamingModal from './FolderNamingModal';
+import useRedirectHook from '../hooks/useRedirectHook';
+
+import { validateCategoryName } from '../utils/validators';
+
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 import adminStyles from '../styles/isomer-cms/pages/Admin.module.scss';
-import { validateCategoryName } from '../utils/validators';
-import { toast } from 'react-toastify';
-import Toast from './Toast';
-import FolderNamingModal from './FolderNamingModal';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -26,11 +27,10 @@ const FolderCreationModal = ({
   pagesData,
   siteName,
   setIsFolderCreationActive,
-  setRedirectToNewPage,
-  setNewPageUrl,
 }) => {
   // Errors
   const [errors, setErrors] = useState('')
+  const { setShouldRedirect, setRedirectUrl } = useRedirectHook()
 
   const [title, setTitle] = useState('')
   const [selectedFiles, setSelectedFiles] = useState(new Set())

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -41,6 +41,19 @@ const FolderCreationModal = ({
   const [redirectToNewPage, setRedirectToNewPage] = useState(false)
   const [sortedPagesData, setSortedPagesData] = useState(pagesData)
 
+  const sortOptions = [
+    ... parentFolder 
+      ? [{
+        value: 'collection',
+        label: 'Collection',
+      }]
+      : [],
+    {
+      value: 'title',
+      label: 'Name'
+    }
+  ]
+
   const baseApiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}${parentFolder ? `/collections/${parentFolder}` : ''}`
 
   const saveHandler = async () => {
@@ -68,6 +81,21 @@ const FolderCreationModal = ({
       })
     }
     setSelectedFiles(newSelectedFiles)
+  }
+
+  const sortFuncs = {
+    'title': (a, b) => {
+      return a.title.localeCompare(b.title)
+    }
+  }
+
+  const sortOrderChangeHandler = (option) => {
+    // Reset to original order in collection
+    if (option.value === 'collection') setSortedPagesData(pagesData)
+    else {
+      const sortedOrder = sortedPagesData.concat().sort(sortFuncs[option.value])
+      setSortedPagesData(sortedOrder)
+    }
   }
 
   return (
@@ -118,13 +146,26 @@ const FolderCreationModal = ({
               </div>
               <div className={`d-flex justify-content-between w-100`}>
                 <span>Pages</span>
-                <div className={`d-flex`}>
-                  <p>{`Sort by`}</p>
+                <span className={`w-25`}>{`Sort by`}
                   <Select
-
+                    onChange={sortOrderChangeHandler}
+                    className={'w-100'}
+                    defaultValue={
+                      parentFolder 
+                      ? {
+                          value: 'collection',
+                          label: 'Collection',
+                        }
+                      : {
+                          value: 'title',
+                          label: 'Name',
+                        }
+                    }
+                    options={sortOptions}
                   />
-                </div>
+                </span>
               </div>
+              <br/>
               {/* Pages */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
@@ -162,8 +203,9 @@ const FolderCreationModal = ({
                 />
                 <LoadingButton
                   label={`Done`}
+                  disabled={selectedFiles.size === 0}
                   disabledStyle={elementStyles.disabled}
-                  className={`${elementStyles.blue}`}
+                  className={`${selectedFiles.size === 0 ? elementStyles.disabled : elementStyles.blue}`}
                   callback={saveHandler}
                 />
               </div>

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -30,7 +30,7 @@ const FolderCreationModal = ({
 }) => {
   // Errors
   const [errors, setErrors] = useState('')
-  const { setShouldRedirect, setRedirectUrl } = useRedirectHook()
+  const { setRedirectToPage } = useRedirectHook()
 
   const [title, setTitle] = useState('')
   const [selectedFiles, setSelectedFiles] = useState(new Set())

--- a/src/components/FolderNamingModal.jsx
+++ b/src/components/FolderNamingModal.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { Base64 } from 'js-base64';
+import PropTypes from 'prop-types';
+import * as _ from 'lodash';
+import { Redirect } from 'react-router-dom';
+import update from 'immutability-helper';
+import Select from 'react-select';
+import FormField from './FormField';
+import FolderCard from './FolderCard';
+import LoadingButton from './LoadingButton';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+import adminStyles from '../styles/isomer-cms/pages/Admin.module.scss';
+import { validateCategoryName } from '../utils/validators';
+import { toast } from 'react-toastify';
+import Toast from './Toast';
+
+const FolderNamingModal = ({
+  onClose,
+  onProceed,
+  folderNameChangeHandler,
+  title,
+  errors,
+}) => {
+
+  return (         
+    <div className={elementStyles['modal-newfolder']}>
+      <div className={elementStyles.modalHeader}>
+        <h1>{`Create new sub folder`}</h1>
+        <button id="settings-CLOSE" type="button" onClick={onClose}>
+          <i id="settingsIcon-CLOSE" className="bx bx-x" />
+        </button>
+      </div>
+      <div className={elementStyles.modalContent}>
+        <div>
+          You may edit folder name anytime.
+          <br/>
+          Choose the pages you would like to group.
+        </div>
+        <div className={elementStyles.modalFormFields}>
+          {/* Title */}
+          <FormField
+            title="Sub folder name"
+            id="subfolder"
+            value={title}
+            errorMessage={errors}
+            isRequired={true}
+            onFieldChange={folderNameChangeHandler}
+          />
+        </div>
+        <div className={elementStyles.modalButtons}>
+          <LoadingButton
+            label="Select Pages"
+            disabled={(errors || !title) ? true : false}
+            disabledStyle={elementStyles.disabled}
+            className={(errors || !title) ? elementStyles.disabled : elementStyles.blue}
+            callback={onProceed}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FolderNamingModal
+
+FolderNamingModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onProceed: PropTypes.func.isRequired,
+  folderNameChangeHandler: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  errors: PropTypes.string,
+};

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { Redirect } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import GenericWarningModal from './GenericWarningModal'
+import useRedirectHook from '../hooks/useRedirectHook';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 // Import context
@@ -19,25 +19,27 @@ const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 const Header = ({
   showButton, title, isEditPage, shouldAllowEditPageBackNav, backButtonText, backButtonUrl,
 }) => {
+  const { shouldRedirect, setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
   const setLogoutState = useContext(LoginContext)
 
-  const [shouldRedirect, setShouldRedirect] = useState(false)
-  const [shouldPerformBackNav, setShouldPerformBackNav] = useState(false)
   const [showBackNavWarningModal, setShowBackNavWarningModal] = useState(false)
 
   useEffect(() => {
     let _isMounted = true
-    if (shouldPerformBackNav && _isMounted) setShouldPerformBackNav(false)
-    if (shouldRedirect && _isMounted) setShouldRedirect(false)
+    if (_isMounted) {
+      setShouldRedirect(false)
+    }
 
     return () => { _isMounted = false }
-  }, [shouldPerformBackNav, shouldRedirect])
+  }, [shouldRedirect])
 
   const clearCookie = async () => {
     try {
       // Call the logout endpoint in the API server to clear the browser cookie
       localStorage.removeItem(userIdKey)
       await axios.get(`${BACKEND_URL}/auth/logout`)
+      setRedirectUrl('/')
+      setRedirectComponentState({ isFromSignOutButton: true })
       setShouldRedirect(true)
       setLogoutState()
     } catch (err) {
@@ -47,7 +49,8 @@ const Header = ({
   }
 
   const toggleBackNav = () => {
-    setShouldPerformBackNav(!shouldPerformBackNav)
+    setRedirectUrl(backButtonUrl)
+    setShouldRedirect(true)
   }
 
   const handleBackNav = () => {
@@ -87,21 +90,6 @@ const Header = ({
           Log Out
         </button>
       </div>
-      { shouldPerformBackNav && 
-        <Redirect
-          to={{
-            pathname: backButtonUrl
-          }}
-        />
-      }
-      { shouldRedirect && 
-        <Redirect
-          to={{
-            pathname: '/',
-            state: { isFromSignOutButton: true },
-          }}
-        />
-      }
       {
         showBackNavWarningModal &&
         <GenericWarningModal

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -19,38 +19,25 @@ const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 const Header = ({
   showButton, title, isEditPage, shouldAllowEditPageBackNav, backButtonText, backButtonUrl,
 }) => {
-  const { shouldRedirect, setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
+  const { setRedirectToPage, setRedirectToLogout } = useRedirectHook()
   const setLogoutState = useContext(LoginContext)
 
   const [showBackNavWarningModal, setShowBackNavWarningModal] = useState(false)
-
-  useEffect(() => {
-    let _isMounted = true
-    if (_isMounted) {
-      setShouldRedirect(false)
-    }
-
-    return () => { _isMounted = false }
-  }, [shouldRedirect])
 
   const clearCookie = async () => {
     try {
       // Call the logout endpoint in the API server to clear the browser cookie
       localStorage.removeItem(userIdKey)
       await axios.get(`${BACKEND_URL}/auth/logout`)
-      setRedirectUrl('/')
-      setRedirectComponentState({ isFromSignOutButton: true })
-      setShouldRedirect(true)
+      setRedirectToLogout()
       setLogoutState()
     } catch (err) {
       console.error(err)
-      setShouldRedirect(false)
     }
   }
 
   const toggleBackNav = () => {
-    setRedirectUrl(backButtonUrl)
-    setShouldRedirect(true)
+    setRedirectToPage(backButtonUrl)
   }
 
   const handleBackNav = () => {

--- a/src/hooks/useRedirectHook.jsx
+++ b/src/hooks/useRedirectHook.jsx
@@ -8,13 +8,33 @@ const useRedirectHook = () => {
   const history = useHistory()
 
   useEffect(() => {
-    if (shouldRedirect) history.push({
-      pathname: redirectUrl,
-      state: redirectComponentState
-    })
+    if (shouldRedirect) {
+      setShouldRedirect(false)
+      history.push({
+        pathname: redirectUrl,
+        state: redirectComponentState
+      })
+    }
   }, [shouldRedirect])
 
-  return { shouldRedirect, setShouldRedirect, setRedirectUrl, setRedirectComponentState }
+  const setRedirectToNotFound = (siteName) => {
+    setRedirectUrl("/not-found")
+    setRedirectComponentState({ siteName })
+    setShouldRedirect(true)
+  }
+
+  const setRedirectToPage = (url) => {
+    setRedirectUrl(url)
+    setShouldRedirect(true)
+  }
+
+  const setRedirectToLogout = () => {
+    setRedirectUrl("/")
+    setRedirectComponentState({ isFromSignOutButton: true })
+    setShouldRedirect(true)
+  }
+
+  return { setRedirectToNotFound, setRedirectToPage, setRedirectToLogout }
 }
 
 export default useRedirectHook;

--- a/src/hooks/useRedirectHook.jsx
+++ b/src/hooks/useRedirectHook.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react"
+import { Redirect, useHistory } from "react-router-dom"
+
+const useRedirectHook = () => {
+  const [shouldRedirect, setShouldRedirect] = useState(false)
+  const [redirectUrl, setRedirectUrl] = useState('')
+  const [redirectComponentState, setRedirectComponentState] = useState({})
+  const history = useHistory()
+
+  useEffect(() => {
+    if (shouldRedirect) history.push({
+      pathname: redirectUrl,
+      state: redirectComponentState
+    })
+  }, [shouldRedirect])
+
+  return { shouldRedirect, setShouldRedirect, setRedirectUrl, setRedirectComponentState }
+}
+
+export default useRedirectHook;

--- a/src/hooks/useRedirectHook.jsx
+++ b/src/hooks/useRedirectHook.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react"
-import { Redirect, useHistory } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { useHistory } from "react-router-dom"
 
 const useRedirectHook = () => {
   const [shouldRedirect, setShouldRedirect] = useState(false)

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -6,7 +6,6 @@ import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
 import { DragDropContext } from 'react-beautiful-dnd';
-import { Redirect } from 'react-router-dom'
 import { toast } from 'react-toastify';
 
 import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody, isEmpty } from '../utils';
@@ -35,6 +34,7 @@ import GenericWarningModal from '../components/GenericWarningModal';
 
 // Import hooks
 import useSiteColorsHook from '../hooks/useSiteColorsHook';
+import useRedirectHook from '../hooks/useRedirectHook';
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-array-index-key */
@@ -111,6 +111,7 @@ const displayDeletedFrontMatter = (deletedFrontMatter) => {
 
 const EditContactUs =  ({ match }) => {
   const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
+  const { setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
 
   const { siteName } = match.params;
   const [hasLoaded, setHasLoaded] = useState(false)
@@ -149,7 +150,6 @@ const EditContactUs =  ({ match }) => {
     type: '',
   })
   const [showDeletedText, setShowDeletedText] = useState(false)
-  const [shouldRedirectToNotFound, setShouldRedirectToNotFound] = useState(false)
 
   useEffect(() => {
     let _isMounted = true
@@ -172,7 +172,9 @@ const EditContactUs =  ({ match }) => {
         sha = pageSha
       } catch (error) {
         if (error?.response?.status === 404) {
-          setShouldRedirectToNotFound(true)
+          setRedirectComponentState({siteName: siteName})
+          setRedirectUrl('/not-found')
+          setShouldRedirect(true)
         } else {
           toast(
             <Toast notificationType='error' text={`There was a problem trying to load your contact us page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
@@ -762,15 +764,6 @@ const EditContactUs =  ({ match }) => {
             />
           </div>
         </div>
-      }
-      {
-        shouldRedirectToNotFound &&
-        <Redirect
-          to={{
-              pathname: '/not-found',
-              state: {siteName: siteName}
-          }}
-        />
       }
     </>
   )

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -111,7 +111,7 @@ const displayDeletedFrontMatter = (deletedFrontMatter) => {
 
 const EditContactUs =  ({ match }) => {
   const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
-  const { setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
+  const { setRedirectToNotFound } = useRedirectHook()
 
   const { siteName } = match.params;
   const [hasLoaded, setHasLoaded] = useState(false)
@@ -172,9 +172,7 @@ const EditContactUs =  ({ match }) => {
         sha = pageSha
       } catch (error) {
         if (error?.response?.status === 404) {
-          setRedirectComponentState({siteName: siteName})
-          setRedirectUrl('/not-found')
-          setShouldRedirect(true)
+          setRedirectToNotFound(siteName)
         } else {
           toast(
             <Toast notificationType='error' text={`There was a problem trying to load your contact us page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -31,7 +31,7 @@ const NAVIGATION_CONTENT_KEY = 'navigation-contents';
 const EditNavBar =  ({ match }) => {
   const { siteName } = match.params
 
-  const { shouldRedirect, setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
+  const { setRedirectToNotFound } = useRedirectHook()
 
   const [sha, setSha] = useState()
   const [links, setLinks] = useState([])
@@ -120,11 +120,7 @@ const EditNavBar =  ({ match }) => {
     if (queryError) {
       if (queryError.status === 404) {
         // redirect if one of the nav bar assets cannot be found
-        if (!shouldRedirect && _isMounted) {
-          setRedirectComponentState({siteName: siteName})
-          setRedirectUrl('/not-found')
-          setShouldRedirect(true)
-        }
+        if (_isMounted) setRedirectToNotFound(siteName)
       } else {
         toast(
           <Toast notificationType='error' text={`There was a problem trying to load your data. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Redirect } from "react-router-dom";
 import axios from 'axios';
 import Bluebird from 'bluebird';
 import PropTypes from 'prop-types';
@@ -49,6 +48,7 @@ import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
 // Import hooks
 import useSiteColorsHook from '../hooks/useSiteColorsHook';
+import useRedirectHook from '../hooks/useRedirectHook';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -100,6 +100,7 @@ const getBackButtonInfo = (resourceCategory, collectionName, siteName) => {
 
 const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) => {
   const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
+  const { setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
 
   const { collectionName, fileName, siteName, resourceName } = match.params;
   const apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })
@@ -118,7 +119,6 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
   const [isFileStagedForUpload, setIsFileStagedForUpload] = useState(false)
   const [stagedFileDetails, setStagedFileDetails] = useState({})
   const [isLoadingPageContent, setIsLoadingPageContent] = useState(true)
-  const [shouldRedirectToNotFound, setShouldRedirectToNotFound] = useState(false)
   const [mediaSearchTerm, setMediaSearchTerm] = useState('')
   const [selectedFile, setSelectedFile] = useState('')
   const [leftNavPages, setLeftNavPages] = useState([])
@@ -147,7 +147,9 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
         sha = pageSha
       } catch (error) {
         if (error?.response?.status === 404) {
-          setShouldRedirectToNotFound(true)
+          setRedirectComponentState({siteName: siteName})
+          setRedirectUrl('/not-found')
+          setShouldRedirect(true)
         } else {
           toast(
             <Toast notificationType='error' text={`There was a problem trying to load your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
@@ -476,15 +478,6 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
           type={isResourcePage ? 'resource' : 'page'}
         />
         )
-      }
-      {
-        shouldRedirectToNotFound &&
-        <Redirect
-          to={{
-              pathname: '/not-found',
-              state: {siteName: siteName}
-          }}
-        />
       }
     </>
   )

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -100,7 +100,7 @@ const getBackButtonInfo = (resourceCategory, collectionName, siteName) => {
 
 const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) => {
   const { retrieveSiteColors, generatePageStyleSheet } = useSiteColorsHook()
-  const { setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
+  const { setRedirectToNotFound } = useRedirectHook()
 
   const { collectionName, fileName, siteName, resourceName } = match.params;
   const apiEndpoint = getApiEndpoint(isResourcePage, isCollectionPage, { collectionName, fileName, siteName, resourceName })
@@ -147,9 +147,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
         sha = pageSha
       } catch (error) {
         if (error?.response?.status === 404) {
-          setRedirectComponentState({siteName: siteName})
-          setRedirectUrl('/not-found')
-          setShouldRedirect(true)
+          setRedirectToNotFound(siteName)
         } else {
           toast(
             <Toast notificationType='error' text={`There was a problem trying to load your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -200,7 +200,7 @@ const Folders = ({ match, location }) => {
               <div className={contentStyles.contentContainerFolderRowMargin}>
                 <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" />
-                <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={subfolderName ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
+                <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={subfolderName || folderOrder.length === 0 ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
               {/* Collections content */}
               {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -39,7 +39,7 @@ const FOLDER_CONTENTS_KEY = 'folder-contents'
 const Folders = ({ match, location }) => {
     const { siteName, folderName, subfolderName } = match.params;
 
-    const { shouldRedirect, setShouldRedirect, setRedirectUrl, setRedirectComponentState } = useRedirectHook()
+    const { setRedirectToPage } = useRedirectHook()
 
     const [isRearrangeActive, setIsRearrangeActive] = useState(false)
     const [directoryFileSha, setDirectoryFileSha] = useState('')
@@ -66,10 +66,8 @@ const Folders = ({ match, location }) => {
       if (queryError) {
         if (queryError.status === 404) {
           // redirect if collection/folder cannot be found
-          if (!shouldRedirect && _isMounted) {
-            setRedirectComponentState({siteName: siteName})
-            setRedirectUrl(`/sites/${siteName}/workspace`)
-            setShouldRedirect(true)
+          if (_isMounted) {
+            setRedirectToPage(`/sites/${siteName}/workspace`)
           }
         } else {
           toast(
@@ -105,11 +103,7 @@ const Folders = ({ match, location }) => {
               setFolderOrderArray(subfolderFiles)
             } else {
               // if subfolderName prop does not match directory file, it's not a valid subfolder
-              if (!shouldRedirect) {
-                setRedirectComponentState({siteName: siteName})
-                setRedirectUrl(`/sites/${siteName}/workspace`)
-                setShouldRedirect(true)
-              }
+              setRedirectToPage(`/sites/${siteName}/workspace`)
             }
           } else {
             setFolderOrderArray(convertFolderOrderToArray(parsedFolderContents))

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -45,6 +45,7 @@ const Folders = ({ match, location }) => {
     const [folderOrder, setFolderOrder] = useState([])
     const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
     const [shouldRedirect, setShouldRedirect] = useState(false)
+    const [redirectUrl, setRedirectUrl] = useState('')
 
     const { data: folderContents, error: queryError } = useQuery(
       FOLDER_CONTENTS_KEY,
@@ -65,7 +66,10 @@ const Folders = ({ match, location }) => {
       if (queryError) {
         if (queryError.status === 404) {
           // redirect if collection/folder cannot be found
-          if (!shouldRedirect && _isMounted) setShouldRedirect(true)
+          if (!shouldRedirect && _isMounted) {
+            setRedirectUrl(`/sites/${siteName}/workspace`)
+            setShouldRedirect(true)
+          }
         } else {
           toast(
             <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
@@ -138,7 +142,7 @@ const Folders = ({ match, location }) => {
         <>
           {
             shouldRedirect &&
-            <Redirect to={{pathname: `/sites/${siteName}/workspace`}} />
+            <Redirect to={{pathname: redirectUrl}} />
           }
           {
             isFolderCreationActive &&
@@ -148,6 +152,8 @@ const Folders = ({ match, location }) => {
               pagesData={folderOrder.filter(item => item.type === 'file')}
               siteName={siteName}
               setIsFolderCreationActive={setIsFolderCreationActive}
+              setRedirectToNewPage={setShouldRedirect}
+              setNewPageUrl={setRedirectUrl}
             />
           }
           <Header

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -9,6 +9,7 @@ import _ from 'lodash';
 // Import components
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
+import FolderCreationModal from '../components/FolderCreationModal'
 import FolderOptionButton from '../components/folders/FolderOptionButton';
 import FolderContent from '../components/folders/FolderContent';
 import Toast from '../components/Toast';
@@ -41,6 +42,8 @@ const Folders = ({ match, location }) => {
     const [directoryFileSha, setDirectoryFileSha] = useState('')
     const [folderOrderArray, setFolderOrderArray] = useState([])
     const [parsedFolderContents, setParsedFolderContents] = useState([])
+    const [folderOrder, setFolderOrder] = useState([])
+    const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
     const [shouldRedirect, setShouldRedirect] = useState(false)
 
     const { data: folderContents, error: queryError } = useQuery(
@@ -137,6 +140,16 @@ const Folders = ({ match, location }) => {
             shouldRedirect &&
             <Redirect to={{pathname: `/sites/${siteName}/workspace`}} />
           }
+          {
+            isFolderCreationActive &&
+            <FolderCreationModal
+              parentFolder={folderName}
+              existingSubfolders={[]}
+              pagesData={folderOrder.filter(item => item.type === 'file')}
+              siteName={siteName}
+              setIsFolderCreationActive={setIsFolderCreationActive}
+            />
+          }
           <Header
             backButtonText={`Back to ${subfolderName ? folderName : 'Workspace'}`}
             backButtonUrl={`/sites/${siteName}/${subfolderName ? `folder/${folderName}` : 'workspace'}`}
@@ -187,7 +200,7 @@ const Folders = ({ match, location }) => {
               <div className={contentStyles.contentContainerFolderRowMargin}>
                 <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" />
-                <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName ? true : false} />
+                <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={subfolderName ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
               {/* Collections content */}
               {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -42,7 +42,6 @@ const Folders = ({ match, location }) => {
     const [directoryFileSha, setDirectoryFileSha] = useState('')
     const [folderOrderArray, setFolderOrderArray] = useState([])
     const [parsedFolderContents, setParsedFolderContents] = useState([])
-    const [folderOrder, setFolderOrder] = useState([])
     const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
     const [shouldRedirect, setShouldRedirect] = useState(false)
     const [redirectUrl, setRedirectUrl] = useState('')
@@ -149,7 +148,7 @@ const Folders = ({ match, location }) => {
             <FolderCreationModal
               parentFolder={folderName}
               existingSubfolders={[]}
-              pagesData={folderOrder.filter(item => item.type === 'file')}
+              pagesData={folderOrderArray.filter(item => item.type === 'file')}
               siteName={siteName}
               setIsFolderCreationActive={setIsFolderCreationActive}
               setRedirectToNewPage={setShouldRedirect}
@@ -206,7 +205,7 @@ const Folders = ({ match, location }) => {
               <div className={contentStyles.contentContainerFolderRowMargin}>
                 <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" />
-                <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={subfolderName || folderOrder.length === 0 ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
+                <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName || folderOrderArray.length === 0 ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
               {/* Collections content */}
               {

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -19,7 +19,6 @@ import { prettifyPageFileName } from '../utils';
 
 // Import hooks
 import useSiteColorsHook from '../hooks/useSiteColorsHook';
-import useRedirectHook from '../hooks/useRedirectHook';
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState, useEffect } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+import { Redirect } from 'react-router-dom';
 
 // Import components
 import Header from '../components/Header';
@@ -32,6 +33,8 @@ const Workspace = ({ match, location }) => {
     const [unlinkedPages, setUnlinkedPages] = useState()
     const [contactUsCard, setContactUsCard] = useState(false)
     const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
+    const [shouldRedirect, setShouldRedirect] = useState(false)
+    const [redirectUrl, setRedirectUrl] = useState('')
 
     useEffect(() => {
       let _isMounted = true
@@ -76,6 +79,10 @@ const Workspace = ({ match, location }) => {
     return (
         <>
           {
+            shouldRedirect &&
+            <Redirect to={{pathname: redirectUrl}} />
+          }
+          {
             isFolderCreationActive &&
             <FolderCreationModal
               existingSubfolders={collections}
@@ -88,6 +95,8 @@ const Workspace = ({ match, location }) => {
               })}
               siteName={siteName}
               setIsFolderCreationActive={setIsFolderCreationActive}
+              setRedirectToNewPage={setShouldRedirect}
+              setNewPageUrl={setRedirectUrl}
             />
           }
           <Header />

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -61,6 +61,7 @@ const Workspace = ({ match, location }) => {
         
         try { 
           const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/unlinkedPages`);
+          console.log(unlinkedPagesResp.data)
           if (_isMounted) {
             setUnlinkedPages(unlinkedPagesResp.data?.pages.filter(page => page.fileName !== 'contact-us.md'))
           }
@@ -148,7 +149,9 @@ const Workspace = ({ match, location }) => {
               {/* Collections */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
-                  <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
+                  { unlinkedPages &&
+                    <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
+                  }
                   {
                     collections && collections.length > 0
                     ? collections.map((collection, collectionIdx) => (

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -162,7 +162,7 @@ const Workspace = ({ match, location }) => {
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
                   { unlinkedPages &&
-                    <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
+                    <FolderOptionButton title="Create new folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
                   }
                   {
                     collections && collections.length > 0

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -7,6 +7,8 @@ import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import CollectionPagesSection from '../components/CollectionPagesSection'
 import FolderCard from '../components/FolderCard'
+import FolderCreationModal from '../components/FolderCreationModal'
+import FolderOptionButton from '../components/folders/FolderOptionButton'
 
 // Import styles
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -29,6 +31,7 @@ const Workspace = ({ match, location }) => {
     const [collections, setCollections] = useState()
     const [unlinkedPages, setUnlinkedPages] = useState()
     const [contactUsCard, setContactUsCard] = useState(false)
+    const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
 
     useEffect(() => {
       let _isMounted = true
@@ -71,6 +74,21 @@ const Workspace = ({ match, location }) => {
 
     return (
         <>
+          {
+            isFolderCreationActive &&
+            <FolderCreationModal
+              existingSubfolders={collections}
+              pagesData={unlinkedPages.map(page => {
+                const newPage = { 
+                  ...page,
+                  title: page.fileName,
+                }
+                return newPage
+              })}
+              siteName={siteName}
+              setIsFolderCreationActive={setIsFolderCreationActive}
+            />
+          }
           <Header />
           {/* main bottom section */}
           <div className={elementStyles.wrapper}>
@@ -130,6 +148,7 @@ const Workspace = ({ match, location }) => {
               {/* Collections */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
+                  <FolderOptionButton title="Create new sub-folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
                   {
                     collections && collections.length > 0
                     ? collections.map((collection, collectionIdx) => (

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -146,6 +146,18 @@ const Workspace = ({ match, location }) => {
                 <i className="bx bx-sm bx-info-circle text-dark" />
                 <span><strong className="ml-1">Note:</strong> Collections cannot be empty, create a page first to create a collection.</span>
               </div>
+              {
+                !collections &&
+                <div className={contentStyles.segment}>
+                  Loading Collections...
+                </div>
+              }
+              {
+                collections && collections.length === 0 &&
+                <div className={contentStyles.segment}>
+                  There are no collections in this repository.
+                </div>
+              }
               {/* Collections */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
@@ -165,11 +177,7 @@ const Workspace = ({ match, location }) => {
                             itemIndex={collectionIdx}
                         />
                     ))
-                    : (
-                        !collections
-                            ? 'Loading Collections...'
-                            : 'There are no collections in this repository'
-                    )
+                    : null
                   }
                 </div>
               </div>

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -1,7 +1,6 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { Redirect } from 'react-router-dom';
 
 // Import components
 import Header from '../components/Header';
@@ -20,6 +19,7 @@ import { prettifyPageFileName } from '../utils';
 
 // Import hooks
 import useSiteColorsHook from '../hooks/useSiteColorsHook';
+import useRedirectHook from '../hooks/useRedirectHook';
 
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
@@ -33,8 +33,6 @@ const Workspace = ({ match, location }) => {
     const [unlinkedPages, setUnlinkedPages] = useState()
     const [contactUsCard, setContactUsCard] = useState(false)
     const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
-    const [shouldRedirect, setShouldRedirect] = useState(false)
-    const [redirectUrl, setRedirectUrl] = useState('')
 
     useEffect(() => {
       let _isMounted = true
@@ -79,10 +77,6 @@ const Workspace = ({ match, location }) => {
     return (
         <>
           {
-            shouldRedirect &&
-            <Redirect to={{pathname: redirectUrl}} />
-          }
-          {
             isFolderCreationActive &&
             <FolderCreationModal
               existingSubfolders={collections}
@@ -95,8 +89,6 @@ const Workspace = ({ match, location }) => {
               })}
               siteName={siteName}
               setIsFolderCreationActive={setIsFolderCreationActive}
-              setRedirectToNewPage={setShouldRedirect}
-              setNewPageUrl={setRedirectUrl}
             />
           }
           <Header />

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -36,6 +36,11 @@ a{
 
 }
 
+.fullscreenWrapper {
+  @extend .wrapper;
+  top: $header-height/2;
+}
+
 h1,h2,h3,h4,h5,h6{
   font-family: 'Lato', sans-serif;
   font-weight: 700 !important;

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -39,6 +39,10 @@ a{
 .fullscreenWrapper {
   @extend .wrapper;
   top: $header-height/2;
+
+  > .wrappedContent {
+    height: calc(100vh - #{$header-height} - #{$footer-height});
+  }
 }
 
 h1,h2,h3,h4,h5,h6{

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -208,4 +208,5 @@
 .folderCard {
   @extend .card;
   padding: 1rem;
+  cursor: pointer;
 }

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -105,7 +105,15 @@
       @extend .folderOptionSelected;
     }
 
-    &:hover > div > i{
+    &:hover > div > i {
+      color: white;
+    }
+
+    > div > span {
+      color: $isomer-blue;
+    }
+
+    &:hover > div > span {
       color: white;
     }
 

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -146,6 +146,14 @@
     &:hover > div > i{
       color: $isomer-dark;
     }
+
+    &:hover > div > span{
+      color: $isomer-dark;
+    }
+    
+    > div > span{
+      color: $isomer-dark;
+    }
   }
 
   &.folderItem{

--- a/src/styles/isomer-cms/elements/modal.scss
+++ b/src/styles/isomer-cms/elements/modal.scss
@@ -103,3 +103,8 @@
   height: 50%;
   width: 70%;
 }
+
+.sortLabel {
+  white-space: nowrap;
+  padding-right: 1rem;
+}

--- a/src/styles/isomer-cms/elements/modal.scss
+++ b/src/styles/isomer-cms/elements/modal.scss
@@ -42,6 +42,7 @@
 
   h1{
     font-size: 24px;
+    color:$isomer-blue
   }
 
   .bx{
@@ -95,4 +96,10 @@
   @extend .modal;
   height: initial;
   width: 40%;
+}
+
+.modal-newfolder {
+  @extend .modal;
+  height: 50%;
+  width: 70%;
 }

--- a/src/styles/isomer-cms/pages/Content.module.scss
+++ b/src/styles/isomer-cms/pages/Content.module.scss
@@ -285,3 +285,19 @@
 .segmentDividerContainer{
   width: 100%;
 }
+
+.sectionFooter{
+  height: $footer-height;
+  background: white;
+  box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.5);
+  position: absolute;
+  bottom: 0;
+  z-index: 10;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 30px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+}


### PR DESCRIPTION
This PR introduces a folder creation modal, to resolve https://github.com/isomerpages/isomercms-frontend/issues/343. Saving functionality will be introduced in a separate PR. In addition, this PR also swaps the existing redirection to use a custom hook, `useRedirectHook`.

The folder/subfolder creation modal consists of two portions. Initially, the user is asked to select a folder name:
<img width="897" alt="Screenshot 2021-02-26 at 11 16 37 AM" src="https://user-images.githubusercontent.com/22111124/109250147-1caa2300-7824-11eb-83b4-f7051e3891fb.png">

Then the user chooses pages from the existing unlinked pages/pages in the folder to add to the new folder/subfolder:
<img width="1231" alt="Screenshot 2021-02-26 at 11 17 24 AM" src="https://user-images.githubusercontent.com/22111124/109250205-377c9780-7824-11eb-8efd-5a098a821759.png">

The pages can be sorted as well. Currently, only sorting by name and order in the collection.yml file are supported.
