### PR TITLE
Revert "Feat/nested images functionality"

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -150,7 +150,7 @@ function App() {
                     <ProtectedRouteWithProps exact path="/sites/:siteName/navbar" component={EditNavBar} />
                     <ProtectedRouteWithProps path="/sites/:siteName/files/:fileName" component={EditFile} />
                     <ProtectedRouteWithProps path="/sites/:siteName/files" component={Files} />
-                    <ProtectedRouteWithProps path="/sites/:siteName/images/:customPath" component={Images} />
+                    <ProtectedRouteWithProps path="/sites/:siteName/images/:fileName" component={EditImage} />
                     <ProtectedRouteWithProps path="/sites/:siteName/images" component={Images} />
                     <ProtectedRouteWithProps path="/sites/:siteName/pages/:fileName" component={EditPage} isCollectionPage={false} isResourcePage={false} />
                     <ProtectedRouteWithProps path="/sites/:siteName/workspace" component={Workspace} />

--- a/src/api.js
+++ b/src/api.js
@@ -240,24 +240,6 @@ const moveFile = async ({selectedFile, siteName, resourceName, folderName, subfo
     return await axios.post(apiEndpoint, params)
 }
 
-const getImages = async (siteName, customPath) => {
-    const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/files/${customPath ? encodeURIComponent(`images/${customPath}`) : 'images'}`);
-    const { directoryContents } = resp.data;
-
-    let respImages = []
-    let respDirectories = []
-    directoryContents.forEach((fileOrDir) => {
-        const modifiedFileOrDir = { ...fileOrDir, fileName: fileOrDir.name }
-        if (fileOrDir.type === 'file') respImages.push(modifiedFileOrDir)
-        if (fileOrDir.type === 'dir') respDirectories.push(modifiedFileOrDir)
-    })
-
-    return {
-        respImages,
-        respDirectories,
-    }
-}
-
 export {
     getDirectoryFile,
     setDirectoryFile,
@@ -281,5 +263,4 @@ export {
     getAllCategories,
     moveFiles,
     moveFile,
-    getImages,
 }

--- a/src/components/FolderCard.jsx
+++ b/src/components/FolderCard.jsx
@@ -25,7 +25,6 @@ const FolderCard = ({
   siteName,
   category,
   selectedIndex,
-  linkPath,
   onClick,
   existingFolders,
 }) => {
@@ -50,8 +49,6 @@ const FolderCard = ({
         return `/sites/${siteName}/contact-us`
       case 'nav':
         return `/sites/${siteName}/navbar`
-      case 'media':
-        return `/sites/${siteName}/${linkPath}`
       default:
         return ''
     }
@@ -175,8 +172,6 @@ FolderCard.propTypes = {
   itemIndex: PropTypes.number,
   pageType: PropTypes.string.isRequired,
   siteName: PropTypes.string.isRequired,
-  category: PropTypes.string,
-  linkPath: PropTypes.string,
 };
 
 export default FolderCard;

--- a/src/components/folders/FolderOptionButton.jsx
+++ b/src/components/folders/FolderOptionButton.jsx
@@ -8,7 +8,6 @@ const iconSelection = {
     'rearrange': 'bx-sort',
     'create-page': 'bx-file-blank',
     'create-sub': 'bx-folder',
-    'upload-image': 'bx-plus-circle',
 }
 
 

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -15,11 +15,6 @@ import { errorToast } from '../../utils/toasts';
 import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 
-const generateImageorFilePath = (customPath, fileName) => {
-  if (customPath) return encodeURIComponent(`${customPath}/${fileName}`)
-  return fileName
-}
-
 export default class MediaSettingsModal extends Component {
   constructor(props) {
     super(props);
@@ -34,7 +29,7 @@ export default class MediaSettingsModal extends Component {
 
   async componentDidMount() {
     const {
-      siteName, customPath, media, isPendingUpload, type,
+      siteName, media, isPendingUpload, type,
     } = this.props;
     const { fileName } = media;
 
@@ -44,16 +39,9 @@ export default class MediaSettingsModal extends Component {
       return;
     }
 
-    let sha, content
-    try {
-      const { data } = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'image' ? 'images' : 'documents'}/${generateImageorFilePath(customPath, fileName)}`, {
-        withCredentials: true,
-      });
-      sha = data.sha
-      content = data.content
-    } catch (err) {
-      errorToast(`We were unable to retrieve data on your image file. ${DEFAULT_RETRY_MSG}`)
-    }
+    const { data: { sha, content } } = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'image' ? 'images' : 'documents'}/${fileName}`, {
+      withCredentials: true,
+    });
     this.setState({ sha, content });
   }
 
@@ -64,7 +52,6 @@ export default class MediaSettingsModal extends Component {
   saveFile = async () => {
     const {
       siteName,
-      customPath,
       media: { fileName },
       isPendingUpload,
       type,
@@ -80,7 +67,6 @@ export default class MediaSettingsModal extends Component {
 
         if (type === 'image') {
           params.imageName = newFileName;
-          params.imageDirectory = `images${customPath ? `/${customPath}` : ''}`;
         } else {
           params.documentName = newFileName;
         }
@@ -98,7 +84,7 @@ export default class MediaSettingsModal extends Component {
         if (newFileName === fileName) {
           return;
         }
-        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'image' ? 'images' : 'documents'}/${generateImageorFilePath(customPath, fileName)}/rename/${generateImageorFilePath(customPath, newFileName)}`, params, {
+        await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'image' ? 'images' : 'documents'}/${fileName}/rename/${newFileName}`, params, {
           withCredentials: true,
         });
       }

--- a/src/layouts/Images.jsx
+++ b/src/layouts/Images.jsx
@@ -1,120 +1,62 @@
-import React, { useEffect, useState } from 'react';
-import _ from 'lodash';
+import React, { Component } from 'react';
+import axios from 'axios';
 import PropTypes from 'prop-types';
-import { useQuery } from 'react-query';
-import { ReactQueryDevtools } from 'react-query/devtools';
-
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
-import FolderCard from '../components/FolderCard'
-import FolderOptionButton from '../components/folders/FolderOptionButton'
-import MediaCard from '../components/media/MediaCard';
-import MediaSettingsModal from '../components/media/MediaSettingsModal';
-
-import { getImages } from '../api';
-
-import useRedirectHook from '../hooks/useRedirectHook';
-
-import { deslugifyDirectory } from '../utils';
-import { errorToast } from '../utils/toasts';
-
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 import mediaStyles from '../styles/isomer-cms/pages/Media.module.scss';
+import MediaUploadCard from '../components/media/MediaUploadCard';
+import MediaCard from '../components/media/MediaCard';
+import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
-// Constants
-const IMAGE_CONTENTS_KEY = 'image-contents'
+export default class Images extends Component {
+  _isMounted = false
 
-const getPrevDirectoryPath = (customPath) => {
-  const customPathArr = customPath.split('%2F')
-
-  let prevDirectoryPath
-  if (customPathArr.length > 1) {
-    prevDirectoryPath = `images/${customPathArr
-      .slice(0, -1) // remove the latest directory
-      .join('/')}`
-  }
-  else {
-    prevDirectoryPath = 'images'
-  }
-
-  return prevDirectoryPath
-}
-
-const getPrevDirectoryName = (customPath) => {
-  const customPathArr = customPath.split('%2F')
-
-  let prevDirectoryName
-  if (customPathArr.length > 1) {
-    prevDirectoryName = customPathArr[customPathArr.length - 2]
-  }
-  else {
-    prevDirectoryName = 'Images'
+  constructor(props) {
+    super(props);
+    this.state = {
+      images: [],
+      chosenImage: null,
+      pendingImageUpload: null,
+    };
   }
 
-  return deslugifyDirectory(prevDirectoryName)
-}
-
-const Images = ({ match: { params: { siteName, customPath } }, location }) => {
-  const [images, setImages] = useState([])
-  const [directories, setDirectories] = useState([])
-  const [pendingImageUpload, setPendingImageUpload] = useState(null)
-  const [chosenImage, setChosenImage] = useState('')
-  const { setRedirectToNotFound } = useRedirectHook()
-
-  const { data: imageData, refetch } = useQuery(
-    IMAGE_CONTENTS_KEY,
-    () => getImages(siteName, customPath ? decodeURIComponent(customPath): ''),
-    {
-      retry: false,
-      onError: (err) => {
-        if (err.response && err.response.status === 404) {
-          setRedirectToNotFound(siteName)
-        } else {
-          errorToast()
-        }
-      }
-    },
-  )
-
-  useEffect(() => {
-    let _isMounted = true
-
-    if (imageData) {
-      const {
-        respImages,
-        respDirectories,
-      } = imageData
-
-      if (_isMounted) {
-        setImages(respImages)
-        setDirectories(respDirectories)
-      }
-    }
-
-    return () => {
-      _isMounted = false
-    }
-  }, [imageData])
-
-  useEffect(() => {
-    refetch()
-  }, [customPath])
-
-  const uploadImage = async (imageName, imageContent) => {
+  async componentDidMount() {
+    this._isMounted = true
     try {
-      // toggle state so that image renaming modal appears
-      setPendingImageUpload({
-        fileName: imageName,
-        path: `images%2F${imageName}`,
-        content: imageContent,
-      })
+      const { match } = this.props;
+      const { siteName } = match.params;
+      const resp = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/images`, {
+        withCredentials: true,
+      });
+      const { images } = resp.data;
+      if (this._isMounted) this.setState({ images });
     } catch (err) {
       console.log(err);
     }
   }
 
