### PR TITLE
chore: set npm run dev 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "yaml": "^1.10.2"
   },
   "scripts": {
-    "start": "source .env.development.local && craco start",
+    "run": "source .env && craco start",
+    "start": "source .env && craco start",
     "build": "craco build",
     "test": "craco test",
     "test-e2e": "cypress run",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "scripts": {
     "run": "source .env && craco start",
-    "start": "source .env && craco start",
     "build": "craco build",
     "test": "craco test",
     "test-e2e": "cypress run",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "scripts": {
     "run": "source .env && craco start",
+    "dev": "source .env && craco start",
     "build": "craco build",
     "test": "craco test",
     "test-e2e": "cypress run",


### PR DESCRIPTION
This PR adds `npm run dev` as a command to make running the CMS frontend consistent with that of the backend. The PR also sets the local env var file to `.env` to match that in the backend repo.