### PR TITLE
Feat/moving media

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -317,6 +317,16 @@ const deleteMedia = async ({siteName, type, sha, customPath, fileName}) => {
     });
 }
 
+const moveMedia = async ({siteName, type, sha, oldCustomPath, newCustomPath, content, fileName, newFileName}) => {
+    const params = {
+        sha,
+        content,
+    };
+    if (newFileName === fileName && newCustomPath === oldCustomPath) {
+        return;
+    }
+    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(oldCustomPath, fileName)}/move/${generateImageorFilePath(newCustomPath, newFileName)}`, params);
+}
 
 const createMediaSubfolder = async (siteName, mediaType, customPath) => {
     if ((mediaType !== 'images' && mediaType !== 'documents') || !customPath) return
@@ -365,6 +375,7 @@ export {
     createMedia,
     renameMedia,
     deleteMedia,
+    moveMedia,
     createMediaSubfolder,
     renameMediaSubfolder,
     deleteMediaSubfolder,

--- a/src/api.js
+++ b/src/api.js
@@ -317,15 +317,15 @@ const deleteMedia = async ({siteName, type, sha, customPath, fileName}) => {
     });
 }
 
-const moveMedia = async ({siteName, type, sha, oldCustomPath, newCustomPath, content, fileName, newFileName}) => {
+const moveMedia = async ({siteName, type, sha, oldCustomPath, newCustomPath, content, fileName}) => {
     const params = {
         sha,
         content,
     };
-    if (newFileName === fileName && newCustomPath === oldCustomPath) {
+    if (newCustomPath === oldCustomPath) {
         return;
     }
-    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(oldCustomPath, fileName)}/move/${generateImageorFilePath(newCustomPath, newFileName)}`, params);
+    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(oldCustomPath, fileName)}/move/${generateImageorFilePath(newCustomPath, fileName)}`, params);
 }
 
 const createMediaSubfolder = async (siteName, mediaType, customPath) => {

--- a/src/api.js
+++ b/src/api.js
@@ -296,7 +296,7 @@ const createMedia = async ( {siteName, type, customPath, newFileName, content} )
     return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}`, params)
 }
 
-const renameMedia = async ({siteName, type, sha, customPath, fileName, newFileName}) => {
+const renameMedia = async ({siteName, type, customPath, fileName, newFileName}) => {
     if (newFileName === fileName) return
     return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(customPath, fileName)}/rename/${generateImageorFilePath(customPath, newFileName)}`);
 }
@@ -311,7 +311,7 @@ const deleteMedia = async ({siteName, type, sha, customPath, fileName}) => {
     });
 }
 
-const moveMedia = async ({siteName, type, sha, oldCustomPath, newCustomPath, content, fileName}) => {
+const moveMedia = async ({siteName, type, oldCustomPath, newCustomPath, fileName}) => {
     if (newCustomPath === oldCustomPath) return
     return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(oldCustomPath, fileName)}/move/${generateImageorFilePath(newCustomPath, fileName)}`);
 }

--- a/src/api.js
+++ b/src/api.js
@@ -296,15 +296,9 @@ const createMedia = async ( {siteName, type, customPath, newFileName, content} )
     return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}`, params)
 }
 
-const renameMedia = async ({siteName, type, sha, customPath, content, fileName, newFileName}) => {
-    const params = {
-        sha,
-        content,
-    };
-    if (newFileName === fileName) {
-        return;
-    }
-    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(customPath, fileName)}/rename/${generateImageorFilePath(customPath, newFileName)}`, params);
+const renameMedia = async ({siteName, type, sha, customPath, fileName, newFileName}) => {
+    if (newFileName === fileName) return
+    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(customPath, fileName)}/rename/${generateImageorFilePath(customPath, newFileName)}`);
 }
 
 const deleteMedia = async ({siteName, type, sha, customPath, fileName}) => {
@@ -318,14 +312,8 @@ const deleteMedia = async ({siteName, type, sha, customPath, fileName}) => {
 }
 
 const moveMedia = async ({siteName, type, sha, oldCustomPath, newCustomPath, content, fileName}) => {
-    const params = {
-        sha,
-        content,
-    };
-    if (newCustomPath === oldCustomPath) {
-        return;
-    }
-    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(oldCustomPath, fileName)}/move/${generateImageorFilePath(newCustomPath, fileName)}`, params);
+    if (newCustomPath === oldCustomPath) return
+    return await axios.post(`${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/${type === 'images' ? 'images' : 'documents'}/${generateImageorFilePath(oldCustomPath, fileName)}/move/${generateImageorFilePath(newCustomPath, fileName)}`);
 }
 
 const createMediaSubfolder = async (siteName, mediaType, customPath) => {

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -96,7 +96,7 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
             const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
             return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.fileName)
         }
