### PR TITLE
Feat/new page folder

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,4 @@
 import axios from 'axios';
-import { generatePageContent } from './utils';
-
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -55,11 +53,8 @@ const updateNavBarData = async (siteName, originalNav, links, sha) => {
     return await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
 }
 
-const createPage = async (fileInfo) => {
-    const { endpointUrl, content, redirectUrl } = generatePageContent(fileInfo)
-    if ( !endpointUrl || !content || !redirectUrl ) return // fileType not recognised
-    await axios.post(`${BACKEND_URL}/sites/${endpointUrl}`, { content });
-    return redirectUrl
+const createPage = async (endpointUrl, content) => {
+    return await axios.post(`${BACKEND_URL}/sites/${endpointUrl}`, { content });
 }
 
 export {

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import { generatePageContent } from './utils';
+
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -53,10 +55,18 @@ const updateNavBarData = async (siteName, originalNav, links, sha) => {
     return await axios.post(`${BACKEND_URL}/sites/${siteName}/navigation`, params);
 }
 
+const createPage = async (fileInfo) => {
+    const { endpointUrl, content, redirectUrl } = generatePageContent(fileInfo)
+    if ( !endpointUrl || !content || !redirectUrl ) return // fileType not recognised
+    await axios.post(`${BACKEND_URL}/sites/${endpointUrl}`, { content });
+    return redirectUrl
+}
+
 export {
     getDirectoryFile,
     setDirectoryFile,
     getFolderContents,
     getEditNavBarData,
     updateNavBarData,
+    createPage,
 }

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -7,6 +7,7 @@ import _ from 'lodash';
 // Import components
 import OverviewCard from '../components/OverviewCard';
 import ComponentSettingsModal from './ComponentSettingsModal'
+import PageSettingsModal from './PageSettingsModal'
 
 // Import styles
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -100,9 +101,9 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     return (
         <>
             {
-                isComponentSettingsActive
-                && (
-                    <ComponentSettingsModal
+                isComponentSettingsActive 
+                && ( isResource 
+                    ? <ComponentSettingsModal
                         modalTitle={isResource ? "Resource Settings" : "Page Settings"}
                         settingsToggle={settingsToggle}
                         category={collectionName}
@@ -119,6 +120,13 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                         collectionPageData={collectionPageData}
                         loadThirdNavOptions={loadThirdNavOptions}
                         setIsComponentSettingsActive={setIsComponentSettingsActive}
+                    /> 
+                    : <PageSettingsModal
+                        pageType='page'
+                        pagesData={pages}
+                        siteName={siteName}
+                        isNewPage={true}
+                        setIsPageSettingsActive={setIsComponentSettingsActive}
                     />
                 )
             }
@@ -150,9 +158,8 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                                     settingsToggle={settingsToggle}
                                     category={collectionName}
                                     siteName={siteName}
-                                    fileName={page.fileName}
-                                    title={page.title}
-                                    resourceType={page.type}
+                                    fileName={page.name}
+                                    resourceType={isResource ? page.type : ''}
                                     date={page.date}
                                     isResource={isResource}
                                     allCategories={allCategories}
@@ -173,7 +180,7 @@ export default CollectionPagesSection
 CollectionPagesSection.propTypes = {
     pages: PropTypes.arrayOf(
         PropTypes.shape({
-            fileName: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
             path: PropTypes.string.isRequired,
             sha: PropTypes.string.isRequired,
         }),

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -85,7 +85,7 @@ const FolderCreationModal = ({
 
   const sortFuncs = {
     'title': (a, b) => {
-      return a.title.localeCompare(b.title)
+      return a.name.localeCompare(b.name)
     }
   }
 
@@ -151,15 +151,15 @@ const FolderCreationModal = ({
                     sortedPagesData && sortedPagesData.length > 0
                     ? sortedPagesData.map((pageData, pageIdx) => (
                           <FolderCard
-                              displayText={deslugifyPage(pageData.title)}
+                              displayText={deslugifyPage(pageData.name)}
                               settingsToggle={() => {}}
-                              key={pageData.title}
+                              key={pageData.name}
                               pageType={"file"}
                               siteName={siteName}
                               itemIndex={pageIdx}
-                              folderStyle={selectedFiles.has(pageData.title) ? `border border-primary` : ''}
+                              folderStyle={selectedFiles.has(pageData.name) ? `border border-primary` : ''}
                               onClick={() => {
-                                  fileSelectChangeHandler(pageData.title)
+                                  fileSelectChangeHandler(pageData.name)
                               }}
                           />
                     ))

--- a/src/components/FormFieldHorizontal.jsx
+++ b/src/components/FormFieldHorizontal.jsx
@@ -15,7 +15,7 @@ const FormFieldHorizontal = ({
 }) => (
   <>
     <div className={elementStyles.formHorizontal}>
-      <p className={elementStyles.formHorizontalLabel}>{`${title}:`}</p>
+      <p className={elementStyles.formHorizontalLabel}>{`${title}`}</p>
       <input
         type="text"
         placeholder={placeholder ? placeholder : title}

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 import FormField from './FormField';
 import {
   DEFAULT_ERROR_TOAST_MSG,
+  generatePageFileName,
 } from '../utils';
 
 import { createPage } from '../api'
@@ -81,6 +82,16 @@ const PageSettingsModal = ({
         )
       }
     )
+
+    useEffect(() => {
+      let exampleTitle = 'Example Title'
+      while (_.find(pagesData, function(v) { return v.type === 'file' && generatePageFileName(exampleTitle) === (v.title || v.name) }) !== undefined) {
+        exampleTitle = exampleTitle+'_1'
+      }
+      const examplePermalink = `/${folderName ? `${folderName}/` : ''}${subfolderName ? `${subfolderName}/` : ''}permalink`
+      setTitle(exampleTitle)
+      setPermalink(examplePermalink)
+    }, [])
 
     useEffect(() => {
       setHasErrors(_.some(errors, (field) => field.length > 0));

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -16,8 +16,7 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 import { validatePageSettings } from '../utils/validators';
 import SaveDeleteButtons from './SaveDeleteButtons';
-import { toast } from 'react-toastify';
-import Toast from './Toast';
+import { errorToast } from '../utils/toasts';
 import FormFieldHorizontal from './FormFieldHorizontal';
 
 import useRedirectHook from '../hooks/useRedirectHook';
@@ -65,10 +64,7 @@ const PageSettingsModal = ({
           setSha(data.sha)
           setMdBody(data.mdBody)
         }, 
-        onError: () => toast(
-          <Toast notificationType='error' text={`The page data could not be retrieved. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-        )
+        onError: () => errorToast(`The page data could not be retrieved. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`)
       }
     )
 
@@ -82,10 +78,7 @@ const PageSettingsModal = ({
       { 
         onSettled: () => setIsPageSettingsActive(false),
         onSuccess: (redirectUrl) => setRedirectToPage(redirectUrl),  
-        onError: () => toast(
-          <Toast notificationType='error' text={`A new page could not be created. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
-          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
-        )
+        onError: () => errorToast(`A new page could not be created. Please try again. ${DEFAULT_ERROR_TOAST_MSG}`)
       }
     )
 

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -59,7 +59,7 @@ const PageSettingsModal = ({
       { 
         enabled: !isNewPage,
         onSuccess: () => {
-          setTitle(data.title)
+          setTitle(data.name)
           setPermalink(data.permalink)
           setSha(data.sha)
           setMdBody(data.mdBody)
@@ -84,7 +84,7 @@ const PageSettingsModal = ({
 
     useEffect(() => {
       let exampleTitle = 'Example Title'
-      while (_.find(pagesData, function(v) { return v.type === 'file' && generatePageFileName(exampleTitle) === (v.title || v.name) }) !== undefined) {
+      while (_.find(pagesData, function(v) { return v.type === 'file' && generatePageFileName(exampleTitle) === v.name }) !== undefined) {
         exampleTitle = exampleTitle+'_1'
       }
       const examplePermalink = `/${folderName ? `${folderName}/` : ''}${subfolderName ? `${subfolderName}/` : ''}permalink`

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -55,7 +55,7 @@ const PageSettingsModal = ({
 
     const { data } = useQuery(
       'page',
-      () => console.log('getting page data'),
+      () => {},  // for page settings editing 
       { 
         enabled: !isNewPage,
         onSuccess: () => {

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -6,6 +6,7 @@ import FormField from './FormField';
 import {
   DEFAULT_ERROR_TOAST_MSG,
   generatePageFileName,
+  generatePageContent,
 } from '../utils';
 
 import { createPage } from '../api'
@@ -72,7 +73,12 @@ const PageSettingsModal = ({
     )
 
     const { mutateAsync: saveHandler } = useMutation(
-      async () => await createPage({ siteName, title, permalink, mdBody, folderName, subfolderName, pageType }),
+      async () => { 
+        const fileInfo = { siteName, title, permalink, mdBody, folderName, subfolderName, pageType }
+        const { endpointUrl, content, redirectUrl } = generatePageContent(fileInfo)
+        await createPage(endpointUrl, content)
+        return redirectUrl
+      },
       { 
         onSettled: () => setIsPageSettingsActive(false),
         onSuccess: (redirectUrl) => setRedirectToPage(redirectUrl),  

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -1,0 +1,181 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import * as _ from 'lodash';
+import FormField from './FormField';
+import {
+  DEFAULT_ERROR_TOAST_MSG,
+} from '../utils';
+
+import { createPage } from '../api'
+
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+
+import { validatePageSettings } from '../utils/validators';
+import SaveDeleteButtons from './SaveDeleteButtons';
+import { toast } from 'react-toastify';
+import Toast from './Toast';
+import FormFieldHorizontal from './FormFieldHorizontal';
+
+import useRedirectHook from '../hooks/useRedirectHook';
+
+// axios settings
+axios.defaults.withCredentials = true
+
+const PageSettingsModal = ({
+    pageType, 
+    folderName,
+    subfolderName,
+    pageName,
+    isNewPage,
+    pagesData,
+    siteName,
+    setIsPageSettingsActive,
+}) => {
+    // Errors
+    const [errors, setErrors] = useState({
+        title: '',
+        permalink: '',
+    })
+    const [hasErrors, setHasErrors] = useState(false)
+
+    // Base hooks
+    const [title, setTitle] = useState('')
+    const [permalink, setPermalink] = useState('')
+    const [sha, setSha] = useState('')
+    const [mdBody, setMdBody] = useState('')
+    const { setRedirectToPage } = useRedirectHook()
+
+    const idToSetterFuncMap = {
+      title: setTitle,
+      permalink: setPermalink,
+    }
+
+    useEffect(() => {
+      let _isMounted = true
+      const fetchData = async () => {
+        if (isNewPage) {
+          // Set default values for new file
+          if (_isMounted) {
+            setTitle('Example Title')
+            setPermalink(`/${folderName ? `${folderName}/` : ''}${subfolderName ? `${subfolderName}/` : ''}permalink`)
+          }
+        } else {
+          // pass
+        }
+      }
+      fetchData().catch((err) => {
+        toast(
+          <Toast notificationType='error' text={`There was a problem retrieving data from your repo. ${DEFAULT_ERROR_TOAST_MSG}`}/>,
+          {className: `${elementStyles.toastError} ${elementStyles.toastLong}`},
+        );
+        console.log(err)
+      })
+      return () => { _isMounted = false }
+    }, [])
+
+    useEffect(() => {
+      setHasErrors(_.some(errors, (field) => field.length > 0));
+    }, [errors])
+
+    const changeHandler = (event) => {
+      const { id, value } = event.target;
+      const errorMessage = validatePageSettings(id, value, pagesData)
+      setErrors((prevState) => ({
+        ...prevState,
+        [id]: errorMessage,
+      }));
+      idToSetterFuncMap[id](value);
+    }
+
+    const saveHandler = async () => {
+      
+      if (isNewPage) {
+        const fileInfo = {
+          siteName,
+          title,
+          permalink,
+          mdBody,
+          folderName,
+          subfolderName,
+          pageType,
+        }
+        const redirectUrl = await createPage(fileInfo)
+        setRedirectToPage(redirectUrl)
+      }
+      else {
+        // pass
+      }
+    }
+
+    return (
+        <>
+          <div className={elementStyles.overlay}>
+            { (sha || isNewPage)
+            && (
+            <div className={elementStyles['modal-settings']}>
+              <div className={elementStyles.modalHeader}>
+                <h1>{ isNewPage  ? 'Create new page' : 'Page settings' }</h1>
+                <button id="settings-CLOSE" type="button" onClick={() => setIsPageSettingsActive((prevState)=> !prevState)}>
+                  <i id="settingsIcon-CLOSE" className="bx bx-x" />
+                </button>
+              </div>
+              <div className={elementStyles.modalContent}>
+                { isNewPage ? 'You may edit page details anytime. ' : ''}
+                To edit page content, simply click on the page title. 
+                <div className={contentStyles.segment}>
+                  <span> 
+                    My workspace >
+                    {
+                      folderName
+                      ? <span> {folderName} > </span>  
+                      : null
+                    }
+                    {
+                      subfolderName
+                      ? <span> {subfolderName} > </span>
+                      : null
+                    } 
+                     <strong className="ml-1">{ title }</strong>
+                  </span>
+                </div>
+                <div className={elementStyles.modalFormFields}>
+                  {/* Title */}
+                  <FormField
+                    title="Page title"
+                    id="title"
+                    value={title}
+                    errorMessage={errors.title}
+                    isRequired={true}
+                    onFieldChange={changeHandler}
+                  />
+                  <br/>
+                  <p className={elementStyles.formLabel}>Page URL</p>
+                  {/* Permalink */}
+                  <FormFieldHorizontal
+                    title={`https://abc.gov.sg`}             
+                    id="permalink"
+                    value={permalink ? permalink : ''}
+                    errorMessage={errors.permalink}
+                    isRequired={true}
+                    onFieldChange={changeHandler}
+                    placeholder=' '
+                  />
+                </div>
+                <SaveDeleteButtons 
+                  isDisabled={isNewPage ? hasErrors : (hasErrors || !sha)}
+                  hasDeleteButton={!isNewPage}
+                  saveCallback={saveHandler}
+                />
+              </div>
+            </div>
+            )}
+          </div>
+        </>
+    );
+}
+
+export default PageSettingsModal
+
+PageSettingsModal.propTypes = {
+};

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -80,7 +80,7 @@ const FolderContent = ({ folderOrderArray, setFolderOrderArray, siteName, folder
                                     draggableId={`folder-${folderContentIndex}-draggable`}
                                     index={folderContentIndex}
                                     isDragDisabled={!enableDragDrop}
-                                    key={folderContentItem.title}
+                                    key={folderContentItem.name}
                                 >
                                     {(draggableProvided) => (
                                         <div
@@ -90,11 +90,11 @@ const FolderContent = ({ folderOrderArray, setFolderOrderArray, siteName, folder
                                             ref={draggableProvided.innerRef}
                                         >        
                                             <FolderContentItem
-                                                key={folderContentItem.title}
-                                                title={deslugifyPage(folderContentItem.title)}
+                                                key={folderContentItem.name}
+                                                title={deslugifyPage(folderContentItem.name)}
                                                 numItems={folderContentItem.type === 'dir' ? folderContentItem.children.length : null}
                                                 isFile={folderContentItem.type === 'dir' ? false: true}
-                                                link={folderContentItem.type === 'dir' ? `/sites/${siteName}/folder/${folderName}/subfolder/${folderContentItem.title}` : `/sites/${siteName}/collections/${folderName}/${folderContentItem.path}`}
+                                                link={folderContentItem.type === 'dir' ? `/sites/${siteName}/folder/${folderName}/subfolder/${folderContentItem.name}` : `/sites/${siteName}/collections/${folderName}/${folderContentItem.path}`}
                                                 itemIndex={folderContentIndex}
                                             />
                                         </div>

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -91,7 +91,7 @@ const getBackButtonInfo = (resourceCategory, collectionName, siteName) => {
   }
   if (collectionName) return {
     backButtonLabel: collectionName,
-    backButtonUrl: `/sites/${siteName}/collections/${collectionName}`,
+    backButtonUrl: `/sites/${siteName}/folder/${collectionName}`,
   }
   return {
     backButtonLabel: 'My Workspace',

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -11,6 +11,8 @@ import Sidebar from '../components/Sidebar';
 import FolderCreationModal from '../components/FolderCreationModal'
 import FolderOptionButton from '../components/folders/FolderOptionButton';
 import FolderContent from '../components/folders/FolderContent';
+import PageSettingsModal from '../components/PageSettingsModal'
+
 import { errorToast, successToast } from '../utils/toasts';
 
 import useRedirectHook from '../hooks/useRedirectHook';
@@ -41,6 +43,7 @@ const Folders = ({ match, location }) => {
     const { setRedirectToPage, setRedirectToNotFound } = useRedirectHook()
 
     const [isRearrangeActive, setIsRearrangeActive] = useState(false)
+    const [isPageSettingsActive, setIsPageSettingsActive] = useState(false)
     const [directoryFileSha, setDirectoryFileSha] = useState('')
     const [folderOrderArray, setFolderOrderArray] = useState([])
     const [parsedFolderContents, setParsedFolderContents] = useState([])
@@ -129,6 +132,20 @@ const Folders = ({ match, location }) => {
               setIsFolderCreationActive={setIsFolderCreationActive}
             />
           }
+          {
+            isPageSettingsActive
+            && (
+              <PageSettingsModal
+                pageType='collection'
+                folderName={folderName}
+                subfolderName={subfolderName}
+                pagesData={folderOrderArray.filter(item => item.type === 'file')}
+                siteName={siteName}
+                isNewPage={true}
+                setIsPageSettingsActive={setIsPageSettingsActive}
+              />
+            )
+          }
           <Header
             backButtonText={`Back to ${subfolderName ? folderName : 'Workspace'}`}
             backButtonUrl={`/sites/${siteName}/${subfolderName ? `folder/${folderName}` : 'workspace'}`}
@@ -178,7 +195,7 @@ const Folders = ({ match, location }) => {
               {/* Options */}
               <div className={contentStyles.contentContainerFolderRowMargin}>
                 <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
-                <FolderOptionButton title="Create new page" option="create-page" />
+                <FolderOptionButton title="Create new page" option="create-page" onClick={() => setIsPageSettingsActive(true)}/>
                 <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName || folderOrderArray.length === 0 ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
               {/* Collections content */}

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -60,10 +60,10 @@ const Workspace = ({ match, location }) => {
         }
         
         try { 
-          const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/unlinkedPages`);
+          const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/files/pages`);
           console.log(unlinkedPagesResp.data)
           if (_isMounted) {
-            setUnlinkedPages(unlinkedPagesResp.data?.pages.filter(page => page.fileName !== 'contact-us.md'))
+            setUnlinkedPages(unlinkedPagesResp.data?.directoryContents.filter(page => page.name !== 'contact-us.md'))
           }
         } catch (e) {
           console.log(e)
@@ -214,7 +214,7 @@ Workspace.propTypes = {
       }),
     }).isRequired,
     location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
+      pathname: PropTypes.string.isRequired,  
     }).isRequired,
 };
   

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -214,7 +214,7 @@ Workspace.propTypes = {
       }),
     }).isRequired,
     location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,  
+      pathname: PropTypes.string.isRequired,
     }).isRequired,
 };
   

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -38,6 +38,7 @@ p {
 
   .formHorizontalLabel{
     @extend .formLabel;
+    padding-right: 5px;
     min-width: min-content;
     width: 20%;
   }

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -38,11 +38,12 @@ p {
 
   .formHorizontalLabel{
     @extend .formLabel;
+    min-width: min-content;
     width: 20%;
   }
 
   .formHorizontalInput{
-    width: 80%;
+    max-width: 80%;
   }
 }
 

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -38,12 +38,11 @@ p {
 
   .formHorizontalLabel{
     @extend .formLabel;
-    width: 25%;
-    margin: 1px;
+    width: 20%;
   }
 
   .formHorizontalInput{
-    width: 75%;
+    width: 80%;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -204,7 +204,7 @@ export function prettifyCollectionPageFileName(fileName) {
 }
 
 export function generatePageFileName(title) {
-  return `${slugify(title).replace(/[^a-zA-Z0-9-]/g, '')}.md`;
+  return `${slugify(title, {lower: true}).replace(/[^a-zA-Z0-9-]/g, '')}.md`;
 }
 
 export function generateCollectionPageFileName(title, groupIdentifier) {
@@ -347,6 +347,51 @@ export async function saveFileAndRetrieveUrl(fileInfo) {
   return newPageUrl
 }
 
+function generateCollectionPageContent(fileInfo) {
+  const {
+    siteName,
+    title,
+    permalink,
+    mdBody,
+    folderName,
+    subfolderName,
+  } = fileInfo
+  const frontMatter = subfolderName
+    ? { title, permalink, third_nav_title: subfolderName }
+    : { title, permalink }
+  const content = concatFrontMatterMdBody(frontMatter, mdBody)
+  
+  const fileName = subfolderName 
+    ? `${subfolderName}/${generatePageFileName(title)}` 
+    : `${generatePageFileName(title)}`
+  const endpointUrl = `${siteName}/collections/${folderName}/pages/new/${encodeURIComponent(fileName)}`
+  
+  const redirectUrl = `/sites/${siteName}/collections/${folderName}/${encodeURIComponent(fileName)}`
+  
+  return { endpointUrl, content, redirectUrl }
+}
+
+function generateUnlinkedPageContent(fileInfo) {
+  const {
+    siteName,
+    title,
+    permalink,
+    mdBody,
+  } = fileInfo
+
+  const frontMatter = { title, permalink }
+  const content = concatFrontMatterMdBody(frontMatter, mdBody)
+  const fileName = `${generatePageFileName(title)}`
+  const endpointUrl = `${siteName}/pages/new/${encodeURIComponent(fileName)}`
+  const redirectUrl = `/sites/${siteName}/pages/${encodeURIComponent(fileName)}`
+  return { endpointUrl, content, redirectUrl }
+}
+
+export function generatePageContent(fileInfo) {
+  const { pageType } = fileInfo
+  if (pageType === 'collection') return generateCollectionPageContent(fileInfo)
+  if (pageType === 'page') return generateUnlinkedPageContent(fileInfo)
+}
 /*
  * Util functions for generating file identifiers (the numeric/alphanumeric strings which filenames begin with)
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -631,7 +631,7 @@ export const convertFolderOrderToArray = (folderOrder) => {
           acc.push({
               type: 'file',
               path: curr,
-              title: curr,
+              name: curr,
           })
       }
 
@@ -647,7 +647,7 @@ export const convertFolderOrderToArray = (folderOrder) => {
 
               currFolderEntry = {
                 type: 'dir',
-                title: subfolderTitle,
+                name: subfolderTitle,
                 path: curr,
                 children: [curr],
               }
@@ -680,7 +680,7 @@ export const retrieveSubfolderContents = (folderOrder, subfolderName) => {
         acc.push({
           type: 'file',
           path: curr,
-          title: subfolderFileName,
+          name: subfolderFileName,
         })
       }
     }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,6 +1,6 @@
 
 import _ from 'lodash';
-import { slugifyLower } from '../utils';
+import { generatePageFileName } from '../utils';
 
 // Common regexes and constants
 // ==============
@@ -640,7 +640,7 @@ const validatePageSettings = (id, value, folderOrderArray) => {
       if ( 
         folderOrderArray !== undefined 
         // need to check both v.title and v.name as Directory.list() backend output is different from frontend parsing of collection.yml
-        && _.find(folderOrderArray, function(v) { return v.type === 'file' && slugifyLower(value) === (v.title?.split('.')[0] || v.name?.split('.')[0]) }) !== undefined 
+        && _.find(folderOrderArray, function(v) { return v.type === 'file' && generatePageFileName(value) === (v.title || v.name) }) !== undefined 
       ) {
         errorMessage = `This title is already in use. Please choose a different title.`;
       }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,5 +1,6 @@
 
-const _ = require('lodash');
+import _ from 'lodash';
+import { slugifyLower } from '../utils';
 
 // Common regexes and constants
 // ==============
@@ -607,7 +608,7 @@ const validateLink = (linkType, value) => {
 
 // Page Settings Modal
 // ===================
-const validatePageSettings = (id, value) => {
+const validatePageSettings = (id, value, folderOrderArray) => {
   let errorMessage = '';
   switch (id) {
     case 'permalink': {
@@ -635,6 +636,12 @@ const validatePageSettings = (id, value) => {
       // Title is too long
       if (value.length > PAGE_SETTINGS_TITLE_MAX_LENGTH) {
         errorMessage = `The title should be shorter than ${PAGE_SETTINGS_TITLE_MAX_LENGTH} characters.`;
+      }
+      if ( 
+        folderOrderArray !== undefined 
+        && _.find(folderOrderArray, function(v) { return v.type === 'file' && slugifyLower(value) === (v.title?.split('.')[0] || v.name?.split('.')[0]) }) !== undefined 
+      ) {
+        errorMessage = `This title is already in use. Please choose a different title.`;
       }
       break;
     }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -639,6 +639,7 @@ const validatePageSettings = (id, value, folderOrderArray) => {
       }
       if ( 
         folderOrderArray !== undefined 
+        // need to check both v.title and v.name as Directory.list() backend output is different from frontend parsing of collection.yml
         && _.find(folderOrderArray, function(v) { return v.type === 'file' && slugifyLower(value) === (v.title?.split('.')[0] || v.name?.split('.')[0]) }) !== undefined 
       ) {
         errorMessage = `This title is already in use. Please choose a different title.`;

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -640,7 +640,7 @@ const validatePageSettings = (id, value, folderOrderArray) => {
       if ( 
         folderOrderArray !== undefined 
         // need to check both v.title and v.name as Directory.list() backend output is different from frontend parsing of collection.yml
-        && _.find(folderOrderArray, function(v) { return v.type === 'file' && generatePageFileName(value) === (v.title || v.name) }) !== undefined 
+        && _.find(folderOrderArray, function(v) { return v.type === 'file' && generatePageFileName(value) === v.name }) !== undefined 
       ) {
         errorMessage = `This title is already in use. Please choose a different title.`;
       }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -639,7 +639,6 @@ const validatePageSettings = (id, value, folderOrderArray) => {
       }
       if ( 
         folderOrderArray !== undefined 
-        // need to check both v.title and v.name as Directory.list() backend output is different from frontend parsing of collection.yml
         && _.find(folderOrderArray, function(v) { return v.type === 'file' && generatePageFileName(value) === v.name }) !== undefined 
       ) {
         errorMessage = `This title is already in use. Please choose a different title.`;


### PR DESCRIPTION
This PR adds functionality to create folder, subfolder and unlinked pages, based on the related issue #356. The functionality to edit these page settings will be added in a later PR. This PR should be reviewed with [#122](https://github.com/isomerpages/isomercms-backend/pull/122) on the backend.

Preview of Page Setting modal when used for creating new page with duplicated title as current files:
<img width="1792" alt="Screenshot 2021-03-08 at 6 48 26 PM" src="https://user-images.githubusercontent.com/39231249/110311536-e1d39680-803e-11eb-87ac-fc1a3966880f.png">


## Notes
- While folder, subfolder and unlinked pages can all be created right now, the redirection to subfolder pages will not work as we currently do not support editing subfolder pages via EditPage on the backend. We should add this functionality in a separate PR. Issue #361
- This PR also does not load the website url from the config page, as we plan to add the website url to the display on the leftbar. Once that is completed, we will have access to this value throughout the site. Issue #372 
- ~Our collection page data retrieved from the `collection.yml` via `convertFolderOrderToArray` and `convertSubfolderArray` has a different format (`{title, type, path}`) from our unlinked page data retrieved via `Directory.list()` on the backend ({`name`, `path`, `sha`, `size`, `type`}). We should consider standardising the name of attributes with the same value i.e. `title`, and `name`.~ fixed with f86253f

