### PR TITLE
fix: resource copy changes

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -198,7 +198,7 @@ const ComponentSettingsModal = ({
             && (
             <div className={elementStyles['modal-settings']}>
               <div className={elementStyles.modalHeader}>
-                <h1>{ isNewFile  ? 'Create new page' : 'Resource settings' }</h1>
+                <h1>{ isNewFile  ? 'Create new resource page' : 'Resource settings' }</h1>
                 <button id="settings-CLOSE" type="button" onClick={() => {setSelectedFile(''); setIsComponentSettingsActive(false)}}>
                   <i id="settingsIcon-CLOSE" className="bx bx-x" />
                 </button>
@@ -208,7 +208,7 @@ const ComponentSettingsModal = ({
                   { isNewFile ? 'You may edit page details anytime. ' : ''}
                   To edit page content, simply click on the page title. <br/>
                   <span className={elementStyles.infoGrey}> 
-                    My workspace > Resources > { category } > <u className='ml-1'>{ title }</u><br/><br/>
+                    Resources > { category } > <u className='ml-1'>{ title }</u><br/><br/>
                   </span>  
                   {/* Title */}
                   <FormField

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -18,6 +18,7 @@ import {
   generateResourceFileName,
   retrieveResourceFileMetadata,
   concatFrontMatterMdBody,
+  deslugifyDirectory,
 } from '../utils';
 
 import { createPageData, updatePageData, renamePageData } from '../api'
@@ -208,7 +209,7 @@ const ComponentSettingsModal = ({
                   { isNewFile ? 'You may edit page details anytime. ' : ''}
                   To edit page content, simply click on the page title. <br/>
                   <span className={elementStyles.infoGrey}> 
-                    Resources > { category } > <u className='ml-1'>{ title }</u><br/><br/>
+                    Resources > { deslugifyDirectory(category) } > <u className='ml-1'>{ title }</u><br/><br/>
                   </span>  
                   {/* Title */}
                   <FormField

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MenuItem } from './MenuDropdown'
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import { deslugifyDirectory } from '../utils'
 
 const FileMoveMenuDropdown = ({ 
   dropdownItems, 
@@ -34,15 +35,31 @@ const FileMoveMenuDropdown = ({
           id='workspace'
           onClick={() => setMoveDropdownQuery({folderName: '', subfolderName: ''})}
           style={ subfolderName || folderName ? {cursor:'pointer'}: {cursor:'default'}}
-      >{subfolderName ? `... >` : !subfolderName && !folderName ? <strong>{rootName}</strong> : rootName}
+      > 
+        {
+          subfolderName 
+          ? `... >` 
+          : !subfolderName && !folderName 
+          ? <strong>{rootName}</strong> 
+          : rootName
+        }
       </span>
       <span 
         id='folder'
         onClick={() => setMoveDropdownQuery({...moveDropdownQuery, subfolderName: ''})}
         style={subfolderName ? {cursor:'pointer'} : {cursor:'default'}}
-      >{folderName && !subfolderName ? <strong> > {folderName}</strong> : `${folderName}`}
+      >
+        {
+          folderName && !subfolderName 
+          ? <strong> > {deslugifyDirectory(folderName)}</strong> 
+          : `${deslugifyDirectory(folderName)}`
+        }
       </span>
-      {subfolderName ? <strong> > {subfolderName}</strong> : ''}
+        {
+          subfolderName 
+          ? <strong> > {deslugifyDirectory(subfolderName)}</strong> 
+          : ''
+        }
     </>
   )
 
@@ -83,7 +100,7 @@ const FileMoveMenuDropdown = ({
               <MenuItem 
                 key={`${categoryName}-${menuIndex}`}
                 item={{
-                  itemName: categoryName,
+                  itemName: deslugifyDirectory(categoryName),
                   itemId: categoryName,
                   iconClassName: "bx bx-sm bx-folder",
                   children: <i className={`${elementStyles.dropdownItemButton} bx bx-sm bx-chevron-right ml-auto`}/>,

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -7,6 +7,7 @@ const FileMoveMenuDropdown = ({
   menuIndex, 
   dropdownRef, 
   onBlur, 
+  rootName,
   moveDropdownQuery,
   setMoveDropdownQuery,
   backHandler, 
@@ -33,7 +34,7 @@ const FileMoveMenuDropdown = ({
           id='workspace'
           onClick={() => setMoveDropdownQuery({folderName: '', subfolderName: ''})}
           style={ subfolderName || folderName ? {cursor:'pointer'}: {cursor:'default'}}
-      >{subfolderName ? `... >` : !subfolderName && !folderName ? <strong>Workspace</strong> : 'Workspace'}
+      >{subfolderName ? `... >` : !subfolderName && !folderName ? <strong>{rootName}</strong> : rootName}
       </span>
       <span 
         id='folder'

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -14,6 +14,7 @@ import {
   prettifyPageFileName,
   prettifyDate,
   retrieveResourceFileMetadata,
+  deslugifyDirectory,
 } from '../utils';
 
 // axios settings
@@ -93,7 +94,7 @@ const OverviewCard = ({
   const CardContent = (
     <>
       <div id={itemIndex} className={contentStyles.componentInfo}>
-        <div className={contentStyles.componentCategory}>{category ? category : ''}</div>
+        <div className={contentStyles.componentCategory}>{category ? deslugifyDirectory(category) : ''}</div>
         <h1 className={resourceType === 'file' ? contentStyles.componentTitle : contentStyles.componentTitleLink}>{generateTitle()}</h1>
         <p className={contentStyles.componentDate}>{`${date ? prettifyDate(date) : ''}${resourceType ? `/${resourceType.toUpperCase()}` : ''}`}</p>
       </div>

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -140,6 +140,7 @@ const OverviewCard = ({
               menuIndex={itemIndex}
               onBlur={handleBlur}
               moveDropdownQuery={moveDropdownQuery}
+              rootName={"Resources"}
               setMoveDropdownQuery={setMoveDropdownQuery}
               backHandler={toggleDropdownModals}
               moveHandler={() => {

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -10,6 +10,7 @@ import {
   concatFrontMatterMdBody,
   frontMatterParser,
   deslugifyPage,
+  deslugifyDirectory,
 } from '../utils';
 
 import { createPageData, updatePageData, renamePageData } from '../api'
@@ -166,12 +167,12 @@ const PageSettingsModal = ({
                     My workspace >
                     {
                       folderName
-                      ? <span> {folderName} > </span>  
+                      ? <span> {deslugifyDirectory(folderName)} > </span>  
                       : null
                     }
                     {
                       subfolderName
-                      ? <span> {subfolderName} > </span>
+                      ? <span> {deslugifyDirectory(subfolderName)} > </span>
                       : null
                     } 
                     <u className='ml-1'>{ title }</u><br/><br/>

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -121,6 +121,7 @@ const FolderContentItem = ({
                             dropdownRef={fileMoveDropdownRef}
                             menuIndex={itemIndex}
                             onBlur={handleBlur}
+                            rootName={"Workspace"}
                             moveDropdownQuery={moveDropdownQuery}
                             setMoveDropdownQuery={setMoveDropdownQuery}
                             backHandler={toggleDropdownModals}

--- a/src/layouts/CategoryPages.jsx
+++ b/src/layouts/CategoryPages.jsx
@@ -13,7 +13,7 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 //Import utils
-import { retrieveResourceFileMetadata } from '../utils.js'
+import { retrieveResourceFileMetadata, deslugifyDirectory } from '../utils.js'
 import { errorToast } from '../utils/toasts';
 import { getResourcePages } from '../api'
 import { RESOURCE_CATEGORY_CONTENT_KEY } from '../constants'
@@ -102,7 +102,7 @@ const CategoryPages = ({ match, location, isResource }) => {
           <div className={contentStyles.mainSection}>
               {/* Collection title */}
               <div className={contentStyles.sectionHeader}>
-                  <h1 className={contentStyles.sectionTitle}>{collectionName}</h1>
+                  <h1 className={contentStyles.sectionTitle}>{deslugifyDirectory(collectionName)}</h1>
               </div>
               {/* Collection pages */}
               <CollectionPagesSection

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -32,6 +32,7 @@ import {
   convertArrayToFolderOrder,
   retrieveSubfolderContents,
   convertSubfolderArray,
+  deslugifyDirectory,
 } from '../utils'
 
 // Import API
@@ -334,7 +335,7 @@ const Folders = ({ match, location }) => {
             <div className={contentStyles.mainSection}>
               {/* Page title */}
               <div className={contentStyles.sectionHeader}>
-                <h1 className={contentStyles.sectionTitle}>{folderName}</h1>
+                <h1 className={contentStyles.sectionTitle}>{deslugifyDirectory(folderName)}</h1>
               </div>
               {/* Info segment */}
               <div className={contentStyles.segment}>
@@ -353,15 +354,15 @@ const Folders = ({ match, location }) => {
                         folderName
                         ? (
                           subfolderName
-                          ? <Link to={`/sites/${siteName}/folder/${folderName}`}><strong className="ml-1"> {folderName}</strong></Link>
-                          : <strong className="ml-1"> {folderName}</strong>
+                          ? <Link to={`/sites/${siteName}/folder/${folderName}`}><strong className="ml-1"> {deslugifyDirectory(folderName)}</strong></Link>
+                          : <strong className="ml-1"> {deslugifyDirectory(folderName)}</strong>
                         )
                         : null
                     }
                     {
                         folderName && subfolderName
                         ? (
-                            <span> ><strong className="ml-1"> {subfolderName}</strong></span>
+                            <span> ><strong className="ml-1"> {deslugifyDirectory(subfolderName)}</strong></span>
                         )
                         : null
                     }

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -19,7 +19,7 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 // Import utils
-import { DEFAULT_RETRY_MSG, prettifyResourceCategory, slugifyCategory } from '../utils';
+import { DEFAULT_RETRY_MSG, deslugifyDirectory, slugifyCategory } from '../utils';
 import { validateResourceRoomName, validateCategoryName } from '../utils/validators'
 import { errorToast } from '../utils/toasts';
 import { getAllResourceCategories, addResourceCategory } from '../api';
@@ -49,7 +49,7 @@ const Resources = ({ match, location }) => {
       retry: false,
       onError: (err) => {
         console.log(err)
-        errorToast(`There was a problem trying to load your resource categories. ${DEFAULT_RETRY_MSG}`)
+        errorToast(`There was a problem trying to load your categories. ${DEFAULT_RETRY_MSG}`)
       }
     },
   );
@@ -57,7 +57,7 @@ const Resources = ({ match, location }) => {
   const { mutateAsync: saveHandler } = useMutation(
     () => addResourceCategory(siteName, slugifyCategory(newFolderName)),
     {
-      onError: () => errorToast(`There was a problem trying to create your new folder. ${DEFAULT_RETRY_MSG}`),
+      onError: () => errorToast(`There was a problem trying to create your new category. ${DEFAULT_RETRY_MSG}`),
       onSuccess: () => {
         const redirectUrl = `/sites/${siteName}/resources/${slugifyCategory(newFolderName)}`
         setRedirectToPage(redirectUrl)
@@ -69,7 +69,7 @@ const Resources = ({ match, location }) => {
     let _isMounted = true
     const fetchData = async () => {
       try {
-        // Get the resource categories in the resource room
+        // Get the categories in the resource room
         if (!resourcesResp) return
         const { resourceRoomName, resources: resourceCategories } = resourcesResp.data;
         if (resourceRoomName) {
@@ -151,7 +151,7 @@ const Resources = ({ match, location }) => {
               ? <>
                   {/* Category title */}
                   <div className={contentStyles.segment}>
-                    Resource Categories
+                    Categories
                   </div>
                   {/* Categories */}
                   <div className={contentStyles.folderContainerBoxes}>
@@ -163,16 +163,16 @@ const Resources = ({ match, location }) => {
                           {
                             resourceFolderNames.length === 0 && 
                             <>
-                              No Resource Categories.
+                              No Categories.
                               <hr className="invisible w-100 mt-3 mb-3" />
                             </>
                           }
-                          <FolderOptionButton title="Create new resource category" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
+                          <FolderOptionButton title="Create new category" option="create-sub" isSubfolder={false} onClick={() => setIsFolderCreationActive(true)}/>
                           {
                             resourceFolderNames.length > 0
                             ? resourceFolderNames.map((resourceCategory, collectionIdx) => (
                                 <FolderCard
-                                  displayText={prettifyResourceCategory(resourceCategory)}
+                                  displayText={deslugifyDirectory(resourceCategory)}
                                   settingsToggle={() => {}}
                                   key={resourceCategory}
                                   pageType={"resources"}
@@ -184,7 +184,7 @@ const Resources = ({ match, location }) => {
                             : null
                           }
                           </>
-                        : 'Loading Resource Categories...'
+                        : 'Loading Categories...'
                       }
                     </div>
                   </div>


### PR DESCRIPTION
This PR makes the Resources copy changes requested by designers in their CMS v1 review, 13 April ([link](https://docs.google.com/document/d/1_aC5FuHqSQqqWx0aOcpDFyw2iEk1vsCpDgt4fLQ1zck/edit#)). 

Additionally, this PR applies the `deslugify` changes to category/ folder names to Resources, Folders and related components such as `ComponentSettingsModal`, `PageSettingsModal`, `FileMoveDropdown` etc.

The list is also copied below for reference.
> Resources Tab
> [Copy changes] Change ‘Resource Categories’ to just ‘Categories’ (done)
> [Copy changes] Button: Change to ‘Create new category’ (done)
> 
> [Copy changes] Can we standardise the category names to Title case instead of all CAPS (done)
> [Copy changes] At the category workspace, can we use the category name without hyphens i.e. ‘Media Release’ instead of ‘media-release’ (done)
> [Copy changes] When moving resources, it should say ‘Resources’ instead of Workspace (done)
> 
> [Copy Changes] Resources settings: Remove ‘My Workspace’ from breadcrumb (done)
