### PR TITLE
fix: fixes toast popup on item select, folder deletion modal

### DIFF
--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -138,7 +138,8 @@ const Folders = ({ match, location }) => {
     const { mutateAsync: deleteHandler } = useMutation(
       async () => {
        if (isSelectedItemPage && pageData) await deletePageData({ siteName, folderName, subfolderName, fileName: selectedPage }, pageData.pageSha)
-       else await deleteSubfolder({ siteName, folderName, subfolderName: selectedPage })
+       else if (!isSelectedItemPage) await deleteSubfolder({ siteName, folderName, subfolderName: selectedPage })
+       else return
       },
       {
         onError: () => errorToast(`Your ${isSelectedItemPage ? 'file' : 'subfolder'} could not be deleted successfully. ${DEFAULT_RETRY_MSG}`),

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -131,18 +131,13 @@ const Folders = ({ match, location }) => {
           setSelectedPage('')
           errorToast(`The page data could not be retrieved. ${DEFAULT_RETRY_MSG}`)
         },
-        onSuccess: () => {
-          successToast(`Successfully updated ${isSelectedItemPage ? 'file' : 'subfolder'}`)
-          queryClient.invalidateQueries([DIR_CONTENT_KEY, siteName, folderName])
-          refetchFolderContents()
-        },
       },
     )
 
     // delete file
     const { mutateAsync: deleteHandler } = useMutation(
       async () => {
-       if (isSelectedItemPage) await deletePageData({ siteName, folderName, subfolderName, fileName: selectedPage }, pageData.pageSha)
+       if (isSelectedItemPage && pageData) await deletePageData({ siteName, folderName, subfolderName, fileName: selectedPage }, pageData.pageSha)
        else await deleteSubfolder({ siteName, folderName, subfolderName: selectedPage })
       },
       {
@@ -268,7 +263,7 @@ const Folders = ({ match, location }) => {
             )
           }
           {
-            isDeleteModalActive && pageData
+            isDeleteModalActive
             && (
               <DeleteWarningModal
                 onCancel={() => setIsDeleteModalActive(false)}


### PR DESCRIPTION
This PR fixes two issues on the folders layout:

- Success toast pops up on selecting the item for settings even if no settings are adjusted
- Folder deletion does not work as the deletion modal does not appear