### PR TITLE
Fix: remove encoding in homepage and when saving edit contact us

### DIFF
--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -146,7 +146,7 @@ const EditContactUs =  ({ match }) => {
     id: null,
     type: '',
   })
-  const [showDeletedText, setShowDeletedText] = useState(false)
+  const [showDeletedText, setShowDeletedText] = useState(true)
 
   useEffect(() => {
     let _isMounted = true

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
-import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
 import { DragDropContext } from 'react-beautiful-dnd';
@@ -583,10 +582,9 @@ const EditContactUs =  ({ match }) => {
       if (!filteredFrontMatter.locations.length) delete filteredFrontMatter.locations
 
       const content = concatFrontMatterMdBody(filteredFrontMatter, '');
-      const base64EncodedContent = Base64.encode(content);
 
       const frontMatterParams = {
-        content: base64EncodedContent,
+        content,
         sha: frontMatterSha,
       };
 

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -164,8 +164,7 @@ const EditHomepage = ({ match }) => {
           withCredentials: true,
         });
         const { content, sha } = resp.data;
-        const base64DecodedContent = Base64.decode(content);
-        const { frontMatter } = frontMatterParser(base64DecodedContent);
+        const { frontMatter } = frontMatterParser(content);
         // Compute hasResources and set displaySections
         let hasResources = false;
         const displaySections = [];
@@ -906,10 +905,9 @@ const EditHomepage = ({ match }) => {
         return newSection
       })
       const content = concatFrontMatterMdBody(filteredFrontMatter, '');
-      const base64EncodedContent = Base64.encode(content);
 
       const params = {
-        content: base64EncodedContent,
+        content,
         sha: sha,
       };
 

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, createRef, useState } from 'react';
 import axios from 'axios';
 import _ from 'lodash';
-import { Base64 } from 'js-base64';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -5,7 +5,6 @@ import { useQuery, useMutation } from 'react-query';
 import PropTypes from 'prop-types';
 import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
-import { Base64 } from 'js-base64';
 import Policy from 'csp-parse';
 
 import SimplePage from '../templates/SimplePage';


### PR DESCRIPTION
This PR fixes a bug involving the editing of contact us pages. In line with the recent changes to page encoding on the backend (PR [#133](https://github.com/isomerpages/isomercms-backend/pull/133)), simple page encoding is now performed in the backend, so we were mistakenly encoding contact us pages twice. This has been corrected to send the data as is.

In addition, this PR also shifts the encoding/decoding to the backend. To be reviewed in conjunction with PR [#151](https://github.com/isomerpages/isomercms-backend/pull/151) on the isomercms-backend repo.