### PR TITLE
Feat/page dropdown api

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -152,14 +152,6 @@ const createPage = async (endpointUrl, content) => {
     return await axios.post(`${BACKEND_URL}/sites/${endpointUrl}`, { content });
 }
 
-const getPage = async (pageType, siteName, collectionName, pageName) => {
-    const endpointUrl = (pageType === 'collection') 
-                      ? `${siteName}/collections/${collectionName}/pages/${pageName}`
-                      : `${siteName}/pages/${pageName}`
-    const resp = await axios.get(`${BACKEND_URL}/sites/${endpointUrl}`);
-    return resp.data
-}
-
 const updatePage = async(endpointUrl, content, sha) => {
     return await axios.post(`${BACKEND_URL}/sites/${endpointUrl}`, { content, sha });
 }
@@ -196,7 +188,6 @@ export {
     getEditNavBarData,
     updateNavBarData,
     createPage,
-    getPage,
     updatePage,
     deletePage,
     moveFiles,

--- a/src/api.js
+++ b/src/api.js
@@ -82,12 +82,12 @@ const createPageData = async ({folderName, subfolderName, newFileName, siteName,
     
     // redirect to new page upon successful creation
     if (folderName) {
-        return `/sites/${siteName}/folder/${folderName}/${encodeURIComponent(`${subfolderName ? `${subfolderName}/` : ''}${newFileName}`)}`
+        return `/sites/${siteName}/folder/${folderName}/${subfolderName ? `subfolder/${subfolderName}/` : ''}${newFileName}`
     } 
     if (resourceName) {
-        return `/sites/${siteName}/resources/${resourceName}/${encodeURIComponent(newFileName)}`
+        return `/sites/${siteName}/resources/${resourceName}/${newFileName}`
     }
-    return `/sites/${siteName}/pages/${encodeURIComponent(newFileName)}`
+    return `/sites/${siteName}/pages/${newFileName}`
 }
 
 const renamePageData = async ({folderName, subfolderName, fileName, siteName, resourceName, newFileName}, content, sha) => {

--- a/src/api.js
+++ b/src/api.js
@@ -18,9 +18,6 @@ const setDirectoryFile = async (siteName, folderName, payload) => {
 
 // EditPage
 const getPageApiEndpoint = ({folderName, subfolderName, fileName, siteName, resourceName, newFileName}) => {
-    if (newFileName && fileName) return getRenamePageApiEndpoint({folderName, subfolderName, fileName, siteName, resourceName, newFileName})
-    if (newFileName) return getCreatePageApiEndpoint({folderName, subfolderName, siteName, resourceName, newFileName})
-
     if (folderName) {
         return `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/${encodeURIComponent(`${subfolderName ? `${subfolderName}/` : ''}${fileName}`)}`
     }
@@ -50,6 +47,16 @@ const getRenamePageApiEndpoint = ({folderName, subfolderName, fileName, siteName
     return `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}/rename/${newFileName}`
 }
 
+const getMovePageEndpoint = ({siteName, resourceName, folderName, subfolderName, newPath}) => {
+    if (folderName) {
+        return `${BACKEND_URL}/sites/${siteName}/collections/${encodeURIComponent(`${folderName ? `${folderName}`: ''}${subfolderName ? `/${subfolderName}` : ''}`)}/move/${encodeURIComponent(`${newPath}`)}`
+    }
+    if (resourceName) {
+        return `${BACKEND_URL}/sites/${siteName}/resources/${resourceName}/move/${encodeURIComponent(`${newPath}`)}`
+    }
+    return `${BACKEND_URL}/sites/${siteName}/pages/move/${encodeURIComponent(`${newPath}`)}`
+}
+
 const getEditPageData = async ({folderName, subfolderName, fileName, siteName, resourceName}) => {
     const apiEndpoint = getPageApiEndpoint({folderName, subfolderName, fileName, siteName, resourceName})
     const resp = await axios.get(apiEndpoint);
@@ -69,7 +76,7 @@ const getCsp = async (siteName) => {
 }
 
 const createPageData = async ({folderName, subfolderName, newFileName, siteName, resourceName}, content) => {
-    const apiEndpoint = getPageApiEndpoint({folderName, subfolderName, newFileName, siteName, resourceName})
+    const apiEndpoint = getCreatePageApiEndpoint({folderName, subfolderName, newFileName, siteName, resourceName})
     const params = { content }
     await axios.post(apiEndpoint, params)
     
@@ -84,7 +91,7 @@ const createPageData = async ({folderName, subfolderName, newFileName, siteName,
 }
 
 const renamePageData = async ({folderName, subfolderName, fileName, siteName, resourceName, newFileName}, content, sha) => {
-    const apiEndpoint = getPageApiEndpoint({folderName, subfolderName, fileName, siteName, resourceName, newFileName})
+    const apiEndpoint = getRenamePageApiEndpoint({folderName, subfolderName, fileName, siteName, resourceName, newFileName})
     const params = {
         content,
         sha,
@@ -212,14 +219,12 @@ const moveFiles = async (siteName, selectedFiles, title, parentFolder) => {
     return await axios.post(`${baseApiUrl}/move/${newPath}`, params)
 }
 
-const moveFile = async ({siteName, selectedFile, isResource, folderName, subfolderName, newPath}) => {
-    const baseApiUrl = `${BACKEND_URL}/sites/${siteName}${isResource ? '/resources' : folderName ? `/collections` : '/pages'}`
-    const collectionPath = encodeURIComponent(`${folderName ? `${folderName}`: ''}${subfolderName ? `/${subfolderName}` : ''}`)
-    const targetPath = encodeURIComponent(`${newPath}`)
+const moveFile = async ({selectedFile, siteName, resourceName, folderName, subfolderName, newPath}) => {
+    const apiEndpoint = getMovePageEndpoint({siteName, resourceName, folderName, subfolderName, newPath})
     const params = {
         files: [selectedFile],
     }
-    return await axios.post(`${baseApiUrl}/${collectionPath ? `${collectionPath}/` : ''}move/${targetPath}`, params)
+    return await axios.post(apiEndpoint, params)
 }
 
 export {

--- a/src/api.js
+++ b/src/api.js
@@ -102,7 +102,8 @@ const updatePageData = async ({folderName, subfolderName, fileName, siteName, re
         content,
         sha,
     };
-    return await axios.post(apiEndpoint, params);
+    await axios.post(apiEndpoint, params);
+    return 
 }
 
 const deletePageData = async ({folderName, subfolderName, fileName, siteName, resourceName}, sha) => {

--- a/src/api.js
+++ b/src/api.js
@@ -130,6 +130,8 @@ const renameSubfolder = async ({ siteName, folderName, subfolderName, newSubfold
 const renameResourceCategory = async ({ siteName, categoryName, newCategoryName}) => {
     const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${categoryName}/rename/${newCategoryName}`
     return await axios.post(apiUrl)
+}
+
 const getAllCategoriesApiEndpoint = ({siteName, isResource}) => {
     if (isResource) {
         return `${BACKEND_URL}/sites/${siteName}/resources`

--- a/src/api.js
+++ b/src/api.js
@@ -27,7 +27,7 @@ const getPageApiEndpoint = ({folderName, subfolderName, fileName, siteName, reso
     return `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/pages/${fileName}`
 }
 
-const getCreatePageApiEndpoint = ({folderName, subfolderName, fileName, siteName, resourceName, newFileName}) => {
+const getCreatePageApiEndpoint = ({folderName, subfolderName, siteName, resourceName, newFileName}) => {
     if (folderName) {
         return `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/collections/${folderName}/pages/new/${encodeURIComponent(`${subfolderName ? `${subfolderName}/` : ''}${newFileName}`)}`
     }

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import axios from 'axios';
-import { Redirect } from 'react-router-dom';
 import { useQuery, useMutation } from 'react-query';
 import PropTypes from 'prop-types';
 import _ from 'lodash';

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -103,7 +103,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     )
 
     const { mutateAsync: moveHandler } = useMutation(
-        () => moveFile({siteName, selectedFile, isResource, folderName: collectionName, newPath: selectedPath}),
+        () => moveFile({siteName, selectedFile, newPath: selectedPath, resourceName: collectionName}),
         {
           onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
           onSuccess: () => {successToast('Successfully moved file'); window.location.reload();},

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -87,30 +87,11 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
         }
     }
 
-    const settingsToggle = (event) => {
-        const { id } = event.target;
-        const idArray = id.split('-');
-
-        // Create new page
-        if (idArray[1] === 'NEW') {
-            setIsComponentSettingsActive((prevState) => !prevState)
-            setSelectedFile('')
-            setCreateNewPage(true)
-        } else {
-          // Modify existing page frontmatter
-          const pageIndex = parseInt(idArray[1], RADIX_PARSE_INT);
-
-          setIsComponentSettingsActive((prevState) => !prevState)
-          setSelectedFile(pages[pageIndex])
-          setCreateNewPage(false)
-        }
-    }
-
     const { data: pageData } = useQuery(
         [PAGE_CONTENT_KEY, { siteName, fileName: selectedFile }],
         () => getEditPageData({ siteName, fileName: selectedFile }),
         {
-          enabled: selectedFile.length > 0,
+          enabled: selectedFile.length > 0 && !collectionName,
           retry: false,
           onError: () => {
             setSelectedFile('')
@@ -134,12 +115,11 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                 isComponentSettingsActive 
                 && ( isResource 
                     ? <ComponentSettingsModal
-                        modalTitle={isResource ? "Resource Settings" : "Page Settings"}
-                        // settingsToggle={settingsToggle}
+                        modalTitle={"Resource Settings"}
                         category={collectionName}
                         isCategoryDisabled={isCategoryDropdownDisabled(createNewPage, collectionName)}
                         siteName={siteName}
-                        fileName={selectedFile ? selectedFile.fileName : ''}
+                        fileName={selectedFile || ''}
                         isNewFile={createNewPage}
                         type={isResource ? "resource" : "page"}
                         pageFileNames={
@@ -149,6 +129,8 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                         }
                         collectionPageData={collectionPageData}
                         loadThirdNavOptions={loadThirdNavOptions}
+                        setSelectedFile={setSelectedFile}
+                        setCreateNewPage={setCreateNewPage}
                         setIsComponentSettingsActive={setIsComponentSettingsActive}
                     /> 
                     : (pageData || createNewPage) 

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -87,10 +87,10 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
             const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
             return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.name)
         }
-        if (allCategories) {
+        if (!queryFolderName && allCategories) {
             return allCategories.collections
         }
-        return []
+        return null
     }
 
     const { mutateAsync: deleteHandler } = useMutation(

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -80,7 +80,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     // parse responses from move-to queries
     const getCategories = (queryFolderName, allCategories, querySubfolders) => {
         if (isResource && allCategories) {
-            allCategories.resources.map(resource => resource.dirName) 
+            return allCategories.resources.map(resource => resource.dirName).filter(dirName => dirName !== collectionName)
         }
         if (queryFolderName && querySubfolders) {
             const parsedFolderContents = parseDirectoryFile(querySubfolders.data.content)
@@ -106,7 +106,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
         () => moveFile({siteName, selectedFile, isResource, folderName: collectionName, newPath: selectedPath}),
         {
           onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
-          onSuccess: () => successToast('Successfully moved file'),
+          onSuccess: () => {successToast('Successfully moved file'); window.location.reload();},
           onSettled: () => setCanShowMoveModal(prevState => !prevState),
         }
     )

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -256,26 +256,14 @@ const ComponentSettingsModal = ({
 
     const changeHandler = (event) => {
         const { id, value } = event.target;
-        const currentFileName = fileName;
-
-        const pageFileNamesExc = pageFileNames ? pageFileNames.filter((filename) => filename !== currentFileName) : null;
-
-        const errorMessage = validateResourceSettings(id, value);
-        const newFileName = generateResourceFileName(id === "title" ? value : title, id==="date" ? value : resourceDate)
-    
-        if (errorMessage === '' && pageFileNamesExc && pageFileNamesExc.includes(newFileName)) {
-            setErrors((prevState) => ({
-                ...prevState,
-                title: 'This title is already in use. Please choose a different one.',
-            }));
-            idToSetterFuncMap[id](value);
-        } else {
-            setErrors((prevState) => ({
-                ...prevState,
-                [id]: errorMessage,
-            }));
-            idToSetterFuncMap[id](value);
-        }
+        const { titleErrorMessage, errorMessage } = validateResourceSettings(id, value, title, resourceDate, isPost, pageFileNames.filter(file => file !== fileName))
+        
+        setErrors((prevState) => ({
+            ...prevState,
+            [id]: errorMessage,
+            title: titleErrorMessage,
+        }));
+        idToSetterFuncMap[id](value);
     }
 
     const dropdownChangeHandler = (event) => {

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -65,10 +65,11 @@ const ComponentSettingsModal = ({
     modalTitle,
     collectionPageData,
     pageFileNames,
-    settingsToggle,
     siteName,
     type,
     loadThirdNavOptions,
+    setSelectedFile,
+    setCreateNewPage,
     setIsComponentSettingsActive,
 }) => {
     const { setRedirectToPage } = useRedirectHook()
@@ -403,7 +404,7 @@ const ComponentSettingsModal = ({
             <div className={elementStyles['modal-settings']}>
               <div className={elementStyles.modalHeader}>
                 <h1>{modalTitle}</h1>
-                <button id="settings-CLOSE" type="button" onClick={settingsToggle}>
+                <button id="settings-CLOSE" type="button" onClick={() => {setCreateNewPage(false); setSelectedFile(''); setIsComponentSettingsActive(false)}}>
                   <i id="settingsIcon-CLOSE" className="bx bx-x" />
                 </button>
               </div>

--- a/src/components/MenuDropdown.jsx
+++ b/src/components/MenuDropdown.jsx
@@ -30,7 +30,7 @@ const MenuItem = ({ item, menuIndex, dropdownRef }) => {
     }
     
   }
-  const { type, handler } = item
+  const { type, handler, noBlur } = item
   const { itemName, itemId, iconClassName, children } = type ? getItemType(type) : item
   return (
     <div
@@ -38,8 +38,9 @@ const MenuItem = ({ item, menuIndex, dropdownRef }) => {
       onMouseDown={(e) => {
         e.stopPropagation()
         e.preventDefault()
-        dropdownRef.current.blur()
-        if (handler && (e.target.id === `${itemId}-${menuIndex}` || !children || children.type !== 'button')) handler(e) // allows children buttons to work
+        if (!noBlur) dropdownRef.current.blur()
+        // if user clicks on nested button, don't run handler
+        if (handler && (e.target.id === `${itemId}-${menuIndex}` || !children || children.type !== 'button')) handler(e) 
       }}
       className={`${elementStyles.dropdownItem}`}
     >

--- a/src/components/MenuDropdown.jsx
+++ b/src/components/MenuDropdown.jsx
@@ -39,13 +39,13 @@ const MenuItem = ({ item, menuIndex, dropdownRef }) => {
         e.stopPropagation()
         e.preventDefault()
         dropdownRef.current.blur()
-        if (handler) handler(e)
+        if (handler && (e.target.id === `${itemId}-${menuIndex}` || !children || children.type !== 'button')) handler(e) // allows children buttons to work
       }}
       className={`${elementStyles.dropdownItem}`}
     >
       <i id={`${itemId}-${menuIndex}`} className={iconClassName}/>
       <div id={`${itemId}-${menuIndex}`} className={elementStyles.dropdownText}>{ itemName }</div>
-      { children }
+      <div className={'ml-auto'}>{ children }</div>
     </div>
   )
 }
@@ -53,9 +53,9 @@ const MenuItem = ({ item, menuIndex, dropdownRef }) => {
 const MenuDropdown = ({ dropdownItems, menuIndex, dropdownRef, tabIndex, onBlur }) => {
   return (
     <div className={`${elementStyles.dropdown} ${elementStyles.right}`} ref={dropdownRef} tabIndex={tabIndex} onBlur={onBlur}>
-      { dropdownItems.map(item =>
+      { dropdownItems.filter(x => x).map(item =>
         ( <MenuItem 
-            key={`${item.type}-${menuIndex}`}
+            key={`${item.type || item.itemId}-${menuIndex}`}
             item={item}
             menuIndex={menuIndex}
             dropdownRef={dropdownRef}

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -156,11 +156,6 @@ const OverviewCard = ({
                       <i className="bx bx-sm bx-chevron-right ml-auto"/>   
                   </button>,
                 })),
-                !isResource && queryFolderName === '' && {
-                    itemName: 'Unlinked pages',
-                    itemId: `unlinked-pages`,
-                    handler: () => { setSelectedPath(`pages`); setCanShowMoveModal(true); },
-                },
               ]}
               setShowDropdown={canShowFileMoveDropdown}
               dropdownRef={fileMoveDropdownRef}

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -34,13 +34,23 @@ import {
 axios.defaults.withCredentials = true
 
 const OverviewCard = ({
-  date, category, settingsToggle, itemIndex, siteName, fileName, isResource, isHomepage, allCategories, resourceType
+  date, 
+  category, 
+  itemIndex, 
+  siteName, 
+  fileName, 
+  isResource, 
+  isHomepage, 
+  allCategories, 
+  resourceType,
+  setIsComponentSettingsActive,
+  setSelectedFile,
+  setCanShowDeleteWarningModal,
 }) => {
   const dropdownRef = useRef(null)
   const fileMoveDropdownRef = useRef(null)
   const [canShowDropdown, setCanShowDropdown] = useState(false)
   const [canShowFileMoveDropdown, setCanShowFileMoveDropdown] = useState(false)
-  const [canShowDeleteWarningModal, setCanShowDeleteWarningModal] = useState(false)
   const [canShowGenericWarningModal, setCanShowGenericWarningModal] = useState(false)
   const [chosenCategory, setChosenCategory] = useState()
   const [isNewCollection, setIsNewCollection] = useState(false)
@@ -104,25 +114,6 @@ const OverviewCard = ({
     }
   }
 
-  const deleteHandler = async () => {
-    try {
-      // Retrieve data from existing page/resource
-      const resp = await axios.get(`${baseApiUrl}/pages/${fileName}`);
-
-      const { sha } = resp.data;
-      const params = { sha };
-      await axios.delete(`${baseApiUrl}/pages/${fileName}`, {
-        data: params,
-      });
-
-      // Refresh page
-      window.location.reload();
-    } catch (err) {
-      errorToast(`There was a problem trying to delete this file. ${DEFAULT_RETRY_MSG}`)
-      console.log(err);
-    }
-  }
-  
   const generateLink = () => {
     if (isResource) {
       return `/sites/${siteName}/resources/${category}/${fileName}`
@@ -171,7 +162,6 @@ const OverviewCard = ({
         <h1 className={contentStyles.componentTitle}>{generateTitle()}</h1>
         <p className={contentStyles.componentDate}>{`${date ? prettifyDate(date) : ''}${resourceType ? `/${resourceType.toUpperCase()}` : ''}`}</p>
       </div>
-      {settingsToggle &&
         <div className="position-relative mt-auto">
           <button 
             type="button"
@@ -179,6 +169,7 @@ const OverviewCard = ({
             onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();
+                setSelectedFile(fileName)
                 setCanShowDropdown(true)
               }}
             className={`${canShowDropdown || canShowFileMoveDropdown ? contentStyles.optionsIconFocus : contentStyles.optionsIcon}`}
@@ -190,7 +181,7 @@ const OverviewCard = ({
               dropdownItems={[
                 {
                   type: 'edit',
-                  handler: (e) => settingsToggle(e),
+                  handler: () => setIsComponentSettingsActive((prevState) => !prevState),
                 },
                 {
                   type: 'move',
@@ -234,7 +225,6 @@ const OverviewCard = ({
             />
           }
         </div>
-      }
     </>
   )
   
@@ -265,16 +255,6 @@ const OverviewCard = ({
         cancelText="Cancel"
       />
     }
-    {
-      canShowDeleteWarningModal
-      && (
-        <DeleteWarningModal
-          onCancel={() => setCanShowDeleteWarningModal(false)}
-          onDelete={deleteHandler}
-          type={isResource ? "resource" : "page"}
-        />
-      )
-    }
     </>
   );
 };
@@ -283,7 +263,6 @@ const OverviewCard = ({
 OverviewCard.propTypes = {
   date: PropTypes.string,
   category: PropTypes.string,
-  settingsToggle: PropTypes.func,
   itemIndex: PropTypes.number.isRequired,
   siteName: PropTypes.string.isRequired,
   fileName: PropTypes.string.isRequired,

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -77,9 +77,9 @@ const OverviewCard = ({
   const handleBlur = (event) => {
     // if the blur was because of outside focus
     // currentTarget is the parent element, relatedTarget is the clicked element
-    if (!event.currentTarget.contains(event.relatedTarget)) {
-      setCanShowFileMoveDropdown(false)
-    }
+    // if (!event.currentTarget.contains(event.relatedTarget)) {
+    //   setCanShowFileMoveDropdown(false)
+    // }
   }
 
   const toggleDropdownModals = () => {

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -47,6 +47,7 @@ const PageSettingsModal = ({
         permalink: '',
     })
     const [hasErrors, setHasErrors] = useState(false)
+    const [hasChanges, setHasChanges] = useState(false)
 
     // Base hooks
     const [title, setTitle] = useState('')
@@ -128,9 +129,13 @@ const PageSettingsModal = ({
       setHasErrors(_.some(errors, (field) => field.length > 0));
     }, [errors])
 
+    useEffect(() => {
+      setHasChanges(!isNewPage && !(originalPageName === generatePageFileName(title) && originalPermalink === permalink))
+    }, [title, permalink])
+
     const changeHandler = (event) => {
       const { id, value } = event.target;
-      const errorMessage = validatePageSettings(id, value, pagesData)
+      const errorMessage = validatePageSettings(id, value, pagesData.filter(page => page.name !== originalPageName))
       setErrors((prevState) => ({
         ...prevState,
         [id]: errorMessage,
@@ -192,7 +197,7 @@ const PageSettingsModal = ({
                   />
                 </div>
                 <SaveDeleteButtons 
-                  isDisabled={isNewPage ? hasErrors : (hasErrors || !sha)}
+                  isDisabled={isNewPage ? hasErrors : (!hasChanges || hasErrors || !sha)}
                   hasDeleteButton={false}
                   saveCallback={saveHandler}
                 />

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery, useMutation } from 'react-query';
+import { useMutation } from 'react-query';
 import axios from 'axios';
 import * as _ from 'lodash';
 import FormField from './FormField';
@@ -10,10 +10,8 @@ import {
   frontMatterParser,
   deslugifyPage,
 } from '../utils';
-import {
-  PAGE_CONTENT_KEY,
-} from '../constants'
-import { createPageData, getEditPageData, updatePageData, renamePageData } from '../api'
+
+import { createPageData, updatePageData, renamePageData } from '../api'
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
@@ -85,11 +83,13 @@ const PageSettingsModal = ({
           const { frontMatter, pageMdBody } = frontMatterParser(pageContent)
           const { permalink: originalPermalink } = frontMatter
         
-          setTitle(deslugifyPage(originalPageName))
-          setPermalink(originalPermalink)
-          setOriginalPermalink(originalPermalink)
-          setSha(pageSha)
-          setMdBody(pageMdBody)
+          if (_isMounted) {
+            setTitle(deslugifyPage(originalPageName))
+            setPermalink(originalPermalink)
+            setOriginalPermalink(originalPermalink)
+            setSha(pageSha)
+            setMdBody(pageMdBody)
+          }
         }
         if (isNewPage) {
           let exampleTitle = 'Example Title'
@@ -97,8 +97,10 @@ const PageSettingsModal = ({
             exampleTitle = exampleTitle+'_1'
           }
           const examplePermalink = `/${folderName ? `${folderName}/` : ''}${subfolderName ? `${subfolderName}/` : ''}permalink`
-          setTitle(exampleTitle)
-          setPermalink(examplePermalink)
+          if (_isMounted) {
+            setTitle(exampleTitle)
+            setPermalink(examplePermalink)
+          } 
         }
       }
       initializePageDetails()

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useMutation } from 'react-query';
 import axios from 'axios';
 import * as _ from 'lodash';
-import FormField from './FormField';
+
 import {
   DEFAULT_RETRY_MSG,
   generatePageFileName,
@@ -14,12 +14,13 @@ import {
 import { createPageData, updatePageData, renamePageData } from '../api'
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 import { validatePageSettings } from '../utils/validators';
-import SaveDeleteButtons from './SaveDeleteButtons';
 import { errorToast } from '../utils/toasts';
+
+import FormField from './FormField';
 import FormFieldHorizontal from './FormFieldHorizontal';
+import SaveDeleteButtons from './SaveDeleteButtons';
 
 import useRedirectHook from '../hooks/useRedirectHook';
 
@@ -139,10 +140,10 @@ const PageSettingsModal = ({
                 </button>
               </div>
               <div className={elementStyles.modalContent}>
-                { isNewPage ? 'You may edit page details anytime. ' : ''}
-                To edit page content, simply click on the page title. 
-                <div className={contentStyles.segment}>
-                  <span> 
+                <div className={elementStyles.modalFormFields}>
+                  { isNewPage ? 'You may edit page details anytime. ' : ''}
+                  To edit page content, simply click on the page title. <br/>
+                  <span className={elementStyles.infoGrey}> 
                     My workspace >
                     {
                       folderName
@@ -154,10 +155,8 @@ const PageSettingsModal = ({
                       ? <span> {subfolderName} > </span>
                       : null
                     } 
-                     <strong className="ml-1">{ title }</strong>
+                    <u className='ml-1'>{ title }</u><br/><br/>
                   </span>
-                </div>
-                <div className={elementStyles.modalFormFields}>
                   {/* Title */}
                   <FormField
                     title="Page title"

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -44,9 +44,9 @@ const FolderContentItem = ({
     const handleBlur = (event) => {
         // if the blur was because of outside focus
         // currentTarget is the parent element, relatedTarget is the clicked element
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setShowFileMoveDropdown(false)
-        }
+        // if (!event.currentTarget.contains(event.relatedTarget)) {
+        //   setShowFileMoveDropdown(false)
+        // }
     }
 
     const generateDropdownItems = () => {

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -21,17 +21,33 @@ const FolderContentItem = ({
     numItems,
     link,
     itemIndex,
+    queryFolderName,
+    allCategories,
+    setQueryFolderName,
     setSelectedPage,
+    setSelectedFolder,
     setIsPageSettingsActive,
     setIsFolderModalOpen,
+    setIsMoveModalActive,
     setIsDeleteModalActive
 }) => {
     const [showDropdown, setShowDropdown] = useState(false)
+    const [showFileMoveDropdown, setShowFileMoveDropdown] = useState(false)
     const dropdownRef = useRef(null)
+    const fileMoveDropdownRef = useRef(null)
 
     useEffect(() => {
         if (showDropdown) dropdownRef.current.focus()
+        if (showFileMoveDropdown) fileMoveDropdownRef.current.focus()
     }, [showDropdown])
+
+    const handleBlur = (event) => {
+        // if the blur was because of outside focus
+        // currentTarget is the parent element, relatedTarget is the clicked element
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setShowFileMoveDropdown(false)
+        }
+    }
 
     const generateDropdownItems = () => {
         const dropdownItems = [
@@ -46,7 +62,7 @@ const FolderContentItem = ({
             },
             {
                 type: 'move',
-                handler: () => {}, // to be added in separate PR
+                handler: () => setShowFileMoveDropdown(true), // to be added in separate PR
             },
             {
                 type: 'delete',
@@ -93,6 +109,49 @@ const FolderContentItem = ({
                                 onBlur={()=>setShowDropdown(false)}
                             />
                         }
+                        { showFileMoveDropdown &&
+                            <MenuDropdown 
+                                dropdownItems={[
+                                    {
+                                        itemName: `Move to`,
+                                        itemId: `move`,
+                                        iconClassName: "bx bx-sm bx-arrow-back",
+                                        handler: () => {
+                                            if (queryFolderName) { setQueryFolderName(''); setShowFileMoveDropdown(true) }
+                                            else { setShowDropdown(true); setShowFileMoveDropdown(false) }
+                                        },
+                                    },
+                                    ...allCategories.map(categoryName => ({
+                                        itemName: categoryName,
+                                        itemId: categoryName,
+                                        handler: () => { setSelectedFolder(`${queryFolderName ? `${queryFolderName}/` : ''}${categoryName}`); setIsMoveModalActive(true) },
+                                        children: queryFolderName === '' && <button
+                                            id={`${categoryName}-more`}
+                                            type="button"
+                                            onClick={(e) => { e.stopPropagation(); e.preventDefault(); setQueryFolderName(categoryName)}}
+                                            className={elementStyles.dropdownItemChildButton}
+                                        >
+                                            <i className="bx bx-sm bx-chevron-right ml-auto"/>   
+                                        </button>, 
+                                    })),
+                                    queryFolderName === '' && {
+                                        itemName: 'Unlinked pages',
+                                        itemId: `unlinked-pages`,
+                                        handler: () => { setSelectedFolder(`pages`); setIsMoveModalActive(true) },
+                                    },
+                                    allCategories.length === 0 && queryFolderName && {
+                                        itemName: 'No subfolders, move here',
+                                        itemId: `move-here`,
+                                        handler: () => { setSelectedFolder(`${queryFolderName}/`); setIsMoveModalActive(true) }
+                                    },
+                                ]}
+                                setShowDropdown={showFileMoveDropdown}
+                                dropdownRef={fileMoveDropdownRef}
+                                menuIndex={itemIndex}
+                                tabIndex={1}
+                                onBlur={handleBlur}
+                            />
+                        }
                     </div>
                 </div>
             </div>
@@ -106,9 +165,14 @@ const FolderContent = ({
     siteName,
     folderName,
     enableDragDrop,
+    allCategories,
+    queryFolderName,
+    setSelectedFolder,
+    setQueryFolderName,
     setSelectedPage,
     setIsPageSettingsActive,
     setIsFolderModalOpen,
+    setIsMoveModalActive,
     setIsDeleteModalActive,
 }) => {
     const generateLink = (folderContentItem) => {
@@ -174,10 +238,15 @@ const FolderContent = ({
                                                 numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
                                                 isFile={folderContentItem.type === 'dir' ? false: true}
                                                 link={generateLink(folderContentItem)}
+                                                allCategories={allCategories}
                                                 itemIndex={folderContentIndex}
+                                                queryFolderName={queryFolderName}
+                                                setQueryFolderName={setQueryFolderName}
                                                 setSelectedPage={setSelectedPage}
+                                                setSelectedFolder={setSelectedFolder}
                                                 setIsPageSettingsActive={setIsPageSettingsActive}
                                                 setIsFolderModalOpen={setIsFolderModalOpen}
+                                                setIsMoveModalActive={setIsMoveModalActive}
                                                 setIsDeleteModalActive={setIsDeleteModalActive}
                                             />
                                         </div>

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -87,7 +87,7 @@ const FolderContentItem = ({
                 }
                 <span className={`${elementStyles.folderItemText} mr-auto`} >{deslugifyPage(title)}</span>
                 {
-                    numItems
+                    numItems !== null
                     ? <span className={`${elementStyles.folderItemText} mr-5`}>{numItems} item{numItems === 1 ? '' : 's'}</span>
                     : null
                 }

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -4,8 +4,6 @@ import { Droppable, Draggable } from 'react-beautiful-dnd';
 import { DragDropContext } from 'react-beautiful-dnd';
 import update from 'immutability-helper';
 
-import FolderModal from '../FolderModal';
-
 import { deslugifyPage } from '../../utils'
 import MenuDropdown from '../MenuDropdown'
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,3 +7,4 @@ export const CSP_CONTENT_KEY = 'csp-contents';
 export const NAVIGATION_CONTENT_KEY = 'navigation-contents';
 export const RESOURCE_CATEGORY_CONTENT_KEY = 'resource-category-contents'
 export const RESOURCE_ROOM_CONTENT_KEY = 'resource-room-contents'
+export const FOLDERS_CONTENT_KEY = 'folders-contents'

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -86,7 +86,7 @@ const Folders = ({ match, location }) => {
         if (subfolderName) {
           const subfolderFiles = retrieveSubfolderContents(parsedFolderContents, subfolderName)
           if (subfolderFiles.length > 0) {
-            setFolderOrderArray(subfolderFiles)
+            setFolderOrderArray(subfolderFiles.filter(item => item.name !== '.keep'))
           } else {
             // if subfolderName prop does not match directory file, it's not a valid subfolder
             setRedirectToPage(`/sites/${siteName}/workspace`)

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -131,7 +131,12 @@ const Folders = ({ match, location }) => {
           successToast(`Successfully deleted ${isSelectedItemPage ? 'file' : 'subfolder'}`)
           refetchFolderContents()
         },
-        onSettled: () => setIsDeleteModalActive((prevState) => !prevState),
+        onSettled: () => {
+          setIsDeleteModalActive((prevState) => !prevState)
+          setSelectedPage('')
+          setSelectedFolder('')
+          setQueryFolderName('')
+        },
       }
     )
 
@@ -140,8 +145,16 @@ const Folders = ({ match, location }) => {
       () => moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedFolder}),
       {
         onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
-        onSuccess: () => {successToast('Successfully moved file');},
-        onSettled: () => setIsMoveModalActive((prevState) => !prevState),
+        onSuccess: () => {
+          successToast('Successfully moved file') 
+          refetchFolderContents()
+        },
+        onSettled: () => {
+          setIsMoveModalActive((prevState) => !prevState)
+          setSelectedPage('')
+          setSelectedFolder('')
+          setQueryFolderName('')
+        },
       }
     )
 

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -96,14 +96,13 @@ const Folders = ({ match, location }) => {
       }
     )
 
-
     const { mutateAsync: deleteHandler } = useMutation(
       async () => {
-       if (isSelectedItemPage) await deletePageData('collection', folderName, subfolderName, selectedPage)
+       if (isSelectedItemPage) await deletePageData({ siteName, folderName, subfolderName, fileName: selectedPage }, pageData.pageSha)
        else await deleteSubfolder({ siteName, folderName, subfolderName: selectedPage })
       },
       {
-        onError: () => errorToast(`Your file could not be deleted successfully. ${DEFAULT_RETRY_MSG}`),
+        onError: () => errorToast(`Your ${isSelectedItemPage ? 'file' : 'subfolder'} could not be deleted successfully. ${DEFAULT_RETRY_MSG}`),
         onSuccess: () => {
           successToast(`Successfully deleted ${isSelectedItemPage ? 'file' : 'subfolder'}`)
           refetchFolderContents()

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -189,7 +189,7 @@ const Folders = ({ match, location }) => {
         return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.name)
       }
       if (allFolders) {
-        return allFolders.collections.filter(name => name !== folderName)
+        return allFolders.collections
       }
       return []
     }

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -70,3 +70,9 @@ i {
   color: $isomer-blue;
   font-size: 14px;
 }
+
+.infoGrey {
+  color: grey;
+  font-size: 14px;
+  margin-bottom: 1.5rem;
+}

--- a/src/styles/isomer-cms/elements/dropdown.scss
+++ b/src/styles/isomer-cms/elements/dropdown.scss
@@ -46,7 +46,7 @@
   }
 
   .dropdownItemChildButton {
-    background: rgba(43, 95, 206, 0.1);
+    background: rgba(0, 0, 0, 0);
 
     &:hover {
       background: rgba(43, 95, 206, 0.3);

--- a/src/styles/isomer-cms/elements/dropdown.scss
+++ b/src/styles/isomer-cms/elements/dropdown.scss
@@ -1,6 +1,8 @@
 .dropdown {
   position: absolute;
   width: 16rem;
+  max-height: 16.75rem;
+  overflow: scroll;
   background: white;
   box-shadow: 2px 2px 12px 0 rgba(43, 95, 206, 0.1);
   border-radius: 5px;
@@ -16,7 +18,7 @@
   .dropdownItem {
     width: 100%;
     height: 3.5rem;
-    padding: 0.75rem 2rem 0.75rem 2rem;
+    padding: 0.75rem 0.25rem 0.75rem 1.5rem;
     display:flex;
     align-items: center;
 
@@ -40,6 +42,14 @@
 
     &:hover {
       background: white;
+    }
+  }
+
+  .dropdownItemChildButton {
+    background: rgba(43, 95, 206, 0.1);
+
+    &:hover {
+      background: rgba(43, 95, 206, 0.3);
     }
   }
 

--- a/src/styles/isomer-cms/pages/Content.module.scss
+++ b/src/styles/isomer-cms/pages/Content.module.scss
@@ -226,6 +226,11 @@
           text-overflow: ellipsis;
         }
 
+        .componentTitleLink{
+          @extend .componentTitle;
+          color: $isomer-blue;
+        }
+
         .componentFolderName{
           font-size: 16px;
           line-height: 24px;

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,7 +172,7 @@ export function dequoteString(str) {
 }
 
 export function generateResourceFileName(title, date, resourceType) {
-  const safeTitle = slugify(title).replace(/[^a-zA-Z0-9-]/g, '');
+  const safeTitle = slugify(title, {lower: true}).replace(/[^a-zA-Z0-9-]/g, '');
   return `${date}-${resourceType}-${safeTitle}.md`;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -171,9 +171,9 @@ export function dequoteString(str) {
   return dequotedString;
 }
 
-export function generateResourceFileName(title, date, resourceType) {
+export function generateResourceFileName(title, date, isPost) {
   const safeTitle = slugify(title, {lower: true}).replace(/[^a-zA-Z0-9-]/g, '');
-  return `${date}-${resourceType}-${safeTitle}.md`;
+  return `${date}-${isPost ? 'post' : 'file'}-${safeTitle}.md`;
 }
 
 export function prettifyResourceCategory(category) {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,7 +1,7 @@
 import { slugifyCategory } from '../utils';
 
 import _ from 'lodash';
-import { generatePageFileName } from '../utils';
+import { generatePageFileName, generateResourceFileName } from '../utils';
 
 // Common regexes and constants
 // ==============
@@ -690,17 +690,18 @@ const validateDayOfMonth = (month, day) => {
   }
 };
 
-const validateResourceSettings = (id, value) => {
-  let errorMessage = '';
+const validateResourceSettings = (id, value, title, resourceDate, isPost, folderOrderArray) => {
+  let titleErrorMessage = '', errorMessage = '';
+  const newFileName = generateResourceFileName(id === "title" ? value : title, id==="date" ? value : resourceDate, isPost ? 'post' : 'file') 
   switch (id) {
     case 'title': {
       // Title is too short
       if (value.length < RESOURCE_SETTINGS_TITLE_MIN_LENGTH) {
-        errorMessage = `The title should be longer than ${RESOURCE_SETTINGS_TITLE_MIN_LENGTH} characters.`;
+        titleErrorMessage = `The title should be longer than ${RESOURCE_SETTINGS_TITLE_MIN_LENGTH} characters.`;
       }
       // Title is too long
       if (value.length > RESOURCE_SETTINGS_TITLE_MAX_LENGTH) {
-        errorMessage = `The title should be shorter than ${RESOURCE_SETTINGS_TITLE_MAX_LENGTH} characters.`;
+        titleErrorMessage = `The title should be shorter than ${RESOURCE_SETTINGS_TITLE_MAX_LENGTH} characters.`;
       }
       break;
     }
@@ -757,7 +758,10 @@ const validateResourceSettings = (id, value) => {
       break;
     }
   }
-  return errorMessage;
+  if (folderOrderArray !== undefined && folderOrderArray.includes(newFileName)) {
+    titleErrorMessage = `This title is already in use. Please choose a different title.`;
+  }
+  return { titleErrorMessage, errorMessage };
 };
 
 // Resource room creation

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -692,7 +692,7 @@ const validateDayOfMonth = (month, day) => {
 
 const validateResourceSettings = (id, value, title, resourceDate, isPost, folderOrderArray) => {
   let titleErrorMessage = '', errorMessage = '';
-  const newFileName = generateResourceFileName(id === "title" ? value : title, id==="date" ? value : resourceDate, isPost ? 'post' : 'file') 
+  const newFileName = generateResourceFileName(id === "title" ? value : title, id==="date" ? value : resourceDate, isPost) 
   switch (id) {
     case 'title': {
       // Title is too short


### PR DESCRIPTION
This PR adds the functionality to support:
- Move
- Delete
- Edit settings

For folder/subfolder pages, unlinked pages and resources. 

This PR is a continuation of #380, and cleans up the `getPage`, `createPage`, `updatePage` APIs added in #380 to resemble those in #379 for better uniformity. 

### Background
This PR focuses on the API integrations above, and should be reviewed with [#139](https://github.com/isomerpages/isomercms-backend/pull/139) on the backend. The visual appearance and UX of the Dropdown modal will be refined in a subsequent PR. ~There is also some buggy behavior on the Dropdown back button behavior, where clicking this series of buttons (`Move To >` > `[folderName] >` > `← Move To` ) will lead to Edit Page rather than triggering the previous Move To dropdown menu as expected. This will also be fixed in a subsequent PR.~ Fixed in 
d697a01

As part of this PR, `OverviewCard`, `ComponentSettingsModal` and `CollectionPagesSection` and `Resources` have been refactored to remove unused functionality and to use ReactQuery. 

~Lastly, the APIs introduced may require some cleanup as there is quite a fair bit of reused variables and flag checks. This will also be done in a subsequent PR.~ Fixed in 7911b8d

### Details
Below, we summarise some key changes to each file. 

#### `ComponentSettingsModal` 
This component is now only used for settings on resource pages, so all functionality for collections and third-nav retrieval has been removed. The only API handler that runs here is Save, while the delete API handler is abstracted into `CollectionPagesSection`. The query call to retrieve the page details is abstracted into `CollectionPagesSection` so that the page details can be reused for deleting functionality. 

Since we plan for the resource creation behavior to match that of page creation behavior, users will be expected to navigate to the category before creating the resource. Hence, the resource category dropdown has also been removed. See below for the new UX:
<img width="1792" alt="Screenshot 2021-03-24 at 6 41 37 PM" src="https://user-images.githubusercontent.com/39231249/112297205-92dd6080-8cd0-11eb-80e2-ed775342f128.png">

#### `PageSettingsModal`
Similar to `ComponentSettingsModal`, the only API handler that runs here is Save, while the delete API handler is abstracted into `CollectionPagesSection`. The delete, create, and update APIs from #380 have been updated. The query call to retrieve the page details is abstracted into `Folders` so that the page details can be reused for  deleting functionality. 

The UX has been updated to match that of `ComponentSettingsModal`. See below for the new UX:
<img width="1792" alt="Screenshot 2021-03-24 at 7 41 08 PM" src="https://user-images.githubusercontent.com/39231249/112304812-e2c02580-8cd8-11eb-8d55-dc54bd9c8233.png">
#### `CollectionPagesSection` and `Folders`
The query call to retrieve the page details is added into `CollectionPagesSection` and `Folders`. The query fires when the user clicks on the ⋮ Options dropdown for any page.  The new delete and move API ReactQuery handlers have been added to `CollectionPagesSection` and to `Folders`. 

Note: `CollectionPagesSection` is actually used for all sections (unlinked pages and resources) apart from collections, so we should rename this during cleanup.

#### `OverviewCard` and `FolderContent`
The delete and the move handlers are abstracted into `CollectionPagesSection` and `Folders` respectively, and the logic for accessing `Move To` folders and subfolders have been added. This logic will be further refined based on designers input.

#### Changes to `Resources` 
Since we plan for the resource creation behavior to match that of page creation behavior, users will be expected to navigate to the category before creating the resource. Hence, the option to create a new file from the Resources folder is removed, and should be replaced by the functionality to create a new resource folder #384. See below for the new UX:
<img width="1792" alt="Screenshot 2021-03-24 at 6 43 09 PM" src="https://user-images.githubusercontent.com/39231249/112297378-c8824980-8cd0-11eb-9c4a-da8ef1fd66fe.png">

### Subsequent work
To highlight the changes that will be accomplished in a separate PR:

1) Improve visual appearance and UX behavior of the Dropdown modal, waiting on designers' finalised input
- For Move To, dropdown should start from location of file e.g. if it is a file in a subfolder, the dropdown should start at that subfolder
- Users should not be able to move the file to the same subfolder as the file is currently in, so disabled? vs filtered out?
2) ~Fix buggy behavior on the Dropdown back button behaviour with Back button (depending on UX flow, may not be necessary, waiting on designers' input)~ Fixed in d697a01
3) ~Clean up introduced APIs for duplicated flag checking and redundant variables~  Fixed in 7911b8d
4) Fix Resource `ComponentSettingsModal` to automatically generate `file_url` when resource is a file
