### PR TITLE
feat/ replace js-yaml library with yaml library

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "html-react-parser": "^1.1.1",
     "immutability-helper": "^3.0.1",
     "js-base64": "^2.5.1",
-    "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "marked": "^0.7.0",
     "node-sass": "^4.13.1",
@@ -37,7 +36,8 @@
     "sgds-govtech": "^1.3.16",
     "slugify": "^1.3.6",
     "toml": "^3.0.0",
-    "uuid": "^3.3.3"
+    "uuid": "^3.3.3",
+    "yaml": "^1.10.2"
   },
   "scripts": {
     "start": "source .env.development.local && react-scripts start",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 // import dependencies
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import cheerio from 'cheerio';
 import slugify from 'slugify';
 import axios from 'axios';
@@ -20,7 +20,7 @@ export const DEFAULT_ERROR_TOAST_MSG = `Something went wrong. ${DEFAULT_RETRY_MS
 export function frontMatterParser(content) {
   // format file to extract yaml front matter
   const results = content.split('---');
-  const frontMatter = yaml.safeLoad(results[1]); // get the front matter as an object
+  const frontMatter = yaml.parse(results[1]); // get the front matter as an object
   const mdBody = results.slice(2).join('---');
 
   return {
@@ -32,7 +32,7 @@ export function frontMatterParser(content) {
 // this function concatenates the front matter with the main content body
 // of the markdown file
 export function concatFrontMatterMdBody(frontMatter, mdBody) {
-  return ['---\n', yaml.safeDump(frontMatter), '---\n', mdBody].join('');
+  return ['---\n', yaml.stringify(frontMatter), '---\n', mdBody].join('');
 }
 
 // this function converts file names into readable form
@@ -611,16 +611,16 @@ export const getObjectDiff = (obj1, obj2) => {
 }
 
 export const parseDirectoryFile = (folderContent) => {
-  const decodedContent = yaml.safeLoad(folderContent)
+  const decodedContent = yaml.parse(folderContent)
   const collectionKey = Object.keys(decodedContent.collections)[0]
   return decodedContent.collections[collectionKey].order
 }
 
 export const updateDirectoryFile = (folderContent, folderOrder) => {
-  const decodedContent = yaml.safeLoad(folderContent)
+  const decodedContent = yaml.parse(folderContent)
   const collectionKey = Object.keys(decodedContent.collections)[0]
   decodedContent.collections[collectionKey].order = folderOrder
-  return yaml.safeDump(decodedContent)
+  return yaml.stringify(decodedContent)
 }
 
 export const getNavFolderDropdownFromFolderOrder = (folderOrder) => {


### PR DESCRIPTION
This PR replaces all use of the npm `js-yaml` library with the npm `yaml` ([link](https://www.npmjs.com/package/yaml)) library. This PR is accompanied by PR #[140](https://github.com/isomerpages/isomercms-backend/pull/140) on the backend.

The main reason for replacing `js-yaml` is because it is unable to handle certain characters, and throws a YAMLException error. An example string which it is unable to handle is: `Stairwells, walkways and fresh
food – making today’s cities healthier cities`, or in unicode, `Stairwells, walkways and fresh food â making todayâs cities healthier cities`

However, the `yaml` library is able to handle such strings. Although it does not have as many weekly downloads as the `js-yaml` library (27 million weekly downloads), it is still widely used (11 million weekly downloads) and actively maintained. It also has an easy interface to use, and substitutes our existing usage of the js-yaml library without any problems.