### PR TITLE
Refactor/page settings

### DIFF
--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -152,7 +152,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource, r
                     /> 
                     : (pageData || createNewPage) 
                     && <PageSettingsModal
-                        pagesData={pages}
+                        pagesData={pages?.map(page => page.fileName) || []}
                         pageData={pageData}
                         siteName={siteName}
                         originalPageName={selectedFile || ''}

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -262,5 +262,11 @@ ComponentSettingsModal.propTypes = {
     fileName: PropTypes.string.isRequired,
     category: PropTypes.string,
     isNewFile: PropTypes.bool.isRequired,
-    settingsToggle: PropTypes.func.isRequired,
+    setSelectedFile: PropTypes.func.isRequired,
+    setIsComponentSettingsActive: PropTypes.func.isRequired,
+    pageData: PropTypes.shape({
+      pageContent: PropTypes.string.isRequired,
+      pageSha: PropTypes.string.isRequired,
+    }),
+    pageFileNames: PropTypes.arrayOf(PropTypes.string),
   };

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -138,7 +138,6 @@ const PageSettingsModal = ({
 
     const changeHandler = (event) => {
       const { id, value } = event.target;
-
       const errorMessage = validatePageSettings(id, value, pagesData.filter(page => page !== originalPageName))
 
       setErrors((prevState) => ({

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -102,7 +102,7 @@ const PageSettingsModal = ({
         }
         if (isNewPage) {
           let exampleTitle = 'Example Title'
-          while (_.find(pagesData, function(v) { return v.type === 'file' && generatePageFileName(exampleTitle) === v.name }) !== undefined) {
+          while (pagesData.includes(generatePageFileName(exampleTitle))) {
             exampleTitle = exampleTitle+'_1'
           }
           const examplePermalink = `/${folderName ? `${folderName}/` : ''}${subfolderName ? `${subfolderName}/` : ''}permalink`
@@ -137,7 +137,9 @@ const PageSettingsModal = ({
 
     const changeHandler = (event) => {
       const { id, value } = event.target;
-      const errorMessage = validatePageSettings(id, value, pagesData.filter(page => page.name !== originalPageName))
+
+      const errorMessage = validatePageSettings(id, value, pagesData.filter(page => page !== originalPageName))
+
       setErrors((prevState) => ({
         ...prevState,
         [id]: errorMessage,

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useMutation } from 'react-query';
+import PropTypes from 'prop-types';
 import axios from 'axios';
 import * as _ from 'lodash';
 
@@ -214,4 +215,16 @@ const PageSettingsModal = ({
 export default PageSettingsModal
 
 PageSettingsModal.propTypes = {
+  folderName: PropTypes.string,
+  subfolderName: PropTypes.string,
+  originalPageName: PropTypes.string,
+  isNewPage: PropTypes.bool,
+  pagesData: PropTypes.arrayOf(PropTypes.string),
+  pageData: PropTypes.shape({
+      pageContent: PropTypes.string.isRequired,
+      pageSha: PropTypes.string.isRequired,
+  }),
+  siteName: PropTypes.string.isRequired,
+  setSelectedPage: PropTypes.func.isRequired,
+  setIsPageSettingsActive: PropTypes.func.isRequired,
 };

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -272,7 +272,7 @@ const Folders = ({ match, location }) => {
               <PageSettingsModal
                 folderName={folderName}
                 subfolderName={subfolderName}
-                pagesData={folderOrderArray.filter(item => item.type === 'file')}
+                pagesData={folderOrderArray.filter(item => item.type === 'file').map(page => page.name)}
                 pageData={pageData}
                 siteName={siteName}
                 originalPageName={selectedPage || ''}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -641,8 +641,7 @@ const validatePageSettings = (id, value, folderOrderArray) => {
         errorMessage = `The title should be shorter than ${PAGE_SETTINGS_TITLE_MAX_LENGTH} characters.`;
       }
       if ( 
-        folderOrderArray !== undefined 
-        && _.find(folderOrderArray, function(v) { return v.type === 'file' && generatePageFileName(value) === v.name }) !== undefined 
+        folderOrderArray !== undefined && folderOrderArray.includes(generatePageFileName(value))
       ) {
         errorMessage = `This title is already in use. Please choose a different title.`;
       }


### PR DESCRIPTION
This PR simplifies the `pagesData` variable in `PageSettingsModal` from an array of objects to an array of strings, as the rest of the attributes in the objects are unused. 

This refactoring simplifies the validation check done for duplicate page names. 

This PR also updates `PropTypes` for `PageSettingsModal` and `ComponentSettingsModal`