### PR TITLE
Feat/create success and error toast wrapper functions

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,12 +1,15 @@
-import React from 'react';
 import axios from 'axios';
-import { toast } from 'react-toastify';
 
+<<<<<<< HEAD
 import Toast from './components/Toast';
 
 import { DEFAULT_ERROR_TOAST_MSG, parseDirectoryFile, getNavFolderDropdownFromFolderOrder } from './utils';
 
 import elementStyles from './styles/isomer-cms/Elements.module.scss';
+=======
+import { errorToast, successToast } from './utils/toasts';
+import { DEFAULT_RETRY_MSG } from './utils'
+>>>>>>> fix: update api file to use successToast and errorToast functions
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -21,10 +24,7 @@ const getDirectoryFile = async (siteName, folderName, errorCallback) => {
         if (err.response && err.response.status === 404) {
             errorCallback()
         } else {
-            toast(
-                <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-                {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-            );
+            errorToast()
         }
         throw err
     }
@@ -33,15 +33,9 @@ const getDirectoryFile = async (siteName, folderName, errorCallback) => {
 const setDirectoryFile = async (siteName, folderName, payload) => {
     try {
         await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
-        return toast(
-            <Toast notificationType='success' text={`Successfully updated page order!`}/>,
-            {className: `${elementStyles.toastSuccess}`},
-        );
+        return successToast('Successfully updated page order')
     } catch (err) {
-        toast(
-            <Toast notificationType='error' text={`Your file reordering could not be saved. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-        );
+        errorToast(`Your file reordering could not be saved. Please try again. ${DEFAULT_RETRY_MSG}`)
         throw err
     }
 }
@@ -108,11 +102,9 @@ const updateNavBarData = async (siteName, originalNav, links, sha) => {
         };
         await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
         window.location.reload();
+        successToast('Successfully updated nav bar!')
     } catch (err) {
-        toast(
-          <Toast notificationType='error' text={`There was a problem trying to save your nav bar. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`There was a problem trying to save your nav bar. ${DEFAULT_RETRY_MSG}`)
         throw err
     }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -14,15 +14,17 @@ axios.defaults.withCredentials = true
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
-const getDirectoryFile = async (siteName, folderName) => {
+const getDirectoryFile = async (siteName, folderName, errorCallback) => {
     try {
         return await axios.get(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`);
     } catch (err) {
         if (err.response && err.response.status === 404) {
-            throw {
-                status: 404,
-                message: err.response.data.message,
-            }
+            errorCallback()
+        } else {
+            toast(
+                <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
+                {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+            );
         }
         throw err
     }
@@ -30,9 +32,16 @@ const getDirectoryFile = async (siteName, folderName) => {
 
 const setDirectoryFile = async (siteName, folderName, payload) => {
     try {
-        return await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+        await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+        return toast(
+            <Toast notificationType='success' text={`Successfully updated page order!`}/>,
+            {className: `${elementStyles.toastSuccess}`},
+        );
     } catch (err) {
-        // if need be, add custom error handling here
+        toast(
+            <Toast notificationType='error' text={`Your file reordering could not be saved. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
+            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+        );
         throw err
     }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,16 +1,5 @@
 import axios from 'axios';
 
-<<<<<<< HEAD
-import Toast from './components/Toast';
-
-import { DEFAULT_ERROR_TOAST_MSG, parseDirectoryFile, getNavFolderDropdownFromFolderOrder } from './utils';
-
-import elementStyles from './styles/isomer-cms/Elements.module.scss';
-=======
-import { errorToast, successToast } from './utils/toasts';
-import { DEFAULT_RETRY_MSG } from './utils'
->>>>>>> fix: update api file to use successToast and errorToast functions
-
 // axios settings
 axios.defaults.withCredentials = true
 
@@ -32,66 +21,36 @@ const getFolderContents = async (siteName, folderName, subfolderName) => {
 // EditNavBar
 
 const getEditNavBarData = async(siteName) => {
-    let navContent, collectionContent, foldersContent, resourceContent, navSha
-      try {
-        const resp = await axios.get(`${BACKEND_URL}/sites/${siteName}/navigation`);
-        const { content, sha } = resp.data;
-        navContent = content
-        navSha = sha
-        const resourceResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/resources`)
-        resourceContent = resourceResp.data
-        const foldersResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/folders/all`)
-        
-        if (foldersResp.data && foldersResp.data.allFolderContent) {
-            // parse directory files
-            foldersContent = foldersResp.data.allFolderContent.reduce((acc, currFolder) => {
-                const folderOrder = parseDirectoryFile(currFolder.content)
-                acc[currFolder.name] = getNavFolderDropdownFromFolderOrder(folderOrder)
-                return acc
-            }, {})
+    let navContent, collectionContent, resourceContent, navSha
 
-            collectionContent = {
-                collections: foldersResp.data.allFolderContent.map((folder) => folder.name),
-            }
-        }
+    const resp = await axios.get(`${BACKEND_URL}/sites/${siteName}/navigation`);
+    const { content, sha } = resp.data;
+    navContent = content
+    navSha = sha
+    const collectionResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`)
+    collectionContent = collectionResp.data
+    const resourceResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/resources`)
+    resourceContent = resourceResp.data
 
-        if (!navContent) return
+    if (!navContent) return
 
-        return {
-            navContent,
-            navSha,
-            collectionContent,
-            foldersContent,
-            resourceContent,
-        }
-      } catch (err) {
-        if (err.response && err.response.status === 404) {
-            throw {
-                status: 404,
-                message: err.response.data.message,
-            }
-        }
-
-        throw err
+    return {
+        navContent,
+        navSha,
+        collectionContent,
+        resourceContent,
     }
 }
 
 const updateNavBarData = async (siteName, originalNav, links, sha) => {
-    try {
-        const params = {
-            content: {
-                ...originalNav,
-                links
-            },
-            sha: sha,
-        };
-        await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
-        window.location.reload();
-        successToast('Successfully updated nav bar!')
-    } catch (err) {
-        errorToast(`There was a problem trying to save your nav bar. ${DEFAULT_RETRY_MSG}`)
-        throw err
-    }
+    const params = {
+        content: {
+            ...originalNav,
+            links
+        },
+        sha: sha,
+    };
+    await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
 }
 
 export {

--- a/src/api.js
+++ b/src/api.js
@@ -17,27 +17,12 @@ axios.defaults.withCredentials = true
 // Constants
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL
 
-const getDirectoryFile = async (siteName, folderName, errorCallback) => {
-    try {
-        return await axios.get(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`);
-    } catch (err) {
-        if (err.response && err.response.status === 404) {
-            errorCallback()
-        } else {
-            errorToast()
-        }
-        throw err
-    }
+const getDirectoryFile = async (siteName, folderName) => {
+    return await axios.get(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`);
 }
 
 const setDirectoryFile = async (siteName, folderName, payload) => {
-    try {
-        await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
-        return successToast('Successfully updated page order')
-    } catch (err) {
-        errorToast(`Your file reordering could not be saved. Please try again. ${DEFAULT_RETRY_MSG}`)
-        throw err
-    }
+    await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
 }
 
 const getFolderContents = async (siteName, folderName, subfolderName) => {

--- a/src/api.js
+++ b/src/api.js
@@ -11,7 +11,7 @@ const getDirectoryFile = async (siteName, folderName) => {
 }
 
 const setDirectoryFile = async (siteName, folderName, payload) => {
-    await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
+    return await axios.post(`${BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/collection.yml`, payload);
 }
 
 const getFolderContents = async (siteName, folderName, subfolderName) => {
@@ -50,7 +50,7 @@ const updateNavBarData = async (siteName, originalNav, links, sha) => {
         },
         sha: sha,
     };
-    await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
+    return await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
 }
 
 export {

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -6,9 +6,16 @@ import { createFilter } from 'react-select';
 import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import * as _ from 'lodash';
+
 import FormField from './FormField';
+import DeleteWarningModal from './DeleteWarningModal';
+import ResourceFormFields from './ResourceFormFields';
+import SaveDeleteButtons from './SaveDeleteButtons';
+
+import useRedirectHook from '../hooks/useRedirectHook';
+
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
   frontMatterParser,
   dequoteString,
   generatePageFileName,
@@ -17,19 +24,11 @@ import {
   saveFileAndRetrieveUrl,
   retrieveResourceFileMetadata,
 } from '../utils';
-
-import useRedirectHook from '../hooks/useRedirectHook';
+import { validatePageSettings, validateResourceSettings } from '../utils/validators';
+import { errorToast } from '../utils/toasts';
+import { retrieveThirdNavOptions } from '../utils/dropdownUtils'
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import { validatePageSettings, validateResourceSettings } from '../utils/validators';
-import DeleteWarningModal from './DeleteWarningModal';
-import ResourceFormFields from './ResourceFormFields';
-import SaveDeleteButtons from './SaveDeleteButtons';
-import { toast } from 'react-toastify';
-import Toast from './Toast';
-
-// Import utils
-import { retrieveThirdNavOptions } from '../utils/dropdownUtils'
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -199,10 +198,7 @@ const ComponentSettingsModal = ({
 
       fetchData().catch((err) => {
         setIsComponentSettingsActive((prevState) => !prevState)
-        toast(
-          <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-        );
+        errorToast(`There was a problem retrieving data from your repo. ${DEFAULT_RETRY_MSG}`)
         console.log(err)
       })
       return () => { _isMounted = false }
@@ -278,15 +274,9 @@ const ComponentSettingsModal = ({
                     ...prevState,
                     title: 'This title is already in use. Please choose a different one.',
                 }));
-                toast(
-                  <Toast notificationType='error' text={`Another ${type === 'resource' ? 'resource' : 'page'} with the same name exists. Please choose a different name.`}/>,
-                  {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-                );
+                errorToast(`Another ${type === 'resource' ? 'resource' : 'page'} with the same name exists. Please choose a different name.`)
             } else {
-              toast(
-                <Toast notificationType='error' text={`There was a problem saving your page settings. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-                {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-              );
+              errorToast(`There was a problem saving your page settings. ${DEFAULT_RETRY_MSG}`)
             }
             console.log(err);
         }
@@ -302,10 +292,7 @@ const ComponentSettingsModal = ({
             // Refresh page
             window.location.reload();
         } catch (err) {
-          toast(
-            <Toast notificationType='error' text={`There was a problem trying to delete this file. ${DEFAULT_ERROR_TOAST_MSG}.`}/>,
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-          );
+          errorToast(`There was a problem trying to delete this file. ${DEFAULT_RETRY_MSG}.`)
           console.log(err);
         }
     }

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -5,14 +5,14 @@ import axios from 'axios';
 
 import FolderModal from './FolderModal';
 import DeleteWarningModal from './DeleteWarningModal'
-import { toast } from 'react-toastify';
-import Toast from './Toast';
+
+import { errorToast } from '../utils/toasts';
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
   checkIsOutOfViewport,
 } from '../utils'
 
@@ -102,10 +102,7 @@ const FolderCard = ({
       // Refresh page
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to delete this folder. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to delete this folder. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import SaveDeleteButtons from './SaveDeleteButtons';
 import FormField from './FormField';
-import { toast } from 'react-toastify';
-import Toast from './Toast';
+
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
 } from '../utils'
+import { errorToast } from '../utils/toasts';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -27,10 +27,7 @@ const FolderModal = ({ displayTitle, displayText, onClose, category, siteName, i
       // Refresh page
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to rename this folder. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to rename this folder. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/components/FormFieldMedia.jsx
+++ b/src/components/FormFieldMedia.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { toast } from 'react-toastify';
 
-import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import MediaModal from './media/MediaModal';
 import MediaSettingsModal from './media/MediaSettingsModal';
-import Toast from './Toast';
+
+import { successToast } from '../utils/toasts';
+
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+
 
 const FormFieldMedia = ({
   title,
@@ -36,10 +38,7 @@ const FormFieldMedia = ({
         value: path,
       },
     };
-    toast(
-      <Toast notificationType='success' text={`Successfully updated ${title.toLowerCase()}!`}/>,
-      {className: `${elementStyles.toastSuccess}`},
-    );
+    successToast(`Successfully updated ${title.toLowerCase()}!`)
     onFieldChange(event);
   }
 

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { toast } from 'react-toastify';
+import { Link } from 'react-router-dom';
+import axios from 'axios'
+import { Base64 } from 'js-base64';
+import PropTypes from 'prop-types';
+
 import DeleteWarningModal from './DeleteWarningModal'
 import GenericWarningModal from './GenericWarningModal'
 import LoadingButton from './LoadingButton'
-import Toast from './Toast';
+
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
   frontMatterParser,
   saveFileAndRetrieveUrl,
   checkIsOutOfViewport,
@@ -16,10 +20,9 @@ import {
 import {
   validateCategoryName,
 } from '../utils/validators'
-import { Link } from 'react-router-dom';
-import axios from 'axios'
-import { Base64 } from 'js-base64';
-import PropTypes from 'prop-types';
+import { errorToast } from '../utils/toasts';
+
+
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
@@ -106,15 +109,9 @@ const OverviewCard = ({
     } catch (err) {
       if (err?.response?.status === 409) {
         // Error due to conflict in name
-        toast(
-          <Toast notificationType='error' text='This file name already exists in the category you are trying to move to. Please rename the file before proceeding.'/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast('This file name already exists in the category you are trying to move to. Please rename the file before proceeding.')
       } else {
-        toast(
-          <Toast notificationType='error' text={`There was a problem trying to move this file. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`There was a problem trying to move this file. ${DEFAULT_RETRY_MSG}`)
       }
       setIsNewCollection(false)
       setCanShowGenericWarningModal(false)
@@ -136,10 +133,7 @@ const OverviewCard = ({
       // Refresh page
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text="There was a problem trying to delete this file. Please try again or check your internet connection."/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to delete this file. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -80,6 +80,7 @@ const FolderContent = ({ folderOrderArray, setFolderOrderArray, siteName, folder
                                     draggableId={`folder-${folderContentIndex}-draggable`}
                                     index={folderContentIndex}
                                     isDragDisabled={!enableDragDrop}
+                                    key={folderContentItem.title}
                                 >
                                     {(draggableProvided) => (
                                         <div

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -1,17 +1,19 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
-import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
+
 import FormField from '../FormField';
 import DeleteWarningModal from '../DeleteWarningModal';
 import SaveDeleteButtons from '../SaveDeleteButtons';
+
 import { validateFileName } from '../../utils/validators';
-import { toast } from 'react-toastify';
-import Toast from '../Toast';
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
 } from '../../utils'
+import { errorToast } from '../../utils/toasts';
+
+import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
+import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 
 export default class MediaSettingsModal extends Component {
   constructor(props) {
@@ -90,21 +92,12 @@ export default class MediaSettingsModal extends Component {
     } catch (err) {
       if (err?.response?.status === 409) {
         // Error due to conflict in name
-        toast(
-          <Toast notificationType='error' text={`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`Another ${type === 'image' ? 'image' : 'file'} with the same name exists. Please choose a different name.`)
       } else if (err?.response?.status === 413 || err?.response === undefined) {
         // Error due to file size too large - we receive 413 if nginx accepts the payload but it is blocked by our express settings, and undefined if it is blocked by nginx
-        toast(
-          <Toast notificationType='error' text={`Unable to upload as the ${type === 'image' ? 'image' : 'file'} size exceeds 5MB. Please reduce your ${type === 'image' ? 'image' : 'file'} size and try again.`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`Unable to upload as the ${type === 'image' ? 'image' : 'file'} size exceeds 5MB. Please reduce your ${type === 'image' ? 'image' : 'file'} size and try again.`)
       } else {
-        toast(
-          <Toast notificationType='error' text={`There was a problem trying to save this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`There was a problem trying to save this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_RETRY_MSG}`)
       }
       console.log(err);
     }
@@ -125,10 +118,7 @@ export default class MediaSettingsModal extends Component {
 
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to delete this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to delete this ${type === 'image' ? 'image' : 'file'}. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -6,31 +6,29 @@ import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
 import { DragDropContext } from 'react-beautiful-dnd';
-import { toast } from 'react-toastify';
 
-import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody, isEmpty } from '../utils';
+import EditorSection from '../components/contact-us/Section';
+import Header from '../components/Header';
+import LoadingButton from '../components/LoadingButton';
+import FormField from '../components/FormField';
+import DeleteWarningModal from '../components/DeleteWarningModal';
+import GenericWarningModal from '../components/GenericWarningModal';
+
+import { DEFAULT_RETRY_MSG, frontMatterParser, concatFrontMatterMdBody, isEmpty } from '../utils';
 import { sanitiseFrontMatter } from '../utils/contact-us/dataSanitisers';
 import { validateFrontMatter } from '../utils/contact-us/validators';
 import { validateContactType, validateLocationType } from '../utils/validators';
-
-import EditorSection from '../components/contact-us/Section';
-import Toast from '../components/Toast';
+import { errorToast } from '../utils/toasts';
 
 import '../styles/isomer-template.scss';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 
-import Header from '../components/Header';
-import LoadingButton from '../components/LoadingButton';
-import FormField from '../components/FormField';
 
 import TemplateContactUsHeader from '../templates/contact-us/ContactUsHeader';
 import TemplateLocationsSection from '../templates/contact-us/LocationsSection'
 import TemplateContactsSection from '../templates/contact-us/ContactsSection'
 import TemplateFeedbackSection from '../templates/contact-us/FeedbackSection';
-
-import DeleteWarningModal from '../components/DeleteWarningModal';
-import GenericWarningModal from '../components/GenericWarningModal';
 
 // Import hooks
 import useSiteColorsHook from '../hooks/useSiteColorsHook';
@@ -174,10 +172,7 @@ const EditContactUs =  ({ match }) => {
         if (error?.response?.status === 404) {
           setRedirectToNotFound(siteName)
         } else {
-          toast(
-            <Toast notificationType='error' text={`There was a problem trying to load your contact us page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-          );
+          errorToast(`There was a problem trying to load your contact us page. ${DEFAULT_RETRY_MSG}`)
         }
         console.log(error)
       }
@@ -190,10 +185,7 @@ const EditContactUs =  ({ match }) => {
         footerContent = retrievedContent
         footerSha = retrievedSha
       } catch (err) {
-        toast(
-          <Toast notificationType='error' text={`There was a problem trying to load your contact us page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`There was a problem trying to load your contact us page. ${DEFAULT_RETRY_MSG}`)
         console.log(err);
       }
 
@@ -620,10 +612,7 @@ const EditContactUs =  ({ match }) => {
 
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to save your contact us page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to save your contact us page. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -5,26 +5,29 @@ import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
-import '../styles/isomer-template.scss';
-import TemplateHeroSection from '../templates/homepage/HeroSection';
-import TemplateInfobarSection from '../templates/homepage/InfobarSection';
-import TemplateInfopicLeftSection from '../templates/homepage/InfopicLeftSection';
-import TemplateInfopicRightSection from '../templates/homepage/InfopicRightSection';
-import TemplateResourcesSection from '../templates/homepage/ResourcesSection';
-import { DEFAULT_ERROR_TOAST_MSG, frontMatterParser, concatFrontMatterMdBody } from '../utils';
+
 import EditorInfobarSection from '../components/homepage/InfobarSection';
 import EditorInfopicSection from '../components/homepage/InfopicSection';
 import EditorResourcesSection from '../components/homepage/ResourcesSection';
 import EditorHeroSection from '../components/homepage/HeroSection';
 import NewSectionCreator from '../components/homepage/NewSectionCreator';
-import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 import Header from '../components/Header';
 import LoadingButton from '../components/LoadingButton';
-import { validateSections, validateHighlights, validateDropdownElems } from '../utils/validators';
 import DeleteWarningModal from '../components/DeleteWarningModal';
-import { toast } from 'react-toastify';
-import Toast from '../components/Toast';
+
+import TemplateHeroSection from '../templates/homepage/HeroSection';
+import TemplateInfobarSection from '../templates/homepage/InfobarSection';
+import TemplateInfopicLeftSection from '../templates/homepage/InfopicLeftSection';
+import TemplateInfopicRightSection from '../templates/homepage/InfopicRightSection';
+import TemplateResourcesSection from '../templates/homepage/ResourcesSection';
+
+import { frontMatterParser, concatFrontMatterMdBody, DEFAULT_RETRY_MSG } from '../utils';
+import { validateSections, validateHighlights, validateDropdownElems } from '../utils/validators';
+import { errorToast } from '../utils/toasts';
+
+import '../styles/isomer-template.scss';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import editorStyles from '../styles/isomer-cms/pages/Editor.module.scss';
 
 // Import hooks
 import useSiteColorsHook from '../hooks/useSiteColorsHook';
@@ -234,10 +237,7 @@ const EditHomepage = ({ match }) => {
       } catch (err) {
         // Set frontMatter to be same to prevent warning message when navigating away
         if (_isMounted) setFrontMatter(originalFrontMatter)
-        toast(
-          <Toast notificationType='error' text={`There was a problem trying to load your homepage. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`There was a problem trying to load your homepage. ${DEFAULT_RETRY_MSG}`)
         console.log(err);
       }
     }
@@ -919,10 +919,7 @@ const EditHomepage = ({ match }) => {
 
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to save your homepage. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to save your homepage. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -114,9 +114,9 @@ const EditNavBar =  ({ match }) => {
       retry: false,
       onError: (err) => {
         if (err.response && err.response.status === 404) {
-          if (!shouldRedirectToNotFound) setShouldRedirectToNotFound(true)
+          setRedirectToNotFound(siteName)
         } else {
-            errorToast(`There was a problem trying to load your data. ${DEFAULT_RETRY_MSG}`)
+          errorToast(`There was a problem trying to load your data. ${DEFAULT_RETRY_MSG}`)
         }
       }
     },

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -5,16 +5,17 @@ import PropTypes from 'prop-types';
 import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
 import { Base64 } from 'js-base64';
+import Policy from 'csp-parse';
+
 import SimplePage from '../templates/SimplePage';
 import LeftNavPage from '../templates/LeftNavPage';
+
 import { checkCSP } from '../utils/cspUtils';
-import Policy from 'csp-parse';
-import { toast } from 'react-toastify';
-import Toast from '../components/Toast';
+import { errorToast } from '../utils/toasts';
 
 // Isomer components
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
   frontMatterParser,
   concatFrontMatterMdBody,
   prependImageSrc,
@@ -149,10 +150,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
         if (error?.response?.status === 404) {
           setRedirectToNotFound(siteName)
         } else {
-          toast(
-            <Toast notificationType='error' text={`There was a problem trying to load your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-          );
+          errorToast(`There was a problem trying to load your page. ${DEFAULT_RETRY_MSG}`)
         }
         console.log(error)
       }
@@ -196,10 +194,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
           setIsLoadingPageContent(false)
         }
       } catch (err) {
-        toast(
-          <Toast notificationType='error' text={`There was a problem trying to load your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-        );
+        errorToast(`There was a problem trying to load your page. ${DEFAULT_RETRY_MSG}`);
         console.log(err);
       }
     }
@@ -232,10 +227,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
       await axios.post(apiEndpoint, params);
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem saving your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem saving your page. ${DEFAULT_RETRY_MSG}`);
       console.log(err);
     }
   }
@@ -248,10 +240,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
       });
       history.goBack();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem deleting your page. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem deleting your page. ${DEFAULT_RETRY_MSG}`);
       console.log(err);
     }
   }

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -49,47 +49,17 @@ const Folders = ({ match, location }) => {
 
     const { data: folderContents, error: queryError } = useQuery(
       FOLDER_CONTENTS_KEY,
-      () => getDirectoryFile(siteName, folderName),
+      () => getDirectoryFile(siteName, folderName, () => { if (!shouldRedirect) setShouldRedirect(true) }),
       { 
         retry: false,
         enabled: !isRearrangeActive,
       },
     );
 
-    const { mutate, error: mutateError } = useMutation(
+    const { mutate } = useMutation(
       payload => setDirectoryFile(siteName, folderName, payload),
       { onSettled: () => setIsRearrangeActive((prevState) => !prevState) }
     )
-
-    useEffect(() => {
-      let _isMounted = true;
-      if (queryError) {
-        if (queryError.status === 404) {
-          // redirect if collection/folder cannot be found
-          if (_isMounted) {
-            setRedirectToPage(`/sites/${siteName}/workspace`)
-          }
-        } else {
-          toast(
-            <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-          );
-        }
-      }
-
-      return () => {
-        _isMounted = false
-      }
-    }, [queryError])
-
-    useEffect(() => {
-      if (mutateError) {
-        toast(
-          <Toast notificationType='error' text={`Your file reordering could not be saved. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-        );
-      }
-    }, [mutateError])
 
     useEffect(() => {
         if (folderContents && folderContents.data) {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { useQuery, useMutation } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Link } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import _ from 'lodash';
 
 // Import components
@@ -12,12 +11,10 @@ import Sidebar from '../components/Sidebar';
 import FolderCreationModal from '../components/FolderCreationModal'
 import FolderOptionButton from '../components/folders/FolderOptionButton';
 import FolderContent from '../components/folders/FolderContent';
-import Toast from '../components/Toast';
 
 import useRedirectHook from '../hooks/useRedirectHook';
 
 import {
-  DEFAULT_ERROR_TOAST_MSG,
   parseDirectoryFile,
   updateDirectoryFile,
   convertFolderOrderToArray,

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -38,7 +38,7 @@ const FOLDER_CONTENTS_KEY = 'folder-contents'
 const Folders = ({ match, location }) => {
     const { siteName, folderName, subfolderName } = match.params;
 
-    const { setRedirectToPage } = useRedirectHook()
+    const { setRedirectToPage, setRedirectToNotFound } = useRedirectHook()
 
     const [isRearrangeActive, setIsRearrangeActive] = useState(false)
     const [directoryFileSha, setDirectoryFileSha] = useState('')
@@ -54,9 +54,9 @@ const Folders = ({ match, location }) => {
         enabled: !isRearrangeActive,
         onError: (err) => {
           if (err.response && err.response.status === 404) {
-            if (!shouldRedirect) setShouldRedirect(true)
+            setRedirectToNotFound(siteName)
           } else {
-              errorToast()
+            errorToast()
           }
         }
       },

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import * as _ from 'lodash';
+
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import LoadingButton from '../components/LoadingButton';
@@ -10,15 +11,16 @@ import FormFieldToggle from '../components/FormFieldToggle';
 import FormFieldMedia from '../components/FormFieldMedia';
 import FormFieldColor from '../components/FormFieldColor';
 import FormFieldHorizontal from '../components/FormFieldHorizontal';
-import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
-import { validateSocialMedia } from '../utils/validators';
-import { toast } from 'react-toastify';
-import Toast from '../components/Toast';
+
 import {
-  DEFAULT_ERROR_TOAST_MSG,
+  DEFAULT_RETRY_MSG,
   getObjectDiff,
 } from '../utils'
+import { errorToast } from '../utils/toasts';
+import { validateSocialMedia } from '../utils/validators';
+
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 const stateFields = {
   title: '',
@@ -341,10 +343,7 @@ export default class Settings extends Component {
 
       window.location.reload();
     } catch (err) {
-      toast(
-        <Toast notificationType='error' text={`There was a problem trying to save your settings. ${DEFAULT_ERROR_TOAST_MSG}`}/>, 
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`}
-      );
+      errorToast(`There was a problem trying to save your settings. ${DEFAULT_RETRY_MSG}`)
       console.log(err);
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,8 +13,8 @@ axios.defaults.withCredentials = true
 const ALPHANUM_REGEX = /^[0-9]+[a-z]*$/ // at least one number, followed by 0 or more lower-cased alphabets
 const NUM_REGEX = /^[0-9]+$/
 const NUM_IDENTIFIER_REGEX = /^[0-9]+/
-export const RETRY_MSG = 'Please try again or check your internet connection'
-export const DEFAULT_ERROR_TOAST_MSG = `Something went wrong. ${RETRY_MSG}`
+export const DEFAULT_RETRY_MSG = 'Please try again or check your internet connection'
+export const DEFAULT_ERROR_TOAST_MSG = `Something went wrong. ${DEFAULT_RETRY_MSG}`
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ axios.defaults.withCredentials = true
 const ALPHANUM_REGEX = /^[0-9]+[a-z]*$/ // at least one number, followed by 0 or more lower-cased alphabets
 const NUM_REGEX = /^[0-9]+$/
 const NUM_IDENTIFIER_REGEX = /^[0-9]+/
-export const DEFAULT_ERROR_TOAST_MSG = 'Please try again or check your internet connection.'
+export const DEFAULT_ERROR_TOAST_MSG = 'Something went wrong. Please try again or check your internet connection.'
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,8 @@ axios.defaults.withCredentials = true
 const ALPHANUM_REGEX = /^[0-9]+[a-z]*$/ // at least one number, followed by 0 or more lower-cased alphabets
 const NUM_REGEX = /^[0-9]+$/
 const NUM_IDENTIFIER_REGEX = /^[0-9]+/
-export const DEFAULT_ERROR_TOAST_MSG = 'Something went wrong. Please try again or check your internet connection.'
+export const RETRY_MSG = 'Please try again or check your internet connection'
+export const DEFAULT_ERROR_TOAST_MSG = `Something went wrong. ${RETRY_MSG}`
 
 // extracts yaml front matter from a markdown file path
 export function frontMatterParser(content) {

--- a/src/utils/dropdownUtils.js
+++ b/src/utils/dropdownUtils.js
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import React from 'react';
-import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import { toast } from 'react-toastify';
-import Toast from '../components/Toast';
-import { DEFAULT_ERROR_TOAST_MSG } from '../utils'
+
+import { DEFAULT_RETRY_MSG } from '../utils'
+import { errorToast } from '../utils/toasts';
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -28,10 +27,7 @@ export const retrieveThirdNavOptions = async (siteName, collectionName, isExisti
             thirdNavOptions,
         }
     } catch (err) {
-        toast(
-            <Toast notificationType='error' text={`There was a problem trying to retrieve data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-            {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-          );
+        errorToast(`There was a problem trying to retrieve data from your repo. ${DEFAULT_RETRY_MSG}`);
         console.log(err);
     }
 }

--- a/src/utils/toasts.js
+++ b/src/utils/toasts.js
@@ -1,0 +1,21 @@
+import { toast } from 'react-toastify';
+
+import Toast from '../components/Toast';
+
+import { DEFAULT_ERROR_TOAST_MSG } from '../utils';
+
+import elementStyles from './styles/isomer-cms/Elements.module.scss';
+
+export function errorToast(message) {
+    return toast(
+        <Toast notificationType='error' text={message ? message : DEFAULT_ERROR_TOAST_MSG}/>,
+        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+    );
+}
+
+export function successToast(message) {
+    toast(
+        <Toast notificationType='success' text={message ? message : `Success!`}/>,
+        {className: `${elementStyles.toastSuccess}`},
+    );
+}

--- a/src/utils/toasts.js
+++ b/src/utils/toasts.js
@@ -10,13 +10,19 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 export function errorToast(message) {
     return toast(
         <Toast notificationType='error' text={message ? message : DEFAULT_ERROR_TOAST_MSG}/>,
-        {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+        {
+            className: `${elementStyles.toastError} ${elementStyles.toastLong}`,
+            toastId: 'error',
+        },
     );
 }
 
 export function successToast(message) {
     toast(
         <Toast notificationType='success' text={message ? message : `Success!`}/>,
-        {className: `${elementStyles.toastSuccess}`},
+        {
+            className: `${elementStyles.toastSuccess}`,
+            toastId: 'success',
+        },
     );
 }

--- a/src/utils/toasts.js
+++ b/src/utils/toasts.js
@@ -1,10 +1,11 @@
+import React from 'react';
 import { toast } from 'react-toastify';
 
 import Toast from '../components/Toast';
 
 import { DEFAULT_ERROR_TOAST_MSG } from '../utils';
 
-import elementStyles from './styles/isomer-cms/Elements.module.scss';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 export function errorToast(message) {
     return toast(


### PR DESCRIPTION
## Overview 

This PR reduces code duplication and unnecessary dependency imports by creating wrapper toast functions `errorToast` and successToast`. These toast functions replace all existing invocations of the `toast` function.

Other things added in this PR:
- Add a success toast as feedback to CMS users upon successful reordering of pages within a `Folder`
- Refactor the `Folders` and `EditNavBar` layouts so that success and error-handling are done with callbacks using the provided `onSuccess` and `onError` config options. @gweiying brought up a good point that we need the flexibility to implement different forms of error-handling needed for each layout/component. Using these config options (instead of putting them in the API functions) reduces complexity while giving us the flexibility we need.