### PR TITLE
Fix: disable creation of resource room link if user has no resource room

### DIFF
--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -55,7 +55,7 @@ export default function LoadingButton(props) {
 LoadingButton.propTypes = {
   label: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  disabledStyle: PropTypes.string.isRequired,
+  disabledStyle: PropTypes.string,
   className: PropTypes.string.isRequired,
   callback: PropTypes.func.isRequired,
 };

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -148,6 +148,7 @@ const NavSection = ({
   displayHandler,
   displayLinks,
   displaySublinks,
+  hasResourceRoom,
   hasResources,
   errors,
 }) => {
@@ -170,7 +171,7 @@ const NavSection = ({
         label: 'Folder',
       }]
       : [],
-    ... !hasResources 
+    ... hasResourceRoom && !hasResources 
       ? [{
         value: 'resourceLink',
         label: 'Resource Room',
@@ -251,7 +252,7 @@ const NavSection = ({
         <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Link</button>
       </div>
       <span className={elementStyles.info}>
-        Note: you can specify a folder or resource room to automatically populate its links. Only one resource room link is allowed. Select "Sublinks" if you want to specify your own links.
+        {`Note: you can specify a folder ${hasResourceRoom ? `or resource room ` : ``}to automatically populate its links. ${hasResourceRoom ? `Only one resource room link is allowed. ` : ``}Select "Sublinks" if you want to specify your own links.`}
       </span>
     </>
   )
@@ -322,6 +323,7 @@ NavSection.propTypes = {
   displayHandler: PropTypes.func.isRequired,
   displayLinks: PropTypes.arrayOf(PropTypes.bool).isRequired,
   displaySublinks: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.bool)).isRequired,
+  hasResourceRoom: PropTypes.bool.isRequired,
   hasResources: PropTypes.bool.isRequired,
   errors: PropTypes.shape({
     links: PropTypes.arrayOf(

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -650,7 +650,7 @@ const EditContactUs =  ({ match }) => {
         siteName={siteName}
         title={"Contact Us"}
         shouldAllowEditPageBackNav={hasChanges()}
-        isEditPage="true"
+        isEditPage={true}
         backButtonText="Back to My Workspace"
         backButtonUrl={`/sites/${siteName}/workspace`}
       />

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1079,7 +1079,7 @@ const EditHomepage = ({ match }) => {
           siteName={siteName}
           title="Homepage"
           shouldAllowEditPageBackNav={JSON.stringify(originalFrontMatter) === JSON.stringify(frontMatter)}
-          isEditPage="true"
+          isEditPage={true}
           backButtonText="Back to My Workspace"
           backButtonUrl={`/sites/${siteName}/workspace`}
         />

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -606,7 +606,7 @@ const EditNavBar =  ({ match }) => {
         siteName={siteName}
         title={"Nav Bar"}
         shouldAllowEditPageBackNav={!hasChanges()}
-        isEditPage="true"
+        isEditPage={true}
         backButtonText="Back to My Workspace"
         backButtonUrl={`/sites/${siteName}/workspace`}
       />

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -14,7 +14,7 @@ import { errorToast } from '../utils/toasts';
 import useRedirectHook from '../hooks/useRedirectHook';
 
 import Header from '../components/Header';
-import LoadingButton from '../components/LoadingButtonReactQuery';
+import LoadingButton from '../components/LoadingButton';
 import DeleteWarningModal from '../components/DeleteWarningModal';
 import GenericWarningModal from '../components/GenericWarningModal';
 import NavSection from '../components/navbar/NavSection'
@@ -128,7 +128,7 @@ const EditNavBar =  ({ match }) => {
   );
 
   // update nav bar data
-  const { mutate: saveNavData, isLoading } = useMutation(
+  const { mutateAsync: saveNavData } = useMutation(
     () => updateNavBarData(siteName, originalNav, links, sha),
     {
       onError: () => errorToast(`There was a problem trying to save your nav bar. ${DEFAULT_RETRY_MSG}`),
@@ -655,7 +655,6 @@ const EditNavBar =  ({ match }) => {
               disabledStyle={elementStyles.disabled}
               className={hasErrors() ? elementStyles.disabled : elementStyles.blue}
               callback={() => saveNavData(siteName, originalNav, links, sha)}
-              isLoading={isLoading}
             />
           </div>
         </div>

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -52,6 +52,7 @@ const EditNavBar =  ({ match }) => {
   )
   const [resources, setResources] = useState()
   const [hasResources, setHasResources] = useState(false)
+  const [hasResourceRoom, setHasResourceRoom] = useState(false)
   const [errors, setErrors] = useState({
     links: [],
     sublinks: [],
@@ -178,7 +179,7 @@ const EditNavBar =  ({ match }) => {
       })
 
       const { collections: initialCollections } = collectionContent
-      const { resources: initialResource } = resourceContent
+      const { resourceRoomName, resources: initialResource } = resourceContent
 
       const initialOptions = initialCollections.map((collection) => ({
         value: collection,
@@ -193,7 +194,8 @@ const EditNavBar =  ({ match }) => {
         setCollections(initialCollections)
         setFolderDropdowns(foldersContent)
         setOptions(initialOptions)
-        setResources(initialResource.map(resource => deslugifyDirectory(resource.dirName)))
+        setHasResourceRoom(!!resourceRoomName)
+        if (resourceRoomName) setResources(initialResource.map(resource => deslugifyDirectory(resource.dirName)))
         setOriginalNav(navContent)
         setSha(navSha)
         setHasResources(navHasResources)
@@ -622,6 +624,7 @@ const EditNavBar =  ({ match }) => {
                   displayHandler={displayHandler}
                   displayLinks={displayLinks}
                   displaySublinks={displaySublinks}
+                  hasResourceRoom={hasResourceRoom}
                   hasResources={hasResources}
                   errors={errors}
                 />

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -350,7 +350,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
         siteName={siteName}
         title={title}
         shouldAllowEditPageBackNav={originalMdValue === editorValue}
-        isEditPage="true"
+        isEditPage={true}
         backButtonText={backButtonLabel}
         backButtonUrl={backButtonUrl}
       />

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -325,7 +325,7 @@ const Folders = ({ match, location }) => {
             backButtonText={`Back to ${subfolderName ? folderName : 'Workspace'}`}
             backButtonUrl={`/sites/${siteName}/${subfolderName ? `folder/${folderName}` : 'workspace'}`}
             shouldAllowEditPageBackNav={!isRearrangeActive}
-            isEditPage="true"
+            isEditPage={true}
           />
           {/* main bottom section */}
           <div className={elementStyles.wrapper}>


### PR DESCRIPTION
This PR fixes an issue with EditNavBar regarding the handling of resource rooms for sites which do not have one. Previously, we always assumed that sites contained a resource room, which caused errors when attempting to retrieve the list of categories. This PR changes it such that we first check if a resource room exists. In addition, the option to create a link with a resource room has now been disabled if a site does not contain a resource room.

Also fixes a minor bug involving the `isEditPage` prop passed to `Header` being a string instead of a boolean.