### PR TITLE
Feat: empty folders, add resource category

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -119,7 +119,8 @@ const getEditNavBarData = async(siteName) => {
     if (foldersResp.data && foldersResp.data.allFolderContent) {
         // parse directory files
         foldersContent = foldersResp.data.allFolderContent.reduce((acc, currFolder) => {
-            const folderOrder = parseDirectoryFile(currFolder.content)
+            const collectionKey = Object.keys(currFolder.content.collections)[0]
+            const folderOrder = currFolder.content.collections[collectionKey].order
             acc[currFolder.name] = getNavFolderDropdownFromFolderOrder(folderOrder)
             return acc
         }, {})

--- a/src/api.js
+++ b/src/api.js
@@ -88,6 +88,10 @@ const renameResourceCategory = async ({ siteName, categoryName, newCategoryName}
     return await axios.post(apiUrl)
 }
 
+const getAllResourceCategories = async (siteName) => {
+    return await axios.get(`${BACKEND_URL}/sites/${siteName}/resources`);
+}
+
 const addResourceCategory = async (siteName, resourceName) => {
     if (!resourceName) return
     const params = { resourceName }
@@ -96,7 +100,7 @@ const addResourceCategory = async (siteName, resourceName) => {
 
 const getResourcePages = async (siteName, resourceName) => {
     if (!resourceName) return
-    return await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}`);
+    return await axios.get(`${BACKEND_URL}/sites/${siteName}/resources/${resourceName}`);
 }
 
 // EditNavBar
@@ -185,6 +189,7 @@ export {
     deleteSubfolder,
     renameSubfolder,
     renameResourceCategory,
+    getAllResourceCategories,
     addResourceCategory,
     getResourcePages,
     getEditNavBarData,

--- a/src/api.js
+++ b/src/api.js
@@ -94,6 +94,11 @@ const addResourceCategory = async (siteName, resourceName) => {
     return await axios.post(`${BACKEND_URL}/sites/${siteName}/resources`, params);
 }
 
+const getResourcePages = async (siteName, resourceName) => {
+    if (!resourceName) return
+    return await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${resourceName}`);
+}
+
 // EditNavBar
 const getEditNavBarData = async(siteName) => {
     let navContent, collectionContent, resourceContent, navSha, foldersContent
@@ -181,6 +186,7 @@ export {
     renameSubfolder,
     renameResourceCategory,
     addResourceCategory,
+    getResourcePages,
     getEditNavBarData,
     updateNavBarData,
     createPage,

--- a/src/api.js
+++ b/src/api.js
@@ -66,7 +66,6 @@ const deletePageData = async ({folderName, subfolderName, fileName, siteName, re
     });
 }
 
-
 // Folder and subfolders
 const renameFolder = async ({ siteName, folderName, newFolderName }) => {
     const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${folderName}/rename/${newFolderName}`
@@ -83,9 +82,16 @@ const renameSubfolder = async ({ siteName, folderName, subfolderName, newSubfold
     return await axios.post(apiUrl)
 }
 
+// Resources
 const renameResourceCategory = async ({ siteName, categoryName, newCategoryName}) => {
     const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${categoryName}/rename/${newCategoryName}`
     return await axios.post(apiUrl)
+}
+
+const addResourceCategory = async (siteName, resourceName) => {
+    if (!resourceName) return
+    const params = { resourceName }
+    return await axios.post(`${BACKEND_URL}/sites/${siteName}/resources`, params);
 }
 
 // EditNavBar
@@ -174,6 +180,7 @@ export {
     deleteSubfolder,
     renameSubfolder,
     renameResourceCategory,
+    addResourceCategory,
     getEditNavBarData,
     updateNavBarData,
     createPage,

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -132,6 +132,13 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                     />
                 )
             }
+            {
+                pages && _.isEmpty(pages) && 
+                <>
+                    <div className='mr-auto'>No files found.</div>
+                    <hr className="invisible w-100 mt-3 mb-3" />
+                </>
+            }
             <div className={contentStyles.contentContainerBoxes}>
                 {/* Display loader if pages have not been retrieved from API call */}
                 { pages
@@ -148,11 +155,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                         </button>
                         {
                             _.isEmpty(pages)
-                            ?   <Redirect
-                                    to={{
-                                    pathname: isResource ? `/sites/${siteName}/resources` : `/sites/${siteName}/workspace`
-                                    }}
-                                />
+                            ?   null
                             : pages.map((page, pageIdx) => (
                                 <OverviewCard
                                     key={page.fileName}

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -57,9 +57,12 @@ const FolderCreationModal = ({
   const { mutateAsync: saveHandler } = useMutation(
     () => moveFiles(siteName, [ ...selectedFiles ], slugifyCategory(title), parentFolder),
     { onSuccess: () => {
-        const redirectUrl = `/sites/${siteName}/folder/${parentFolder ? `${parentFolder}/subfolder/${slugifyCategory(title)}` : slugifyCategory(title)}`
-        setRedirectToPage(redirectUrl)
-        setIsFolderCreationActive(false)
+        // We set a delay here because the new collection.yml information takes time to propagate, redirecting too soon retrieves the old data
+        setTimeout(function() {
+          const redirectUrl = `/sites/${siteName}/folder/${parentFolder ? `${parentFolder}/subfolder/${slugifyCategory(title)}` : slugifyCategory(title)}`
+          setRedirectToPage(redirectUrl)
+          setIsFolderCreationActive(false)
+        }, 2000)
       },
       onError: (error) => {
         if (error.response.status === 409) {

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -170,7 +170,7 @@ const FolderCreationModal = ({
                     : (
                         !sortedPagesData
                             ? 'Loading Pages...'
-                            : 'There are no pages in this folder'
+                            : 'There are no pages in this folder.'
                     )
                   }
                 </div>

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -120,6 +120,8 @@ const FolderCreationModal = ({
             folderNameChangeHandler={folderNameChangeHandler}
             title={title}
             errors={errors}
+            folderType={parentFolder ? 'subfolder' : 'folder'}
+            proceedText='Select pages'
           />
         }
         { !isSelectingTitle &&

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -57,12 +57,9 @@ const FolderCreationModal = ({
   const { mutateAsync: saveHandler } = useMutation(
     () => moveFiles(siteName, [ ...selectedFiles ], slugifyCategory(title), parentFolder),
     { onSuccess: () => {
-        // We set a delay here because the new collection.yml information takes time to propagate, redirecting too soon retrieves the old data
-        setTimeout(function() {
-          const redirectUrl = `/sites/${siteName}/folder/${parentFolder ? `${parentFolder}/subfolder/${slugifyCategory(title)}` : slugifyCategory(title)}`
-          setRedirectToPage(redirectUrl)
-          setIsFolderCreationActive(false)
-        }, 2000)
+        const redirectUrl = `/sites/${siteName}/folder/${parentFolder ? `${parentFolder}/subfolder/${slugifyCategory(title)}` : slugifyCategory(title)}`
+        setRedirectToPage(redirectUrl)
+        setIsFolderCreationActive(false)
       },
       onError: (error) => {
         if (error.response.status === 409) {

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -184,10 +184,9 @@ const FolderCreationModal = ({
                   callback={() => setIsFolderCreationActive(false)}
                 />
                 <LoadingButton
-                  label={`Done`}
-                  disabled={selectedFiles.size === 0}
+                  label={selectedFiles.size === 0 ? `Skip` : `Done`}
                   disabledStyle={elementStyles.disabled}
-                  className={`${selectedFiles.size === 0 ? elementStyles.disabled : elementStyles.blue}`}
+                  className={elementStyles.blue}
                   callback={saveHandler}
                 />
               </div>

--- a/src/components/FolderNamingModal.jsx
+++ b/src/components/FolderNamingModal.jsx
@@ -1,20 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
-import { Base64 } from 'js-base64';
+import React from 'react';
 import PropTypes from 'prop-types';
 import * as _ from 'lodash';
-import { Redirect } from 'react-router-dom';
-import update from 'immutability-helper';
-import Select from 'react-select';
 import FormField from './FormField';
-import FolderCard from './FolderCard';
 import LoadingButton from './LoadingButton';
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
-import adminStyles from '../styles/isomer-cms/pages/Admin.module.scss';
-import { validateCategoryName } from '../utils/validators';
-import { toast } from 'react-toastify';
-import Toast from './Toast';
 
 const FolderNamingModal = ({
   onClose,
@@ -22,27 +11,35 @@ const FolderNamingModal = ({
   folderNameChangeHandler,
   title,
   errors,
+  folderType,
+  proceedText,
 }) => {
+  const capitalizedFolderType = folderType.charAt(0).toUpperCase() + folderType.slice(1)
 
   return (         
     <div className={elementStyles['modal-newfolder']}>
       <div className={elementStyles.modalHeader}>
-        <h1>{`Create new sub folder`}</h1>
+        <h1>{`Create new ${folderType}`}</h1>
         <button id="settings-CLOSE" type="button" onClick={onClose}>
           <i id="settingsIcon-CLOSE" className="bx bx-x" />
         </button>
       </div>
       <div className={elementStyles.modalContent}>
         <div>
-          You may edit folder name anytime.
-          <br/>
-          Choose the pages you would like to group.
+          {`You may edit ${folderType} name anytime.`}
+          {
+            folderType !== 'resource' &&
+            <>
+              <br/>
+              Choose the pages you would like to group.
+            </>
+          }
         </div>
         <div className={elementStyles.modalFormFields}>
           {/* Title */}
           <FormField
-            title="Sub folder name"
-            id="subfolder"
+            title={`${capitalizedFolderType} name`}
+            id={folderType}
             value={title}
             errorMessage={errors}
             isRequired={true}
@@ -51,7 +48,7 @@ const FolderNamingModal = ({
         </div>
         <div className={elementStyles.modalButtons}>
           <LoadingButton
-            label="Select Pages"
+            label={proceedText}
             disabled={(errors || !title) ? true : false}
             disabledStyle={elementStyles.disabled}
             className={(errors || !title) ? elementStyles.disabled : elementStyles.blue}

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -19,7 +19,12 @@ export default function LoadingButton(props) {
     let _isMounted = true
 
     const runCallback = async () => {
-      await callback();
+      try {
+        await callback();
+      } catch (err) {
+        if (_isMounted) setButtonLoading(false);
+        throw err
+      }
       if (_isMounted) setButtonLoading(false);
     }
 

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -171,7 +171,7 @@ const FolderContent = ({
                                                 siteName={siteName}
                                                 title={folderContentItem.name}
                                                 folderName={folderName}
-                                                numItems={folderContentItem.type === 'dir' ? folderContentItem.children.length : null}
+                                                numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
                                                 isFile={folderContentItem.type === 'dir' ? false: true}
                                                 link={generateLink(folderContentItem)}
                                                 itemIndex={folderContentIndex}

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,3 +6,4 @@ export const DIR_CONTENT_KEY = 'dir-contents';
 export const CSP_CONTENT_KEY = 'csp-contents';
 export const NAVIGATION_CONTENT_KEY = 'navigation-contents';
 export const RESOURCE_CATEGORY_CONTENT_KEY = 'resource-category-contents'
+export const RESOURCE_ROOM_CONTENT_KEY = 'resource-room-contents'

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,3 +5,4 @@ export const PAGE_CONTENT_KEY = 'page-contents';
 export const DIR_CONTENT_KEY = 'dir-contents';
 export const CSP_CONTENT_KEY = 'csp-contents';
 export const NAVIGATION_CONTENT_KEY = 'navigation-contents';
+export const RESOURCE_CATEGORY_CONTENT_KEY = 'resource-category-contents'

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -112,6 +112,7 @@ const EditNavBar =  ({ match }) => {
     () => getEditNavBarData(siteName),
     {
       retry: false,
+      cacheTime: 0, // We want to refetch data on every page load because file order may have changed
       onError: (err) => {
         if (err.response && err.response.status === 404) {
           setRedirectToNotFound(siteName)

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -142,7 +142,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
 
   // get directory data
   const { data: dirData } = useQuery(
-    [DIR_CONTENT_KEY, siteName, folderName],
+    [DIR_CONTENT_KEY, siteName, folderName, subfolderName],
     () => getDirectoryFile(siteName, folderName),
     {
       retry: false,

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -234,7 +234,9 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
           content: dirContent,
         } = dirData.data
         const parsedFolderContents = parseDirectoryFile(dirContent)
-        generatedLeftNavPages = parsedFolderContents.map((name) => 
+        // Filter out placeholder files
+        const filteredFolderContents = parsedFolderContents.filter(name => !name.includes('.keep'))
+        generatedLeftNavPages = filteredFolderContents.map((name) => 
           ({
             fileName: name.includes('/') ? name.split('/')[1] : name,
             third_nav_title: name.includes('/') ? name.split('/')[0] : null,

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -260,7 +260,7 @@ const Folders = ({ match, location }) => {
               </div>
               {/* Collections content */}
               {
-                !isLoadingDirectory && folderOrderArray.length === 0 && <span>There are no pages in this {subfolderName ? `subfolder` : `folder`}.</span>
+                !isLoadingDirectory && !queryError && folderOrderArray.length === 0 && <span>There are no pages in this {subfolderName ? `subfolder` : `folder`}.</span>
               }
               {
                   queryError && <span>There was an error retrieving your content. Please refresh the page.</span>

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -58,8 +58,8 @@ const Folders = ({ match, location }) => {
     const [selectedPage, setSelectedPage] = useState('')
     const [isSelectedItemPage, setIsSelectedItemPage] = useState(false)
 
-    const { data: folderContents, error: queryError, refetch: refetchFolderContents } = useQuery(
-      [DIR_CONTENT_KEY, siteName, folderName],
+    const { data: folderContents, error: queryError, isLoading: isLoadingDirectory, refetch: refetchFolderContents } = useQuery(
+      [DIR_CONTENT_KEY, siteName, folderName, subfolderName],
       () => getDirectoryFile(siteName, folderName),
       { 
         retry: false,
@@ -77,8 +77,11 @@ const Folders = ({ match, location }) => {
     const { mutate: rearrangeFolder } = useMutation(
       payload => setDirectoryFile(siteName, folderName, payload),
       {
-        onError: () => errorToast(`Your file reordering could not be saved. ${DEFAULT_RETRY_MSG}`),
-        onSuccess: () => successToast('Successfully updated page order'),
+        onError: () => errorToast(`Your file reordering could not be saved. Please try again. ${DEFAULT_RETRY_MSG}`),
+        onSuccess: () => {
+          successToast('Successfully updated page order')
+          refetch()
+        },
         onSettled: () => setIsRearrangeActive((prevState) => !prevState),
       }
     )

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -111,7 +111,7 @@ const Folders = ({ match, location }) => {
           if (subfolderName) {
             const subfolderFiles = retrieveSubfolderContents(parsedFolderContents, subfolderName)
             if (subfolderFiles.length > 0) {
-              setFolderOrderArray(subfolderFiles)
+              setFolderOrderArray(subfolderFiles.filter(item => item.name !== '.keep'))
             } else {
               // if subfolderName prop does not match directory file, it's not a valid subfolder
               setRedirectToPage(`/sites/${siteName}/workspace`)
@@ -256,9 +256,12 @@ const Folders = ({ match, location }) => {
               <div className={contentStyles.contentContainerFolderRowMargin}>
                 <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" id="pageSettings-new" onClick={() => setIsPageSettingsActive((prevState) => !prevState)}/>
-                <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName || folderOrderArray.length === 0 ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
+                <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName || isLoadingDirectory ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
               {/* Collections content */}
+              {
+                !isLoadingDirectory && folderOrderArray.length === 0 && <span>There are no pages in this {subfolderName ? `subfolder` : `folder`}.</span>
+              }
               {
                   queryError && <span>There was an error retrieving your content. Please refresh the page.</span>
               }

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -80,7 +80,7 @@ const Folders = ({ match, location }) => {
         onError: () => errorToast(`Your file reordering could not be saved. Please try again. ${DEFAULT_RETRY_MSG}`),
         onSuccess: () => {
           successToast('Successfully updated page order')
-          refetch()
+          refetchFolderContents()
         },
         onSettled: () => setIsRearrangeActive((prevState) => !prevState),
       }

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -140,11 +140,6 @@ const Workspace = ({ match, location }) => {
               <div className={contentStyles.segment}>
                 Collections
               </div>
-              {/* Info segment */}
-              <div className={contentStyles.segment}>
-                <i className="bx bx-sm bx-info-circle text-dark" />
-                <span><strong className="ml-1">Note:</strong> Collections cannot be empty, create a page first to create a collection.</span>
-              </div>
               {
                 !collections &&
                 <div className={contentStyles.segment}>
@@ -160,8 +155,8 @@ const Workspace = ({ match, location }) => {
               {/* Collections */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
-                  { unlinkedPages &&
-                    <FolderOptionButton title="Create new folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
+                  {
+                    collections && unlinkedPages && <FolderOptionButton title="Create new folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
                   }
                   {
                     collections && collections.length > 0

--- a/src/utils.js
+++ b/src/utils.js
@@ -369,12 +369,13 @@ function generateCollectionPageContent(fileInfo) {
   let endpointUrl, redirectUrl = ''
   if (isNewPage) {
     endpointUrl = `${siteName}/collections/${folderName}/pages/new/${encodeURIComponent(fileName)}`
-    redirectUrl = `/sites/${siteName}/collections/${folderName}/${encodeURIComponent(fileName)}`
+    redirectUrl = `/sites/${siteName}/folder/${folderName}/${subfolderName ? `subfolder/` : ''}${fileName}`
   } else if (originalPageName !== fileName) {
     endpointUrl = `${siteName}/collections/${folderName}/pages/${encodeURIComponent(originalPageName)}/rename/${encodeURIComponent(fileName)}`
   } else {
     endpointUrl = `${siteName}/collections/${folderName}/pages/${encodeURIComponent(fileName)}`
   }
+  
   return { endpointUrl, content, redirectUrl }
 }
 
@@ -706,7 +707,10 @@ export const retrieveSubfolderContents = (folderOrder, subfolderName) => {
 }
 
 export const convertSubfolderArray = (folderOrderArray, rawFolderContents, subfolderName) => {
-  const arrayCopy = _.cloneDeep(folderOrderArray)
+  const placeholderItem = {
+    path: `${subfolderName}/.keep`
+  }
+  const arrayCopy = [placeholderItem].concat(_.cloneDeep(folderOrderArray))
   return rawFolderContents.map((curr) => {
     const folderPathArr = curr.split('/')
     const subfolderTitle = folderPathArr[0]

--- a/src/utils.js
+++ b/src/utils.js
@@ -631,7 +631,7 @@ export const getNavFolderDropdownFromFolderOrder = (folderOrder) => {
       acc.push(deslugifyDirectory(curr.split('.')[0])) // remove file extension
     }
 
-    if (pathArr.length === 2 && deslugifyDirectory(pathArr[0]) !== acc[acc.length - 1]) {
+    if (pathArr.length === 2 && deslugifyDirectory(pathArr[0]) !== acc[acc.length - 1] && pathArr[1] !== '.keep') {
       acc.push(deslugifyDirectory(pathArr[0]))
     }
 


### PR DESCRIPTION
This PR adds functionality for allowing empty folders, subfolders, and resource pages, as well as the associated changes required. To be reviewed in conjunction with PR #[137](https://github.com/isomerpages/isomercms-backend/pull/137) on the isomercms frontend repo. A discussion of the reasoning behind this change can be found [here](https://docs.google.com/document/d/1EccpS_ATrfOe4DmU4ChXtU9kV6Jl1rFOdKqBLyG6ym8/edit#).

The changes introduced in this PR are:

- Users can skip adding files to newly created folders/subfolders, allowing for the existence of empty folders
- The behaviour for handling empty subfolders and resource pages has been changed:
  - Previously, if it was detected that no pages were returned from the backend, we would automatically redirect them to the workspace/resources tab - this was to handle non-existent folders. However, since empty resource categories also return no files, this check has been moved to the backend, and categories that do not exist will throw an error, which is caught by the frontend and used to redirect users to the resources tab.
  - For subfolders, a new placeholder file has been added instead - we now check for this placeholder file to determine whether to redirect users. The placeholder files are also hidden from users.
-  To support the creation of new subfolders, an additional timeout has been added when creating folders. The reason for this is that the new collection.yml information takes time to propagate, and redirecting too soon retrieves the old data, which causes an immediate redirection to workspace. If anyone has a better fix for this, please let me know.
- `FolderNamingModal` has been fixed to allow for different field titles for the different types of folders.
- Misc bug fixes involving reorder page functionality, loading, and redirection bugs.
- Refactoring of Resources and partial refactoring of CategoryPages to use react-query - we will update CategoryPages in a future PR to only handle Resources.