### PR TITLE
fix: third nav title on page creation

### DIFF
--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -72,7 +72,7 @@ const PageSettingsModal = ({
     const { mutateAsync: saveHandler } = useMutation(
       () => {
         const frontMatter = subfolderName 
-          ? { ...originalFrontMatter, title, permalink, third_nav_title: subfolderName }
+          ? { ...originalFrontMatter, title, permalink, third_nav_title: deslugifyDirectory(subfolderName) }
           : { ...originalFrontMatter, title, permalink }
         const newPageData = concatFrontMatterMdBody(frontMatter, mdBody)
         if (isNewPage) return createPageData({ siteName, folderName, subfolderName, newFileName: generatePageFileName(title) },  newPageData) 


### PR DESCRIPTION
This PR fixes a bug involving the creation of collection pages. Currently, when we create a new collection page, the third nav title placed into the front matter is unslugified, meaning that the display on the actual site also shows the unslugified version. This can result in 2 separate third nav categories:
<img width="293" alt="Screenshot 2021-05-04 at 5 46 43 PM" src="https://user-images.githubusercontent.com/22111124/117394193-48364180-af28-11eb-9afe-8f9a260f5366.png">

To fix this, we unslugify the third-nav-title of the frontmatter on page creation.

Note that this only affects third nav page creation, as page movement correctly unslugifies the third nav title.