### PR TITLE
Feat/add ordering to new files when moving

### DIFF
--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -24,7 +24,7 @@ const FolderCard = ({
   pageType,
   siteName,
   category,
-  folderStyle,
+  selectedIndex,
   onClick,
 }) => {
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
@@ -146,12 +146,18 @@ const FolderCard = ({
       }
       {generateLink() 
         ? 
-          <Link className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard} ${folderStyle}`} to={generateLink()}>
+          <Link className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard}`} to={generateLink()}>
             {FolderCardContent()}
           </Link>
         :
-        <div className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard} ${folderStyle}`} onClick={onClick}>
+        <div className={`${contentStyles.component} ${contentStyles.card} ${elementStyles.folderCard} ${selectedIndex ? `border border-primary` : ''}`} onClick={onClick}>
           {FolderCardContent()}
+          { selectedIndex &&
+            <div className={elementStyles.orderCircleContainer}>
+              <div className={elementStyles.orderCircle}>{selectedIndex}</div>
+            </div>
+          }
+          
         </div>
       }
     </>

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -218,8 +218,8 @@
 
 .orderCircleContainer {
   position: absolute;
-  left: calc(100% - 36px);
-  bottom: calc(100% - 36px);
+  left: calc(100% - 40px);
+  bottom: calc(100% - 40px);
 
   .orderCircle {
     border-radius: 50%;

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -212,5 +212,23 @@
 .folderCard {
   @extend .card;
   padding: 1rem;
+  position: relative;
   cursor: pointer;
+}
+
+.orderCircleContainer {
+  position: absolute;
+  left: calc(100% - 36px);
+  bottom: calc(100% - 36px);
+
+  .orderCircle {
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    padding: 6px;
+
+    background: $isomer-blue;
+    color: white;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
This PR adds in functionality to display the order in which new files are added to newly created folders/subfolders. A number has been added to the top right corner of the file cards to indicate the order in which each file will show up in the new folder/subfolder. This order is determined by the order in which the user selects the files.

<img width="1140" alt="Screenshot 2021-03-29 at 1 42 54 PM" src="https://user-images.githubusercontent.com/22111124/112791704-adc72080-9094-11eb-9f3b-81d36baf9c46.png">
