### PR TITLE
fix: workspace copy changes for Collections > Folders

### DIFF
--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -155,21 +155,21 @@ const Workspace = ({ match, location }) => {
               </div>
               {/* Collections title */}
               <div className={contentStyles.segment}>
-                Collections
+                Folders
               </div>
               {
                 !collections &&
                 <div className={contentStyles.segment}>
-                  Loading Collections...
+                  Loading Folders...
                 </div>
               }
               {
                 collections && collections.length === 0 &&
                 <div className={contentStyles.segment}>
-                  There are no collections in this repository.
+                  There are no folders in this repository.
                 </div>
               }
-              {/* Collections */}
+              {/* Folders */}
               <div className={contentStyles.folderContainerBoxes}>
                 <div className={contentStyles.boxesContainer}>
                   {
@@ -197,12 +197,12 @@ const Workspace = ({ match, location }) => {
                 <hr className="invisible w-100 mt-3 mb-5" />
               </div>                {/* Pages title */}
               <div className={contentStyles.segment}>
-                Unlinked Pages
+                Pages
               </div>
               {/* Info segment */}
               <div className={contentStyles.segment}>
                 <i className="bx bx-sm bx-info-circle text-dark" />
-                <span><strong className="ml-1">Note:</strong> Unlinked pages are pages which do not belong to any collection.</span>
+                <span><strong className="ml-1">Note:</strong> The pages here do not belong to any folders.</span>
               </div>
               {/* Pages */}
               <CollectionPagesSection


### PR DESCRIPTION
This PR makes the Workspace copy changes requested by designers in their CMS v1 review, 13 April ([link](https://docs.google.com/document/d/1_aC5FuHqSQqqWx0aOcpDFyw2iEk1vsCpDgt4fLQ1zck/edit#))

The list is also copied below for reference.
> Workspace
> [Copy changes] Change ‘Collections’ to ‘Folders’ (done)
> [Copy changes] Any mentions of ‘Collection’ should be ‘Folders (done)
> [Copy changes] Change ‘Unlinked Pages’ to ‘Pages’. And ‘Note: The pages here do not belong to any folders.’ (done)