### PR TITLE
Fix/workspace folder pages ux

### DIFF
--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -176,7 +176,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
                             className={`${elementStyles.card} ${contentStyles.card} ${elementStyles.addNew}`}
                         >
                             <i id="settingsIcon-NEW" className={`bx bx-plus-circle ${elementStyles.bxPlusCircle}`} />
-                            <h2 id="settingsText-NEW">Add a new page</h2>
+                            <h2 id="settingsText-NEW">Create new page</h2>
                         </button>
                         { pages ?
                             pages.map((page, pageIdx) => (

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -53,7 +53,7 @@ const Workspace = ({ match, location }) => {
 
         try { 
           const collectionsResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/collections`);
-          if (_isMounted) setCollections(collectionsResp.data?.collections)
+          if (_isMounted) setCollections(collectionsResp.data?.collections || [])
         } catch (e) {
           setCollections(undefined)
           console.log(e)
@@ -62,7 +62,7 @@ const Workspace = ({ match, location }) => {
         try { 
           const unlinkedPagesResp = await axios.get(`${BACKEND_URL}/sites/${siteName}/files/pages`);
           if (_isMounted) {
-            setUnlinkedPages(unlinkedPagesResp.data?.directoryContents.filter(page => page.name !== 'contact-us.md'))
+            setUnlinkedPages(unlinkedPagesResp.data?.directoryContents.filter(page => page.name !== 'contact-us.md') || [])
           }
         } catch (e) {
           console.log(e)
@@ -136,30 +136,16 @@ const Workspace = ({ match, location }) => {
               <div className={contentStyles.segmentDividerContainer}>
                 <hr className="w-100 mt-3 mb-5" />
               </div>
-              {/* Collections title */}
+              {/* Folders title */}
               <div className={contentStyles.segment}>
-                Collections
+                Folders
               </div>
-              {
-                !collections &&
-                <div className={contentStyles.segment}>
-                  Loading Collections...
-                </div>
-              }
-              {
-                collections && collections.length === 0 &&
-                <div className={contentStyles.segment}>
-                  There are no collections in this repository.
-                </div>
-              }
-              {/* Collections */}
+              {/* Folders */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
+                  <FolderOptionButton title="Create new folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
                   {
-                    collections && unlinkedPages && <FolderOptionButton title="Create new folder" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
-                  }
-                  {
-                    collections && collections.length > 0
+                    collections
                     ? collections.map((collection, collectionIdx) => (
                         <FolderCard
                             displayText={prettifyPageFileName(collection)}
@@ -171,14 +157,15 @@ const Workspace = ({ match, location }) => {
                             itemIndex={collectionIdx}
                         />
                     ))
-                    : null
+                    : 'Loading Folders...'
                   }
                 </div>
               </div>
               {/* Segment divider  */}
               <div className={contentStyles.segmentDividerContainer}>
                 <hr className="invisible w-100 mt-3 mb-5" />
-              </div>                {/* Pages title */}
+              </div>
+              {/* Pages title */}
               <div className={contentStyles.segment}>
                 Unlinked Pages
               </div>

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -79,8 +79,13 @@
     }
 
     &:hover{
-      background-color: rgba(255,255,255,0.5);
-      border: 1px dashed $isomer-blue;
+      background: $isomer-blue;
+      border: 1px solid $isomer-blue;
+      color: white;
+
+      > i {
+        color: white;
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes inconsistent behavior & layout on Workspace between the folders and the unlinked pages. Namely, these bugs are fixed:
- On hover, create button for both folders and pages turns blue
- Create button for pages changed from "Add a new page" to "Create new page" to match folders
- Create button for folders appears before ReactQuery completes. While query is running, loading message will appear. If no folders are retrieved, loading message will disappear. This behavior matches that of unlinked pages below.
