### PR TITLE
Fix: remove loading spinner for images/files which are being uploaded

### DIFF
--- a/src/components/SaveDeleteButtons.jsx
+++ b/src/components/SaveDeleteButtons.jsx
@@ -4,8 +4,8 @@ import LoadingButton from './LoadingButton'
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 
 const SaveDeleteButtons = ({ saveLabel, deleteLabel, isDisabled, isSaveDisabled, isDeleteDisabled, hasDeleteButton, saveCallback, deleteCallback, isLoading }) => {
-  const shouldDisableSave = isSaveDisabled ? isSaveDisabled : isDisabled
-  const shouldDisableDelete = isDeleteDisabled ? isDeleteDisabled : isDisabled
+  const shouldDisableSave = (isSaveDisabled !== undefined) ? isSaveDisabled : isDisabled
+  const shouldDisableDelete = (isDeleteDisabled !== undefined) ? isDeleteDisabled : isDisabled
   return (
     <div className={elementStyles.modalButtons}>
       { hasDeleteButton

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -184,7 +184,7 @@ export default class MediaSettingsModal extends Component {
               hasDeleteButton={!isPendingUpload}
               saveCallback={this.saveFile}
               deleteCallback={() => this.setState({ canShowDeleteWarningModal: true })}
-              isLoading={!sha}
+              isLoading={isPendingUpload ? false : !sha}
             />
           </form>
         </div>


### PR DESCRIPTION
This PR fixes 2 minor bugs:
- The loading spinner when uploading new files/images has been removed
- SaveDelete buttons now correctly take state of save/delete variable if specified