### PR TITLE
Fix/handle invalid folders in edit nav bar

### DIFF
--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -192,7 +192,7 @@ const EditContactUs =  ({ match }) => {
       if (!footerContent) return
 
       // split the markdown into front matter and content
-      const { frontMatter } = frontMatterParser(Base64.decode(content));
+      const { frontMatter } = frontMatterParser(content);
 
       // data cleaning for non-comforming data
       const { sanitisedFrontMatter, deletedFrontMatter } = sanitiseFrontMatter(frontMatter)


### PR DESCRIPTION
This PR fixes the handling of EditNavBar to handle cases where links specify collections which do not exist. A warning modal has been added to display to the users which items have been deleted:
<img width="1357" alt="Screenshot 2021-03-31 at 11 50 08 AM" src="https://user-images.githubusercontent.com/22111124/113087962-41285f00-9217-11eb-973e-aa590f960bae.png">

This PR also fixes a bug in which EditContactUs was decoding already decoded content, in line with our recent changes made in PR #[133](https://github.com/isomerpages/isomercms-backend/pull/133) on the isomercms backend.