### PR TITLE
Fix/misc UI fixes

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -117,7 +117,7 @@ const Header = ({
         showStagingWarningModal &&
         <GenericWarningModal
           displayTitle=""
-          displayText="Your changes may take some time to be reflected. <br/> Refresh your page to see if your changes have been built."
+          displayText="Your changes may take some time to be reflected. <br/> Refresh your staging site to see if your changes have been built."
           displayImg="/publishModal.svg"
           displayImgAlt="View Staging Modal Image"
           onProceed={handleViewStaging}

--- a/src/components/LoadingButton.jsx
+++ b/src/components/LoadingButton.jsx
@@ -9,6 +9,7 @@ export default function LoadingButton(props) {
     disabledStyle,
     className,
     callback,
+    showLoading,
     ...remainingProps
   } = props;
 
@@ -44,7 +45,7 @@ export default function LoadingButton(props) {
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...remainingProps}
     >
-      {isLoading
+      {isLoading || showLoading
         ? (
           <div className="spinner-border text-primary" role="status" />
         ) : label}
@@ -58,6 +59,7 @@ LoadingButton.propTypes = {
   disabledStyle: PropTypes.string,
   className: PropTypes.string.isRequired,
   callback: PropTypes.func.isRequired,
+  showLoading: PropTypes.bool,
 };
 
 LoadingButton.defaultProps = {

--- a/src/components/SaveDeleteButtons.jsx
+++ b/src/components/SaveDeleteButtons.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import LoadingButton from './LoadingButton'
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
-const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, isSaveDisabled, isDeleteDisabled, hasDeleteButton, saveCallback, deleteCallback }) => {
+const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, isSaveDisabled, isDeleteDisabled, hasDeleteButton, saveCallback, deleteCallback, isLoading }) => {
   const shouldDisableSave = isSaveDisabled ? isSaveDisabled : isDisabled
   const shouldDisableDelete = isDeleteDisabled ? isDeleteDisabled : isDisabled
   return (
@@ -16,6 +16,7 @@ const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, isSaveDisabled,
             disabledStyle={elementStyles.disabled}
             className={`ml-auto ${shouldDisableDelete ? elementStyles.disabled : elementStyles.warning}`}
             callback={deleteCallback}
+            showLoading={isLoading}
           />
         ) : null}
       <LoadingButton
@@ -24,6 +25,7 @@ const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, isSaveDisabled,
         disabledStyle={elementStyles.disabled}
         className={`${hasDeleteButton ? null : `ml-auto`} ${shouldDisableSave ? elementStyles.disabled : elementStyles.blue}`}
         callback={saveCallback}
+        showLoading={isLoading}
       />
       
     </div>
@@ -39,6 +41,7 @@ SaveDeleteButtons.propTypes = {
   hasDeleteButton: PropTypes.bool.isRequired,
   saveCallback: PropTypes.func.isRequired,
   deleteCallback: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
 };
 
 export default SaveDeleteButtons

--- a/src/components/SaveDeleteButtons.jsx
+++ b/src/components/SaveDeleteButtons.jsx
@@ -3,24 +3,26 @@ import PropTypes from 'prop-types';
 import LoadingButton from './LoadingButton'
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
-const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, hasDeleteButton, saveCallback, deleteCallback }) => {
+const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, isSaveDisabled, isDeleteDisabled, hasDeleteButton, saveCallback, deleteCallback }) => {
+  const shouldDisableSave = isSaveDisabled ? isSaveDisabled : isDisabled
+  const shouldDisableDelete = isDeleteDisabled ? isDeleteDisabled : isDisabled
   return (
     <div className={elementStyles.modalButtons}>
       { hasDeleteButton
         ? (
           <LoadingButton
             label={deleteLabel || 'Delete'}
-            disabled={isDisabled}
+            disabled={shouldDisableDelete}
             disabledStyle={elementStyles.disabled}
-            className={`ml-auto ${isDisabled ? elementStyles.disabled : elementStyles.warning}`}
+            className={`ml-auto ${shouldDisableDelete ? elementStyles.disabled : elementStyles.warning}`}
             callback={deleteCallback}
           />
         ) : null}
       <LoadingButton
         label={saveLabel || 'Save'}
-        disabled={isDisabled}
+        disabled={shouldDisableSave}
         disabledStyle={elementStyles.disabled}
-        className={`${hasDeleteButton ? null : `ml-auto`} ${isDisabled ? elementStyles.disabled : elementStyles.blue}`}
+        className={`${hasDeleteButton ? null : `ml-auto`} ${shouldDisableSave ? elementStyles.disabled : elementStyles.blue}`}
         callback={saveCallback}
       />
       
@@ -32,6 +34,8 @@ SaveDeleteButtons.propTypes = {
   saveLabel: PropTypes.string,
   deleteLabel: PropTypes.string,
   isDisabled: PropTypes.bool,
+  isSaveDisabled: PropTypes.bool,
+  isDeleteDisabled: PropTypes.bool,
   hasDeleteButton: PropTypes.bool.isRequired,
   saveCallback: PropTypes.func.isRequired,
   deleteCallback: PropTypes.func.isRequired,

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -64,7 +64,7 @@ const typeInfoDict = {
     icon: 'bx bx-buoy'
   },
   Guide: {
-    url: 'https://v2.isomer.gov.sg/',
+    url: 'https://go.gov.sg/isomercms-guide/',
     icon: 'bx bx-book'
   },
   Settings: {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -77,7 +77,7 @@ const typeInfoDict = {
 
 const Sidebar = ({ siteName, currPath }) => {
   const { setRedirectToLogout } = useRedirectHook()
-  const [lastUpdated, setLastUpdated] = useState('Updated 2 days ago')
+  const [lastUpdated, setLastUpdated] = useState('Updated')
   const [siteUrl, setSiteUrl] = useState()
   const { retrieveSiteUrl } = useSiteUrlHook()
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -107,7 +107,7 @@ const Sidebar = ({ siteName, currPath }) => {
     return () => {
       _isMounted = false
     }
-  }, [])
+  }, [siteName])
 
   useEffect(() => {
     if (lastUpdatedResp) setLastUpdated(lastUpdatedResp.lastUpdated)

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -129,7 +129,7 @@ const Sidebar = ({ siteName, currPath }) => {
       case 'Guide':
         return (
           <a
-            className={`px-4 py-3 h-100 w-100 font-weight-bold text-dark`}
+            className={`px-4 py-3 h-100 w-100 font-weight-bold text-dark ${elementStyles.noExtLink}`}
             href={typeInfoDict[title].url}
             target="_blank"
             rel="noopener noreferrer"
@@ -184,7 +184,7 @@ const Sidebar = ({ siteName, currPath }) => {
     const isActive = `/sites/${siteName}/${pathname}` === convertCollectionsPathToWorkspace(currPath, siteName)
     return (
       <li
-        className={`d-flex p-0 ${isActive ? styles.active : ''}`}
+        className={`d-flex p-0 ${isActive ? styles.active : ''} ${pathname === 'user' ? styles.noHover: ''}`}
         key={title}
       >
         {generateContent(title, siteName, pathname, isActive)}

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -179,7 +179,7 @@ export default class MediaSettingsModal extends Component {
             </div>
             <SaveDeleteButtons
               saveLabel={isPendingUpload ? "Upload" : "Save"}
-              isDisabled={isPendingUpload ? false : (errorMessage || !sha)}
+              isDisabled={isPendingUpload ? false : !sha}
               isSaveDisabled={isPendingUpload ? false : (fileName === this.state.newFileName || errorMessage || !sha)}
               hasDeleteButton={!isPendingUpload}
               saveCallback={this.saveFile}

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -127,6 +127,7 @@ export default class MediaSettingsModal extends Component {
     const {
       onClose, media, type, isPendingUpload, siteName,
     } = this.props;
+    const { fileName } = media
     const {
       newFileName,
       sha,
@@ -140,9 +141,7 @@ export default class MediaSettingsModal extends Component {
         <div className={elementStyles.modal}>
           <div className={elementStyles.modalHeader}>
             <h1>
-              Edit
-              { ' ' }
-              { type }
+              {isPendingUpload ? `Upload new ${type}` : `Edit ${type} details`}
             </h1>
             <button type="button" onClick={onClose}>
               <i className="bx bx-x" />
@@ -179,8 +178,9 @@ export default class MediaSettingsModal extends Component {
               />
             </div>
             <SaveDeleteButtons
-              saveLabel="Upload"
+              saveLabel={isPendingUpload ? "Upload" : "Save"}
               isDisabled={isPendingUpload ? false : (errorMessage || !sha)}
+              isSaveDisabled={isPendingUpload ? false : (fileName === this.state.newFileName || errorMessage || !sha)}
               hasDeleteButton={!isPendingUpload}
               saveCallback={this.saveFile}
               deleteCallback={() => this.setState({ canShowDeleteWarningModal: true })}

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -184,6 +184,7 @@ export default class MediaSettingsModal extends Component {
               hasDeleteButton={!isPendingUpload}
               saveCallback={this.saveFile}
               deleteCallback={() => this.setState({ canShowDeleteWarningModal: true })}
+              isLoading={!sha}
             />
           </form>
         </div>

--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -56,19 +56,19 @@ const NavElem = ({
 
   const generateTitle = () => {
     if (collection) {
-      return `Folder: ${title}`
+      return `${title}`
     }
     if (sublinks) {
-      return `Sublinks: ${title}`
+      return `${title}`
     }
     if (isResource) {
-      return `Resource: ${title}`
+      return `${title}`
     }
-    return `Page: ${title}`
+    return `${title}`
   }
 
   return (
-    <div className={`${elementStyles.card} ${!shouldDisplay && (!isEmpty(linkErrors) || !isEmpty(sublinkErrors)) ? elementStyles.error : ''}`}>
+    <div className={`${elementStyles.navCard} ${!shouldDisplay && (!isEmpty(linkErrors) || !isEmpty(sublinkErrors)) ? elementStyles.error : ''}`}>
       <div className={elementStyles.cardHeader}>
         <h2>
           {generateTitle()}
@@ -82,7 +82,7 @@ const NavElem = ({
           <>
             <div className={elementStyles.cardContent}>
               <FormField
-                title="Nav title"
+                title="Menu title"
                 id={`link-${linkIndex}-title`}
                 value={title}
                 isRequired
@@ -130,7 +130,7 @@ const NavElem = ({
               }
             </div>
             <div className={elementStyles.inputGroup}>
-              <button type="button" id={`link-${linkIndex}-delete`} className={`ml-auto ${elementStyles.warning}`} onClick={deleteHandler}>Delete link</button>
+              <button type="button" id={`link-${linkIndex}-delete`} className={`ml-auto ${elementStyles.warning}`} onClick={deleteHandler}>Delete Menu</button>
             </div>
           </>
         )
@@ -183,7 +183,7 @@ const NavSection = ({
     },
     {
       value: 'sublinkLink',
-      label: 'Sublinks',
+      label: 'Submenu',
     },
   ]
   return (
@@ -198,7 +198,7 @@ const NavSection = ({
           >
             { (links && links.length > 0)
               ? <>
-                  <b>Links</b>
+                  <b>Menu</b>
                   {links.map((link, linkIndex) => (
                     <Draggable
                       draggableId={`link-${linkIndex}-draggable`}
@@ -241,7 +241,7 @@ const NavSection = ({
           </div>
         )}
       </Droppable>
-      <div className='d-flex justify-content-between'>
+      <div className='d-flex justify-content-between mt-4'>
         <Select
           ref={selectInputRef}
           className='w-50'
@@ -249,10 +249,10 @@ const NavSection = ({
           placeholder={"Select link type..."}
           options={sectionCreationOptions}
         />
-        <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Link</button>
+        <button type="button" className={newSectionType ? elementStyles.blue: elementStyles.disabled} onClick={sectionCreationHandler} disabled={!newSectionType}>Create New Menu</button>
       </div>
       <span className={elementStyles.info}>
-        {`Note: you can specify a folder ${hasResourceRoom ? `or resource room ` : ``}to automatically populate its links. ${hasResourceRoom ? `Only one resource room link is allowed. ` : ``}Select "Sublinks" if you want to specify your own links.`}
+        {`Note: you can specify a folder ${hasResourceRoom ? `or resource room ` : ``}to automatically populate its links. ${hasResourceRoom ? `Only one resource room link is allowed. ` : ``}Select "Submenu" if you want to specify your own links.`}
       </span>
     </>
   )

--- a/src/components/navbar/NavSublinkSection.jsx
+++ b/src/components/navbar/NavSublinkSection.jsx
@@ -17,7 +17,7 @@ const SublinkElem = ({
   displayHandler,
   errors,
 }) => (
-  <div className={`${elementStyles.card} ${!shouldDisplay && !isEmpty(errors) ? elementStyles.error : ''}`}>
+  <div className={`${elementStyles.navCard} ${!shouldDisplay && !isEmpty(errors) ? elementStyles.error : ''}`}>
     <div className={elementStyles.cardHeader}>
       <h2>
         {title}
@@ -31,7 +31,7 @@ const SublinkElem = ({
         <>
           <div className={elementStyles.cardContent}>
             <FormField
-              title="Sublink title"
+              title="Submenu title"
               id={`sublink-${linkIndex}-${sublinkIndex}-title`}
               value={title}
               isRequired
@@ -39,7 +39,7 @@ const SublinkElem = ({
               errorMessage={errors.title}
             />
             <FormField
-              title="Sublink URL"
+              title="Submenu URL"
               id={`sublink-${linkIndex}-${sublinkIndex}-url`}
               value={url}
               isRequired
@@ -48,7 +48,7 @@ const SublinkElem = ({
             />
           </div>
           <div className={elementStyles.inputGroup}>
-            <button type="button" id={`sublink-${linkIndex}-${sublinkIndex}-delete`} className={`ml-auto ${elementStyles.warning}`} onClick={deleteHandler}>Delete sublink</button>
+            <button type="button" id={`sublink-${linkIndex}-${sublinkIndex}-delete`} className={`ml-auto ${elementStyles.warning}`} onClick={deleteHandler}>Delete Submenu</button>
           </div>
         </>
       )
@@ -76,7 +76,7 @@ const NavSublinkSection = ({
       >
         { (sublinks && sublinks.length > 0)
           ? <>
-              <b>Sublinks</b>
+              <b>Submenu</b>
               {sublinks.map((sublink, sublinkIndex) => (
                 <Draggable
                   draggableId={`sublink-${linkIndex}-${sublinkIndex}-draggable`}
@@ -110,7 +110,7 @@ const NavSublinkSection = ({
             </>
           : null}
         {droppableProvided.placeholder}
-        <button type="button" id={`sublink-${linkIndex}-${sublinks.length}-create`} className={`ml-auto ${elementStyles.blue}`} onClick={createHandler}>Create Sublink</button>
+        <button type="button" id={`sublink-${linkIndex}-${sublinks.length}-create`} className={`ml-auto mt-4 ${elementStyles.blue}`} onClick={createHandler}>Create Submenu</button>
       </div>
     )}
   </Droppable>

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -604,7 +604,7 @@ const EditNavBar =  ({ match }) => {
       }
       <Header
         siteName={siteName}
-        title={"Nav Bar"}
+        title={"Navigation Bar"}
         shouldAllowEditPageBackNav={!hasChanges()}
         isEditPage={true}
         backButtonText="Back to My Workspace"

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -61,28 +61,28 @@ const EditNavBar =  ({ match }) => {
   const [deletedLinks, setDeletedLinks] = useState('')
 
   const LinkCollectionSectionConstructor = () => ({
-    title: 'Link Title',
+    title: 'Menu Title',
     collection: collections[0],
   });
   
   const LinkResourceSectionConstructor = () => ({
-    title: 'Link Title',
+    title: 'Menu Title',
     resource_room: true,
   });
 
   const LinkPageSectionConstructor = () => ({
-    title: 'Link Title',
+    title: 'Menu Title',
     url: '/permalink',
   });
 
   const LinkSublinkSectionConstructor = () => ({
-    title: 'Link Title',
+    title: 'Menu Title',
     url: '/permalink',
     sublinks: [],
   });
 
   const SublinkSectionConstructor = () => ({
-    title: 'Sublink Title',
+    title: 'Submenu Title',
     url: '/permalink'
   });
 

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -320,12 +320,12 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
 
   const stageFileForUpload = (fileName, fileData) => {
     const baseFolder = type === 'file' ? 'files' : 'images';
-    setIsFileStagedForUpload(true)
     setStagedFileDetails({
       path: `${baseFolder}%2F${fileName}`,
       content: fileData,
       fileName,
     })
+    setIsFileStagedForUpload(true)
   }
 
   const readFileToStageUpload = async (event) => {

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -100,6 +100,10 @@ export default class Settings extends Component {
     try {
       const { match } = this.props;
       const { siteName } = match.params;
+      if (this._isMounted) this.setState((currState) => ({
+        ...currState,
+        siteName,
+      }))
 
       // get settings data from backend
       const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`, {
@@ -143,7 +147,6 @@ export default class Settings extends Component {
       // set state properly
       if (this._isMounted) this.setState((currState) => ({
         ...currState,
-        siteName,
         originalState: _.cloneDeep(originalState),
         ...originalState,
       }));

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -76,3 +76,9 @@ i {
   font-size: 14px;
   margin-bottom: 1.5rem;
 }
+
+.noExtLink {
+  &:after {
+    display:none !important;
+  }
+}

--- a/src/styles/isomer-cms/elements/card.scss
+++ b/src/styles/isomer-cms/elements/card.scss
@@ -232,3 +232,8 @@
     text-align: center;
   }
 }
+
+.navCard {
+  @extend .card;
+  margin-bottom: 0rem;
+}

--- a/src/styles/isomer-cms/pages/Admin.module.scss
+++ b/src/styles/isomer-cms/pages/Admin.module.scss
@@ -64,6 +64,12 @@
           border-left: 5px solid $isomer-blue;
         }
       }
+
+      .noHover {
+        &:hover{
+          background:none;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes a range of UI issues brought up in the recent [UX review](https://docs.google.com/document/d/1_aC5FuHqSQqqWx0aOcpDFyw2iEk1vsCpDgt4fLQ1zck/edit#bookmark=id.tae0sux04cgu).

The changes made in this PR are:
- **Top Nav Bar**
  - [Copy changes] Modal copy: Second sentence can change to ‘Refresh your staging site to see if your changes have been built’
- **Side Nav Bar**
  - The Settings tab sets the sitename first, so there is no more jumping of the sidebar when moving to settings.
  - The external link icons have been removed from Guide and Help
  - The hover state for the logged in as tab has been removed
- **Images/Files Modal**
  - [Copy changes] Modal title (it’s important for the title to reflect the intent of the task)
    - When user is uploading a new image, modal title should say ‘Upload new image’
    - When user is editing file name, modal title should say ‘Edit image details’
  - [Copy changes] At ‘Edit image details’ modal, change the button name ‘Upload’ to ‘Save’. It should be disabled first, only when the filename is changed, ‘Save’ button becomes blue.
- **EditPage Upload Image Modal**
  - Fixed bug preventing upload of images
- **EditNavBar**
  - Header: Spell out ‘Nav Bar’ to ‘Navigation Bar’
  - Replace `Links` with `Menu` and `Sublinks` with `Submenu`
    - Title: ‘Links’ should be called ‘Menu’.
    - Remove ‘Sublinks’ in the card title ‘Sublinks: Start Business’. Menu cards should just show the Menu titles aka ‘Start Business’ 
    - Title: ‘Sublinks’ should be ‘Submenu’
    - Input text field: ‘Nav title’ should be ‘Menu title’
    - Input text field: ‘Sublink title’ should be ‘Submenu title’
    - Button: ‘Delete link’ change to ‘Delete Menu’
    - Button: ‘Delete sublink’ change to ‘Delete Submenu’
  - Tighten the spacing between the cards



