### PR TITLE
Fix/original frontmatter

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -60,6 +60,7 @@ const ComponentSettingsModal = ({
     // Track original values
     const [originalPermalink, setOriginalPermalink] = useState('')
     const [originalFileUrl, setOriginalFileUrl] = useState('')
+    const [originalFrontMatter, setOriginalFrontMatter] = useState({})
 
     // Resource-related
     const [resourceDate, setResourceDate] = useState('')
@@ -97,6 +98,7 @@ const ComponentSettingsModal = ({
             setOriginalPermalink(originalPermalink)
             setFileUrl(originalFileUrl)
             setOriginalFileUrl(originalFileUrl)
+            setOriginalFrontMatter(originalFrontMatter)
 
             setResourceDate(originalDate)
           }
@@ -149,12 +151,13 @@ const ComponentSettingsModal = ({
     const { mutateAsync: saveHandler } = useMutation(
       () => {
         const frontMatter = isPost 
-          ? { title, date: resourceDate, permalink }
-          : { title, date: resourceDate, file_url: fileUrl }
+          ? { ...originalFrontMatter, title, date: resourceDate, permalink }
+          : { ...originalFrontMatter, title, date: resourceDate, file_url: fileUrl }
         const newFileName = generateResourceFileName(title, resourceDate, isPost)
-        if (isNewFile) return createPageData({ siteName, resourceName: category, newFileName }, concatFrontMatterMdBody(frontMatter, mdBody)) 
-        if (fileName !== newFileName) return renamePageData({ siteName, resourceName: category, fileName, newFileName }, concatFrontMatterMdBody(frontMatter, mdBody), sha)
-        return updatePageData({ siteName, resourceName: category, fileName }, concatFrontMatterMdBody(frontMatter, mdBody), sha)
+        const newPageData = concatFrontMatterMdBody(frontMatter, mdBody)
+        if (isNewFile) return createPageData({ siteName, resourceName: category, newFileName }, newPageData) 
+        if (fileName !== newFileName) return renamePageData({ siteName, resourceName: category, fileName, newFileName }, newPageData, sha)
+        return updatePageData({ siteName, resourceName: category, fileName }, newPageData, sha)
       },
       { 
         onSettled: () => {setSelectedFile(''); setIsComponentSettingsActive(false)},

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -83,7 +83,7 @@ const ComponentSettingsModal = ({
       const initializePageDetails = () => {
         if (pageData !== undefined) { // is existing page
           const { pageContent, pageSha } = pageData
-          const { frontMatter, pageMdBody } = frontMatterParser(pageContent)
+          const { frontMatter, mdBody: pageMdBody } = frontMatterParser(pageContent)
           const { file_url: originalFileUrl, permalink: originalPermalink } = frontMatter
           const { title: originalTitle, type: originalType, date: originalDate } = retrieveResourceFileMetadata(fileName)
           if (_isMounted) {

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -50,6 +50,7 @@ const PageSettingsModal = ({
     const [title, setTitle] = useState('')
     const [permalink, setPermalink] = useState('')
     const [originalPermalink, setOriginalPermalink] = useState('')
+    const [originalFrontMatter, setOriginalFrontMatter] = useState({})
     const [sha, setSha] = useState('')
     const [mdBody, setMdBody] = useState('')
     const { setRedirectToPage } = useRedirectHook()
@@ -62,11 +63,12 @@ const PageSettingsModal = ({
     const { mutateAsync: saveHandler } = useMutation(
       () => {
         const frontMatter = subfolderName 
-          ? { title, permalink, third_nav_title: subfolderName }
-          : { title, permalink }
-        if (isNewPage) return createPageData({ siteName, folderName, subfolderName, newFileName: generatePageFileName(title) }, concatFrontMatterMdBody(frontMatter, mdBody)) 
-        if (originalPageName !== generatePageFileName(title)) return renamePageData({ siteName, folderName, subfolderName, fileName: originalPageName, newFileName: generatePageFileName(title) }, concatFrontMatterMdBody(frontMatter, mdBody), sha)
-        return updatePageData({ siteName, folderName, subfolderName, fileName: originalPageName }, concatFrontMatterMdBody(frontMatter, mdBody), sha)
+          ? { ...originalFrontMatter, title, permalink, third_nav_title: subfolderName }
+          : { ...originalFrontMatter, title, permalink }
+        const newPageData = concatFrontMatterMdBody(frontMatter, mdBody)
+        if (isNewPage) return createPageData({ siteName, folderName, subfolderName, newFileName: generatePageFileName(title) },  newPageData) 
+        if (originalPageName !== generatePageFileName(title)) return renamePageData({ siteName, folderName, subfolderName, fileName: originalPageName, newFileName: generatePageFileName(title) }, newPageData, sha)
+        return updatePageData({ siteName, folderName, subfolderName, fileName: originalPageName }, newPageData, sha)
       },
       { 
         onSettled: () => {setSelectedPage(''); setIsPageSettingsActive(false)},
@@ -90,6 +92,7 @@ const PageSettingsModal = ({
             setOriginalPermalink(originalPermalink)
             setSha(pageSha)
             setMdBody(pageMdBody)
+            setOriginalFrontMatter(frontMatter)
           }
         }
         if (isNewPage) {

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -83,7 +83,7 @@ const PageSettingsModal = ({
       const initializePageDetails = () => {
         if (pageData !== undefined) { // is existing page
           const { pageContent, pageSha } = pageData
-          const { frontMatter, pageMdBody } = frontMatterParser(pageContent)
+          const { frontMatter, mdBody: pageMdBody } = frontMatterParser(pageContent)
           const { permalink: originalPermalink } = frontMatter
         
           if (_isMounted) {


### PR DESCRIPTION
This PR adds functionality to keep original frontmatter in place when page settings are edited. This is useful for repos such as GoBusiness, where pages may have additional custom frontmatter ([example](https://raw.githubusercontent.com/isomerpages/govtech-gobusiness-main-clone-v4/migration/_business-grants-faqs/productivity-solutions-grant-psg/vendors-edited.md?token=AJLJ6EI2O7UYPIIA2MM7WHLAOPJNI)) that is not editable via the CMS. With this functionality, users such as GoBusiness will be able to keep their custom frontmatter when saving their page settings, even if the custom frontmatter is not editable on the CMS. 