-  const onImageSelect = async (event) => {
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  uploadImage = async (imageName, imageContent) => {
+    try {
+      // toggle state so that image renaming modal appears
+      this.setState({
+        pendingImageUpload: {
+          fileName: imageName,
+          path: `images%2F${imageName}`,
+          content: imageContent,
+        },
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  onImageSelect = async (event) => {
     const imgReader = new FileReader();
     const imgName = event.target.files[0].name;
     imgReader.onload = (() => {
@@ -125,169 +67,100 @@ const Images = ({ match: { params: { siteName, customPath } }, location }) => {
 
       const imgData = imgReader.result.split(',')[1];
 
-      uploadImage(imgName, imgData);
+      this.uploadImage(imgName, imgData);
     });
     imgReader.readAsDataURL(event.target.files[0]);
   }
 
-  return (
-    <>
-      <Header
-        siteName={siteName}
-        backButtonText={`Back to ${customPath ? getPrevDirectoryName(customPath) : 'Sites'}`}
-        backButtonUrl={customPath ? `/sites/${siteName}/${getPrevDirectoryPath(customPath)}` : '/sites'}
-      />
-      {/* main bottom section */}
-      <div className={elementStyles.wrapper}>
-        <Sidebar siteName={siteName} currPath={location.pathname} />
-        {/* main section starts here */}
-        <div className={contentStyles.mainSection}>
-          <div className={contentStyles.sectionHeader}>
-            <h1 className={contentStyles.sectionTitle}>Images</h1>
-          </div>
-          {/* Info segment */}
-          <div className={contentStyles.segment}>
-            <i className="bx bx-sm bx-info-circle text-dark" />
-            <span><strong className="ml-1">Note:</strong> Upload images here to link to them in pages and resources. The maximum image size allowed is 5MB.</span>
-          </div>
-          {/* Creation buttons */}
-          <div className={contentStyles.folderContainerBoxes}>
-            <div className={contentStyles.boxesContainer}>
-              {/* Upload Image */}
-              <FolderOptionButton
-                title="Upload new image"
-                option="upload-image"
-                onClick={() => document.getElementById('file-upload').click()}
-              />
-              <FolderOptionButton
-                title="Create new directory"
-                option="create-sub"
-                isSubfolder={false}
-                onClick={() => console.log('placeholder')}
-              />
-              <input
-                onChange={onImageSelect}
-                onClick={(event) => {
-                  // eslint-disable-next-line no-param-reassign
-                  event.target.value = '';
-                }}
-                type="file"
-                id="file-upload"
-                accept="image/*"
-                hidden
-              />
+  render() {
+    const { images, chosenImage, pendingImageUpload } = this.state;
+    const { match, location } = this.props;
+    const { siteName } = match.params;
+    return (
+      <>
+        <Header 
+          siteName={siteName}
+        />
+        {/* main bottom section */}
+        <div className={elementStyles.wrapper}>
+          <Sidebar siteName={siteName} currPath={location.pathname} />
+          {/* main section starts here */}
+          <div className={contentStyles.mainSection}>
+            <div className={contentStyles.sectionHeader}>
+              <h1 className={contentStyles.sectionTitle}>Images</h1>
             </div>
-          </div>
-          {/* Segment divider  */}
-          <div className={contentStyles.segmentDividerContainer}>
-            <hr className="w-100 mt-3 mb-5" />
-          </div>
-          {/* Directories title segment */}
-          <div className={contentStyles.segment}>
-            <span>Directories</span>
-          </div>
-          {/* Image directories */}
-          <div className={contentStyles.folderContainerBoxes}>
-            <div className={contentStyles.boxesContainer}>
-              {
-                directories && directories.length > 0
-                ? directories.map((directory, idx) => (
-                    <FolderCard
-                      displayText={deslugifyDirectory(directory.name)}
-                      settingsToggle={() => {}}
-                      key={directory.name}
-                      pageType={"media"}
-                      linkPath={`images/${encodeURIComponent(directory.path
-                          .split('/')
-                          .slice(1) // remove `images` prefix
-                          .join('/')
-                        )}`
-                      }
-                      siteName={siteName}
-                      itemIndex={idx}
-                    />
-                ))
-                : (
-                  <div className={contentStyles.segment}>
-                    There are no image sub-directories in this directory.
-                  </div>
-                )
-              }
+            {/* Info segment */}
+            <div className={contentStyles.segment}>
+              <i className="bx bx-sm bx-info-circle text-dark" />
+              <span><strong className="ml-1">Note:</strong> Upload images here to link to them in pages and resources. The maximum image size allowed is 5MB.</span>
             </div>
-          </div>
-          {/* Segment divider  */}
-          <div className={contentStyles.segmentDividerContainer}>
-            <hr className="invisible w-100 mt-3 mb-5" />
-          </div>
-          {/* Ungrouped Images title segment */}
-          <div className={contentStyles.segment}>
-            <span>Ungrouped Images</span>
-          </div>
-          {/* Images segment */}
-          <div className={contentStyles.contentContainerBars}>
-            <div className={contentStyles.boxesContainer}>
-              <div className={mediaStyles.mediaCards}>
-                {/* Images */}
-                {
-                  images && images.length > 0
-                  ? images.map((image) => (
+            <div className={contentStyles.contentContainerBars}>
+              <div className={contentStyles.boxesContainer}>
+                <div className={mediaStyles.mediaCards}>
+                  {/* Upload Image */}
+                  <MediaUploadCard
+                    type="image"
+                    onClick={() => document.getElementById('file-upload').click()}
+                  />
+                  <input
+                    onChange={this.onImageSelect}
+                    onClick={(event) => {
+                      // eslint-disable-next-line no-param-reassign
+                      event.target.value = '';
+                    }}
+                    type="file"
+                    id="file-upload"
+                    accept="image/*"
+                    hidden
+                  />
+                  {/* Images */}
+                  {images.length > 0 && images.map((image) => (
                     <MediaCard
                       type="image"
                       media={image}
                       siteName={siteName}
-                      onClick={() => setChosenImage(image)}
+                      onClick={() => this.setState({ chosenImage: image })}
                       key={image.fileName}
                     />
-                  )) : (
-                    <div className={contentStyles.segment}>
-                      There are no images in this directory.
-                    </div>
-                  )
-                }
+                  ))}
+                </div>
               </div>
             </div>
+            {/* End of image cards */}
           </div>
-          {/* End of image cards */}
+          {/* main section ends here */}
         </div>
-        {/* main section ends here */}
-      </div>
-      {
-        chosenImage
-        && (
-        <MediaSettingsModal
-          type="image"
-          media={chosenImage}
-          siteName={siteName}
-          customPath={customPath}
-          isPendingUpload={false}
-          onClose={() => setChosenImage(null)}
-          onSave={() => window.location.reload()}
-        />
-        )
-      }
-      {
-        pendingImageUpload
-        && (
-        <MediaSettingsModal
-          type="image"
-          media={pendingImageUpload}
-          siteName={siteName}
-          customPath={customPath}
-          // eslint-disable-next-line react/jsx-boolean-value
-          isPendingUpload
-          onClose={() => setPendingImageUpload(null)}
-          onSave={() => window.location.reload()}
-        />
-        )
-      }
-      {
-          process.env.REACT_APP_ENV === 'LOCAL_DEV' && <ReactQueryDevtools initialIsOpen={false} />
-      }
-    </>
-  );
+        {
+          chosenImage
+          && (
+          <MediaSettingsModal
+            type="image"
+            media={chosenImage}
+            siteName={siteName}
+            isPendingUpload={false}
+            onClose={() => this.setState({ chosenImage: null })}
+            onSave={() => window.location.reload()}
+          />
+          )
+        }
+        {
+          pendingImageUpload
+          && (
+          <MediaSettingsModal
+            type="image"
+            media={pendingImageUpload}
+            siteName={siteName}
+            // eslint-disable-next-line react/jsx-boolean-value
+            isPendingUpload
+            onClose={() => this.setState({ pendingImageUpload: null })}
+            onSave={() => window.location.reload()}
+          />
+          )
+        }
+      </>
+    );
+  }
 }
-
-export default Images
 
 Images.propTypes = {
   match: PropTypes.shape({

--- a/src/styles/isomer-cms/elements/variable.scss
+++ b/src/styles/isomer-cms/elements/variable.scss
@@ -29,7 +29,7 @@ $site-margin-horizontal: 20px;
 $site-margin-vertical: 15px;
 $sites-container-width: ($site-width*3) + ($site-margin-horizontal*6);
 
-$component-card-height: 14.9rem;
+$component-card-height: 12.5rem;
 $component-card-margin: 2.5%;
 $component-card-width: (100% - ($component-card-margin*3) )/3 ;
 

--- a/src/styles/isomer-cms/pages/Content.module.scss
+++ b/src/styles/isomer-cms/pages/Content.module.scss
@@ -50,7 +50,7 @@
   margin-bottom: 2.5rem;
 
   span {
-    font-size: 18px;
+    font-size: 16px;
   }
 
   strong {

--- a/src/styles/isomer-cms/pages/Media.module.scss
+++ b/src/styles/isomer-cms/pages/Media.module.scss
@@ -17,9 +17,6 @@
 
 .mediaCardDimensions {
   @include single-site;
-  width: $component-folder-width;
-  margin-right: $component-folder-margin;
-  margin-bottom: $component-folder-margin;
 }
 
 .mediaModal {
@@ -62,11 +59,6 @@
       border: none;
       box-sizing: border-box;
       transition: transform 0.2s ease-in;
-      min-width: 250px;
-      width: $component-card-width;
-      height: $component-card-height;
-      margin-right: $component-card-margin;
-      margin-bottom: $component-card-margin;
 
       .mediaCardPreviewContainer {
         height: 70%;


### PR DESCRIPTION
Reverts isomerpages/isomercms-frontend#370

After discussing with designers + Lisa, we have decided to hold off on introducing nested images feature on CMS, as the functionality on that page is not complete. Namely, we would like to finish the following features:
- Create image subfolder
- Hide `.keep` file in image subfolder
- Create breadcrumb for navigate between subfolder and image folder
- Achieve feature parity on Files

This PR reverts #370 as we would like to push the CMS to production. We will release this PR in the following weeks as we complete other features. 