### PR TITLE
Fix/rearrange layout

### DIFF
--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -95,7 +95,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource, r
             return []
         }
         if (folderName !== '' && querySubfolders) { // inside folder, show all subfolders
-            const parsedFolderContents = parseDirectoryFile(querySubfolders.data.content)
+            const { order: parsedFolderContents } = parseDirectoryFile(querySubfolders.data.content)
             const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
             return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.fileName)
         }

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -139,7 +139,7 @@ const FolderReorderingModal = ({
                     {
                       folderOrder.map((folderContentItem, folderContentIndex) => (
                         <Draggable
-                          draggableId={`folder-${folderContentIndex}-draggable`}
+                          draggableId={folderContentItem.fileName}
                           index={folderContentIndex}
                           key={folderContentItem.fileName}
                         >

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -107,7 +107,7 @@ const FolderReorderingModal = ({
             </div>
             <div className={contentStyles.segment}>
               <i className="bx bx-sm bx-bulb text-dark" />
-              <span><strong className="ml-1">Pro tip:</strong> Drag and drop to rearrange pages</span>
+              <span><strong className="ml-1">Pro tip:</strong> Drag and drop the pages below to rearrange the order of pages or sub pages in your site.</span>
             </div>
             {/* Segment divider  */}
             <div className={contentStyles.segmentDividerContainer}>

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -169,6 +169,12 @@ const FolderReorderingModal = ({
           </div>
           <div className={contentStyles.sectionFooter}>
             <LoadingButton
+              label={`Cancel`}
+              disabledStyle={elementStyles.disabled}
+              className={`${elementStyles.warning}`}
+              callback={() => setIsRearrangeActive(false)}
+            />
+            <LoadingButton
               label={`Done`}
               className={elementStyles.blue}
               callback={saveHandler}

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -37,7 +37,6 @@ const FolderReorderingModal = ({
 }) => {
   const [folderOrder, setFolderOrder] = useState(folderOrderArray)
 
-  console.log('here', folderName, subfolderName);
   const onDragEnd = (result) => {
     const { source, destination } = result;
 
@@ -95,7 +94,6 @@ const FolderReorderingModal = ({
     await rearrangeFolder(payload) // setIsRearrangeActive(false) handled by mutate
   }
   
-  
   return (
     <>
       <div className={elementStyles.overlay}>
@@ -117,12 +115,12 @@ const FolderReorderingModal = ({
             <br/>
             <div className={contentStyles.segment}>
               <span>
-                  Workspace > 
-                  {
-                    subfolderName
-                    ? deslugifyDirectory(folderName) > <strong>{deslugifyDirectory(subfolderName)}</strong>
-                    : <strong>{deslugifyDirectory(folderName)}</strong>
-                  }
+                Workspace > 
+                {
+                  subfolderName  
+                    ? <> {deslugifyDirectory(folderName)} <strong> > {deslugifyDirectory(subfolderName)}</strong> </>
+                    : <strong> {deslugifyDirectory(folderName)}</strong>
+                }
               </span>
             </div>
             {/* Pages */}

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -107,7 +107,7 @@ const FolderReorderingModal = ({
             </div>
             <div className={contentStyles.segment}>
               <i className="bx bx-sm bx-bulb text-dark" />
-              <span><strong className="ml-1">Pro tip:</strong> Drag and drop the pages below to rearrange the order of pages or sub pages in your site.</span>
+              <span><strong className="ml-1">Pro tip:</strong> Drag and drop the items below to rearrange their order in your site.</span>
             </div>
             {/* Segment divider  */}
             <div className={contentStyles.segmentDividerContainer}>

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -1,0 +1,185 @@
+import React, { useState } from 'react';
+import { Droppable, Draggable } from 'react-beautiful-dnd';
+import { DragDropContext } from 'react-beautiful-dnd';
+import { useMutation } from 'react-query';
+import update from 'immutability-helper';
+
+import { FolderContentItem } from './folders/FolderContent'
+import LoadingButton from '../components/LoadingButton';
+
+import { 
+  DEFAULT_RETRY_MSG,
+  deslugifyDirectory,
+  convertSubfolderArray,
+  updateDirectoryFile,
+  convertArrayToFolderOrder,
+} from "../utils"
+
+import { errorToast, successToast } from '../utils/toasts';
+
+import { setDirectoryFile } from '../api'
+  
+
+// Import styles
+import adminStyles from '../styles/isomer-cms/pages/Admin.module.scss';
+import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+
+const FolderReorderingModal = ({
+  siteName,
+  folderName,
+  subfolderName,
+  folderOrderArray,
+  setIsRearrangeActive,
+  directoryFileSha,
+  parsedFolderContents,
+  parsedFolderOutput,
+}) => {
+  const [folderOrder, setFolderOrder] = useState(folderOrderArray)
+
+  console.log('here', folderName, subfolderName);
+  const onDragEnd = (result) => {
+    const { source, destination } = result;
+
+    // If the user dropped the draggable to no known droppable
+    if (!destination) return;
+
+    // The draggable elem was returned to its original position
+    if (
+        destination.droppableId === source.droppableId
+        && destination.index === source.index
+    ) return;
+
+    const elem = folderOrder[source.index]
+    const newFolderOrder = update(folderOrder, {
+        $splice: [
+            [source.index, 1], // Remove elem from its original position
+            [destination.index, 0, elem], // Splice elem into its new position
+        ],
+    });
+    setFolderOrder(newFolderOrder)
+  }
+
+  // REORDERING
+  // save file-reordering
+  const { mutateAsync: rearrangeFolder } = useMutation(
+    payload => setDirectoryFile(siteName, folderName, payload),
+    {
+      onError: () => errorToast(`Your file reordering could not be saved. ${DEFAULT_RETRY_MSG}`),
+      onSuccess: () => successToast('Successfully updated page order'),
+      onSettled: () => setIsRearrangeActive((prevState) => !prevState),
+    }
+  )
+  
+  // REORDERING utils
+  const saveHandler =  async () => {  
+    // drag and drop complete, save new order 
+    let newFolderOrder
+    if (subfolderName) {
+      newFolderOrder = convertSubfolderArray(folderOrder, parsedFolderContents, subfolderName)
+    } else {
+      newFolderOrder = convertArrayToFolderOrder(folderOrder)
+    }
+    if (JSON.stringify(newFolderOrder) === JSON.stringify(parsedFolderContents)) { 
+      // no change in file order
+      setIsRearrangeActive((prevState) => !prevState)
+      return
+    }
+
+    const updatedDirectoryFile = updateDirectoryFile(folderName, parsedFolderOutput, newFolderOrder)
+
+    const payload = {
+      content: updatedDirectoryFile,
+      sha: directoryFileSha,
+    } 
+    await rearrangeFolder(payload) // setIsRearrangeActive(false) handled by mutate
+  }
+  
+  
+  return (
+    <>
+      <div className={elementStyles.overlay}>
+        <div className={`${elementStyles.fullscreenWrapper}`}>
+          <div className={`${adminStyles.adminSidebar} ${elementStyles.wrappedContent} bg-transparent`} />
+          <div className={`${contentStyles.mainSection} ${elementStyles.wrappedContent} bg-light`}>
+            {/* Page title */}
+            <div className={contentStyles.sectionHeader}>
+              <h1 className={contentStyles.sectionTitle}>{`Rearrange items in ${subfolderName? deslugifyDirectory(subfolderName) : deslugifyDirectory(folderName)}`}</h1>
+            </div>
+            <div className={contentStyles.segment}>
+              <i className="bx bx-sm bx-bulb text-dark" />
+              <span><strong className="ml-1">Pro tip:</strong> Drag and drop to rearrange pages</span>
+            </div>
+            {/* Segment divider  */}
+            <div className={contentStyles.segmentDividerContainer}>
+              <hr className="w-100 mt-3 mb-5" />
+            </div>
+            <br/>
+            <div className={contentStyles.segment}>
+              <span>
+                  Workspace > 
+                  {
+                    subfolderName
+                    ? deslugifyDirectory(folderName) > <strong>{deslugifyDirectory(subfolderName)}</strong>
+                    : <strong>{deslugifyDirectory(folderName)}</strong>
+                  }
+              </span>
+            </div>
+            {/* Pages */}
+            <DragDropContext onDragEnd={onDragEnd}>
+              <Droppable 
+                droppableId="folder" 
+                type="folder" 
+              >
+                {(droppableProvided) => (        
+                  <div 
+                    className={`${contentStyles.contentContainerFolderColumn} mb-5`}
+                    ref={droppableProvided.innerRef}
+                    {...droppableProvided.droppableProps}
+                  >
+                    {
+                      folderOrder.map((folderContentItem, folderContentIndex) => (
+                        <Draggable
+                          draggableId={`folder-${folderContentIndex}-draggable`}
+                          index={folderContentIndex}
+                          key={folderContentItem.fileName}
+                        >
+                          {(draggableProvided) => (
+                            <div
+                              key={folderContentIndex}
+                              {...draggableProvided.draggableProps}
+                              {...draggableProvided.dragHandleProps}
+                              ref={draggableProvided.innerRef}
+                            >        
+                              <FolderContentItem
+                                key={folderContentItem.fileName}
+                                title={folderContentItem.fileName}
+                                isFile={folderContentItem.type === 'dir' ? false: true}
+                                numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
+                                itemIndex={folderContentIndex}
+                              />
+                            </div>
+                          )}
+                        </Draggable>
+                      ))
+                    }
+                    {droppableProvided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+          </div>
+          <div className={contentStyles.sectionFooter}>
+            <LoadingButton
+              label={`Done`}
+              className={elementStyles.blue}
+              callback={saveHandler}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default FolderReorderingModal

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -154,7 +154,7 @@ const FolderReorderingModal = ({
                                 key={folderContentItem.fileName}
                                 folderContentItem={folderContentItem}
                                 itemIndex={folderContentIndex}
-                                disableButton={true}
+                                disableLink={true}
                               />
                             </div>
                           )}

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -153,10 +153,9 @@ const FolderReorderingModal = ({
                             >        
                               <FolderContentItem
                                 key={folderContentItem.fileName}
-                                title={folderContentItem.fileName}
-                                isFile={folderContentItem.type === 'dir' ? false: true}
-                                numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
+                                folderContentItem={folderContentItem}
                                 itemIndex={folderContentIndex}
+                                disableButton={true}
                               />
                             </div>
                           )}

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 import { DragDropContext } from 'react-beautiful-dnd';
 import { useMutation } from 'react-query';
@@ -180,3 +181,21 @@ const FolderReorderingModal = ({
 }
 
 export default FolderReorderingModal
+
+FolderReorderingModal.propTypes = {
+  siteName: PropTypes.string.isRequired,
+  folderName: PropTypes.string.isRequired,
+  subfolderName: PropTypes.string,
+  folderOrderArray: PropTypes.arrayOf(
+    PropTypes.shape({
+      fileName: PropTypes.string.isRequired,
+      path: PropTypes.string.isRequired,
+      sha: PropTypes.string,
+      type: PropTypes.string,
+    }),
+  ).isRequired,
+  setIsRearrangeActive: PropTypes.func.isRequired,
+  directoryFileSha: PropTypes.string.isRequired,
+  parsedFolderContents: PropTypes.arrayOf(PropTypes.string).isRequired,
+  parsedFolderOutput: PropTypes.bool.isRequired,
+};

--- a/src/components/FolderReorderingModal.jsx
+++ b/src/components/FolderReorderingModal.jsx
@@ -34,7 +34,7 @@ const FolderReorderingModal = ({
   setIsRearrangeActive,
   directoryFileSha,
   parsedFolderContents,
-  parsedFolderOutput,
+  isFolderLive,
 }) => {
   const [folderOrder, setFolderOrder] = useState(folderOrderArray)
 
@@ -86,7 +86,7 @@ const FolderReorderingModal = ({
       return
     }
 
-    const updatedDirectoryFile = updateDirectoryFile(folderName, parsedFolderOutput, newFolderOrder)
+    const updatedDirectoryFile = updateDirectoryFile(folderName, isFolderLive, newFolderOrder)
 
     const payload = {
       content: updatedDirectoryFile,
@@ -203,5 +203,5 @@ FolderReorderingModal.propTypes = {
   setIsRearrangeActive: PropTypes.func.isRequired,
   directoryFileSha: PropTypes.string.isRequired,
   parsedFolderContents: PropTypes.arrayOf(PropTypes.string).isRequired,
-  parsedFolderOutput: PropTypes.bool.isRequired,
+  isFolderLive: PropTypes.bool.isRequired,
 };

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -1,8 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Droppable, Draggable } from 'react-beautiful-dnd';
-import { DragDropContext } from 'react-beautiful-dnd';
-import update from 'immutability-helper';
 import PropTypes from 'prop-types';
 
 import { deslugifyPage } from '../../utils'
@@ -153,7 +150,6 @@ const FolderContent = ({
     setFolderOrderArray,
     siteName,
     folderName,
-    enableDragDrop,
     allCategories,
     setSelectedPath,
     setSelectedPage,
@@ -170,90 +166,37 @@ const FolderContent = ({
         return `/sites/${siteName}/folder/${folderName}/${folderContentItem.path.includes('/') ? `subfolder/` : ''}${folderContentItem.path}`
     }
 
-    const onDragEnd = (result) => {
-        const { source, destination } = result;
-
-        // If the user dropped the draggable to no known droppable
-        if (!destination) return;
-
-        // The draggable elem was returned to its original position
-        if (
-            destination.droppableId === source.droppableId
-            && destination.index === source.index
-        ) return;
-
-        const elem = folderOrderArray[source.index]
-        const newFolderOrderArray = update(folderOrderArray, {
-            $splice: [
-                [source.index, 1], // Remove elem from its original position
-                [destination.index, 0, elem], // Splice elem into its new position
-            ],
-        });
-        setFolderOrderArray(newFolderOrderArray)
-    }
-
     return (
-        <DragDropContext onDragEnd={onDragEnd}>
-            <Droppable 
-                droppableId="folder" 
-                type="folder" 
-                isDropDisabled={!enableDragDrop}
-            >
-                {(droppableProvided) => (        
-                    <div 
-                        className={`${contentStyles.contentContainerFolderColumn} mb-5`}
-                        ref={droppableProvided.innerRef}
-                        {...droppableProvided.droppableProps}
-                    >
-                        {
-                            folderOrderArray.map((folderContentItem, folderContentIndex) => (
-                                <Draggable
-                                    draggableId={`folder-${folderContentIndex}-draggable`}
-                                    index={folderContentIndex}
-                                    isDragDisabled={!enableDragDrop}
-                                    key={folderContentItem.fileName}
-                                >
-                                    {(draggableProvided) => (
-                                        <div
-                                            key={folderContentIndex}
-                                            {...draggableProvided.draggableProps}
-                                            {...draggableProvided.dragHandleProps}
-                                            ref={draggableProvided.innerRef}
-                                        >        
-                                            <FolderContentItem
-                                                key={folderContentItem.fileName}
-                                                siteName={siteName}
-                                                title={folderContentItem.fileName}
-                                                folderName={folderName}
-                                                numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
-                                                isFile={folderContentItem.type === 'dir' ? false: true}
-                                                link={generateLink(folderContentItem)}
-                                                allCategories={allCategories}
-                                                itemIndex={folderContentIndex}
-                                                setSelectedPage={setSelectedPage}
-                                                setSelectedPath={setSelectedPath}
-                                                setIsPageSettingsActive={setIsPageSettingsActive}
-                                                setIsFolderModalOpen={setIsFolderModalOpen}
-                                                setIsMoveModalActive={setIsMoveModalActive}
-                                                setIsDeleteModalActive={setIsDeleteModalActive}
-                                                moveDropdownQuery={moveDropdownQuery}
-                                                setMoveDropdownQuery={setMoveDropdownQuery}
-                                                clearMoveDropdownQueryState={clearMoveDropdownQueryState}
-                                            />
-                                        </div>
-                                    )}
-                                </Draggable>
-                            ))
-                        }
-                        {droppableProvided.placeholder}
-                    </div>
-                )}
-            </Droppable>
-        </DragDropContext>
+        <div className={`${contentStyles.contentContainerFolderColumn} mb-5`}>
+            {
+                folderOrderArray.map((folderContentItem, folderContentIndex) => (
+                    <FolderContentItem
+                        key={folderContentItem.fileName}
+                        siteName={siteName}
+                        title={folderContentItem.fileName}
+                        folderName={folderName}
+                        numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
+                        isFile={folderContentItem.type === 'dir' ? false: true}
+                        link={generateLink(folderContentItem)}
+                        allCategories={allCategories}
+                        itemIndex={folderContentIndex}
+                        setSelectedPage={setSelectedPage}
+                        setSelectedPath={setSelectedPath}
+                        setIsPageSettingsActive={setIsPageSettingsActive}
+                        setIsFolderModalOpen={setIsFolderModalOpen}
+                        setIsMoveModalActive={setIsMoveModalActive}
+                        setIsDeleteModalActive={setIsDeleteModalActive}
+                        moveDropdownQuery={moveDropdownQuery}
+                        setMoveDropdownQuery={setMoveDropdownQuery}
+                        clearMoveDropdownQueryState={clearMoveDropdownQueryState}
+                    />
+                ))
+            }
+        </div>
     )
 }
 
-export default FolderContent
+export { FolderContent, FolderContentItem }
 
 FolderContentItem.propTypes = {
     title: PropTypes.string.isRequired,
@@ -291,7 +234,6 @@ FolderContent.propTypes = {
     setFolderOrderArray: PropTypes.func.isRequired,
     siteName: PropTypes.string.isRequired,
     folderName: PropTypes.string.isRequired,
-    enableDragDrop: PropTypes.func.isRequired,
     allCategories: PropTypes.arrayOf(
         PropTypes.string.isRequired
     ),

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -12,7 +12,7 @@ import contentStyles from '../../styles/isomer-cms/pages/Content.module.scss';
 
 const FolderContentItem = ({
     folderContentItem,
-    disableButton,
+    disableLink,
     siteName,
     folderName,
     itemIndex,
@@ -114,19 +114,20 @@ const FolderContentItem = ({
                     : null
                 }
                 <div className={`position-relative mt-auto mb-auto`}>
-                    <button
-                        className={`${showDropdown ? contentStyles.optionsIconFocus : contentStyles.optionsIcon}`}
-                        type="button"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            e.preventDefault()
-                            if (disableButton) return
-                            setSelectedPage(fileName)
-                            setShowDropdown(true)
-                        }}
-                    >
-                        <i className="bx bx-dots-vertical-rounded" />     
-                    </button>
+                    { !disableLink &&
+                        <button
+                            className={`${showDropdown ? contentStyles.optionsIconFocus : contentStyles.optionsIcon}`}
+                            type="button"
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                e.preventDefault()
+                                setSelectedPage(fileName)
+                                setShowDropdown(true)
+                            }}
+                        >
+                            <i className="bx bx-dots-vertical-rounded" />
+                        </button>
+                    }
                     { showDropdown &&
                         <MenuDropdown
                             menuIndex={itemIndex}
@@ -158,7 +159,7 @@ const FolderContentItem = ({
     )
 
     return (
-        !showFileMoveDropdown && !showDropdown
+        !showFileMoveDropdown && !showDropdown && !disableLink
         ? 
             <Link className={`${contentStyles.component} ${contentStyles.card}`} to={link}>
                 {FolderItemContent}
@@ -198,7 +199,7 @@ FolderContentItem.propTypes = {
         type: PropTypes.string,
     }).isRequired,
     itemIndex: PropTypes.number.isRequired,
-    disableButton: PropTypes.bool,
+    disableLink: PropTypes.bool,
     allCategories: PropTypes.arrayOf(
         PropTypes.string
     ),

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -11,10 +11,10 @@ import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../../styles/isomer-cms/pages/Content.module.scss';
 
 const FolderContentItem = ({
-    title,
-    isFile,
-    numItems,
-    link,
+    folderContentItem,
+    disableButton,
+    siteName,
+    folderName,
     itemIndex,
     allCategories,
     setSelectedPage,
@@ -27,6 +27,30 @@ const FolderContentItem = ({
     setMoveDropdownQuery,
     clearMoveDropdownQueryState,
 }) => {
+
+    const parseFolderContentItem = (folderContentItem) => {
+        const { fileName, children, type, path } = folderContentItem 
+        const numItems = type === 'dir' 
+            ? children.filter(name => !name.includes('.keep')).length 
+            : null
+        const isFile = type === 'dir' 
+            ? false
+            : true
+        const link = type === 'dir' 
+            ? `/sites/${siteName}/folder/${folderName}/subfolder/${fileName}`
+            : `/sites/${siteName}/folder/${folderName}/${path.includes('/') ? `subfolder/` : ''}${path}`
+        const title = deslugifyPage(fileName)
+        return {
+            fileName,
+            numItems,
+            isFile,
+            link,
+            title
+        }
+    }
+
+    const { numItems, isFile, link, title, fileName } = parseFolderContentItem(folderContentItem)
+
     const [showDropdown, setShowDropdown] = useState(false)
     const [showFileMoveDropdown, setShowFileMoveDropdown] = useState(false)
     const dropdownRef = useRef(null)
@@ -83,7 +107,7 @@ const FolderContentItem = ({
                     ? <i className={`bx bxs-file-blank ${elementStyles.folderItemIcon}`} />
                     : <i className={`bx bxs-folder ${elementStyles.folderItemIcon}`} />
                 }
-                <span className={`${elementStyles.folderItemText} mr-auto`} >{deslugifyPage(title)}</span>
+                <span className={`${elementStyles.folderItemText} mr-auto`} >{title}</span>
                 {
                     numItems !== null
                     ? <span className={`${elementStyles.folderItemText} mr-5`}>{numItems} item{numItems === 1 ? '' : 's'}</span>
@@ -96,7 +120,8 @@ const FolderContentItem = ({
                         onClick={(e) => {
                             e.stopPropagation()
                             e.preventDefault()
-                            setSelectedPage(title)
+                            if (disableButton) return
+                            setSelectedPage(fileName)
                             setShowDropdown(true)
                         }}
                     >
@@ -147,78 +172,48 @@ const FolderContentItem = ({
 
 const FolderContent = ({ 
     folderOrderArray,
-    setFolderOrderArray,
-    siteName,
-    folderName,
-    allCategories,
-    setSelectedPath,
-    setSelectedPage,
-    setIsPageSettingsActive,
-    setIsFolderModalOpen,
-    setIsMoveModalActive,
-    setIsDeleteModalActive,
-    moveDropdownQuery,
-    setMoveDropdownQuery,
-    clearMoveDropdownQueryState,
-}) => {
-    const generateLink = (folderContentItem) => {
-        if (folderContentItem.type === 'dir') return `/sites/${siteName}/folder/${folderName}/subfolder/${folderContentItem.fileName}`
-        return `/sites/${siteName}/folder/${folderName}/${folderContentItem.path.includes('/') ? `subfolder/` : ''}${folderContentItem.path}`
-    }
-
-    return (
-        <div className={`${contentStyles.contentContainerFolderColumn} mb-5`}>
-            {
-                folderOrderArray.map((folderContentItem, folderContentIndex) => (
-                    <FolderContentItem
-                        key={folderContentItem.fileName}
-                        siteName={siteName}
-                        title={folderContentItem.fileName}
-                        folderName={folderName}
-                        numItems={folderContentItem.type === 'dir' ? folderContentItem.children.filter(name => !name.includes('.keep')).length : null}
-                        isFile={folderContentItem.type === 'dir' ? false: true}
-                        link={generateLink(folderContentItem)}
-                        allCategories={allCategories}
-                        itemIndex={folderContentIndex}
-                        setSelectedPage={setSelectedPage}
-                        setSelectedPath={setSelectedPath}
-                        setIsPageSettingsActive={setIsPageSettingsActive}
-                        setIsFolderModalOpen={setIsFolderModalOpen}
-                        setIsMoveModalActive={setIsMoveModalActive}
-                        setIsDeleteModalActive={setIsDeleteModalActive}
-                        moveDropdownQuery={moveDropdownQuery}
-                        setMoveDropdownQuery={setMoveDropdownQuery}
-                        clearMoveDropdownQueryState={clearMoveDropdownQueryState}
-                    />
-                ))
-            }
-        </div>
-    )
-}
+    ...rest
+}) => (
+    <div className={`${contentStyles.contentContainerFolderColumn} mb-5`}>
+        {
+            folderOrderArray.map((folderContentItem, folderContentIndex) => (
+                <FolderContentItem
+                    key={folderContentItem.fileName}
+                    folderContentItem={folderContentItem}
+                    itemIndex={folderContentIndex}
+                    {...rest}
+                />
+            ))
+        }
+    </div>
+)
 
 export { FolderContent, FolderContentItem }
 
 FolderContentItem.propTypes = {
-    title: PropTypes.string.isRequired,
-    isFile: PropTypes.bool.isRequired,
-    numItems: PropTypes.number,
-    link: PropTypes.string.isRequired,
-    itemIndex: PropTypes.number.isRequired,
-    allCategories: PropTypes.arrayOf(
-        PropTypes.string.isRequired
-    ),
-    setSelectedPage: PropTypes.func.isRequired,
-    setSelectedPath: PropTypes.func.isRequired,
-    setIsPageSettingsActive: PropTypes.func.isRequired,
-    setIsFolderModalOpen: PropTypes.func.isRequired,
-    setIsMoveModalActive: PropTypes.func.isRequired,
-    setIsDeleteModalActive: PropTypes.func.isRequired,
-    moveDropdownQuery: PropTypes.shape({
-        folderName: PropTypes.string.isRequired,
-        subfolderName: PropTypes.string.isRequired,
+    folderContentItem: PropTypes.shape({
+        fileName: PropTypes.string.isRequired,
+        path: PropTypes.string.isRequired,
+        sha: PropTypes.string,
+        type: PropTypes.string,
     }).isRequired,
-    setMoveDropdownQuery: PropTypes.func.isRequired,
-    clearMoveDropdownQueryState: PropTypes.func.isRequired,
+    itemIndex: PropTypes.number.isRequired,
+    disableButton: PropTypes.bool,
+    allCategories: PropTypes.arrayOf(
+        PropTypes.string
+    ),
+    setSelectedPage: PropTypes.func,
+    setSelectedPath: PropTypes.func,
+    setIsPageSettingsActive: PropTypes.func,
+    setIsFolderModalOpen: PropTypes.func,
+    setIsMoveModalActive: PropTypes.func,
+    setIsDeleteModalActive: PropTypes.func,
+    moveDropdownQuery: PropTypes.shape({
+        folderName: PropTypes.string,
+        subfolderName: PropTypes.string,
+    }),
+    setMoveDropdownQuery: PropTypes.func,
+    clearMoveDropdownQueryState: PropTypes.func,
 };
 
 
@@ -228,25 +223,8 @@ FolderContent.propTypes = {
             fileName: PropTypes.string.isRequired,
             path: PropTypes.string.isRequired,
             sha: PropTypes.string,
-            title: PropTypes.string,
+            type: PropTypes.string,
         }),
     ).isRequired,
-    setFolderOrderArray: PropTypes.func.isRequired,
-    siteName: PropTypes.string.isRequired,
-    folderName: PropTypes.string.isRequired,
-    allCategories: PropTypes.arrayOf(
-        PropTypes.string.isRequired
-    ),
-    setSelectedPath: PropTypes.func.isRequired,
-    setSelectedPage: PropTypes.func.isRequired,
-    setIsPageSettingsActive: PropTypes.func.isRequired,
-    setIsFolderModalOpen: PropTypes.func.isRequired,
-    setIsMoveModalActive: PropTypes.func.isRequired,
-    setIsDeleteModalActive: PropTypes.func.isRequired,
-    moveDropdownQuery: PropTypes.shape({
-        folderName: PropTypes.string.isRequired,
-        subfolderName: PropTypes.string.isRequired,
-    }).isRequired,
-    setMoveDropdownQuery: PropTypes.func.isRequired,
-    clearMoveDropdownQueryState: PropTypes.func.isRequired,
+    rest: PropTypes.object,
 };

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -234,7 +234,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history, type }) =>
         const {
           content: dirContent,
         } = dirData.data
-        const parsedFolderContents = parseDirectoryFile(dirContent)
+        const { order: parsedFolderContents } = parseDirectoryFile(dirContent)
         // Filter out placeholder files
         const filteredFolderContents = parsedFolderContents.filter(name => !name.includes('.keep'))
         generatedLeftNavPages = filteredFolderContents.map((name) => 

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -10,7 +10,8 @@ import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import FolderCreationModal from '../components/FolderCreationModal'
 import FolderOptionButton from '../components/folders/FolderOptionButton';
-import FolderContent from '../components/folders/FolderContent';
+import FolderReorderingModal from '../components/FolderReorderingModal';
+import { FolderContent } from '../components/folders/FolderContent';
 import FolderModal from '../components/FolderModal';
 import PageSettingsModal from '../components/PageSettingsModal'
 import DeleteWarningModal from '../components/DeleteWarningModal'
@@ -27,16 +28,13 @@ import {
 import {
   DEFAULT_RETRY_MSG,
   parseDirectoryFile,
-  updateDirectoryFile,
   convertFolderOrderToArray,
-  convertArrayToFolderOrder,
   retrieveSubfolderContents,
-  convertSubfolderArray,
   deslugifyDirectory,
 } from '../utils'
 
 // Import API
-import { getDirectoryFile, setDirectoryFile, getEditPageData, deleteSubfolder, deletePageData, moveFile, getAllCategories } from '../api';
+import { getDirectoryFile, getEditPageData, deleteSubfolder, deletePageData, moveFile, getAllCategories } from '../api';
 
 // Import styles
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
@@ -219,44 +217,6 @@ const Folders = ({ match, location }) => {
       setMoveDropdownQuery({ ...initialMoveDropdownQueryState });
     };
 
-    // REORDERING
-    // save file-reordering
-    const { mutate: rearrangeFolder } = useMutation(
-      payload => setDirectoryFile(siteName, folderName, payload),
-      {
-        onError: () => errorToast(`Your file reordering could not be saved. ${DEFAULT_RETRY_MSG}`),
-        onSuccess: () => successToast('Successfully updated page order'),
-        onSettled: () => setIsRearrangeActive((prevState) => !prevState),
-      }
-    )
-    
-    // REORDERING utils
-    const toggleRearrange = () => { 
-      if (isRearrangeActive) { 
-        // drag and drop complete, save new order 
-        let newFolderOrder
-        if (subfolderName) {
-          newFolderOrder = convertSubfolderArray(folderOrderArray, parsedFolderContents, subfolderName)
-        } else {
-          newFolderOrder = convertArrayToFolderOrder(folderOrderArray)
-        }
-        if (JSON.stringify(newFolderOrder) === JSON.stringify(parsedFolderContents)) { 
-          // no change in file order
-          setIsRearrangeActive((prevState) => !prevState)
-          return
-        }
-        const updatedDirectoryFile = updateDirectoryFile(folderName, parsedFolderOutput, newFolderOrder)
-
-        const payload = {
-          content: updatedDirectoryFile,
-          sha: directoryFileSha,
-        } 
-        rearrangeFolder(payload) // setIsRearrangeActive(false) handled by mutate
-      } else {
-        setIsRearrangeActive((prevState) => !prevState) 
-      }
-    }
-
     return (
         <>
           {
@@ -324,6 +284,21 @@ const Folders = ({ match, location }) => {
               />
             )
           }
+          {
+            isRearrangeActive
+            && (
+              <FolderReorderingModal
+                siteName={siteName}
+                folderName={folderName}
+                subfolderName={subfolderName}
+                folderOrderArray={folderOrderArray}
+                setIsRearrangeActive={setIsRearrangeActive}
+                directoryFileSha={directoryFileSha}
+                parsedFolderContents={parsedFolderContents}
+                parsedFolderOutput={parsedFolderOutput}
+              />
+            )
+          }
           <Header
             siteName={siteName}
             backButtonText={`Back to ${subfolderName ? folderName : 'Workspace'}`}
@@ -373,7 +348,7 @@ const Folders = ({ match, location }) => {
               </div>
               {/* Options */}
               <div className={contentStyles.contentContainerFolderRowMargin}>
-                <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={toggleRearrange} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
+                <FolderOptionButton title="Rearrange items" isSelected={isRearrangeActive} onClick={() => setIsRearrangeActive(true)} option="rearrange" isDisabled={folderOrderArray.length <= 1 || !folderContents}/>
                 <FolderOptionButton title="Create new page" option="create-page" id="pageSettings-new" onClick={() => setIsPageSettingsActive((prevState) => !prevState)}/>
                 <FolderOptionButton title="Create new subfolder" option="create-sub" isDisabled={subfolderName || isLoadingDirectory ? true : false} onClick={() => setIsFolderCreationActive(true)}/>
               </div>
@@ -393,7 +368,6 @@ const Folders = ({ match, location }) => {
                     allCategories={getCategories(moveDropdownQuery, allFolders, querySubfolders)}
                     siteName={siteName} 
                     folderName={folderName}
-                    enableDragDrop={isRearrangeActive}
                     setIsPageSettingsActive={setIsPageSettingsActive}
                     setIsFolderModalOpen={setIsFolderModalOpen}
                     setIsDeleteModalActive={setIsDeleteModalActive}

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -58,6 +58,7 @@ const Folders = ({ match, location }) => {
     const [directoryFileSha, setDirectoryFileSha] = useState('')
     const [folderOrderArray, setFolderOrderArray] = useState([])
     const [parsedFolderContents, setParsedFolderContents] = useState([])
+    const [parsedFolderOutput, setParsedFolderOutput] = useState(true)
     const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
     const [isDeleteModalActive, setIsDeleteModalActive] = useState(false)
     const [isMoveModalActive, setIsMoveModalActive] = useState(false)
@@ -91,9 +92,10 @@ const Folders = ({ match, location }) => {
     // parse contents of current folder directory
     useEffect(() => {
       if (folderContents && folderContents.data) {
-        const parsedFolderContents = parseDirectoryFile(folderContents.data.content)
+        const { order: parsedFolderContents, output: parsedFolderOutput } = parseDirectoryFile(folderContents.data.content)
         setDirectoryFileSha(folderContents.data.sha)
         setParsedFolderContents(parsedFolderContents)
+        setParsedFolderOutput(parsedFolderOutput)
 
         if (subfolderName) {
           const subfolderFiles = retrieveSubfolderContents(parsedFolderContents, subfolderName)
@@ -202,7 +204,7 @@ const Folders = ({ match, location }) => {
         return []
       }
       if (folderName !== '' && querySubfolders) { // inside folder, show all subfolders
-        const parsedFolderContents = parseDirectoryFile(querySubfolders.data.content)
+        const { order: parsedFolderContents } = parseDirectoryFile(querySubfolders.data.content)
         const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
         return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.fileName)
       }
@@ -243,7 +245,7 @@ const Folders = ({ match, location }) => {
           setIsRearrangeActive((prevState) => !prevState)
           return
         }
-        const updatedDirectoryFile = updateDirectoryFile(folderContents.data.content, newFolderOrder)
+        const updatedDirectoryFile = updateDirectoryFile(folderName, parsedFolderOutput, newFolderOrder)
 
         const payload = {
           content: updatedDirectoryFile,

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -56,7 +56,7 @@ const Folders = ({ match, location }) => {
     const [directoryFileSha, setDirectoryFileSha] = useState('')
     const [folderOrderArray, setFolderOrderArray] = useState([])
     const [parsedFolderContents, setParsedFolderContents] = useState([])
-    const [parsedFolderOutput, setParsedFolderOutput] = useState(true)
+    const [isFolderLive, setIsFolderLive] = useState(true)
     const [isFolderCreationActive, setIsFolderCreationActive] = useState(false)
     const [isDeleteModalActive, setIsDeleteModalActive] = useState(false)
     const [isMoveModalActive, setIsMoveModalActive] = useState(false)
@@ -90,13 +90,13 @@ const Folders = ({ match, location }) => {
     // parse contents of current folder directory
     useEffect(() => {
       if (folderContents && folderContents.data) {
-        const { order: parsedFolderContents, output: parsedFolderOutput } = parseDirectoryFile(folderContents.data.content)
+        const { order: directoryFileOrder, output: directoryFileOutput } = parseDirectoryFile(folderContents.data.content)
         setDirectoryFileSha(folderContents.data.sha)
-        setParsedFolderContents(parsedFolderContents)
-        setParsedFolderOutput(parsedFolderOutput)
+        setParsedFolderContents(directoryFileOrder)
+        setIsFolderLive(directoryFileOutput)
 
         if (subfolderName) {
-          const subfolderFiles = retrieveSubfolderContents(parsedFolderContents, subfolderName)
+          const subfolderFiles = retrieveSubfolderContents(directoryFileOrder, subfolderName)
           if (subfolderFiles.length > 0) {
             setFolderOrderArray(subfolderFiles.filter(item => item.fileName !== '.keep'))
           } else {
@@ -104,7 +104,7 @@ const Folders = ({ match, location }) => {
             setRedirectToPage(`/sites/${siteName}/workspace`)
           }
         } else {
-          setFolderOrderArray(convertFolderOrderToArray(parsedFolderContents))
+          setFolderOrderArray(convertFolderOrderToArray(directoryFileOrder))
         }
       }
     }, [folderContents, subfolderName])
@@ -295,7 +295,7 @@ const Folders = ({ match, location }) => {
                 setIsRearrangeActive={setIsRearrangeActive}
                 directoryFileSha={directoryFileSha}
                 parsedFolderContents={parsedFolderContents}
-                parsedFolderOutput={parsedFolderOutput}
+                isFolderLive={isFolderLive}
               />
             )
           }

--- a/src/utils.js
+++ b/src/utils.js
@@ -616,11 +616,11 @@ export const parseDirectoryFile = (folderContent) => {
   return decodedContent.collections[collectionKey]
 }
 
-export const updateDirectoryFile = (folderName, showFolder, folderOrder) => {
+export const updateDirectoryFile = (folderName, isFolderLive, folderOrder) => {
   const newContent = {
     collections: { 
       [folderName]: {
-        output: showFolder,
+        output: isFolderLive,
         order: folderOrder
       }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -613,14 +613,19 @@ export const getObjectDiff = (obj1, obj2) => {
 export const parseDirectoryFile = (folderContent) => {
   const decodedContent = yaml.parse(folderContent)
   const collectionKey = Object.keys(decodedContent.collections)[0]
-  return decodedContent.collections[collectionKey].order
+  return decodedContent.collections[collectionKey]
 }
 
-export const updateDirectoryFile = (folderContent, folderOrder) => {
-  const decodedContent = yaml.parse(folderContent)
-  const collectionKey = Object.keys(decodedContent.collections)[0]
-  decodedContent.collections[collectionKey].order = folderOrder
-  return yaml.stringify(decodedContent)
+export const updateDirectoryFile = (folderName, showFolder, folderOrder) => {
+  const newContent = {
+    collections: { 
+      [folderName]: {
+        output: showFolder,
+        order: folderOrder
+      }
+    }
+  }
+  return yaml.stringify(newContent)
 }
 
 export const getNavFolderDropdownFromFolderOrder = (folderOrder) => {


### PR DESCRIPTION
This PR revises the layout for rearranging folder content.

This is based on the designers' feedback for the UX review of V1 CMS, where the rearrange feature lacks user guidance. Specifically, the feedback given is as follows: 

- *Rearrange Feature* - Need to discuss this
  - Not intuitive for now, feature is very hidden 
  - Not obvious for users to click on button again to get out of the mode/ save changes 
  - [Copy changes] Change ‘Rearrange items’ to ‘Reorder items’
  - Other functions should be disabled in Reorder mode
  - Cursor should change to Grab cursor to make it more obvious users can drag and drop
  - Critical UX changes:
    - Obvious mode change into reordering mode
    - User need a more intuitive way of how to save changes and get out of Reorder mode

This PR revises the layout to be inline with the previously discussed design layout:
https://www.figma.com/proto/4qNhGTBMs521pDvCAIh4ON/IsomerCMS?node-id=780%3A7264&viewport=-257%2C-424%2C0.15383589267730713&scaling=scale-down

Attached are photos of the updated behavior on Staging CMS:
<img width="1792" alt="Screenshot 2021-04-26 at 1 51 00 PM" src="https://user-images.githubusercontent.com/39231249/116034774-713c1400-a696-11eb-9d09-1670cddd4014.png">


Additionally, this PR refactors `FolderContent` to simplify the logic and parameter passing. 

