### PR TITLE
Feat/nested images functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -150,7 +150,7 @@ function App() {
                     <ProtectedRouteWithProps exact path="/sites/:siteName/navbar" component={EditNavBar} />
                     <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
                     <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/images/:customPath" component={Images} />
                     <ProtectedRouteWithProps path="/sites/:siteName/images" component={Images} />
                     <ProtectedRouteWithProps path="/sites/:siteName/pages/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={false} />
                     <ProtectedRouteWithProps path="/sites/:siteName/workspace" component={Workspace} />

--- a/src/api.js
+++ b/src/api.js
@@ -239,6 +239,24 @@ const moveFile = async ({selectedFile, siteName, resourceName, folderName, subfo
     return await axios.post(apiEndpoint, params)
 }
 
+const getImages = async (siteName, customPath) => {
+    const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/files/${customPath ? encodeURIComponent(`images/${customPath}`) : 'images'}`);
+    const { directoryContents } = resp.data;
+
+    let respImages = []
+    let respDirectories = []
+    directoryContents.forEach((fileOrDir) => {
+        const modifiedFileOrDir = { ...fileOrDir, fileName: fileOrDir.name }
+        if (fileOrDir.type === 'file') respImages.push(modifiedFileOrDir)
+        if (fileOrDir.type === 'dir') respDirectories.push(modifiedFileOrDir)
+    })
+
+    return {
+        respImages,
+        respDirectories,
+    }
+}
+
 export {
     getDirectoryFile,
     setDirectoryFile,
@@ -262,4 +280,5 @@ export {
     getAllCategories,
     moveFiles,
     moveFile,
+    getImages,
 }

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -48,6 +48,8 @@ const FolderCard = ({
         return `/sites/${siteName}/contact-us`
       case 'nav':
         return `/sites/${siteName}/navbar`
+      case 'media':
+        return `/sites/${siteName}/${linkPath}`
       default:
         return ''
     }
@@ -170,6 +172,8 @@ FolderCard.propTypes = {
   itemIndex: PropTypes.number,
   pageType: PropTypes.string.isRequired,
   siteName: PropTypes.string.isRequired,
+  category: PropTypes.string,
+  linkPath: PropTypes.string,
 };
 
 export default FolderCard;

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -25,6 +25,7 @@ const FolderCard = ({
   siteName,
   category,
   selectedIndex,
+  linkPath,
   onClick,
 }) => {
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)

--- a/src/components/folders/FolderOptionButton.jsx
+++ b/src/components/folders/FolderOptionButton.jsx
@@ -8,6 +8,7 @@ const iconSelection = {
     'rearrange': 'bx-sort',
     'create-page': 'bx-file-blank',
     'create-sub': 'bx-folder',
+    'upload-image': 'bx-plus-circle',
 }
 
 

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -98,7 +98,7 @@ export default class MediaSettingsModal extends Component {
         if (newFileName === fileName) {
           return;
         }
-        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'image' ? 'images' : 'documents'}/${fileName}/rename/${newFileName}`, params, {
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'image' ? 'images' : 'documents'}/${generateImageorFilePath(customPath, fileName)}/rename/${generateImageorFilePath(customPath, newFileName)}`, params, {
           withCredentials: true,
         });
       }

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -80,8 +80,7 @@ export default class MediaSettingsModal extends Component {
 
         if (type === 'image') {
           params.imageName = newFileName;
-          params.imageDirectory = customPath ? customPath : '';
-          console.log(params)
+          params.imageDirectory = `images${customPath ? `/${customPath}` : ''}`;
         } else {
           params.documentName = newFileName;
         }

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -7,7 +7,7 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import FolderCard from '../components/FolderCard'
-import MediaUploadCard from '../components/media/MediaUploadCard';
+import FolderOptionButton from '../components/folders/FolderOptionButton'
 import MediaCard from '../components/media/MediaCard';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
@@ -96,11 +96,9 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
     try {
       // toggle state so that image renaming modal appears
       setPendingImageUpload({
-        pendingImageUpload: {
-          fileName: imageName,
-          path: `images%2F${imageName}`,
-          content: imageContent,
-        },
+        fileName: imageName,
+        path: `images%2F${imageName}`,
+        content: imageContent,
       })
     } catch (err) {
       console.log(err);
@@ -146,9 +144,16 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
           <div className={contentStyles.folderContainerBoxes}>
             <div className={contentStyles.boxesContainer}>
               {/* Upload Image */}
-              {/* <MediaUploadCard
-                type="image"
+              <FolderOptionButton
+                title="Upload new image"
+                option="create-sub"
                 onClick={() => document.getElementById('file-upload').click()}
+              />
+              <FolderOptionButton
+                title="Create new directory"
+                option="create-sub"
+                isSubfolder={false}
+                onClick={() => console.log('placeholder')}
               />
               <input
                 onChange={onImageSelect}
@@ -160,7 +165,7 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
                 id="file-upload"
                 accept="image/*"
                 hidden
-              /> */}
+              />
             </div>
           </div>
           {/* Segment divider  */}

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -61,7 +61,7 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
 
   const { data: imageData, refetch } = useQuery(
     IMAGE_CONTENTS_KEY,
-    () => getImages(siteName, customPath),
+    () => getImages(siteName, customPath ? decodeURIComponent(customPath): ''),
     {
       retry: false,
       // TO-DO: error-handling
@@ -152,7 +152,12 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
                       settingsToggle={() => {}}
                       key={directory.name}
                       pageType={"media"}
-                      linkPath={directory.path}
+                      linkPath={`images/${encodeURIComponent(directory.path
+                          .split('/')
+                          .slice(1) // remove `images` prefix
+                          .join('/')
+                        )}`
+                      }
                       siteName={siteName}
                       itemIndex={idx}
                     />

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -134,6 +134,7 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
   return (
     <>
       <Header
+        siteName={siteName}
         backButtonText={`Back to ${customPath ? getPrevDirectoryName(customPath) : 'Sites'}`}
         backButtonUrl={customPath ? `/sites/${siteName}/${getPrevDirectoryPath(customPath)}` : '/sites'}
       />

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -258,6 +258,7 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
           type="image"
           media={chosenImage}
           siteName={siteName}
+          customPath={customPath}
           isPendingUpload={false}
           onClose={() => setChosenImage(null)}
           onSave={() => window.location.reload()}
@@ -271,6 +272,7 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
           type="image"
           media={pendingImageUpload}
           siteName={siteName}
+          customPath={customPath}
           // eslint-disable-next-line react/jsx-boolean-value
           isPendingUpload
           onClose={() => setPendingImageUpload(null)}

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useEffect, useState } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import Header from '../components/Header';
@@ -10,53 +10,48 @@ import MediaUploadCard from '../components/media/MediaUploadCard';
 import MediaCard from '../components/media/MediaCard';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
-export default class Images extends Component {
-  _isMounted = false
+const Images = ({ match: { params: { siteName } }, location }) => {
+  const [images, setImages] = useState([])
+  const [pendingImageUpload, setPendingImageUpload] = useState(null)
+  const [chosenImage, setChosenImage] = useState('')
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      images: [],
-      chosenImage: null,
-      pendingImageUpload: null,
-    };
-  }
-
-  async componentDidMount() {
-    this._isMounted = true
-    try {
-      const { match } = this.props;
-      const { siteName } = match.params;
-      const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, {
-        withCredentials: true,
-      });
-      const { images } = resp.data;
-      if (this._isMounted) this.setState({ images });
-    } catch (err) {
-      console.log(err);
+  useEffect(() => {
+    let _isMounted = true
+    const fetchData = async () => {
+      try {
+        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, {
+          withCredentials: true,
+        });
+        const { images } = resp.data;
+        if (_isMounted) setImages(images);
+      } catch (err) {
+        console.log(err);
+      }
     }
-  }
 
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
+    fetchData()
 
-  uploadImage = async (imageName, imageContent) => {
+    return () => {
+      _isMounted = false
+    }
+  }, [])
+
+  const uploadImage = async (imageName, imageContent) => {
     try {
       // toggle state so that image renaming modal appears
-      this.setState({
+      setPendingImageUpload({
         pendingImageUpload: {
           fileName: imageName,
           path: `images%2F${imageName}`,
           content: imageContent,
         },
-      });
+      })
     } catch (err) {
       console.log(err);
     }
   }
 
-  onImageSelect = async (event) => {
+  const onImageSelect = async (event) => {
     const imgReader = new FileReader();
     const imgName = event.target.files[0].name;
     imgReader.onload = (() => {
@@ -67,100 +62,95 @@ export default class Images extends Component {
 
       const imgData = imgReader.result.split(',')[1];
 
-      this.uploadImage(imgName, imgData);
+      uploadImage(imgName, imgData);
     });
     imgReader.readAsDataURL(event.target.files[0]);
   }
 
-  render() {
-    const { images, chosenImage, pendingImageUpload } = this.state;
-    const { match, location } = this.props;
-    const { siteName } = match.params;
-    return (
-      <>
-        <Header 
-          siteName={siteName}
-        />
-        {/* main bottom section */}
-        <div className={elementStyles.wrapper}>
-          <Sidebar siteName={siteName} currPath={location.pathname} />
-          {/* main section starts here */}
-          <div className={contentStyles.mainSection}>
-            <div className={contentStyles.sectionHeader}>
-              <h1 className={contentStyles.sectionTitle}>Images</h1>
-            </div>
-            {/* Info segment */}
-            <div className={contentStyles.segment}>
-              <i className="bx bx-sm bx-info-circle text-dark" />
-              <span><strong className="ml-1">Note:</strong> Upload images here to link to them in pages and resources. The maximum image size allowed is 5MB.</span>
-            </div>
-            <div className={contentStyles.contentContainerBars}>
-              <div className={contentStyles.boxesContainer}>
-                <div className={mediaStyles.mediaCards}>
-                  {/* Upload Image */}
-                  <MediaUploadCard
+  return (
+    <>
+      <Header />
+      {/* main bottom section */}
+      <div className={elementStyles.wrapper}>
+        <Sidebar siteName={siteName} currPath={location.pathname} />
+        {/* main section starts here */}
+        <div className={contentStyles.mainSection}>
+          <div className={contentStyles.sectionHeader}>
+            <h1 className={contentStyles.sectionTitle}>Images</h1>
+          </div>
+          {/* Info segment */}
+          <div className={contentStyles.segment}>
+            <i className="bx bx-sm bx-info-circle text-dark" />
+            <span><strong className="ml-1">Note:</strong> Upload images here to link to them in pages and resources. The maximum image size allowed is 5MB.</span>
+          </div>
+          <div className={contentStyles.contentContainerBars}>
+            <div className={contentStyles.boxesContainer}>
+              <div className={mediaStyles.mediaCards}>
+                {/* Upload Image */}
+                <MediaUploadCard
+                  type="image"
+                  onClick={() => document.getElementById('file-upload').click()}
+                />
+                <input
+                  onChange={onImageSelect}
+                  onClick={(event) => {
+                    // eslint-disable-next-line no-param-reassign
+                    event.target.value = '';
+                  }}
+                  type="file"
+                  id="file-upload"
+                  accept="image/*"
+                  hidden
+                />
+                {/* Images */}
+                {images.length > 0 && images.map((image) => (
+                  <MediaCard
                     type="image"
-                    onClick={() => document.getElementById('file-upload').click()}
+                    media={image}
+                    siteName={siteName}
+                    onClick={() => setChosenImage(image)}
+                    key={image.fileName}
                   />
-                  <input
-                    onChange={this.onImageSelect}
-                    onClick={(event) => {
-                      // eslint-disable-next-line no-param-reassign
-                      event.target.value = '';
-                    }}
-                    type="file"
-                    id="file-upload"
-                    accept="image/*"
-                    hidden
-                  />
-                  {/* Images */}
-                  {images.length > 0 && images.map((image) => (
-                    <MediaCard
-                      type="image"
-                      media={image}
-                      siteName={siteName}
-                      onClick={() => this.setState({ chosenImage: image })}
-                      key={image.fileName}
-                    />
-                  ))}
-                </div>
+                ))}
               </div>
             </div>
-            {/* End of image cards */}
           </div>
-          {/* main section ends here */}
+          {/* End of image cards */}
         </div>
-        {
-          chosenImage
-          && (
-          <MediaSettingsModal
-            type="image"
-            media={chosenImage}
-            siteName={siteName}
-            isPendingUpload={false}
-            onClose={() => this.setState({ chosenImage: null })}
-            onSave={() => window.location.reload()}
-          />
-          )
-        }
-        {
-          pendingImageUpload
-          && (
-          <MediaSettingsModal
-            type="image"
-            media={pendingImageUpload}
-            siteName={siteName}
-            // eslint-disable-next-line react/jsx-boolean-value
-            isPendingUpload
-            onClose={() => this.setState({ pendingImageUpload: null })}
-            onSave={() => window.location.reload()}
-          />
-          )
-        }
-      </>
-    );
-  }
+        {/* main section ends here */}
+      </div>
+      {
+        chosenImage
+        && (
+        <MediaSettingsModal
+          type="image"
+          media={chosenImage}
+          siteName={siteName}
+          isPendingUpload={false}
+          onClose={() => setChosenImage(null)}
+          onSave={() => window.location.reload()}
+        />
+        )
+      }
+      {
+        pendingImageUpload
+        && (
+        <MediaSettingsModal
+          type="image"
+          media={pendingImageUpload}
+          siteName={siteName}
+          // eslint-disable-next-line react/jsx-boolean-value
+          isPendingUpload
+          onClose={() => setPendingImageUpload(null)}
+          onSave={() => window.location.reload()}
+        />
+        )
+      }
+    </>
+  );
 }
+
+export default Images
 
 Images.propTypes = {
   match: PropTypes.shape({

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -12,6 +12,7 @@ import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
 const Images = ({ match: { params: { siteName } }, location }) => {
   const [images, setImages] = useState([])
+  const [directories, setDirectories] = useState([])
   const [pendingImageUpload, setPendingImageUpload] = useState(null)
   const [chosenImage, setChosenImage] = useState('')
 
@@ -19,11 +20,23 @@ const Images = ({ match: { params: { siteName } }, location }) => {
     let _isMounted = true
     const fetchData = async () => {
       try {
-        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, {
+        const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/files/images`, {
           withCredentials: true,
         });
-        const { images } = resp.data;
-        if (_isMounted) setImages(images);
+        const { directoryContents } = resp.data;
+
+        let respImages = []
+        let respDirectories = []
+        directoryContents.forEach((fileOrDir) => {
+          const modifiedFileOrDir = { ...fileOrDir, fileName: fileOrDir.name }
+          if (fileOrDir.type === 'file') respImages.push(modifiedFileOrDir)
+          if (fileOrDir.type === 'dir') respDirectories.push(modifiedFileOrDir)
+        })
+
+        if (_isMounted) {
+          setImages(respImages);
+          setDirectories(respDirectories)
+        }
       } catch (err) {
         console.log(err);
       }

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -156,7 +156,7 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
               {/* Upload Image */}
               <FolderOptionButton
                 title="Upload new image"
-                option="create-sub"
+                option="upload-image"
                 onClick={() => document.getElementById('file-upload').click()}
               />
               <FolderOptionButton

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -137,11 +137,41 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
           <div className={contentStyles.sectionHeader}>
             <h1 className={contentStyles.sectionTitle}>Images</h1>
           </div>
-          {/* Directories segment */}
+          {/* Info segment */}
           <div className={contentStyles.segment}>
-            Folders
+            <i className="bx bx-sm bx-info-circle text-dark" />
+            <span><strong className="ml-1">Note:</strong> Upload images here to link to them in pages and resources. The maximum image size allowed is 5MB.</span>
           </div>
-          {/* Image folders */}
+          {/* Creation buttons */}
+          <div className={contentStyles.folderContainerBoxes}>
+            <div className={contentStyles.boxesContainer}>
+              {/* Upload Image */}
+              {/* <MediaUploadCard
+                type="image"
+                onClick={() => document.getElementById('file-upload').click()}
+              />
+              <input
+                onChange={onImageSelect}
+                onClick={(event) => {
+                  // eslint-disable-next-line no-param-reassign
+                  event.target.value = '';
+                }}
+                type="file"
+                id="file-upload"
+                accept="image/*"
+                hidden
+              /> */}
+            </div>
+          </div>
+          {/* Segment divider  */}
+          <div className={contentStyles.segmentDividerContainer}>
+            <hr className="w-100 mt-3 mb-5" />
+          </div>
+          {/* Directories title segment */}
+          <div className={contentStyles.segment}>
+            <span>Directories</span>
+          </div>
+          {/* Image directories */}
           <div className={contentStyles.folderContainerBoxes}>
             <div className={contentStyles.boxesContainer}>
               {
@@ -172,32 +202,16 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
           </div>
           {/* Segment divider  */}
           <div className={contentStyles.segmentDividerContainer}>
-            <hr className="w-100 mt-3 mb-5" />
+            <hr className="invisible w-100 mt-3 mb-5" />
           </div>
-          {/* Info segment */}
+          {/* Ungrouped Images title segment */}
           <div className={contentStyles.segment}>
-            <i className="bx bx-sm bx-info-circle text-dark" />
-            <span><strong className="ml-1">Note:</strong> Upload images here to link to them in pages and resources. The maximum image size allowed is 5MB.</span>
+            <span>Ungrouped Images</span>
           </div>
+          {/* Images segment */}
           <div className={contentStyles.contentContainerBars}>
             <div className={contentStyles.boxesContainer}>
               <div className={mediaStyles.mediaCards}>
-                {/* Upload Image */}
-                <MediaUploadCard
-                  type="image"
-                  onClick={() => document.getElementById('file-upload').click()}
-                />
-                <input
-                  onChange={onImageSelect}
-                  onClick={(event) => {
-                    // eslint-disable-next-line no-param-reassign
-                    event.target.value = '';
-                  }}
-                  type="file"
-                  id="file-upload"
-                  accept="image/*"
-                  hidden
-                />
                 {/* Images */}
                 {images.length > 0 && images.map((image) => (
                   <MediaCard

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -1,14 +1,19 @@
-import React, { Component, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
-import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
-import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
+import FolderCard from '../components/FolderCard'
 import MediaUploadCard from '../components/media/MediaUploadCard';
 import MediaCard from '../components/media/MediaCard';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
+
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
+
+import { deslugifyDirectory } from '../utils';
 
 const Images = ({ match: { params: { siteName } }, location }) => {
   const [images, setImages] = useState([])
@@ -90,6 +95,34 @@ const Images = ({ match: { params: { siteName } }, location }) => {
         <div className={contentStyles.mainSection}>
           <div className={contentStyles.sectionHeader}>
             <h1 className={contentStyles.sectionTitle}>Images</h1>
+          </div>
+          {/* Directories segment */}
+          <div className={contentStyles.segment}>
+            Folders
+          </div>
+          {/* Image folders */}
+          <div className={contentStyles.folderContainerBoxes}>
+            <div className={contentStyles.boxesContainer}>
+              {
+                directories && directories.length > 0
+                ? directories.map((directory, idx) => (
+                    <FolderCard
+                      displayText={deslugifyDirectory(directory.name)}
+                      settingsToggle={() => {}}
+                      key={directory.name}
+                      pageType={"media"}
+                      linkPath={directory.path}
+                      siteName={siteName}
+                      itemIndex={idx}
+                    />
+                ))
+                : null
+              }
+            </div>
+          </div>
+          {/* Segment divider  */}
+          <div className={contentStyles.segmentDividerContainer}>
+            <hr className="w-100 mt-3 mb-5" />
           </div>
           {/* Info segment */}
           <div className={contentStyles.segment}>

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -26,14 +26,13 @@ import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
 const IMAGE_CONTENTS_KEY = 'image-contents'
 
 const getPrevDirectoryPath = (customPath) => {
-  const customPathArr = customPath.split('/')
+  const customPathArr = customPath.split('%2F')
 
   let prevDirectoryPath
   if (customPathArr.length > 1) {
-    prevDirectoryPath = customPathArr
+    prevDirectoryPath = `images/${customPathArr
       .slice(0, -1) // remove the latest directory
-      .join('/')
-      .slice(1) // remove starting `/`
+      .join('/')}`
   }
   else {
     prevDirectoryPath = 'images'
@@ -43,7 +42,7 @@ const getPrevDirectoryPath = (customPath) => {
 }
 
 const getPrevDirectoryName = (customPath) => {
-  const customPathArr = customPath.split('/')
+  const customPathArr = customPath.split('%2F')
 
   let prevDirectoryName
   if (customPathArr.length > 1) {

--- a/src/styles/isomer-cms/elements/variable.scss
+++ b/src/styles/isomer-cms/elements/variable.scss
@@ -29,7 +29,7 @@ $site-margin-horizontal: 20px;
 $site-margin-vertical: 15px;
 $sites-container-width: ($site-width*3) + ($site-margin-horizontal*6);
 
-$component-card-height: 12.5rem;
+$component-card-height: 14.9rem;
 $component-card-margin: 2.5%;
 $component-card-width: (100% - ($component-card-margin*3) )/3 ;
 

--- a/src/styles/isomer-cms/pages/Content.module.scss
+++ b/src/styles/isomer-cms/pages/Content.module.scss
@@ -50,7 +50,7 @@
   margin-bottom: 2.5rem;
 
   span {
-    font-size: 16px;
+    font-size: 18px;
   }
 
   strong {

--- a/src/styles/isomer-cms/pages/Media.module.scss
+++ b/src/styles/isomer-cms/pages/Media.module.scss
@@ -17,6 +17,9 @@
 
 .mediaCardDimensions {
   @include single-site;
+  width: $component-folder-width;
+  margin-right: $component-folder-margin;
+  margin-bottom: $component-folder-margin;
 }
 
 .mediaModal {
@@ -59,6 +62,11 @@
       border: none;
       box-sizing: border-box;
       transition: transform 0.2s ease-in;
+      min-width: 250px;
+      width: $component-card-width;
+      height: $component-card-height;
+      margin-right: $component-card-margin;
+      margin-bottom: $component-card-margin;
 
       .mediaCardPreviewContainer {
         height: 70%;


### PR DESCRIPTION
## Notes
- This PR is to be reviewed with PR #[154](https://github.com/isomerpages/isomercms-backend/pull/154) on the backend
- The "Create new directory" button does not yet work - this will be worked on in a subsequent PR
- The UI for accessing nested directories is expected to change, since the designers did not have much time to work on the design for this screen. The Figma design for the screen can be found here ([link](https://www.figma.com/file/4qNhGTBMs521pDvCAIh4ON/IsomerCMS?node-id=1025%3A8585))

_Target design_
<img width="834" alt="Screenshot 2021-03-09 at 6 02 10 PM" src="https://user-images.githubusercontent.com/31984694/110488302-52ef7880-8129-11eb-9d7a-3047e553ca42.png">

## To-do in subsequent PRs
- Update nested document upload and updating process (#413)
- Add functionality to the `Create new directory` button on the `Images` layout (#414)
- Refactor `MediaSettingsModal` to be a functional component (#415)
- Refactor `MediaSettingsModal` to use `react-query` (#416)

## Overview

This PR modifies the `Images` layout so that it is able to retrieve images from nested directories. Users can navigate between parent and child directories using the `FolderCard` component (accessing child directory) and the back button in the `Header` component (going back into the parent directory).

_Parent directory_
<img width="1666" alt="Screenshot 2021-03-09 at 10 47 18 PM" src="https://user-images.githubusercontent.com/31984694/110488565-8e8a4280-8129-11eb-8fe0-e02a84ea68f1.png">

_Child directory ("carousel" directory)_
<img width="1661" alt="Screenshot 2021-03-09 at 10 47 33 PM" src="https://user-images.githubusercontent.com/31984694/110488577-92b66000-8129-11eb-86bb-5818145b3cab.png">

Other changes:
- Update the `Images` layout to use the `react-query` library for retrieving images from the backend
- Update styling for the `MediaCard` component so that there are 3 of them per row, as per the Figma designs