-        if (!!!folderName && !!!subfolderName && allCategories) { // inside workspace, show all folders
+        if (!folderName && !subfolderName && allCategories) { // inside workspace, show all folders
             return allCategories.collections
         }
         return null

--- a/src/components/CollectionPagesSection.jsx
+++ b/src/components/CollectionPagesSection.jsx
@@ -70,8 +70,8 @@ const CollectionPagesSection = ({ collectionName, pages, siteName, isResource })
     // MOVE-TO Dropdown
     // get subfolders of selected folder for move-to dropdown
     const { data: querySubfolders } = useQuery(
-        [DIR_CONTENT_KEY, siteName, moveDropdownQuery.split('/')[0]],
-        async () => getDirectoryFile(siteName, moveDropdownQuery.split('/')[0]),
+        [DIR_CONTENT_KEY, siteName, moveDropdownQuery.split('/')[0]], // moveDropdownQuery has format {folderName} or {folderName}/{subfolderName}
+        async () => getDirectoryFile(siteName, moveDropdownQuery.split('/')[0]), 
         {   
             enabled: selectedFile.length > 0 && moveDropdownQuery.split('/')[0].length > 0 && !isResource,
             onError: () => errorToast(`The folders data could not be retrieved. ${DEFAULT_RETRY_MSG}`),

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
-import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 import { MenuItem } from './MenuDropdown'
 import { deslugifyDirectory } from '../utils'
@@ -125,4 +125,22 @@ const FileMoveMenuDropdown = ({
   )
 }
 
-export default FileMoveMenuDropdown
+export default FileMoveMenuDropdown;
+
+FileMoveMenuDropdown.propTypes = {
+  dropdownItems: PropTypes.arrayOf(
+    PropTypes.string.isRequired
+  ),
+  menuIndex: PropTypes.number.isRequired, 
+  dropdownRef: PropTypes.oneOfType([
+    PropTypes.func, 
+    PropTypes.shape({ current: PropTypes.any })
+  ]).isRequired,
+  onBlur: PropTypes.func,
+  rootName: PropTypes.string.isRequired,
+  moveDropdownQuery: PropTypes.string.isRequired,
+  setMoveDropdownQuery: PropTypes.func.isRequired,
+  backHandler: PropTypes.func.isRequired,
+  moveHandler: PropTypes.func,
+  moveDisabled: PropTypes.bool,
+}

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -33,18 +33,18 @@ const FileMoveMenuDropdown = ({
   const BreadcrumbButton = ({ name, idx }) => {
     const newMoveDropdownQuery = moveDropdownQuery.split('/').slice(0, idx+1).join('/') // retrieves paths elements up to (excluding) element idx
     return (
-      <button className={`${elementStyles.breadcrumbText} ml-1`} type="button" onClick={() => setMoveDropdownQuery(newMoveDropdownQuery)}>
+      <button className={`${elementStyles.breadcrumbText} ml-1`} type="button" onClick={(e) => {e.stopPropagation(); e.preventDefault(); setMoveDropdownQuery(newMoveDropdownQuery)}}>
         {name}
       </button>
     )
   }
 
   const Breadcrumb = (
-    <div className={contentStyles.segment}>
+    <div className="d-flex justify-content-start">
       { moveDropdownQuery !== '' 
         ? 
           <>
-          <BreadcrumbButton name={deslugifyDirectory(rootName)} idx={-1}/>
+          <BreadcrumbButton name={moveDropdownQuery.split("/").length > 1 ? '...' : deslugifyDirectory(rootName)} idx={-1}/>
           { 
             moveDropdownQuery.split("/").map((folderName, idx, arr) => {
               return idx === arr.length - 1

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { MenuItem } from './MenuDropdown'
+
 import elementStyles from '../styles/isomer-cms/Elements.module.scss';
+import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
+
+import { MenuItem } from './MenuDropdown'
 import { deslugifyDirectory } from '../utils'
 
 const FileMoveMenuDropdown = ({ 
@@ -16,8 +19,6 @@ const FileMoveMenuDropdown = ({
   moveDisabled,
 }) => {
 
-  const { folderName, subfolderName } = moveDropdownQuery
-
   const MoveButton = (
     <button
       type="button"
@@ -29,44 +30,39 @@ const FileMoveMenuDropdown = ({
     </button>
   )
 
+  const BreadcrumbButton = ({ name, idx }) => {
+    const newMoveDropdownQuery = moveDropdownQuery.split('/').slice(0, idx+1).join('/') // retrieves paths elements up to (excluding) element idx
+    return (
+      <button className={`${elementStyles.breadcrumbText} ml-1`} type="button" onClick={() => setMoveDropdownQuery(newMoveDropdownQuery)}>
+        {name}
+      </button>
+    )
+  }
+
   const Breadcrumb = (
-    <>
-      <span
-          id='workspace'
-          onClick={() => setMoveDropdownQuery({folderName: '', subfolderName: ''})}
-          style={ subfolderName || folderName ? {cursor:'pointer'}: {cursor:'default'}}
-      > 
-        {
-          subfolderName 
-          ? `... >` 
-          : !subfolderName && !folderName 
-          ? <strong>{rootName}</strong> 
-          : rootName
-        }
-      </span>
-      <span 
-        id='folder'
-        onClick={() => setMoveDropdownQuery({...moveDropdownQuery, subfolderName: ''})}
-        style={subfolderName ? {cursor:'pointer'} : {cursor:'default'}}
-      >
-        {
-          folderName && !subfolderName 
-          ? <strong> > {deslugifyDirectory(folderName)}</strong> 
-          : `${deslugifyDirectory(folderName)}`
-        }
-      </span>
-        {
-          subfolderName 
-          ? <strong> > {deslugifyDirectory(subfolderName)}</strong> 
-          : ''
-        }
-    </>
+    <div className={contentStyles.segment}>
+      { moveDropdownQuery !== '' 
+        ? 
+          <>
+          <BreadcrumbButton name={deslugifyDirectory(rootName)} idx={-1}/>
+          { 
+            moveDropdownQuery.split("/").map((folderName, idx, arr) => {
+              return idx === arr.length - 1
+              ? <> > <strong className="ml-1"> {deslugifyDirectory(folderName)}</strong></>
+              : <> > <BreadcrumbButton idx={idx} name={deslugifyDirectory(folderName)}/></>
+            })
+          }
+          </>
+        : <strong className="ml-1">{deslugifyDirectory(rootName)}</strong>
+      }
+    </div>
   )
 
-  const queryHandler = (categoryName) => {
-    if (folderName) setMoveDropdownQuery({...moveDropdownQuery, subfolderName: categoryName})
-    else setMoveDropdownQuery({...moveDropdownQuery, folderName: categoryName})
-  }
+  const queryHandler = (categoryName) => setMoveDropdownQuery((prevState) =>
+    prevState 
+      ? `${moveDropdownQuery}/${categoryName}`
+      : categoryName
+  )
 
   return (
     <div className={`${elementStyles.fileMoveDropdown} ${elementStyles.right}`} ref={dropdownRef} tabIndex={1} onBlur={onBlur}>

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -49,7 +49,7 @@ const FileMoveMenuDropdown = ({
             moveDropdownQuery.split("/").map((folderName, idx, arr) => {
               return idx === arr.length - 1
               ? <> > <strong className="ml-1"> {deslugifyDirectory(folderName)}</strong></>
-              : <> > <BreadcrumbButton idx={idx} name={deslugifyDirectory(folderName)}/></>
+              : <> > <BreadcrumbButton idx={idx} name={ idx < arr.length - 2 ? '...' : deslugifyDirectory(folderName) }/></> // shorten all except the last link
             })
           }
           </>

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -179,6 +179,17 @@ OverviewCard.propTypes = {
   siteName: PropTypes.string.isRequired,
   fileName: PropTypes.string.isRequired,
   isResource: PropTypes.bool,
+  isHomepage: PropTypes.bool,
+  allCategories: PropTypes.arrayOf(PropTypes.string),
+  resourceType: PropTypes.oneOf(['file', 'post', '']),
+  setIsComponentSettingsActive: PropTypes.func,
+  setSelectedFile: PropTypes.func,
+  setSelectedPath: PropTypes.func,
+  setCanShowDeleteWarningModal: PropTypes.func,
+  setCanShowMoveModal: PropTypes.func,
+  moveDropdownQuery: PropTypes.string,
+  setMoveDropdownQuery: PropTypes.func,
+  clearMoveDropdownQueryState: PropTypes.func,
 };
 
 export default OverviewCard

--- a/src/components/OverviewCard.jsx
+++ b/src/components/OverviewCard.jsx
@@ -145,10 +145,10 @@ const OverviewCard = ({
               setMoveDropdownQuery={setMoveDropdownQuery}
               backHandler={toggleDropdownModals}
               moveHandler={() => {
-                setSelectedPath(`${moveDropdownQuery.folderName ? moveDropdownQuery.folderName : 'pages'}${moveDropdownQuery.subfolderName ? `/${moveDropdownQuery.subfolderName}` : ''}`)
+                setSelectedPath(`${moveDropdownQuery ? moveDropdownQuery : 'pages'}`)
                 setCanShowMoveModal(true)
               }}
-              moveDisabled={isResource && !moveDropdownQuery.folderName} // cannot move resources to Workspace
+              moveDisabled={isResource && !moveDropdownQuery} // cannot move resources to Workspace
             />
           }
         </div>

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -148,7 +148,7 @@ const FolderContentItem = ({
                             setMoveDropdownQuery={setMoveDropdownQuery}
                             backHandler={toggleDropdownModals}
                             moveHandler={() => {
-                                setSelectedPath(`${moveDropdownQuery.folderName ? moveDropdownQuery.folderName : 'pages'}${moveDropdownQuery.subfolderName ? `/${moveDropdownQuery.subfolderName}` : ''}`)
+                                setSelectedPath(`${moveDropdownQuery ? moveDropdownQuery : 'pages'}`)
                                 setIsMoveModalActive(true)
                             }}
                         />
@@ -209,10 +209,7 @@ FolderContentItem.propTypes = {
     setIsFolderModalOpen: PropTypes.func,
     setIsMoveModalActive: PropTypes.func,
     setIsDeleteModalActive: PropTypes.func,
-    moveDropdownQuery: PropTypes.shape({
-        folderName: PropTypes.string,
-        subfolderName: PropTypes.string,
-    }),
+    moveDropdownQuery: PropTypes.string,
     setMoveDropdownQuery: PropTypes.func,
     clearMoveDropdownQueryState: PropTypes.func,
 };

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -72,8 +72,10 @@ const MediaCard = ({
       className={isSelected ? mediaStyles.selectedMediaCard : mediaStyles.mediaCard}
       key={media.path}
       onClick={(e) => { 
+        e.stopPropagation();
         e.preventDefault(); 
-        if (onClick) onClick();
+        setSelectedMedia(media);
+        onClick();
       }}
     > 
       {
@@ -102,7 +104,7 @@ const MediaCard = ({
           </div>
         )
       }
-      <div className={mediaStyles.mediaCardDescription}>
+      <div className={`${mediaStyles.mediaCardDescription} ${contentStyles.card} ${contentStyles.component}`}>
         <div className={mediaStyles.mediaCardName}>{media.fileName}</div>
         {/* Settings dropdown */}
         { showSettings && (

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -1,15 +1,81 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+
+import { MenuDropdown } from '../MenuDropdown'
+import FileMoveMenuDropdown from '../FileMoveMenuDropdown'
+
 import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
+import contentStyles from '../../styles/isomer-cms/pages/Content.module.scss';
 
 const MediaCard = ({
-  type, siteName, onClick, media, isSelected, canShowEditIcon,
-}) => (
-  <div
-    className={isSelected ? mediaStyles.selectedMediaCard : mediaStyles.mediaCard}
-    key={media.path}
-  >
-    <a href="/" onClick={(e) => { e.preventDefault(); onClick(); }}>
+  type, 
+  siteName, 
+  onClick, 
+  media, 
+  mediaItemIndex,
+  isSelected,
+  setSelectedMedia,
+  setSelectedPath,
+  allCategories,
+  showSettings,
+  moveDropdownQuery,
+  setIsMoveModalActive,
+  setIsMediaSettingsActive, 
+  setIsDeleteModalActive,
+  setMoveDropdownQuery,
+  clearMoveDropdownQueryState,
+}) => {
+  const [showDropdown, setShowDropdown] = useState(false)
+  const [showFileMoveDropdown, setShowFileMoveDropdown] = useState(false)
+  const dropdownRef = useRef(null)
+  const fileMoveDropdownRef = useRef(null)
+
+  useEffect(() => {
+      if (showDropdown) dropdownRef.current.focus()
+      if (showFileMoveDropdown) fileMoveDropdownRef.current.focus()
+  }, [showDropdown, showFileMoveDropdown])
+
+  const handleBlur = (event) => {
+      // if the blur was because of outside focus
+      // currentTarget is the parent element, relatedTarget is the clicked element
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+          setShowFileMoveDropdown(false)
+          clearMoveDropdownQueryState()
+      }
+  }
+
+  const toggleDropdownModals = () => {
+      setShowFileMoveDropdown(!showFileMoveDropdown)
+      setShowDropdown(!showDropdown)
+  }
+
+  const generateDropdownItems = () => {
+    const dropdownItems = [
+      {
+        type: 'edit',
+        handler: () => setIsMediaSettingsActive(true)
+      },
+      {
+        type: 'move',
+        handler: toggleDropdownModals
+      },
+      {
+        type: 'delete',
+        handler: () => setIsDeleteModalActive(true)
+      },
+    ]
+    return dropdownItems
+  }
+
+  return (
+    <div
+      className={isSelected ? mediaStyles.selectedMediaCard : mediaStyles.mediaCard}
+      key={media.path}
+      onClick={(e) => { 
+        e.preventDefault(); 
+        if (onClick) onClick();
+      }}
+    > 
       {
         type === 'images' && (
           <div className={mediaStyles.mediaCardImagePreviewContainer}>
@@ -38,11 +104,52 @@ const MediaCard = ({
       }
       <div className={mediaStyles.mediaCardDescription}>
         <div className={mediaStyles.mediaCardName}>{media.fileName}</div>
-        { canShowEditIcon && <i className="bx bxs-edit" /> }
+        {/* Settings dropdown */}
+        { showSettings && (
+          <div className={`position-relative mt-auto mb-auto`}>
+            <button
+              className={`${showDropdown ? contentStyles.optionsIconFocus : contentStyles.optionsIcon}`}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                setShowDropdown(true)
+                setSelectedMedia(media)
+              }}
+            >
+              <i className="bx bx-dots-vertical-rounded" />
+            </button>
+            { showDropdown &&
+              <MenuDropdown
+                menuIndex={mediaItemIndex}
+                dropdownItems={generateDropdownItems()}
+                dropdownRef={dropdownRef}
+                tabIndex={2}
+                onBlur={()=>setShowDropdown(false)}
+              />
+            }
+            { showFileMoveDropdown &&
+              <FileMoveMenuDropdown 
+                dropdownItems={allCategories}
+                dropdownRef={fileMoveDropdownRef}
+                menuIndex={mediaItemIndex}
+                onBlur={handleBlur}
+                rootName={type}
+                moveDropdownQuery={moveDropdownQuery}
+                setMoveDropdownQuery={setMoveDropdownQuery}
+                backHandler={toggleDropdownModals}
+                moveHandler={() => {
+                  setSelectedPath(moveDropdownQuery)
+                  setIsMoveModalActive(true)
+                }}
+              />
+            }
+          </div>
+        )}
       </div>
-    </a>
-  </div>
-);
+    </div>
+  )
+};
 
 MediaCard.propTypes = {
   type: PropTypes.oneOf(['images', 'files', 'dirs']).isRequired,

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -156,13 +156,23 @@ const MediaCard = ({
 MediaCard.propTypes = {
   type: PropTypes.oneOf(['images', 'files', 'dirs']).isRequired,
   siteName: PropTypes.string,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   media: PropTypes.shape({
     fileName: PropTypes.string,
     path: PropTypes.string,
   }).isRequired,
+  mediaItemIndex: PropTypes.number,
   isSelected: PropTypes.bool,
-  canShowEditIcon: PropTypes.bool,
+  setSelectedMedia: PropTypes.func,
+  setSelectedPath: PropTypes.func,
+  allCategories: PropTypes.arrayOf(PropTypes.string),
+  showSettings: PropTypes.bool,
+  moveDropdownQuery: PropTypes.string,
+  setIsMoveModalActive: PropTypes.func,
+  setIsMediaSettingsActive: PropTypes.func,
+  setIsDeleteModalActive: PropTypes.func,
+  setMoveDropdownQuery: PropTypes.func,
+  clearMoveDropdownQueryState: PropTypes.func,
 };
 
 MediaCard.defaultProps = {

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -74,7 +74,7 @@ const MediaCard = ({
       onClick={(e) => { 
         e.stopPropagation();
         e.preventDefault(); 
-        setSelectedMedia(media);
+        if (setSelectedMedia) setSelectedMedia(media);
         if (!showFileMoveDropdown && !showDropdown && onClick) onClick();
       }}
     > 

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -75,7 +75,7 @@ const MediaCard = ({
         e.stopPropagation();
         e.preventDefault(); 
         setSelectedMedia(media);
-        onClick();
+        if (!showFileMoveDropdown && !showDropdown && onClick) onClick();
       }}
     > 
       {

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -18,27 +18,10 @@ import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 
 const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingUpload, customPath }) => {
   const fileName = media.fileName || ''
+  const sha = media.sha || ''
   const [newFileName, setNewFileName] = useState(fileName)
-  const [sha, setSha] = useState()
-  const [content, setContent] = useState()
   const errorMessage = validateFileName(newFileName);
   const queryClient = useQueryClient()
-
-  // Retrieve media information
-  const { data: mediaData } = useQuery(
-    type === 'images' ? [IMAGE_DETAILS_KEY, customPath, fileName] : [DOCUMENT_DETAILS_KEY, customPath, fileName],
-    () => {if (!isPendingUpload) return getMediaDetails({siteName, type, customPath, fileName})},
-    {
-      retry: false,
-      onError: (err) => {
-        if (err.response && err.response.status === 404) {
-          setRedirectToNotFound(siteName)
-        } else {
-          errorToast()
-        }
-      }
-    },
-  )
 
   // Handling save
   const { mutateAsync: saveHandler } = useMutation(
@@ -48,7 +31,7 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
         return createMedia({siteName, type, customPath, newFileName, content})
       } else {
         // Renaming an existing file
-        return renameMedia({siteName, type, customPath, sha, content, fileName, newFileName})
+        return renameMedia({siteName, type, customPath, sha, fileName, newFileName})
       }
     },
     {
@@ -73,27 +56,6 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
       },
     }
   )
-
-  useEffect(() => {
-    let _isMounted = true
-    if (_isMounted && isPendingUpload) {
-      const { content:retrievedContent } = media
-      setContent(retrievedContent)
-      return
-    }
-    if (mediaData) {
-      const retrievedSha = mediaData.sha
-      const retrievedContent = mediaData.content
-      if (_isMounted) {
-        setContent(retrievedContent)
-        setSha(retrievedSha)
-      }
-    }
-
-    return () => {
-      _isMounted = false
-    }
-  }, [mediaData])
 
   return (
     <div className={elementStyles.overlay}>

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -10,8 +10,8 @@ import {
   DEFAULT_RETRY_MSG,
 } from '../../utils'
 import { errorToast, successToast } from '../../utils/toasts';
-import { getMediaDetails, createMedia, renameMedia } from '../../api';
-import { IMAGE_DETAILS_KEY, IMAGE_CONTENTS_KEY, DOCUMENT_DETAILS_KEY, DOCUMENT_CONTENTS_KEY} from '../../constants'
+import { createMedia, renameMedia } from '../../api';
+import { IMAGE_CONTENTS_KEY, DOCUMENT_CONTENTS_KEY } from '../../constants'
 
 import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
@@ -28,10 +28,10 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
     () => {
       if (isPendingUpload) {
         // Creating a new file
-        return createMedia({siteName, type, customPath, newFileName, content})
+        return createMedia({siteName, type, customPath, newFileName, content: media.content})
       } else {
         // Renaming an existing file
-        return renameMedia({siteName, type, customPath, sha, fileName, newFileName})
+        return renameMedia({siteName, type, customPath, fileName, newFileName})
       }
     },
     {
@@ -73,7 +73,7 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
             <div className={mediaStyles.editImagePreview}>
               <img
                 alt={`${media.fileName}`}
-                src={isPendingUpload ? `data:image/png;base64,${content}`
+                src={isPendingUpload ? `data:image/png;base64,${media.content}`
                   : (
                     `https://raw.githubusercontent.com/isomerpages/${siteName}/staging/${media.path}${media.path.endsWith('.svg')
                       ? '?sanitize=true'

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import FormField from '../FormField';
 import SaveDeleteButtons from '../SaveDeleteButtons';
 
-import { validateFileName } from '../../utils/validators';
+import { validateMediaSettings } from '../../utils/validators';
 import {
   DEFAULT_RETRY_MSG,
 } from '../../utils'
@@ -16,11 +16,19 @@ import { IMAGE_CONTENTS_KEY, DOCUMENT_CONTENTS_KEY } from '../../constants'
 import mediaStyles from '../../styles/isomer-cms/pages/Media.module.scss';
 import elementStyles from '../../styles/isomer-cms/Elements.module.scss';
 
-const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingUpload, customPath }) => {
+const MediaSettingsModal = ({
+  type,
+  siteName,
+  onClose,
+  onSave,
+  media,
+  mediaFileNames,
+  isPendingUpload,
+  customPath,
+}) => {
   const fileName = media.fileName || ''
-  const sha = media.sha || ''
   const [newFileName, setNewFileName] = useState(fileName)
-  const errorMessage = validateFileName(newFileName);
+  const errorMessage = validateMediaSettings(newFileName, mediaFileNames)
   const queryClient = useQueryClient()
 
   // Handling save
@@ -100,11 +108,10 @@ const MediaSettingsModal = ({ type, siteName, onClose, onSave, media, isPendingU
           </div>
           <SaveDeleteButtons
             saveLabel={isPendingUpload ? "Upload" : "Save"}
-            isDisabled={isPendingUpload ? false : !sha}
-            isSaveDisabled={isPendingUpload ? false : (fileName === newFileName || errorMessage || !sha)}
+            isSaveDisabled={errorMessage || (!isPendingUpload && fileName === newFileName)}
             hasDeleteButton={false}
             saveCallback={saveHandler}
-            isLoading={isPendingUpload ? false : !sha}
+            isLoading={!!!media}
           />
         </form>
       </div>
@@ -120,6 +127,7 @@ MediaSettingsModal.propTypes = {
     path: PropTypes.string,
     content: PropTypes.string,
   }).isRequired,
+  mediaFileNames: PropTypes.arrayOf(PropTypes.string),
   type: PropTypes.oneOf(['images', 'files']).isRequired,
   siteName: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -111,7 +111,7 @@ const MediaSettingsModal = ({
             isSaveDisabled={errorMessage || (!isPendingUpload && fileName === newFileName)}
             hasDeleteButton={false}
             saveCallback={saveHandler}
-            isLoading={!!!media}
+            isLoading={!media}
           />
         </form>
       </div>

--- a/src/components/media/MediaSettingsModal.jsx
+++ b/src/components/media/MediaSettingsModal.jsx
@@ -131,6 +131,7 @@ MediaSettingsModal.propTypes = {
   type: PropTypes.oneOf(['images', 'files']).isRequired,
   siteName: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
   isPendingUpload: PropTypes.bool.isRequired,
   customPath: PropTypes.string,
 };

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Link } from 'react-router-dom';
 import _ from 'lodash';
@@ -41,8 +41,6 @@ import elementStyles from '../styles/isomer-cms/Elements.module.scss';
 import contentStyles from '../styles/isomer-cms/pages/Content.module.scss';
 
 const Folders = ({ match, location }) => {
-    // Instantiate queryClient
-    const queryClient = useQueryClient()
     const { siteName, folderName, subfolderName } = match.params;
 
     // set Move-To dropdown to start from current location of file
@@ -187,7 +185,7 @@ const Folders = ({ match, location }) => {
     // MOVE-TO Dropdown
     // get subfolders of selected folder for move-to dropdown
     const { data: querySubfolders } = useQuery(
-      [DIR_CONTENT_KEY, siteName, moveDropdownQuery.split('/')[0]],
+      [DIR_CONTENT_KEY, siteName, moveDropdownQuery.split('/')[0]],  // moveDropdownQuery has format {folderName} or {folderName}/{subfolderName}
       async () => getDirectoryFile(siteName, moveDropdownQuery.split('/')[0]),
       {
         enabled: selectedPage.length > 0 && moveDropdownQuery.split('/')[0].length > 0 && isSelectedItemPage,

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -46,7 +46,7 @@ const Folders = ({ match, location }) => {
     const { siteName, folderName, subfolderName } = match.params;
 
     // set Move-To dropdown to start from current location of file
-    const initialMoveDropdownQueryState = `${folderName}/${subfolderName}`
+    const initialMoveDropdownQueryState = `${folderName}${subfolderName ? `/${subfolderName}` : ''}`
 
     const { setRedirectToPage } = useRedirectHook()
 

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -205,7 +205,7 @@ const Folders = ({ match, location }) => {
         const parsedFolderArray = convertFolderOrderToArray(parsedFolderContents)
         return parsedFolderArray.filter(file => file.type === 'dir').map(file => file.fileName)
       }
-      if (!!!folderName && !!!subfolderName && allFolders) { // inside workspace, show all folders
+      if (!folderName && !subfolderName && allFolders) { // inside workspace, show all folders
         return allFolders.collections
       }
       return null

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -423,6 +423,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
                       setSelectedMedia={setSelectedMedia}
                       setSelectedPath={setSelectedPath}
                       showSettings={true}
+                      onClick={() => setIsMediaSettingsActive(true)}
                       setIsMoveModalActive={setIsMoveModalActive}
                       setIsDeleteModalActive={setIsDeleteModalActive}
                       setIsMediaSettingsActive={setIsMediaSettingsActive}
@@ -453,8 +454,8 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
           siteName={siteName}
           customPath={customPath}
           isPendingUpload={false}
-          onClose={() => setIsMediaSettingsActive(false)}
-          onSave={() => setIsMediaSettingsActive(false)}
+          onClose={() => {setIsMediaSettingsActive(false); setSelectedMedia(null);}}
+          onSave={() => {setIsMediaSettingsActive(false); setSelectedMedia(null);}}
         />
         )
       }

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -204,7 +204,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
   const { mutateAsync: moveHandler } = useMutation(
     async () => {
       const { fileName } = selectedMedia
-      await moveMedia({ siteName, type: mediaNames[mediaType], oldCustomPath: customPath, newCustomPath: selectedPath, fileName, newFileName: fileName})
+      await moveMedia({ siteName, type: mediaNames[mediaType], oldCustomPath: customPath, newCustomPath: selectedPath, fileName})
     },
     {
       onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -92,7 +92,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
   
   const { data: mediaData, refetch } = useQuery(
     mediaType === 'images' ? [IMAGE_CONTENTS_KEY, customPath] : [DOCUMENT_CONTENTS_KEY, customPath],
-    async () => getMedia(siteName, customPath ? decodeURIComponent(customPath): '', mediaNames[mediaType]),
+    () => getMedia(siteName, customPath ? decodeURIComponent(customPath): '', mediaNames[mediaType]),
     {
       retry: false,
       onError: (err) => {
@@ -215,7 +215,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
       },
       onSettled: () => {
         setIsMoveModalActive((prevState) => !prevState)
-        setSelectedMedia('')
+        setSelectedMedia(null)
         setSelectedPath('')
         setMoveDropdownQuery(initialMoveDropdownQueryState)
       },

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -451,6 +451,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         <MediaSettingsModal
           type={mediaNames[mediaType]}
           media={selectedMedia}
+          mediaFileNames={media.filter(media => media.fileName !== selectedMedia.fileName).map(media => media.fileName)}
           siteName={siteName}
           customPath={customPath}
           isPendingUpload={false}
@@ -465,6 +466,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         <MediaSettingsModal
           type={mediaNames[mediaType]}
           media={pendingMediaUpload}
+          mediaFileNames={media.filter(media => media.fileName !== pendingMediaUpload.fileName).map(media => media.fileName)}
           siteName={siteName}
           customPath={customPath}
           // eslint-disable-next-line react/jsx-boolean-value

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -10,10 +10,12 @@ import Sidebar from '../components/Sidebar';
 import FolderCard from '../components/FolderCard'
 import FolderOptionButton from '../components/folders/FolderOptionButton'
 import FolderNamingModal from '../components/FolderNamingModal'
+import GenericWarningModal from '../components/GenericWarningModal'
+import DeleteWarningModal from '../components/DeleteWarningModal';
 import MediaCard from '../components/media/MediaCard';
 import MediaSettingsModal from '../components/media/MediaSettingsModal';
 
-import { createMediaSubfolder, getMedia } from '../api';
+import { createMediaSubfolder, getMedia, moveMedia, deleteMedia } from '../api';
 import { IMAGE_CONTENTS_KEY, DOCUMENT_CONTENTS_KEY } from '../constants'
 
 import useRedirectHook from '../hooks/useRedirectHook';
@@ -62,19 +64,35 @@ const getPrevDirectoryName = (customPath, mediaType) => {
 }
 
 const Media = ({ match: { params: { siteName, customPath } }, location, mediaType }) => {
+  // set Move-To dropdown to start from current location of media
+  const initialMoveDropdownQueryState = customPath ? decodeURIComponent(customPath) : ''
+
   const [media, setMedia] = useState([])
   const [directories, setDirectories] = useState([])
   const [directoryNames, setDirectoryNames] = useState([])
   const [pendingMediaUpload, setPendingMediaUpload] = useState(null)
-  const [chosenMedia, setChosenMedia] = useState('')
   const [newFolderName, setNewFolderName] = useState('')
   const [errors, setErrors] = useState('')
   const [isCreateModalActive, setIsCreateModalActive] = useState(false)
   const { setRedirectToNotFound } = useRedirectHook()
 
+  const [isMediaSettingsActive, setIsMediaSettingsActive] = useState(false)
+  const [isDeleteModalActive, setIsDeleteModalActive] = useState(false)
+  
+  // for dropdown settings
+  const [selectedMedia, setSelectedMedia] = useState(null)
+  const [selectedPath, setSelectedPath] = useState('')
+  const [moveDropdownQuery, setMoveDropdownQuery] = useState('')
+  const [isMoveModalActive, setIsMoveModalActive] = useState(false)
+
+  // re-initialize query whenever we navigate between folders and subfolder pages
+  useEffect(() => {
+    setMoveDropdownQuery(initialMoveDropdownQueryState)
+  }, [customPath])
+  
   const { data: mediaData, refetch } = useQuery(
     mediaType === 'images' ? [IMAGE_CONTENTS_KEY, customPath] : [DOCUMENT_CONTENTS_KEY, customPath],
-    () => getMedia(siteName, customPath ? decodeURIComponent(customPath): '', mediaNames[mediaType]),
+    async () => getMedia(siteName, customPath ? decodeURIComponent(customPath): '', mediaNames[mediaType]),
     {
       retry: false,
       onError: (err) => {
@@ -103,7 +121,6 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
     }
   )
   
-
   useEffect(() => {
     let _isMounted = true
 
@@ -182,6 +199,68 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
     setNewFolderName(value)
     setErrors(errorMessage)
   }
+
+  // move file
+  const { mutateAsync: moveHandler } = useMutation(
+    async () => {
+      const { fileName } = selectedMedia
+      await moveMedia({ siteName, type: mediaNames[mediaType], oldCustomPath: customPath, newCustomPath: selectedPath, fileName, newFileName: fileName})
+    },
+    {
+      onError: () => errorToast(`Your file could not be moved successfully. ${DEFAULT_RETRY_MSG}`),
+      onSuccess: (noChange) => {
+        if (noChange) return successToast('Page is already in this folder') 
+        successToast('Successfully moved file') 
+        refetch()
+      },
+      onSettled: () => {
+        setIsMoveModalActive((prevState) => !prevState)
+        setSelectedMedia('')
+        setSelectedPath('')
+        setMoveDropdownQuery(initialMoveDropdownQueryState)
+      },
+    }
+  )
+
+  // MOVE-TO Dropdown
+  // get folders for move-to dropdown
+  const { data: dropdownMediaData } = useQuery(
+    mediaType === 'images' ? [IMAGE_CONTENTS_KEY, moveDropdownQuery] : [DOCUMENT_CONTENTS_KEY, moveDropdownQuery],
+    async () => getMedia(siteName, moveDropdownQuery || '', mediaNames[mediaType]),
+    {
+      enabled: !!selectedMedia,
+      retry: false,
+      onError: () => errorToast(`The ${mediaType} data could not be retrieved. ${DEFAULT_RETRY_MSG}`)
+    },
+  )
+
+  // MOVE-TO Dropdown utils
+  // parse responses from move-to queries
+  const getCategories = (dropdownMediaData) => {
+    if (!!!dropdownMediaData) return []
+    const { respDirectories } = dropdownMediaData
+    return respDirectories.map(directory => directory.name)
+  }
+
+  // Handling delete
+  const { mutateAsync: deleteHandler } = useMutation(
+    async () => {
+      const { sha, fileName } = selectedMedia
+      return await deleteMedia({ siteName, type: mediaNames[mediaType], sha, customPath, fileName })
+    },
+    {
+      onError: () => errorToast(`There was a problem trying to delete this ${mediaType.slice(0,-1)}. ${DEFAULT_RETRY_MSG}`),
+      onSuccess: () => {
+        successToast(`Successfully deleted ${mediaType.slice(0,-1)}!`)
+        refetch()
+      },
+      onSettled: () => {
+        setIsDeleteModalActive(false)
+        setIsMediaSettingsActive(false)
+        setPendingMediaUpload(null)
+      },
+    }
+  )
 
   return (
     <>
@@ -334,12 +413,22 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
                 {/* Media */}
                 {
                   media && media.length > 0
-                  ? media.map((media) => (
+                  ? media.map((media, mediaItemIndex) => (
                     <MediaCard
                       type={mediaNames[mediaType]}
+                      allCategories={getCategories(dropdownMediaData)}
                       media={media}
                       siteName={siteName}
-                      onClick={() => setChosenMedia(media)}
+                      mediaItemIndex={mediaItemIndex}
+                      setSelectedMedia={setSelectedMedia}
+                      setSelectedPath={setSelectedPath}
+                      showSettings={true}
+                      setIsMoveModalActive={setIsMoveModalActive}
+                      setIsDeleteModalActive={setIsDeleteModalActive}
+                      setIsMediaSettingsActive={setIsMediaSettingsActive}
+                      moveDropdownQuery={moveDropdownQuery}
+                      setMoveDropdownQuery={setMoveDropdownQuery}
+                      clearMoveDropdownQueryState={() => setMoveDropdownQuery(initialMoveDropdownQueryState)}
                       key={media.fileName}
                     />
                   )) : (
@@ -356,21 +445,21 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         {/* main section ends here */}
       </div>
       {
-        chosenMedia
-        && (
+        isMediaSettingsActive && selectedMedia // existing media
+        && ( 
         <MediaSettingsModal
           type={mediaNames[mediaType]}
-          media={chosenMedia}
+          media={selectedMedia}
           siteName={siteName}
           customPath={customPath}
           isPendingUpload={false}
-          onClose={() => setChosenMedia(null)}
-          onSave={() => setChosenMedia(null)}
+          onClose={() => setIsMediaSettingsActive(false)}
+          onSave={() => setIsMediaSettingsActive(false)}
         />
         )
       }
       {
-        pendingMediaUpload
+        pendingMediaUpload // new media
         && (
         <MediaSettingsModal
           type={mediaNames[mediaType]}
@@ -382,6 +471,29 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
           onClose={() => setPendingMediaUpload(null)}
           onSave={() => setPendingMediaUpload(null)}
         />
+        )
+      }
+      {
+        isMoveModalActive && selectedMedia
+        && (
+          <GenericWarningModal
+            displayTitle="Warning"
+            displayText={`Moving ${mediaType.slice(0,-1)} to a different folder might lead to user confusion. You may wish to change the permalinks for this ${mediaType.slice(0,-1)} afterwards.`}
+            onProceed={moveHandler}
+            onCancel={() => setIsMoveModalActive(false)}
+            proceedText="Continue"
+            cancelText="Cancel"
+          />
+        )
+      }
+      {
+        isDeleteModalActive && selectedMedia
+        && (
+          <DeleteWarningModal
+            onCancel={() => setIsDeleteModalActive(false)}
+            onDelete={deleteHandler}
+            type="image"
+          />
         )
       }
       {

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -237,7 +237,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
   // MOVE-TO Dropdown utils
   // parse responses from move-to queries
   const getCategories = (dropdownMediaData) => {
-    if (!!!dropdownMediaData) return []
+    if (!dropdownMediaData) return []
     const { respDirectories } = dropdownMediaData
     return respDirectories.map(directory => directory.name)
   }
@@ -313,7 +313,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
                   decodeURIComponent(customPath).split("/").map((folderName, idx, arr) => {
                     return idx === arr.length - 1
                     ? <span> ><strong className="ml-1"> {deslugifyDirectory(folderName)}</strong></span>
-                    : <span> ><Link to={`/sites/${siteName}/${mediaType}/${encodeURIComponent(arr.slice(0,idx+1))}`}><strong className="ml-1"> {deslugifyDirectory(folderName)}</strong></Link></span>
+                    : <span> ><Link to={`/sites/${siteName}/${mediaType}/${encodeURIComponent(arr.slice(0,idx+1).join('/'))}`}><strong className="ml-1"> {deslugifyDirectory(folderName)}</strong></Link></span>
                   })
                 }
               </span>
@@ -466,7 +466,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         <MediaSettingsModal
           type={mediaNames[mediaType]}
           media={pendingMediaUpload}
-          mediaFileNames={media.filter(media => media.fileName !== pendingMediaUpload.fileName).map(media => media.fileName)}
+          mediaFileNames={media.map(media => media.fileName)}
           siteName={siteName}
           customPath={customPath}
           // eslint-disable-next-line react/jsx-boolean-value

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -481,7 +481,7 @@ const Media = ({ match: { params: { siteName, customPath } }, location, mediaTyp
         && (
           <GenericWarningModal
             displayTitle="Warning"
-            displayText={`Moving ${mediaType.slice(0,-1)} to a different folder might lead to user confusion. You may wish to change the permalinks for this ${mediaType.slice(0,-1)} afterwards.`}
+            displayText={`Moving ${mediaType} to a different folder might lead to user confusion. You may wish to change the permalinks for this ${mediaType.slice(0,-1)} afterwards.`}
             onProceed={moveHandler}
             onCancel={() => setIsMoveModalActive(false)}
             proceedText="Continue"

--- a/src/styles/isomer-cms/pages/Media.module.scss
+++ b/src/styles/isomer-cms/pages/Media.module.scss
@@ -133,7 +133,7 @@
       }
 
       &:hover{
-        transform: translateY(-5px);
+        cursor: pointer;
       }
     }
   }

--- a/src/styles/isomer-cms/pages/Media.module.scss
+++ b/src/styles/isomer-cms/pages/Media.module.scss
@@ -110,14 +110,11 @@
         justify-content: center;
         align-items: center;
         padding-left: 15px;
-
-        i {
-          color: black;
-          margin-right: 16px;
-          font-size: x-large;
-        }
+        padding-right: 15px;
 
         .mediaCardName{
+          color: black;
+          font-size: x-large;
           width: 100%;
           font-size: .9em;
           color: $body-text;

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -760,6 +760,18 @@ const validateResourceSettings = (id, value, folderOrderArray) => {
   return errorMessage;
 };
 
+// Media Settings Modal
+// ===================
+
+const validateMediaSettings = (value, mediaFileNames) => {
+  let errorMessage = validateFileName(value)
+  
+  if (mediaFileNames !== undefined && mediaFileNames.includes(value)) {
+    errorMessage = `This title is already in use. Please choose a different title.`;
+  }
+  return errorMessage
+}
+
 // Resource room creation
 // ===================
 const validateResourceRoomName = (value) => {
@@ -837,6 +849,7 @@ export {
   validateSections,
   validatePageSettings,
   validateResourceSettings,
+  validateMediaSettings,
   validateCategoryName,
   validateSocialMedia,
   validateFileName,


### PR DESCRIPTION
This PR introduces the feature to move media between folders. Previously in #441, we've refactored our Media layouts to support nested media folders, but we did not support file moving between folders. This closes #452. 
This PR should be reviewed with [#isomercms-backend/178](https://github.com/isomerpages/isomercms-backend/pull/178).

#### Other minor changes introduced in this PR:
- [feature] duplicate filename checking on `MediaSettingsModal` ** (see below)
- [refactor] removes call to retrieve media content in `MediaSettingsModal` on the frontend during rename operations
- [refactor] generalizes `FileMoveDropdownModal` to accept path query of any length
- [fix] bug in Media Breadcrumb

#### Technical Notes
Even though we introduce duplicate filename checking on `MediaSettingsModal`, this functionality will not work in `EditPage` and `FormFieldMedia` as `MediaSettingsModal` (where the check for duplication occurs) and `MediaModal` (where the call to retrieve media is performed) do not share state. We should tackle this issue in a later refactor. To simplify this, we can consider using hooks and/or context to abstract out the logic and state in `MediaSettingsModal` and `MediaModal`  for reuse. 

#### UX Notes
After consulting with Nat, we've decided on some of the following UX decisions:
- Remove the bounce hover state for `MediaCards` in favor of a pointer to standardize hover state across CMS 
- Preserve the `onClick -> Edit media` functionality of `MediaCards` in `Media`
