### PR TITLE
fix: validates that resource page dates are not in future

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14373,6 +14373,19 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.21",
     "marked": "^0.7.0",
     "module-alias": "^2.2.2",
+    "moment-timezone": "^0.5.33",
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,5 +1,5 @@
-import moment from "moment-timezone"
 import _ from "lodash"
+import moment from "moment-timezone"
 
 import {
   generatePageFileName,
@@ -761,7 +761,7 @@ const validateDayOfMonth = (month, day) => {
 }
 
 const validateNonFutureDate = (dateStr) => {
-  const today = new Date(moment().tz('Asia/Singapore').format('YYYY-MM-DD'))
+  const today = new Date(moment().tz("Asia/Singapore").format("YYYY-MM-DD"))
   const chosenDate = new Date(dateStr)
   const daysDiff = today - chosenDate
   return daysDiff >= 0
@@ -791,7 +791,7 @@ const validateResourceSettings = (id, value, folderOrderArray) => {
       }
       break
     }
-    case "date": {      
+    case "date": {
       // Date is in the future
       if (!validateNonFutureDate(value)) {
         errorMessage = "Selected date is greater than today's date."

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,3 +1,4 @@
+import moment from "moment-timezone"
 import _ from "lodash"
 
 import {
@@ -759,6 +760,13 @@ const validateDayOfMonth = (month, day) => {
   }
 }
 
+const validateNonFutureDate = (dateStr) => {
+  const today = new Date(moment().tz('Asia/Singapore').format('YYYY-MM-DD'))
+  const chosenDate = new Date(dateStr)
+  const daysDiff = today - chosenDate
+  return daysDiff >= 0
+}
+
 const validateResourceSettings = (id, value, folderOrderArray) => {
   let errorMessage = ""
   switch (id) {
@@ -783,7 +791,11 @@ const validateResourceSettings = (id, value, folderOrderArray) => {
       }
       break
     }
-    case "date": {
+    case "date": {      
+      // Date is in the future
+      if (!validateNonFutureDate(value)) {
+        errorMessage = "Selected date is greater than today's date."
+      }
       // Date is in wrong format
       if (!dateRegexTest.test(value)) {
         errorMessage = "The date should be in the format YYYY-MM-DD."


### PR DESCRIPTION
This PR addresses #494.

### Problem
Currently, users are able to choose a resource date that's in the future. Since we currently do not have a cron job running to build sites regularly, we cannot trigger a rebuild when these resource pages are supposed to appear, hence the posts will not appear when users expect them to. 

### Fix
For now, we have decided to disable future resource posts, and explore supporting this in the future.

