### PR TITLE
Refactor/media settings modal

### DIFF
--- a/src/components/ResourceFormFields.jsx
+++ b/src/components/ResourceFormFields.jsx
@@ -63,7 +63,7 @@ const ResourceFormFields = ({date, errors, changeHandler, onToggle, isPost, setI
         inlineButtonText={"Select File"}
         siteName={siteName}
         placeholder=" "
-        type="file"
+        type="files"
         errorMessage={errors.fileUrl}
         isDisabled={isPost}
       />

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -73,7 +73,7 @@ const EditorHeroSection = ({
             inlineButtonText="Choose Image"
             placeholder=" "
             siteName={siteName}
-            type="image"
+            type="images"
           />
           <div className={styles.card}>
             <p className={elementStyles.formLabel}>Hero Section Type</p>

--- a/src/components/homepage/InfopicSection.jsx
+++ b/src/components/homepage/InfopicSection.jsx
@@ -86,7 +86,7 @@ const EditorInfopicSection = ({
               inlineButtonText="Choose Image"
               placeholder=" "
               siteName={siteName}
-              type="image"
+              type="images"
             />
             <FormField
               title="Infopic image alt text"

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -57,12 +57,12 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
       onError: (err) => {
         if (err?.response?.status === 409) {
           // Error due to conflict in name
-          errorToast(`Another ${type === 'images' ? 'image' : 'file'} with the same name exists. Please choose a different name.`)
+          errorToast(`Another ${type.slice(0,-1)} with the same name exists. Please choose a different name.`)
         } else if (err?.response?.status === 413 || err?.response === undefined) {
           // Error due to file size too large - we receive 413 if nginx accepts the payload but it is blocked by our express settings, and undefined if it is blocked by nginx
-          errorToast(`Unable to upload as the ${type === 'images' ? 'image' : 'file'} size exceeds 5MB. Please reduce your ${type === 'images' ? 'image' : 'file'} size and try again.`)
+          errorToast(`Unable to upload as the ${type.slice(0,-1)} size exceeds 5MB. Please reduce your ${type.slice(0,-1)} size and try again.`)
         } else {
-          errorToast(`There was a problem trying to save this ${type === 'images' ? 'image' : 'file'}. ${DEFAULT_RETRY_MSG}`)
+          errorToast(`There was a problem trying to save this ${type.slice(0,-1)}. ${DEFAULT_RETRY_MSG}`)
         }
         console.log(err);
       },
@@ -80,7 +80,7 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
   const { mutateAsync: deleteHandler } = useMutation(
     () => deleteMedia({siteName, type, sha, customPath, fileName}),
     {
-      onError: () => errorToast(`There was a problem trying to delete this ${type === 'images' ? 'image' : 'file'}. ${DEFAULT_RETRY_MSG}`),
+      onError: () => errorToast(`There was a problem trying to delete this ${type.slice(0,-1)}. ${DEFAULT_RETRY_MSG}`),
       onSuccess: () => {
         successToast(`Successfully deleted ${type.slice(0,-1)}!`)
         queryClient.invalidateQueries(type === 'images' ? [IMAGE_CONTENTS_KEY, customPath] : [DOCUMENT_CONTENTS_KEY, customPath])
@@ -118,7 +118,7 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
       <div className={elementStyles.modal}>
         <div className={elementStyles.modalHeader}>
           <h1>
-            {isPendingUpload ? `Upload new ${type}` : `Edit ${type} details`}
+            {isPendingUpload ? `Upload new ${type.slice(0,-1)}` : `Edit ${type.slice(0,-1)} details`}
           </h1>
           <button type="button" onClick={onClose}>
             <i className="bx bx-x" />

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -192,4 +192,5 @@ MediaSettingsModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   isPendingUpload: PropTypes.bool.isRequired,
+  customPath: PropTypes.string,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,3 +12,5 @@ export const LAST_UPDATED_KEY = 'last-updated'
 export const PAGE_SETTINGS_KEY = 'page-settings';
 export const IMAGE_CONTENTS_KEY = 'image-contents'
 export const DOCUMENT_CONTENTS_KEY = 'document-contents'
+export const IMAGE_DETAILS_KEY = 'image-details'
+export const DOCUMENT_DETAILS_KEY = 'document-details'

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -364,7 +364,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
           customPath={customPath}
           isPendingUpload={false}
           onClose={() => setChosenMedia(null)}
-          onSave={() => window.location.reload()}
+          onSave={() => setChosenMedia(null)}
         />
         )
       }
@@ -379,7 +379,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
           // eslint-disable-next-line react/jsx-boolean-value
           isPendingUpload
           onClose={() => setPendingMediaUpload(null)}
-          onSave={() => window.location.reload()}
+          onSave={() => setPendingMediaUpload(null)}
         />
         )
       }

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -358,7 +358,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         chosenMedia
         && (
         <MediaSettingsModal
-          type={mediaNames[mediaType].slice(0,-1)}
+          type={mediaNames[mediaType]}
           media={chosenMedia}
           siteName={siteName}
           customPath={customPath}
@@ -372,7 +372,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         pendingMediaUpload
         && (
         <MediaSettingsModal
-          type={mediaNames[mediaType].slice(0,-1)}
+          type={mediaNames[mediaType]}
           media={pendingMediaUpload}
           siteName={siteName}
           customPath={customPath}

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -556,7 +556,7 @@ export default class Settings extends Component {
                     inlineButtonText={"Choose Image"}
                     siteName={siteName}
                     placeholder=" "
-                    type="image"
+                    type="images"
                   />
                   <FormFieldMedia
                     title="Favicon"
@@ -568,7 +568,7 @@ export default class Settings extends Component {
                     inlineButtonText={"Choose Image"}
                     siteName={siteName}
                     placeholder=" "
-                    type="image"
+                    type="images"
                   />
                   <FormFieldMedia
                     title="Shareicon"
@@ -580,7 +580,7 @@ export default class Settings extends Component {
                     inlineButtonText={"Choose Image"}
                     siteName={siteName}
                     placeholder=" "
-                    type="image"
+                    type="images"
                   />
                 </div>
                 {/* Analytics fields */}

--- a/src/utils.js
+++ b/src/utils.js
@@ -725,4 +725,9 @@ export const convertSubfolderArray = (folderOrderArray, rawFolderContents, subfo
     }
     return curr
   })
-} 
+}
+
+export const generateImageorFilePath = (customPath, fileName) => {
+  if (customPath) return encodeURIComponent(`${customPath}/${fileName}`)
+  return fileName
+}


### PR DESCRIPTION
Previously, we were unable to simply refetch the data as `MediaSettingsModal` was still a class component. This PR refactors the `MediaSettingsModal` into a functional component, and adds react-query to it, in order to handle updates to media details by refetching data instead of reloading the page. 

In addition, this PR also changes the type parameter of MediaSettingsModal to expect `images` and `files` instead of `image` and `file`, for greater consistency with the rest of the components.