### PR TITLE
fix: pass parameters to wrapped components

### DIFF
--- a/src/routing/ProtectedRoute.jsx
+++ b/src/routing/ProtectedRoute.jsx
@@ -13,7 +13,10 @@ const ProtectedRoute = ({ children, component: WrappedComponent, ...rest }) => {
     <LoginConsumer>
       {({userId}) => (
         userId ? (
-        children || WrappedComponent && <Route {...rest} component={WrappedComponent}/>
+        children || WrappedComponent && 
+        <Route {...rest}
+          render={(props) => <WrappedComponent {...rest} {...props} /> }
+        />
       ) : (
         <Redirect to="/" /> 
       ))}


### PR DESCRIPTION
This PR fixes a bug in which params given to the `ProtectedRoute` were not being passed to the wrapped component.