### PR TITLE
Fix: disable save button for folder modal on error

### DIFF
--- a/src/components/FolderModal.jsx
+++ b/src/components/FolderModal.jsx
@@ -127,7 +127,7 @@ const FolderModal = ({ displayTitle, displayText, onClose, folderOrCategoryName,
             errorMessage={errors}
           />
           <SaveDeleteButtons
-            isDisabled={false}
+            isDisabled={!!errors}
             hasDeleteButton={false}
             saveCallback={renameDirectory}
           />


### PR DESCRIPTION
This PR fixes a minor bug where users could still save even if the renamed folder title was invalid.