### PR TITLE
fix: duplicate resource title check for example_title

### DIFF
--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -20,6 +20,7 @@ import {
   retrieveResourceFileMetadata,
   concatFrontMatterMdBody,
   deslugifyDirectory,
+  slugifyCategory,
 } from '../utils';
 
 import { createPageData, updatePageData, renamePageData } from '../api'
@@ -118,7 +119,7 @@ const ComponentSettingsModal = ({
           const exampleDate = new Date().toISOString().split("T")[0]
           const examplePermalink = `/${category}/permalink`
           let exampleTitle = 'Example Title'
-          while (_.find(pageFileNames, (v) => generateResourceFileName(exampleTitle, exampleDate, isPost) === v ) !== undefined) {
+          while (pageFileNames.map(fileName => slugifyCategory(retrieveResourceFileMetadata(fileName).title)).includes(slugifyCategory(exampleTitle))) {
             exampleTitle = exampleTitle+'_1'
           }
           if (_isMounted) {


### PR DESCRIPTION
This bug fixes a small bug where upon file creation with title "Example Title", "Example Title" should be automatically postpended with "_1" if the title already exists. 

The bug was caused by checking for the uniqueness of the full resource post filename `{date}-{filetype}-{name}.md` as opposed to the uniqueness of just the `name` as we've now decided upon. 