### PR TITLE
lint: code formatting

### DIFF
--- a/.eslintIgnore
+++ b/.eslintIgnore
@@ -1,4 +1,3 @@
 .env
 node_modules/
 .vscode/
-*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,11 +4,11 @@
       "es2021": true,
       "jest": true
   },
-  // "extends": [
-  //     "plugin:react/recommended",
-  //     "airbnb",
-  //     "plugin:prettier/recommended"
-  // ],
+  "extends": [
+      "plugin:react/recommended",
+      "airbnb",
+      "plugin:prettier/recommended"
+  ],
   "parserOptions": {
       "ecmaFeatures": {
           "jsx": true

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,5 +13,3 @@ build/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-*

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "bracketSpacing": true,
+    "semi": false,
+    "singleQuote": false,
+    "useTabs": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3114,153 +3114,6 @@
         }
       }
     },
-    "@trivago/prettier-plugin-sort-imports": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-2.0.2.tgz",
-      "integrity": "sha512-esk6vplzXYwXQs079wBbKog4AFuZfxpJU+MygiijV0wbAibI0tEm+diFFhYP7B2lAaKKdU4+w+BW+McNZCw9HA==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "7.13.10",
-        "@babel/generator": "7.13.9",
-        "@babel/parser": "7.13.10",
-        "@babel/traverse": "7.13.0",
-        "@babel/types": "7.13.0",
-        "@types/lodash": "4.14.168",
-        "javascript-natural-sort": "0.7.1",
-        "lodash": "4.17.21",
-        "prettier": "2.2.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/core": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-          "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-compilation-targets": "^7.13.10",
-            "@babel/helper-module-transforms": "^7.13.0",
-            "@babel/helpers": "^7.13.10",
-            "@babel/parser": "^7.13.10",
-            "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.19",
-            "semver": "^6.3.0",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helpers": {
-          "version": "7.13.17",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
-          "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.17",
-            "@babel/types": "^7.13.17"
-          },
-          "dependencies": {
-            "@babel/generator": {
-              "version": "7.13.16",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
-              "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
-              "dev": true,
-              "requires": {
-                "@babel/types": "^7.13.16",
-                "jsesc": "^2.5.1",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.13.16",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
-              "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
-              "dev": true
-            },
-            "@babel/traverse": {
-              "version": "7.13.17",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
-              "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
-              "dev": true,
-              "requires": {
-                "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.16",
-                "@babel/helper-function-name": "^7.12.13",
-                "@babel/helper-split-export-declaration": "^7.12.13",
-                "@babel/parser": "^7.13.16",
-                "@babel/types": "^7.13.17",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0"
-              }
-            },
-            "@babel/types": {
-              "version": "7.13.17",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
-              "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.12.11",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "gensync": {
-          "version": "1.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-          "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -3393,12 +3246,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-    },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
-      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -10988,12 +10835,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "javascript-natural-sort": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=",
-      "dev": true
     },
     "jest": {
       "version": "26.6.0",
@@ -20245,7 +20086,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "test-e2e": "cypress run",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",
     "lint-fix": "eslint --ext .js --ext .jsx --ignore-path .gitignore . --fix",
+    "format": "npx prettier --check .",
+    "format-fix": "npx prettier --write .",
     "cypress:open": "cypress open"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
-    "@trivago/prettier-plugin-sort-imports": "^2.0.2",
     "cypress": "^7.2.0",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^7.21.0",


### PR DESCRIPTION
This PR reactivates our prettier code-formatting configs by adding the prettier  config files, and removing the catchall `*` in the ignore files for both eslint and prettier.