### PR TITLE
Feat/front matter changes for resources and pages

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -148,6 +148,13 @@ const renameSubfolder = async ({ siteName, folderName, subfolderName, newSubfold
     return await axios.post(apiUrl)
 }
 
+const getResourceRoomName = async(siteName) => {
+    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resource-room`
+    const resp = await axios.get(apiUrl)
+    const { resourceRoom } = resp.data
+    return resourceRoom
+}
+
 // Resources
 const deleteResourceCategory = async ({ siteName, categoryName}) => {
     const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/resources/${categoryName}`
@@ -347,6 +354,7 @@ export {
     renameFolder,
     deleteSubfolder,
     renameSubfolder,
+    getResourceRoomName,
     deleteResourceCategory,
     renameResourceCategory,
     getAllResourceCategories,

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -111,8 +111,8 @@ const ComponentSettingsModal = ({
         if (pageData !== undefined) { // is existing page
           const { pageContent, pageSha } = pageData
           const { frontMatter, mdBody: pageMdBody } = frontMatterParser(pageContent)
-          const { file_url: originalFileUrl, permalink: originalPermalink } = frontMatter
-          const { title: originalTitle, type: originalType, date: originalDate } = retrieveResourceFileMetadata(fileName)
+          const { title: originalTitle, file_url: originalFileUrl, permalink: originalPermalink } = frontMatter
+          const { type: originalType, date: originalDate } = retrieveResourceFileMetadata(fileName)
           if (_isMounted) {
             setSha(pageSha)
             setMdBody(pageMdBody)

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -77,7 +77,6 @@ const ComponentSettingsModal = ({
     const [resourceDate, setResourceDate] = useState('')
     const [fileUrl, setFileUrl] = useState('')
 
-    const [resourceRoomName, setResourceRoomName] = useState('')
     const [siteUrl, setSiteUrl] = useState('https://abc.com.sg')
 
     // Map element ID to setter functions
@@ -88,14 +87,11 @@ const ComponentSettingsModal = ({
         fileUrl: setFileUrl,
     }
 
-    useQuery(
+    const { data: resourceRoomName } = useQuery(
       [RESOURCE_ROOM_NAME_KEY, siteName],
       () => getResourceRoomName(siteName),
       {
         retry: false,
-        onSuccess: (retrievedName) => {
-          setResourceRoomName(retrievedName)
-        },
         onError: () => {
           errorToast(`The resource room name could not be retrieved. ${DEFAULT_RETRY_MSG}`)
         }

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -189,9 +189,8 @@ const ComponentSettingsModal = ({
     const { mutateAsync: saveHandler } = useMutation(
       () => {
         const frontMatter = isPost 
-          ? { ...originalFrontMatter, title, date: resourceDate, permalink }
+          ? { ...originalFrontMatter, title, date: resourceDate, permalink, layout: 'post' }
           : { ...originalFrontMatter, title, date: resourceDate, file_url: fileUrl }
-        if (isNewFile && isPost) frontMatter.layout = 'post'
         const newFileName = generateResourceFileName(title, resourceDate, isPost)
         const newPageData = concatFrontMatterMdBody(frontMatter, mdBody)
         if (isNewFile) return createPageData({ siteName, resourceName: category, newFileName }, newPageData) 

--- a/src/components/ComponentSettingsModal.jsx
+++ b/src/components/ComponentSettingsModal.jsx
@@ -178,6 +178,7 @@ const ComponentSettingsModal = ({
         const frontMatter = isPost 
           ? { ...originalFrontMatter, title, date: resourceDate, permalink }
           : { ...originalFrontMatter, title, date: resourceDate, file_url: fileUrl }
+        if (isNewFile && isPost) frontMatter.layout = 'post'
         const newFileName = generateResourceFileName(title, resourceDate, isPost)
         const newPageData = concatFrontMatterMdBody(frontMatter, mdBody)
         if (isNewFile) return createPageData({ siteName, resourceName: category, newFileName }, newPageData) 

--- a/src/components/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal.jsx
@@ -104,7 +104,7 @@ const PageSettingsModal = ({
           const { permalink: originalPermalink } = frontMatter
         
           if (_isMounted) {
-            setTitle(deslugifyPage(originalPageName))
+            setTitle(frontMatter.title)
             setPermalink(originalPermalink)
             setOriginalPermalink(originalPermalink)
             setSha(pageSha)

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ export const DIR_CONTENT_KEY = 'dir-contents';
 export const CSP_CONTENT_KEY = 'csp-contents';
 export const NAVIGATION_CONTENT_KEY = 'navigation-contents';
 export const RESOURCE_CATEGORY_CONTENT_KEY = 'resource-category-contents'
+export const RESOURCE_ROOM_NAME_KEY = 'resource-room-name'
 export const RESOURCE_ROOM_CONTENT_KEY = 'resource-room-contents'
 export const FOLDERS_CONTENT_KEY = 'folders-contents'
 export const LAST_UPDATED_KEY = 'last-updated'


### PR DESCRIPTION
This PR introduces several changes to resource file handling and page settings.

- Previously, newly created resource post pages on the cms were using the same layout as those for pages - this was due to us not setting the layout properly for newly created resource pages. This PR adds in the additional layout field.
- The layout field is also enforced now when changing any resource page settings, regardless of its previous value
- The default permalink for newly created resource pages now also includes the resource room, to bring it closer to the way users access the page on the actual site (resource room -> filter by resource category -> click on post)
- The page title for existing pages is now retrieved from the frontmatter, instead of the file name - this is to prevent unintentional changes to the title when editing other portions of the settings, since the file name on github does not contain special characters while the title in the front matter can.

It resolves #476 and resolves #477. 