### PR TITLE
Fix/folder naming copy ux

### DIFF
--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -177,7 +177,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource, r
                 && (
                     <GenericWarningModal
                         displayTitle="Warning"
-                        displayText="Moving a page to a different collection might lead to user confusion. You may wish to change the permalink for this page afterwards."
+                        displayText="Moving a page to a different folder might lead to user confusion. You may wish to change the permalink for this page afterwards."
                         onProceed={moveHandler}
                         onCancel={() => {
                             setCanShowMoveModal(false)

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -129,8 +129,8 @@ const FolderCard = ({
     <>
       { isFolderModalOpen &&
         <FolderModal
-          displayTitle={pageType === 'collection' ? 'Rename Collection' : 'Rename Resource Category'}
-          displayText={pageType === 'collection' ? 'Collection name' : "Resource category name"}
+          displayTitle={pageType === 'collection' ? 'Rename Folder' : 'Rename Category'}
+          displayText={pageType === 'collection' ? 'Folder name' : "Category name"}
           onClose={() => setIsFolderModalOpen(false)}
           folderOrCategoryName={category}
           siteName={siteName}

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -26,6 +26,7 @@ const FolderCard = ({
   category,
   selectedIndex,
   onClick,
+  existingFolders,
 }) => {
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
   const [canShowDropdown, setCanShowDropdown] = useState(false)
@@ -135,6 +136,7 @@ const FolderCard = ({
           folderOrCategoryName={category}
           siteName={siteName}
           isCollection={pageType === 'collection'}
+          existingFolders={existingFolders}
         />
       }
       { canShowDeleteWarningModal &&

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -134,7 +134,7 @@ const FolderCreationModal = ({
               </div>
               <div className={`d-flex justify-content-between w-100`}>
                 <span>Pages</span>
-                <span className={`w-25 ${contentStyles.segment}`}>
+                {/* <span className={`w-25 ${contentStyles.segment}`}>
                   <span className={elementStyles.sortLabel}>
                     {`Sort by `}
                   </span>
@@ -150,7 +150,7 @@ const FolderCreationModal = ({
                     }
                     options={sortOptions}
                   />
-                </span>
+                </span> */}
               </div>
               <br/>
               {/* Pages */}

--- a/src/components/FolderCreationModal.jsx
+++ b/src/components/FolderCreationModal.jsx
@@ -97,7 +97,7 @@ const FolderCreationModal = ({
 
   const sortFuncs = {
     'title': (a, b) => {
-      return a.fileName.localeCompare(b.fileName)
+      return a.name.localeCompare(b.name)
     }
   }
 
@@ -160,15 +160,15 @@ const FolderCreationModal = ({
                     sortedPagesData && sortedPagesData.length > 0
                     ? sortedPagesData.map((pageData, pageIdx) => (
                           <FolderCard
-                              displayText={deslugifyPage(pageData.fileName)}
+                              displayText={deslugifyPage(pageData.name)}
                               settingsToggle={() => {}}
-                              key={pageData.fileName}
+                              key={pageData.name}
                               pageType={"file"}
                               siteName={siteName}
                               itemIndex={pageIdx}
-                              selectedIndex={selectedFiles[pageData.fileName]}
+                              selectedIndex={selectedFiles[pageData.name]}
                               onClick={() => {
-                                  fileSelectChangeHandler(pageData.fileName)
+                                  fileSelectChangeHandler(pageData.name)
                               }}
                           />
                     ))

--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -18,6 +18,7 @@ import {
   deslugifyDirectory,
 } from '../utils'
 
+import { validateCategoryName } from '../utils/validators'
 import { errorToast } from '../utils/toasts';
 
 // axios settings
@@ -51,8 +52,9 @@ const selectRenameApiCall = (isCollection, siteName, folderOrCategoryName, subfo
   return renameResourceCategory(params)
 }
 
-const FolderModal = ({ displayTitle, displayText, onClose, folderOrCategoryName, subfolderName, siteName, isCollection }) => {
+const FolderModal = ({ displayTitle, displayText, onClose, folderOrCategoryName, subfolderName, siteName, isCollection, existingFolders }) => {
   const [newDirectoryName, setNewDirectoryName] = useState(deslugifyDirectory(subfolderName || folderOrCategoryName))
+  const [errors, setErrors] = useState('')
 
   // rename folder/subfolder/resource category
   const { mutateAsync: renameDirectory } = useMutation(
@@ -65,6 +67,9 @@ const FolderModal = ({ displayTitle, displayText, onClose, folderOrCategoryName,
 
   const folderNameChangeHandler = (event) => {
     const { value } = event.target
+    const comparisonCategoryArray = subfolderName ? existingFolders.filter(name => name !== subfolderName) : existingFolders.filter(name => name !== folderOrCategoryName)
+    let errorMessage = validateCategoryName(value, isCollection ? 'page' : 'resource', comparisonCategoryArray)
+    setErrors(errorMessage)
     setNewDirectoryName(value)
   }
 
@@ -85,6 +90,7 @@ const FolderModal = ({ displayTitle, displayText, onClose, folderOrCategoryName,
             id="newDirectoryName"
             value={newDirectoryName}
             onFieldChange={folderNameChangeHandler}
+            errorMessage={errors}
           />
           <SaveDeleteButtons
             isDisabled={false}

--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -15,7 +15,9 @@ import {
 import {
   DEFAULT_RETRY_MSG,
   slugifyCategory,
+  deslugifyDirectory,
 } from '../utils'
+
 import { errorToast } from '../utils/toasts';
 
 // axios settings
@@ -50,7 +52,7 @@ const selectRenameApiCall = (isCollection, siteName, folderOrCategoryName, subfo
 }
 
 const FolderModal = ({ displayTitle, displayText, onClose, folderOrCategoryName, subfolderName, siteName, isCollection }) => {
-  const [newDirectoryName, setNewDirectoryName] = useState(subfolderName || folderOrCategoryName)
+  const [newDirectoryName, setNewDirectoryName] = useState(deslugifyDirectory(subfolderName || folderOrCategoryName))
 
   // rename folder/subfolder/resource category
   const { mutateAsync: renameDirectory } = useMutation(

--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -25,6 +25,7 @@ import { errorToast } from '../utils/toasts';
 axios.defaults.withCredentials = true
 
 const selectRenameApiCall = (isCollection, siteName, folderOrCategoryName, subfolderName, newDirectoryName) => {
+  if (slugifyCategory(newDirectoryName) === subfolderName || slugifyCategory(newDirectoryName) === folderOrCategoryName ) return
   if (isCollection && !subfolderName) {
     const params = {
       siteName,

--- a/src/components/FolderNamingModal.jsx
+++ b/src/components/FolderNamingModal.jsx
@@ -27,13 +27,6 @@ const FolderNamingModal = ({
       <div className={elementStyles.modalContent}>
         <div>
           {`You may edit ${folderType} name anytime.`}
-          {
-            folderType !== 'resource' &&
-            <>
-              <br/>
-              Choose the pages you would like to group.
-            </>
-          }
         </div>
         <div className={elementStyles.modalFormFields}>
           {/* Title */}

--- a/src/layouts/CategoryPages.jsx
+++ b/src/layouts/CategoryPages.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-query';
+import { Link } from 'react-router-dom';
 
 // Import components
 import Header from '../components/Header';
@@ -103,6 +104,18 @@ const CategoryPages = ({ match, location, isResource }) => {
               {/* Collection title */}
               <div className={contentStyles.sectionHeader}>
                   <h1 className={contentStyles.sectionTitle}>{deslugifyDirectory(collectionName)}</h1>
+              </div>
+              <div className={contentStyles.segment}>
+                <span>
+                    <Link to={`/sites/${siteName}/resources`}><strong>Resources</strong></Link> > 
+                    {
+                        collectionName 
+                        ? (
+                            <span><strong className="ml-1"> {deslugifyDirectory(collectionName)}</strong></span>
+                        )
+                        : null
+                    }
+                </span>
               </div>
               {/* Collection pages */}
               <CollectionPagesSection

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -312,7 +312,7 @@ const Folders = ({ match, location }) => {
             && (
               <GenericWarningModal
                 displayTitle="Warning"
-                displayText="Moving a page to a different collection might lead to user confusion. You may wish to change the permalink for this page afterwards."
+                displayText="Moving a page to a different folder might lead to user confusion. You may wish to change the permalink for this page afterwards."
                 onProceed={moveHandler}
                 onCancel={() => {
                 setIsMoveModalActive(false)
@@ -341,7 +341,7 @@ const Folders = ({ match, location }) => {
               {/* Info segment */}
               <div className={contentStyles.segment}>
                 <i className="bx bx-sm bx-bulb text-dark" />
-                <span><strong className="ml-1">Pro tip:</strong> You can make a new section by creating sub folders</span>
+                <span><strong className="ml-1">Pro tip:</strong> You can make a new section by creating subfolders</span>
               </div>
               {/* Segment divider  */}
               <div className={contentStyles.segmentDividerContainer}>
@@ -350,7 +350,7 @@ const Folders = ({ match, location }) => {
               {/* Collections title */}
               <div className={contentStyles.segment}>
                 <span>
-                    My workspace >
+                    <Link to={`/sites/${siteName}/workspace`}><strong>Workspace</strong></Link> > 
                     {
                         folderName
                         ? (
@@ -373,7 +373,7 @@ const Folders = ({ match, location }) => {
               <div className={contentStyles.contentContainerFolderRowMargin}>
                 <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" id="pageSettings-new" onClick={() => setIsPageSettingsActive((prevState) => !prevState)}/>
-                <FolderOptionButton title="Create new sub-folder" option="create-sub" isDisabled={subfolderName || isLoadingDirectory ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
+                <FolderOptionButton title="Create new subfolder" option="create-sub" isDisabled={subfolderName || isLoadingDirectory ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
               {/* Collections content */}
               {

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -292,7 +292,8 @@ const Folders = ({ match, location }) => {
                 folderOrCategoryName={folderName}
                 subfolderName={selectedPage}
                 siteName={siteName}
-                isCollection
+                isCollection={true}
+                existingFolders={folderOrderArray.filter(item => item.type === 'dir').map(item => item.name)}
               />
             )
           }

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -179,6 +179,7 @@ const Resources = ({ match, location }) => {
                                   siteName={siteName}
                                   category={resourceCategory}
                                   itemIndex={collectionIdx}
+                                  existingFolders={resourceFolderNames}
                                 />
                               ))
                             : null

--- a/src/layouts/Resources.jsx
+++ b/src/layouts/Resources.jsx
@@ -127,7 +127,7 @@ const Resources = ({ match, location }) => {
             folderNameChangeHandler={folderNameChangeHandler}
             title={newFolderName}
             errors={folderNameErrors}
-            folderType='resource'
+            folderType='category'
             proceedText='Save'
           />
         </div>

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -97,6 +97,7 @@ const Workspace = ({ match, location }) => {
                 const newPage = { 
                   ...page,
                   title: page.fileName,
+                  name: page.fileName,
                 }
                 return newPage
               })}

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -186,6 +186,7 @@ const Workspace = ({ match, location }) => {
                             siteName={siteName}
                             category={collection}
                             itemIndex={collectionIdx}
+                            existingFolders={collections}
                         />
                     ))
                     : null

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -22,7 +22,7 @@ const alphabetsRegexTest = RegExp(ALPHABETS_ONLY_REGEX);
 const alphanumericRegexTest = RegExp(ALPHANUMERICS_ONLY_REGEX);
 const fileNameRegexTest = /^[a-zA-Z0-9" "_-]+$/;
 const fileNameExtensionRegexTest = /^[a-zA-z]{3,4}$/;
-const RESOURCE_CATEGORY_REGEX = '^([a-zA-Z0-9]+[- ])*[a-zA-Z0-9]+$';
+const RESOURCE_CATEGORY_REGEX = '^([a-zA-Z0-9]*[- ]?)+$';
 const resourceRoomNameRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX);
 
@@ -791,7 +791,7 @@ const validateCategoryName = (value, componentName, existingNames) => {
   }
   // Resource category fails regex
   else if (!resourceCategoryRegexTest.test(value)) {
-    errorMessage = `The ${componentName} category should only have alphanumeric characters separated by hypens or spaces.`;
+    errorMessage = `The ${componentName} category should not contain special characters such as: ?!#\\$%.`;
   }
 
   return errorMessage;


### PR DESCRIPTION
This PR addresses a number of miscellaneous copy and UX bugs to do with Folder/Resource Creation & Folder/Resource Renaming, and the Folders/ Resources/ Category pages, based on the designers' review linked [here](https://docs.google.com/document/d/1_aC5FuHqSQqqWx0aOcpDFyw2iEk1vsCpDgt4fLQ1zck/edit#)

A list of the changes accomplished:
- Copy changes 
- Adds validation to check for duplicated names during Folder & Subfolder & Resource renaming
- Suppresses API call for renaming if no change in name
- Fixes bug with creation of Subfolder
- Relaxes Resource & Folder name regex
- Adds Breadcrumb to CategoryPages