### PR TITLE
fix: prevent eslint errors from blocking build

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,6 +3,7 @@ export REACT_APP_BACKEND_URL=''
 export REACT_APP_SENTRY_ENV=''
 export REACT_APP_SENTRY_DSN=''
 export REACT_APP_ENV='LOCAL_DEV'
+export ESLINT_NO_DEV_ERRORS=true
 
 # Cypress test environment variables
 export CYPRESS_BASEURL=''


### PR DESCRIPTION
## Overview
Currently, when we attempt to start our react app, `create-react-app` fails to compile when there are any eslint or prettier errors. The reason for this is documented in this github issue: https://github.com/facebook/create-react-app/issues/9887#issuecomment-720902192

This issue is fixed with react-scripts v`4.0.2` with the use of an `ESLINT_NO_DEV_ERRORS` env var (this is documented under Create React App's advanced configuration here: https://create-react-app.dev/docs/advanced-configuration/)

This commit adds the `ESLINT_NO_DEV_ERRORS` env var to our env-example file. We will need to separately add it to our production and staging environments too.

## To-dos
- [x] Add `ESLINT_NO_DEV_ERRORS` env var to production and staging CMS frontend before merging into develop

