### PR TITLE
fix: add resourceRoomName and resourceName to breadcrumb

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -67,13 +67,14 @@ const getMovePageEndpoint = ({siteName, resourceName, folderName, subfolderName,
 const getEditPageData = async ({folderName, subfolderName, fileName, siteName, resourceName}) => {
     const apiEndpoint = getPageApiEndpoint({folderName, subfolderName, fileName, siteName, resourceName})
     const resp = await axios.get(apiEndpoint);
-    const { content:pageContent, sha:pageSha } = resp.data;
+    const { content:pageContent, sha:pageSha, resourceRoomName } = resp.data;
     
     if (!pageContent) return
 
     return {
         pageContent,
         pageSha,
+        resourceRoomName,
     }
 }
 

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -118,6 +118,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
   const [mediaSearchTerm, setMediaSearchTerm] = useState('')
   const [selectedFile, setSelectedFile] = useState('')
   const [leftNavPages, setLeftNavPages] = useState([])
+  const [resourceRoomName, setResourceRoomName] = useState('')
   const [isCspViolation, setIsCspViolation] = useState(false)
   const [chunk, setChunk] = useState('')
 
@@ -218,6 +219,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
       const {
         pageContent,
         pageSha,
+        resourceRoomName,
       } = pageData
       const {
         netlifyTomlHeaderValues
@@ -250,6 +252,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
         setEditorValue(retrievedMdBody.trim())
         setFrontMatter(retrievedFrontMatter)
         setLeftNavPages(generatedLeftNavPages)
+        setResourceRoomName(resourceRoomName || '')
         setIsLoadingPageContent(false)
       }
     }
@@ -466,6 +469,8 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
                 chunk={chunk}
                 title={title}
                 date={date}
+                resourceRoomName={deslugifyDirectory(resourceRoomName)}
+                collection={resourceName}
               />
             )
           }

--- a/src/templates/SimplePage.jsx
+++ b/src/templates/SimplePage.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import PageHeader from './pageComponents/PageHeader';
 
 // This following template was taken from the 'Simple Page'
-const SimplePage = ({ chunk, title, date }) => (
+const SimplePage = ({ chunk, title, date, collection, resourceRoomName }) => (
   <div>
-    <PageHeader title={title} date={date}/>
+    <PageHeader title={title} date={date} collection={collection} resourceRoomName={resourceRoomName}/>
     <section className="bp-section">
       <div className="bp-container content padding--top--lg padding--bottom--xl">
         <div className="row">

--- a/src/templates/pageComponents/Breadcrumb.jsx
+++ b/src/templates/pageComponents/Breadcrumb.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Breadcrumb = ({ title, collection }) => (
+const Breadcrumb = ({ title, collection, resourceRoomName }) => (
   <nav className="bp-breadcrumb" aria-label="breadcrumbs">
     <ul>
       <li><small><a>HOME</a></small></li>
+      { resourceRoomName ? (
+        <li><small><a>{ resourceRoomName.toUpperCase() }</a></small></li>
+      ) : null}
       { collection ? (
         <li><small><a>{ collection.toUpperCase() }</a></small></li>
       ) : null}

--- a/src/templates/pageComponents/PageHeader.jsx
+++ b/src/templates/pageComponents/PageHeader.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Breadcrumb from './Breadcrumb';
 
-const PageHeader = ({ title, date, collection }) => (
+const PageHeader = ({ title, date, collection, resourceRoomName }) => (
   <section className="bp-section is-small bp-section-pagetitle">
     <div className="bp-container page-header-container">
     <div className="row">
         <div className="col">
-        <Breadcrumb title={ title } collection={ collection } />
+        <Breadcrumb title={ title } collection={ collection } resourceRoomName={ resourceRoomName } />
         </div>
     </div>
     </div>


### PR DESCRIPTION
This PR adds `resourceRoomName` and `resourceName` as a breadcrumb for resource pages, so that the `EditPage` preview shows an accurate breadcrumb similar to that on the actual Isomer site. This PR should be reviewed with [#153](https://github.com/isomerpages/isomercms-backend/pull/153) on the backend.