### PR TITLE
Feat/dropdown ux

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -162,6 +162,11 @@ const addResourceCategory = async (siteName, resourceName) => {
     return await axios.post(`${BACKEND_URL}/sites/${siteName}/resources`, params);
 }
 
+const getPages = async ({ siteName }) => {
+    const pagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/pages`)
+    return pagesResp.data.pages
+}
+
 const getResourcePages = async (siteName, resourceName) => {
     if (!resourceName) return
     return await axios.get(`${BACKEND_URL}/sites/${siteName}/resources/${resourceName}`);
@@ -240,6 +245,7 @@ export {
     renameResourceCategory,
     getAllResourceCategories,
     addResourceCategory,
+    getPages,
     getResourcePages,
     getEditNavBarData,
     updateNavBarData,

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -32,13 +32,19 @@ axios.defaults.withCredentials = true
 
 // Clean up note: Should be renamed, only used for resource pages and unlinked pages sections
 const CollectionPagesSection = ({ collectionName, pages, siteName, isResource }) => {
+    
+    const initialMoveDropdownQueryState = {
+        folderName: '',
+        subfolderName: '',
+    }
+
     const [isComponentSettingsActive, setIsComponentSettingsActive] = useState(false)
     const [selectedFile, setSelectedFile] = useState('')
     const [selectedPath, setSelectedPath] = useState('')
     const [createNewPage, setCreateNewPage] = useState(false)
     const [canShowDeleteWarningModal, setCanShowDeleteWarningModal] = useState(false)
     const [canShowMoveModal, setCanShowMoveModal] = useState(false)
-    const [queryFolderName, setQueryFolderName] = useState('')
+    const [moveDropdownQuery, setMoveDropdownQuery] = useState(initialMoveDropdownQueryState)
 
     const { data: pageData } = useQuery(
         [PAGE_CONTENT_KEY, { siteName, fileName: selectedFile, resourceName: collectionName }],
@@ -67,30 +73,42 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     // MOVE-TO Dropdown
     // get subfolders of selected folder for move-to dropdown
     const { data: querySubfolders } = useQuery(
-        [DIR_CONTENT_KEY, siteName, queryFolderName],
-        async () => getDirectoryFile(siteName, queryFolderName),
+        [DIR_CONTENT_KEY, siteName, moveDropdownQuery.folderName],
+        async () => getDirectoryFile(siteName, moveDropdownQuery.folderName),
         {   
-            enabled: selectedFile.length > 0 && queryFolderName.length > 0,
+            enabled: selectedFile.length > 0 && moveDropdownQuery.folderName.length > 0 && !isResource,
             onError: () => errorToast(`The folders data could not be retrieved. ${DEFAULT_RETRY_MSG}`),
         },
     )
 
     // MOVE-TO Dropdown utils
     // parse responses from move-to queries
-    const getCategories = (queryFolderName, allCategories, querySubfolders) => {
-        if (isResource && allCategories) {
+    const getCategories = (moveDropdownQuery, allCategories, querySubfolders) => {
+        const { folderName, subfolderName } = moveDropdownQuery
+        if (isResource && folderName) { // inside resource folder, show empty
+            return []
+        }
+        if (isResource && allCategories) { // inside workspace, show all resource folders
             return allCategories.resources.map(resource => resource.dirName).filter(dirName => dirName !== collectionName)
         }
-        if (queryFolderName && querySubfolders) {
+        if (subfolderName !== '') { // inside subfolder, show empty 
+            return []
+        }
+        if (folderName !== '' && querySubfolders) { // inside folder, show all subfolders
             const parsedFolderContents = parseDirectoryFile(querySubfolders.data.content)
             const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
             return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.name)
         }
-        if (!queryFolderName && allCategories) {
+        if (folderName === '' && subfolderName === '' && allCategories) { // inside workspace, show all folders
             return allCategories.collections
         }
         return null
     }
+
+    // MOVE-TO Clear Query utils
+    const clearMoveDropdownQueryState = () => {
+        setMoveDropdownQuery({ ...initialMoveDropdownQueryState });
+    };
 
     const { mutateAsync: deleteHandler } = useMutation(
         async () => deletePageData({ siteName, fileName: selectedFile, resourceName: collectionName }, pageData.pageSha),
@@ -189,14 +207,15 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                                     resourceType={isResource ? page.type : ''}
                                     date={page.date}
                                     isResource={isResource}
-                                    allCategories={getCategories(queryFolderName, allCategories, querySubfolders)}
+                                    allCategories={getCategories(moveDropdownQuery, allCategories, querySubfolders)}
                                     setIsComponentSettingsActive={setIsComponentSettingsActive}
                                     setSelectedFile={setSelectedFile}
                                     setCanShowDeleteWarningModal={setCanShowDeleteWarningModal}
                                     setCanShowMoveModal={setCanShowMoveModal}
                                     setSelectedPath={setSelectedPath}
-                                    queryFolderName={queryFolderName}
-                                    setQueryFolderName={setQueryFolderName}
+                                    moveDropdownQuery={moveDropdownQuery}
+                                    setMoveDropdownQuery={setMoveDropdownQuery}
+                                    clearMoveDropdownQueryState={clearMoveDropdownQueryState}
                                 />
                             ))
                             /* Display loader if pages have not been retrieved from API call */

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -120,10 +120,17 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     )
 
     const { mutateAsync: moveHandler } = useMutation(
-        () => moveFile({siteName, selectedFile, newPath: selectedPath, resourceName: collectionName}),
+        () => {
+            if ('pages' === selectedPath) return true
+            moveFile({siteName, selectedFile, newPath: selectedPath, resourceName: collectionName})
+        },
         {
           onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
-          onSuccess: () => {successToast('Successfully moved file'); window.location.reload();},
+          onSuccess: (samePage) => {
+            if (samePage) return successToast('Page is already in this folder')   
+            successToast('Successfully moved file'); 
+            window.location.reload();
+          },
           onSettled: () => setCanShowMoveModal(prevState => !prevState),
         }
     )

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -31,7 +31,7 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 axios.defaults.withCredentials = true
 
 // Clean up note: Should be renamed, only used for resource pages and unlinked pages sections
-const CollectionPagesSection = ({ collectionName, pages, siteName, isResource }) => {
+const CollectionPagesSection = ({ collectionName, pages, siteName, isResource, refetchPages }) => {
     
     const initialMoveDropdownQueryState = {
         folderName: '',
@@ -111,25 +111,25 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     };
 
     const { mutateAsync: deleteHandler } = useMutation(
-        async () => deletePageData({ siteName, fileName: selectedFile, resourceName: collectionName }, pageData.pageSha),
+        async () => await deletePageData({ siteName, fileName: selectedFile, resourceName: collectionName }, pageData.pageSha),
         {
           onError: () => errorToast(`Your file could not be deleted successfully. ${DEFAULT_RETRY_MSG}`),
-          onSuccess: () => {successToast('Successfully deleted file'); window.location.reload();},
+          onSuccess: () => {successToast('Successfully deleted file'); refetchPages();},
           onSettled: () => setCanShowDeleteWarningModal((prevState) => !prevState),
         }
     )
 
     const { mutateAsync: moveHandler } = useMutation(
-        () => {
+        async () => {
             if ('pages' === selectedPath) return true
-            moveFile({siteName, selectedFile, newPath: selectedPath, resourceName: collectionName})
+            await moveFile({siteName, selectedFile, newPath: selectedPath, resourceName: collectionName})
         },
         {
           onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
           onSuccess: (samePage) => {
             if (samePage) return successToast('Page is already in this folder')   
-            successToast('Successfully moved file'); 
-            window.location.reload();
+            successToast('Successfully moved file')
+            refetchPages()
           },
           onSettled: () => setCanShowMoveModal(prevState => !prevState),
         }

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { MenuItem } from './MenuDropdown'
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+
+const FileMoveMenuDropdown = ({ 
+  dropdownItems, 
+  queryHandler,
+  menuIndex, 
+  dropdownRef, 
+  onBlur, 
+  breadcrumb, 
+  backHandler, 
+  moveHandler,
+  moveDisabled,
+}) => {
+
+  const MoveButton = (
+    <button
+      type="button"
+      className={`ml-auto ${moveDisabled ? elementStyles.disabled : elementStyles.green}`}
+      disabled={moveDisabled}
+      onMouseDown={() => moveHandler()}
+    >
+      Move Here
+    </button>
+  )
+
+  return (
+    <div className={`${elementStyles.fileMoveDropdown} ${elementStyles.right}`} ref={dropdownRef} tabIndex={1} onBlur={onBlur}>
+      <MenuItem 
+        key={`back-${menuIndex}`}
+        item={{
+          itemName: 'Move to',
+          itemId: `back`,
+          iconClassName: "bx bx-sm bx-arrow-back text-white",
+          handler: () => backHandler(),
+        }}
+        menuIndex={menuIndex}
+        dropdownRef={dropdownRef}
+        className={elementStyles.dropdownHeader}
+      /> 
+      <MenuItem 
+        key={`breadcrumb-${menuIndex}`}
+        item={{
+          itemName: breadcrumb,
+          itemId: `breadcrumb`,
+          noBlur: true,
+        }}
+        menuIndex={menuIndex}
+        dropdownRef={dropdownRef}
+        className={elementStyles.dropdownFirstItem}
+      />
+      <div className={elementStyles.dropdownContentItems}> 
+        { dropdownItems 
+          ?
+            dropdownItems.map(categoryName =>
+              <MenuItem 
+                key={`${categoryName}-${menuIndex}`}
+                item={{
+                  itemName: categoryName,
+                  itemId: categoryName,
+                  iconClassName: "bx bx-sm bx-folder",
+                  children: <i className="bx bx-sm bx-chevron-right ml-auto"/>,
+                  noBlur: true,
+                  handler: () => queryHandler(categoryName)
+                }}
+                menuIndex={menuIndex}
+                dropdownRef={dropdownRef}
+              /> 
+              )
+          : 
+            <div className="spinner-border text-primary mt-3" role="status" />
+        }
+      </div>
+      <MenuItem 
+        key={`move-here-${menuIndex}`}
+        className={elementStyles.dropdownLastItem}
+        item={{children: MoveButton}}
+        menuIndex={menuIndex}
+        dropdownRef={dropdownRef}
+      />
+    </div>
+  )
+}
+
+export default FileMoveMenuDropdown

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -85,7 +85,7 @@ const FileMoveMenuDropdown = ({
                   itemName: categoryName,
                   itemId: categoryName,
                   iconClassName: "bx bx-sm bx-folder",
-                  children: <i className="bx bx-sm bx-chevron-right ml-auto"/>,
+                  children: <i className={`${elementStyles.dropdownItemButton} bx bx-sm bx-chevron-right ml-auto`}/>,
                   noBlur: true,
                   handler: () => queryHandler(categoryName)
                 }}

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -100,7 +100,10 @@ const FileMoveMenuDropdown = ({
       <MenuItem 
         key={`move-here-${menuIndex}`}
         className={elementStyles.dropdownLastItem}
-        item={{children: MoveButton}}
+        item={{
+          children: MoveButton,
+          noBlur: true,
+        }}
         menuIndex={menuIndex}
         dropdownRef={dropdownRef}
       />

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -4,15 +4,17 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 const FileMoveMenuDropdown = ({ 
   dropdownItems, 
-  queryHandler,
   menuIndex, 
   dropdownRef, 
   onBlur, 
-  breadcrumb, 
+  moveDropdownQuery,
+  setMoveDropdownQuery,
   backHandler, 
   moveHandler,
   moveDisabled,
 }) => {
+
+  const { folderName, subfolderName } = moveDropdownQuery
 
   const MoveButton = (
     <button
@@ -24,6 +26,29 @@ const FileMoveMenuDropdown = ({
       Move Here
     </button>
   )
+
+  const Breadcrumb = (
+    <>
+      <span
+          id='workspace'
+          onClick={() => setMoveDropdownQuery({folderName: '', subfolderName: ''})}
+          style={ subfolderName || folderName ? {cursor:'pointer'}: {cursor:'default'}}
+      >{subfolderName ? `... >` : !subfolderName && !folderName ? <strong>Workspace</strong> : 'Workspace'}
+      </span>
+      <span 
+        id='folder'
+        onClick={() => setMoveDropdownQuery({...moveDropdownQuery, subfolderName: ''})}
+        style={subfolderName ? {cursor:'pointer'} : {cursor:'default'}}
+      >{folderName && !subfolderName ? <strong> > {folderName}</strong> : `${folderName}`}
+      </span>
+      {subfolderName ? <strong> > {subfolderName}</strong> : ''}
+    </>
+  )
+
+  const queryHandler = (categoryName) => {
+    if (folderName) setMoveDropdownQuery({...moveDropdownQuery, subfolderName: categoryName})
+    else setMoveDropdownQuery({...moveDropdownQuery, folderName: categoryName})
+  }
 
   return (
     <div className={`${elementStyles.fileMoveDropdown} ${elementStyles.right}`} ref={dropdownRef} tabIndex={1} onBlur={onBlur}>
@@ -42,7 +67,7 @@ const FileMoveMenuDropdown = ({
       <MenuItem 
         key={`breadcrumb-${menuIndex}`}
         item={{
-          itemName: breadcrumb,
+          itemName: Breadcrumb,
           itemId: `breadcrumb`,
           noBlur: true,
         }}

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -5,7 +5,7 @@ import axios from 'axios';
 
 import FolderModal from './FolderModal';
 import DeleteWarningModal from './DeleteWarningModal'
-import MenuDropdown from './MenuDropdown'
+import { MenuDropdown } from './MenuDropdown'
 
 import { errorToast } from '../utils/toasts';
 

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -97,7 +97,7 @@ const FolderCreationModal = ({
 
   const sortFuncs = {
     'title': (a, b) => {
-      return a.name.localeCompare(b.name)
+      return a.fileName.localeCompare(b.fileName)
     }
   }
 
@@ -160,15 +160,15 @@ const FolderCreationModal = ({
                     sortedPagesData && sortedPagesData.length > 0
                     ? sortedPagesData.map((pageData, pageIdx) => (
                           <FolderCard
-                              displayText={deslugifyPage(pageData.name)}
+                              displayText={deslugifyPage(pageData.fileName)}
                               settingsToggle={() => {}}
-                              key={pageData.name}
+                              key={pageData.fileName}
                               pageType={"file"}
                               siteName={siteName}
                               itemIndex={pageIdx}
-                              selectedIndex={selectedFiles[pageData.name]}
+                              selectedIndex={selectedFiles[pageData.fileName]}
                               onClick={() => {
-                                  fileSelectChangeHandler(pageData.name)
+                                  fileSelectChangeHandler(pageData.fileName)
                               }}
                           />
                     ))

--- a/src/components/MenuDropdown.jsx
+++ b/src/components/MenuDropdown.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
-const MenuItem = ({ item, menuIndex, dropdownRef }) => {
+const MenuItem = ({ item, menuIndex, dropdownRef, className }) => {
   
   const getItemType = (type) => {
     switch(type) {
@@ -34,15 +34,15 @@ const MenuItem = ({ item, menuIndex, dropdownRef }) => {
   const { itemName, itemId, iconClassName, children } = type ? getItemType(type) : item
   return (
     <div
+      tabIndex={2}
       id={`${itemId}-${menuIndex}`}
       onMouseDown={(e) => {
         e.stopPropagation()
         e.preventDefault()
         if (!noBlur) dropdownRef.current.blur()
-        // if user clicks on nested button, don't run handler
-        if (handler && (e.target.id === `${itemId}-${menuIndex}` || !children || children.type !== 'button')) handler(e) 
+        if (handler) handler(e) 
       }}
-      className={`${elementStyles.dropdownItem}`}
+      className={className ? className : `${elementStyles.dropdownItem}`}
     >
       <i id={`${itemId}-${menuIndex}`} className={iconClassName}/>
       <div id={`${itemId}-${menuIndex}`} className={elementStyles.dropdownText}>{ itemName }</div>
@@ -66,4 +66,4 @@ const MenuDropdown = ({ dropdownItems, menuIndex, dropdownRef, tabIndex, onBlur 
   )
 }
 
-export default MenuDropdown
+export { MenuItem, MenuDropdown }

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios'
 import PropTypes from 'prop-types';
-import MenuDropdown from './MenuDropdown'
+import { MenuDropdown } from './MenuDropdown'
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -76,27 +76,6 @@ const OverviewCard = ({
     return title
   }
 
-  const generateDropdownBreadcrumb = () => {
-    const { folderName, subfolderName } = moveDropdownQuery
-    return (
-      <>
-        <span
-            id='workspace'
-            onClick={() => setMoveDropdownQuery({folderName: '', subfolderName: ''})}
-            style={ subfolderName || folderName ? {cursor:'pointer'}: {cursor:'default'}}
-        >{subfolderName ? `... >` : !subfolderName && !folderName ? <strong>Workspace</strong> : 'Workspace'}
-        </span>
-        <span 
-          id='workspace'
-          onClick={() => setMoveDropdownQuery({...moveDropdownQuery, subfolderName: ''})}
-          style={subfolderName ? {cursor:'pointer'} : {cursor:'default'}}
-        >{folderName && !subfolderName ? <strong> > {folderName}</strong> : `${folderName}`}
-        </span>
-        {subfolderName ? <strong> > {subfolderName}</strong> : ''}
-      </>
-    )
-  }
-
   const handleBlur = (event) => {
     // if the blur was because of outside focus
     // currentTarget is the parent element, relatedTarget is the clicked element
@@ -109,12 +88,6 @@ const OverviewCard = ({
   const toggleDropdownModals = () => {
     setCanShowFileMoveDropdown(!canShowFileMoveDropdown)
     setCanShowDropdown(!canShowDropdown)
-  }
-
-  const moveDropdownQueryHandler = (categoryName) => {
-    const { folderName } = moveDropdownQuery
-    if (folderName) setMoveDropdownQuery({...moveDropdownQuery, subfolderName: categoryName})
-    else setMoveDropdownQuery({...moveDropdownQuery, folderName: categoryName})
   }
 
   const CardContent = (
@@ -163,11 +136,11 @@ const OverviewCard = ({
           { canShowFileMoveDropdown &&
             <FileMoveMenuDropdown 
               dropdownItems={allCategories}
-              queryHandler={moveDropdownQueryHandler}
               dropdownRef={fileMoveDropdownRef}
               menuIndex={itemIndex}
               onBlur={handleBlur}
-              breadcrumb={generateDropdownBreadcrumb()}
+              moveDropdownQuery={moveDropdownQuery}
+              setMoveDropdownQuery={setMoveDropdownQuery}
               backHandler={toggleDropdownModals}
               moveHandler={() => {
                 setSelectedPath(`${moveDropdownQuery.folderName ? moveDropdownQuery.folderName : 'pages'}${moveDropdownQuery.subfolderName ? `/${moveDropdownQuery.subfolderName}` : ''}`)

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -5,7 +5,7 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import update from 'immutability-helper';
 
 import { deslugifyPage } from '../../utils'
-import MenuDropdown from '../MenuDropdown'
+import { MenuDropdown } from '../MenuDropdown'
 
 // Import styles
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -79,32 +79,6 @@ const FolderContentItem = ({
         return dropdownItems.filter(item => item.type !== 'move')
     }
 
-    const generateDropdownBreadcrumb = () => {
-        const { folderName, subfolderName } = moveDropdownQuery
-        return ( 
-        <>
-            <span
-                id='workspace'
-                onClick={() => setMoveDropdownQuery({folderName: '', subfolderName: ''})}
-                style={subfolderName || folderName ? {cursor:'pointer'}: {cursor:'default'}}
-            >{subfolderName ? `... >` : !subfolderName && !folderName ? <strong>Workspace</strong> : 'Workspace'}
-            </span>
-            <span 
-                id='workspace'
-                onClick={() => setMoveDropdownQuery({...moveDropdownQuery, subfolderName: ''})}
-                style={subfolderName ? {cursor:'pointer'} : {cursor:'default'}}
-            >{folderName && !subfolderName ? <strong> > {folderName}</strong> : `${folderName}`}
-            </span>
-            {subfolderName ? <strong> > {subfolderName}</strong> : ''}
-        </>)
-    }
-
-    const moveDropdownQueryHandler = (categoryName) => {
-        const { folderName } = moveDropdownQuery
-        if (folderName) setMoveDropdownQuery({...moveDropdownQuery, subfolderName: categoryName})
-        else setMoveDropdownQuery({...moveDropdownQuery, folderName: categoryName})
-    }
-
     const FolderItemContent = (
         <div type="button" className={`${elementStyles.card} ${contentStyles.card} ${elementStyles.folderItem}`}>
             <div className={contentStyles.contentContainerFolderRow}>
@@ -144,11 +118,11 @@ const FolderContentItem = ({
                     { showFileMoveDropdown &&
                         <FileMoveMenuDropdown 
                             dropdownItems={allCategories}
-                            queryHandler={moveDropdownQueryHandler}
                             dropdownRef={fileMoveDropdownRef}
                             menuIndex={itemIndex}
                             onBlur={handleBlur}
-                            breadcrumb={generateDropdownBreadcrumb()}
+                            moveDropdownQuery={moveDropdownQuery}
+                            setMoveDropdownQuery={setMoveDropdownQuery}
                             backHandler={toggleDropdownModals}
                             moveHandler={() => {
                                 setSelectedPath(`${moveDropdownQuery.folderName ? moveDropdownQuery.folderName : 'pages'}${moveDropdownQuery.subfolderName ? `/${moveDropdownQuery.subfolderName}` : ''}`)

--- a/src/layouts/CategoryPages.jsx
+++ b/src/layouts/CategoryPages.jsx
@@ -42,7 +42,7 @@ const CategoryPages = ({ match, location, isResource }) => {
 
   const [categoryPages, setCategoryPages] = useState()
 
-  const { data: resourcePagesResp } = useQuery(
+  const { data: resourcePagesResp, refetch: refetchPages } = useQuery(
     [RESOURCE_CATEGORY_CONTENT_KEY, siteName, collectionName, isResource],
     () => getResourcePages(siteName, collectionName),
     {
@@ -109,6 +109,7 @@ const CategoryPages = ({ match, location, isResource }) => {
                   pages={categoryPages}
                   siteName={siteName}
                   isResource={isResource}
+                  refetchPages={refetchPages}
               />
           </div>
           {/* main section ends here */}

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -151,10 +151,14 @@ const Folders = ({ match, location }) => {
 
     // move file
     const { mutateAsync: moveHandler } = useMutation(
-      () => moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedPath}),
+      () => {
+        if (`${folderName ? folderName : ''}${subfolderName ? `/${subfolderName}` : ''}` === selectedPath) return true
+        moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedPath})
+      },
       {
         onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
-        onSuccess: () => {
+        onSuccess: (noChange) => {
+          if (noChange) return successToast('Page is already in this folder') 
           successToast('Successfully moved file') 
           refetchFolderContents()
         },

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -151,9 +151,9 @@ const Folders = ({ match, location }) => {
 
     // move file
     const { mutateAsync: moveHandler } = useMutation(
-      () => {
+      async () => {
         if (`${folderName ? folderName : ''}${subfolderName ? `/${subfolderName}` : ''}` === selectedPath) return true
-        moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedPath})
+        await moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedPath})
       },
       {
         onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -44,6 +44,12 @@ import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 const Folders = ({ match, location }) => {
     const { siteName, folderName, subfolderName } = match.params;
 
+    // set Move-To dropdown to start from current location of file
+    const initialMoveDropdownQueryState = {
+      folderName: folderName || '',
+      subfolderName: subfolderName || '',
+    }
+
     const { setRedirectToPage } = useRedirectHook()
 
     const [isRearrangeActive, setIsRearrangeActive] = useState(false)
@@ -56,9 +62,9 @@ const Folders = ({ match, location }) => {
     const [isMoveModalActive, setIsMoveModalActive] = useState(false)
     const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
     const [selectedPage, setSelectedPage] = useState('')
-    const [selectedFolder, setSelectedFolder] = useState('')
+    const [selectedPath, setSelectedPath] = useState('')
     const [isSelectedItemPage, setIsSelectedItemPage] = useState(false)
-    const [queryFolderName, setQueryFolderName] = useState('')
+    const [moveDropdownQuery, setMoveDropdownQuery] = useState({})
 
     const { data: folderContents, error: queryError, isLoading: isLoadingDirectory, refetch: refetchFolderContents } = useQuery(
       [DIR_CONTENT_KEY, siteName, folderName, subfolderName],
@@ -75,6 +81,11 @@ const Folders = ({ match, location }) => {
         }
       },
     )
+
+    // re-initialize query whenever we navigate between folders and subfolder pages
+    useEffect(() => {
+      setMoveDropdownQuery(initialMoveDropdownQueryState)
+    }, [folderName, subfolderName])
 
     // parse contents of current folder directory
     useEffect(() => {
@@ -134,15 +145,13 @@ const Folders = ({ match, location }) => {
         onSettled: () => {
           setIsDeleteModalActive((prevState) => !prevState)
           setSelectedPage('')
-          setSelectedFolder('')
-          setQueryFolderName('')
         },
       }
     )
 
     // move file
     const { mutateAsync: moveHandler } = useMutation(
-      () => moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedFolder}),
+      () => moveFile({siteName, selectedFile: selectedPage, folderName, subfolderName, newPath: selectedPath}),
       {
         onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
         onSuccess: () => {
@@ -152,8 +161,8 @@ const Folders = ({ match, location }) => {
         onSettled: () => {
           setIsMoveModalActive((prevState) => !prevState)
           setSelectedPage('')
-          setSelectedFolder('')
-          setQueryFolderName('')
+          setSelectedPath('')
+          clearMoveDropdownQueryState()
         },
       }
     )
@@ -161,7 +170,7 @@ const Folders = ({ match, location }) => {
     // MOVE-TO Dropdown
     // get all folders for move-to dropdown
     const { data: allFolders } = useQuery(
-      [FOLDERS_CONTENT_KEY, { siteName, folderName }],
+      [FOLDERS_CONTENT_KEY, { siteName, isResource: false }],
       async () => getAllCategories({ siteName }),
       {
         enabled: selectedPage.length > 0 && isSelectedItemPage,
@@ -172,27 +181,36 @@ const Folders = ({ match, location }) => {
     // MOVE-TO Dropdown
     // get subfolders of selected folder for move-to dropdown
     const { data: querySubfolders } = useQuery(
-      [DIR_CONTENT_KEY, siteName, queryFolderName],
-      async () => getDirectoryFile(siteName, queryFolderName),
+      [DIR_CONTENT_KEY, siteName, moveDropdownQuery.folderName],
+      async () => getDirectoryFile(siteName, moveDropdownQuery.folderName),
       {
-        enabled: selectedPage.length > 0 && queryFolderName.length > 0 && isSelectedItemPage,
+        enabled: selectedPage.length > 0 && moveDropdownQuery.folderName.length > 0 && isSelectedItemPage,
         onError: () => errorToast(`The folders data could not be retrieved. ${DEFAULT_RETRY_MSG}`)
       },
     )
 
     // MOVE-TO Dropdown utils
     // parse responses from move-to queries
-    const getCategories = (queryFolderName, allFolders, querySubfolders) => {
-      if (queryFolderName && querySubfolders) {
+    const getCategories = (query, allFolders, querySubfolders) => {
+      const { folderName, subfolderName } = query
+      if (subfolderName !== '') { // inside subfolder, show empty 
+        return []
+      }
+      if (folderName !== '' && querySubfolders) { // inside folder, show all subfolders
         const parsedFolderContents = parseDirectoryFile(querySubfolders.data.content)
         const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
         return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.name)
       }
-      if (allFolders) {
+      if (folderName === '' && subfolderName === '' && allFolders) { // inside workspace, show all folders
         return allFolders.collections
       }
-      return []
+      return null
     }
+
+    // MOVE-TO Clear Query utils
+    const clearMoveDropdownQueryState = () => {
+      setMoveDropdownQuery({ ...initialMoveDropdownQueryState });
+    };
 
     // REORDERING
     // save file-reordering
@@ -363,18 +381,19 @@ const Folders = ({ match, location }) => {
                 && <FolderContent 
                     folderOrderArray={folderOrderArray} 
                     setFolderOrderArray={setFolderOrderArray} 
-                    allCategories={getCategories(queryFolderName, allFolders, querySubfolders)}
+                    allCategories={getCategories(moveDropdownQuery, allFolders, querySubfolders)}
                     siteName={siteName} 
                     folderName={folderName}
                     enableDragDrop={isRearrangeActive}
-                    queryFolderName={queryFolderName}
-                    setQueryFolderName={setQueryFolderName}
                     setIsPageSettingsActive={setIsPageSettingsActive}
                     setIsFolderModalOpen={setIsFolderModalOpen}
                     setIsDeleteModalActive={setIsDeleteModalActive}
                     setIsMoveModalActive={setIsMoveModalActive}
                     setSelectedPage={setSelectedPage}
-                    setSelectedFolder={setSelectedFolder}
+                    setSelectedPath={setSelectedPath}
+                    moveDropdownQuery={moveDropdownQuery}
+                    setMoveDropdownQuery={setMoveDropdownQuery}
+                    clearMoveDropdownQueryState={clearMoveDropdownQueryState}
                   />
               }
             </div>

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -42,7 +42,7 @@ const Workspace = ({ match, location }) => {
         onError: () => errorToast(`There was a problem trying to load your pages. ${DEFAULT_RETRY_MSG}`),
         onSuccess: (pagesResp) => {
           if (pagesResp.some(page => page.fileName === 'contact-us.md')) setContactUsCard(true)
-          setUnlinkedPages(pagesResp.filter(page => page.fileName !== 'contact-us.md'))
+          setUnlinkedPages(pagesResp.filter(page => page.fileName !== 'contact-us.md') || [])
         },
       },
     )
@@ -53,7 +53,7 @@ const Workspace = ({ match, location }) => {
       async () => getAllCategories({ siteName }),
       {
         onError: () => errorToast(`The folders data could not be retrieved. ${DEFAULT_RETRY_MSG}`),
-        onSuccess: (allFolders) => setCollections(allFolders.collections)
+        onSuccess: (allFolders) => setCollections(allFolders.collections || [])
       },
     )
 
@@ -189,6 +189,7 @@ const Workspace = ({ match, location }) => {
               <CollectionPagesSection
                 pages={unlinkedPages}
                 siteName={siteName}
+                refetchPages={refetchPages}
               />
             </div>
             {/* main section ends here */}

--- a/src/styles/isomer-cms/elements/dropdown.scss
+++ b/src/styles/isomer-cms/elements/dropdown.scss
@@ -47,7 +47,7 @@
 .fileMoveDropdown {
   @extend .dropdown;
   width: 20rem;
-  height: 17.25rem;
+  height: 20.25rem;
   overflow: hidden;
 
   .dropdownHeader {
@@ -78,7 +78,7 @@
   }
 
   .dropdownContentItems {
-    height: 7.75rem;
+    height: 10.75rem;
     overflow-y: scroll;
     text-align: center;
   }

--- a/src/styles/isomer-cms/elements/dropdown.scss
+++ b/src/styles/isomer-cms/elements/dropdown.scss
@@ -1,8 +1,7 @@
 .dropdown {
   position: absolute;
-  width: 16rem;
-  max-height: 16.75rem;
-  overflow: scroll;
+  width: 14rem;
+  overflow: hidden;
   background: white;
   box-shadow: 2px 2px 12px 0 rgba(43, 95, 206, 0.1);
   border-radius: 5px;
@@ -17,7 +16,7 @@
 
   .dropdownItem {
     width: 100%;
-    height: 3.5rem;
+    height: 3rem;
     padding: 0.75rem 0.25rem 0.75rem 1.5rem;
     display:flex;
     align-items: center;
@@ -34,25 +33,6 @@
     }
   }
 
-  .dropdownItemWarning {
-    @extend .dropdownItem;
-    height: auto;
-    cursor: default;
-    white-space: normal;
-
-    &:hover {
-      background: white;
-    }
-  }
-
-  .dropdownItemChildButton {
-    background: rgba(0, 0, 0, 0);
-
-    &:hover {
-      background: rgba(43, 95, 206, 0.3);
-    }
-  }
-
   hr {
     margin: 0;
   }
@@ -66,5 +46,59 @@
   button {
     padding: 0.5rem;
     margin-left: 0.5rem;
+  }
+}
+
+.fileMoveDropdown {
+  @extend .dropdown;
+  width: 20rem;
+  height: 17.25rem;
+  overflow: hidden;
+
+  .dropdownHeader {
+    @extend .dropdownItem;
+    top: 0;
+    position: sticky;
+    background: $isomer-blue;
+
+    &:hover {
+      background: $isomer-blue;
+    }
+
+    .dropdownText {
+      color: white;
+    }
+  }
+
+  .dropdownFirstItem {
+    @extend .dropdownItem;
+    top: 3rem;
+    position: sticky;
+    background: white;
+    border-bottom: 0.5px solid rgba(43, 95, 206, 0.3);
+
+    &:hover {
+      background: white;
+    }
+  }
+
+  .dropdownContentItems {
+    height: 7.75rem;
+    overflow-y: scroll;
+    text-align: center;
+  }
+
+  .dropdownLastItem {
+    @extend .dropdownItem;
+    border-top: 0.5px solid rgba(43, 95, 206, 0.3);
+    bottom: 0;
+    height: 3.5rem;
+    position: sticky;
+    background: white;
+    z-index: 3;
+
+    &:hover {
+      background: white;
+    }
   }
 }

--- a/src/styles/isomer-cms/elements/dropdown.scss
+++ b/src/styles/isomer-cms/elements/dropdown.scss
@@ -42,11 +42,6 @@
     vertical-align: middle;
     line-height:inherit;
   }
-
-  button {
-    padding: 0.5rem;
-    margin-left: 0.5rem;
-  }
 }
 
 .fileMoveDropdown {
@@ -86,6 +81,14 @@
     height: 7.75rem;
     overflow-y: scroll;
     text-align: center;
+  }
+
+  .dropdownItemButton {
+    display: none;
+  }
+
+  .dropdownItem:hover .dropdownItemButton {
+    display: block;
   }
 
   .dropdownLastItem {


### PR DESCRIPTION
This PR integrates the new page-moving UX designs from Nat and Sarah, outlined [here](https://www.figma.com/proto/4qNhGTBMs521pDvCAIh4ON/IsomerCMS?node-id=1171%3A11534&viewport=1101%2C235%2C0.25&scaling=min-zoom&page-id=1108%3A3). A preview of the behavior can be seen here:

https://user-images.githubusercontent.com/39231249/113124265-ed823980-9247-11eb-890c-3ff04a37361f.mov

### Update from 1 April review
~A further UX review with Sarah will be conducted on 1 April.~
Suggested changes from Sarah:

- [x] Dropdown menu arrows should appear on hover aa55674
- [x] Success message should differentiate between moved pages and files where move location is the same as original location 806a941
- [x] Increase scroll height to 3.5 instead of 2.5 rows 6703ce6

###  Details
This PR creates a new component `FileMoveMenuDropdown` to hold various custom components for the page-moving dropdown. This PR also refactors `OverviewCard`, `CollectionPagesSection`, `FolderContent`, and `Folders` to use the `FileMoveMenuDropdown`. 

For pages, the initial `moveDropdownQuery` is set based on the location of the page, so a page on Workspace would have the dropdown start in Workspace, whereas a page in a subfolder would have the dropdown start from that subfolder. 



