### PR TITLE
Fix/resource name check

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -56,6 +56,7 @@ const ComponentSettingsModal = ({
         resourceDate: '',
     })
     const [hasErrors, setHasErrors] = useState(false)
+    const [hasChanges, setHasChanges] = useState(false)
 
     // Base hooks
     const [title, setTitle] = useState('')
@@ -65,9 +66,11 @@ const ComponentSettingsModal = ({
     const [isPost, setIsPost] = useState(true)
 
     // Track original values
+    const [originalTitle, setOriginalTitle] = useState('')
     const [originalPermalink, setOriginalPermalink] = useState('')
     const [originalFileUrl, setOriginalFileUrl] = useState('')
     const [originalFrontMatter, setOriginalFrontMatter] = useState({})
+    const [originalResourceDate, setOriginalResourceDate] = useState()
 
     // Resource-related
     const [resourceDate, setResourceDate] = useState('')
@@ -98,6 +101,7 @@ const ComponentSettingsModal = ({
             setIsPost(originalType === 'post')
 
             // Front matter properties
+            setOriginalTitle(originalTitle)
             setTitle(originalTitle)
 
             setPermalink(originalPermalink)
@@ -106,6 +110,7 @@ const ComponentSettingsModal = ({
             setOriginalFileUrl(originalFileUrl)
             setOriginalFrontMatter(originalFrontMatter)
 
+            setOriginalResourceDate(originalDate)
             setResourceDate(originalDate)
           }
         }
@@ -141,6 +146,10 @@ const ComponentSettingsModal = ({
     useEffect(() => {
         setHasErrors(!isPost ? (_.some(errors, (field) => field.length > 0) || !fileUrl ) : _.some(errors, (field) => field.length > 0) );
     }, [errors])
+
+    useEffect(() => {
+      setHasChanges(!(title === originalTitle && permalink === originalPermalink && fileUrl === originalFileUrl && resourceDate === originalResourceDate))
+    }, [title, permalink, fileUrl, resourceDate])
 
     const handlePermalinkFileUrlToggle = (event) => {
         const { target: { value } } = event;
@@ -248,7 +257,7 @@ const ComponentSettingsModal = ({
                   />
                 </div>
                 <SaveDeleteButtons 
-                  isDisabled={isNewFile ? hasErrors : (hasErrors || !sha)}
+                  isDisabled={isNewFile ? hasErrors : (!hasChanges || hasErrors || !sha)}
                   hasDeleteButton={false}
                   saveCallback={saveHandler}
                 />

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,7 +1,5 @@
-import { slugifyCategory } from '../utils';
-
 import _ from 'lodash';
-import { generatePageFileName, retrieveResourceFileMetadata, } from '../utils';
+import { generatePageFileName, retrieveResourceFileMetadata, slugifyCategory } from '../utils';
 
 // Common regexes and constants
 // ==============
@@ -701,7 +699,7 @@ const validateResourceSettings = (id, value, folderOrderArray) => {
       if (value.length > RESOURCE_SETTINGS_TITLE_MAX_LENGTH) {
         errorMessage = `The title should be shorter than ${RESOURCE_SETTINGS_TITLE_MAX_LENGTH} characters.`;
       }
-      if (folderOrderArray !== undefined && folderOrderArray.map(fileName => retrieveResourceFileMetadata(fileName).title).includes(value)) {
+      if (folderOrderArray !== undefined && folderOrderArray.map(fileName => slugifyCategory(retrieveResourceFileMetadata(fileName).title)).includes(slugifyCategory(value))) {
         errorMessage = `This title is already in use. Please choose a different title.`;
       }
       break;


### PR DESCRIPTION
This PR fixes a bug in which duplicate resource names were not being checked properly, resolving https://github.com/isomerpages/isomercms-frontend/issues/455.

Previously, we compared our resource name against a prettified version of the original resource title, meaning that only those matching the casing of the prettified title would be identified as a duplicate. We now slugify both the new title and the list of other resource file titles before running the duplicate check.

In addition, this PR also disables the save button for resource files if no changes have been made.