### PR TITLE
test: cleanup e2e tests

### DIFF
--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -187,10 +187,12 @@ describe("Edit unlinked page", () => {
 
     // Cancel works properly in modal
     cy.get("#modal-cancel").click()
+    cy.get("#modal-cancel").should("not.exist")
 
     cy.contains(":button", "Delete").click()
 
     // Test delete in modal
+    cy.get("#modal-delete").should("exist")
     cy.get("#modal-delete").click()
 
     // Assert: page no longer exists

--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -27,7 +27,7 @@ describe("Edit unlinked page", () => {
     TEST_UNLINKED_PAGE_TITLE
   )}.md`
 
-  const DEFAULT_IMAGE_TITLE = "hero-banner.png"
+  const DEFAULT_IMAGE_TITLE = "isomer-logo.svg"
   const ADDED_IMAGE_TITLE = "balloon.png"
   const ADDED_IMAGE_PATH = "images/balloon.png"
 

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -363,7 +363,12 @@ describe("Files", () => {
       cy.visit(`/sites/${TEST_REPO_NAME}/documents`)
       cy.contains(FILE_TITLE) // file should be contained in directory
 
-      cy.deleteMedia(FILE_TITLE) // cleanup
+      cy.intercept({
+        method: "DELETE",
+        url: `/v1/sites/${TEST_REPO_NAME}/documents/${FILE_TITLE}`,
+      }).as("deleteFile")
+      cy.deleteMedia(FILE_TITLE)
+      cy.wait("@deleteFile")
     })
 
     it("Should be able to move file from Files to file directory", () => {
@@ -390,8 +395,6 @@ describe("Files", () => {
         `/sites/${TEST_REPO_NAME}/documents/${SLUGIFIED_DIRECTORY_TITLE}`
       )
       cy.contains(FILE_TITLE) // file should be contained in directory
-
-      cy.deleteMedia(FILE_TITLE) // cleanup
     })
 
     after(() => {

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -117,6 +117,7 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
 
       // title should not allow for names without extensions
       cy.renameMedia(FILE_TITLE, MISSING_EXTENSION, ACTION_DISABLED)
@@ -128,6 +129,7 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
 
       // should not be able to save if no change
       cy.renameMedia(FILE_TITLE, FILE_TITLE, ACTION_DISABLED)
@@ -136,6 +138,7 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
 
       // users should not be able to create file with duplicated filename in folder (NOT SUPPORTED YET)
       cy.uploadMedia(OTHER_FILE_TITLE, TEST_FILE_PATH)
@@ -148,6 +151,8 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
+
       cy.deleteMedia(OTHER_FILE_TITLE) // clean up
     })
 

--- a/cypress/integration/images.spec.js
+++ b/cypress/integration/images.spec.js
@@ -350,7 +350,12 @@ describe("Images", () => {
       cy.visit(`/sites/${TEST_REPO_NAME}/images`)
       cy.contains(IMAGE_TITLE) // image should be contained in album
 
-      cy.deleteMedia(IMAGE_TITLE) // cleanup
+      cy.intercept({
+        method: "DELETE",
+        url: `/v1/sites/${TEST_REPO_NAME}/images/${IMAGE_TITLE}`,
+      }).as("deleteFile")
+      cy.deleteMedia(IMAGE_TITLE)
+      cy.wait("@deleteFile")
     })
 
     it("Should be able to move image from Images to image album", () => {
@@ -375,8 +380,6 @@ describe("Images", () => {
       cy.wait("@moveImage") // should intercept POST request
       cy.visit(`/sites/${TEST_REPO_NAME}/images/${SLUGIFIED_ALBUM_TITLE}`)
       cy.contains(IMAGE_TITLE) // image should be contained in album
-
-      cy.deleteMedia(IMAGE_TITLE) // cleanup
     })
 
     after(() => {

--- a/cypress/integration/pages.spec.js
+++ b/cypress/integration/pages.spec.js
@@ -364,6 +364,11 @@ describe("Pages flow", () => {
 
     // Rename
     it("Should be able to rename a sub-folder", () => {
+      cy.intercept({
+        method: "POST",
+        url: `/v1/sites/e2e-test-repo/folders/${PARSED_TEST_FOLDER_WITH_PAGES_TITLE}/subfolder/${PARSED_TEST_SUBFOLDER_NO_PAGES_TITLE}/rename/${PARSED_EDITED_TEST_SUBFOLDER_WITH_PAGES_TITLE}`,
+      }).as("renameSubfolder")
+
       cy.contains(PRETTIFIED_FOLDER_WITH_PAGES_TITLE, {
         timeout: CUSTOM_TIMEOUT,
       })
@@ -378,7 +383,8 @@ describe("Pages flow", () => {
       cy.contains("button", "Save").click()
 
       // Assert
-      cy.contains("1 item", { timeout: CUSTOM_TIMEOUT }).should("exist")
+      cy.wait("@renameSubfolder")
+      cy.contains("1 item").should("exist")
       cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE).click()
       cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
       cy.url().should(

--- a/cypress/support/medias.js
+++ b/cypress/support/medias.js
@@ -27,7 +27,7 @@ Cypress.Commands.add("moveMedia", (mediaTitle, newMediaFolder) => {
   cy.contains("Move to").click()
   cy.get("[data-cy=menu-dropdown]").children().should("have.length.gt", 3) // assert that "Move to" options have loaded
   if (newMediaFolder) {
-    cy.get(`[id^="${newMediaFolder}-1"]`, { timeout: CUSTOM_TIMEOUT })
+    cy.get(`[data-cy=${newMediaFolder}]`, { timeout: CUSTOM_TIMEOUT })
       .should("have.length.gte", 1)
       .should("be.visible")
       .first()

--- a/cypress/support/medias.js
+++ b/cypress/support/medias.js
@@ -1,3 +1,6 @@
+import "cypress-pipe"
+
+const click = ($el) => $el.click()
 const CUSTOM_TIMEOUT = 30000 // 30 seconds
 
 Cypress.Commands.add("uploadMedia", (mediaTitle, mediaPath, disableAction) => {
@@ -23,14 +26,20 @@ Cypress.Commands.add("moveMedia", (mediaTitle, newMediaFolder) => {
   cy.get(`[id^="${mediaTitle}-settings-"]`).click()
   cy.contains("Move to").click()
   if (newMediaFolder) {
-    cy.get(`[id^="${newMediaFolder}"]`, { timeout: CUSTOM_TIMEOUT })
-      .should("exist")
+    cy.get(`[id^="${newMediaFolder}-1"]`, { timeout: CUSTOM_TIMEOUT })
+      .should("have.length.gte", 1)
+      .should("be.visible")
       .first()
       .click()
   } else {
     cy.get(`[id^="breadcrumbItem-0"]`, { timeout: CUSTOM_TIMEOUT })
-      .should("exist")
-      .click()
+      .should("be.visible")
+      // breadcrumb elements in FileMoveMenuDropdown are flaky, so we need to
+      // use cypress-pipe
+      .pipe(click)
+      .should(($el) => {
+        expect($el).to.not.exist
+      })
   }
   cy.contains("button", "Move Here").click({ scrollBehavior: false }) // necessary because it will otherwise scroll to top of page
   cy.contains("button", "Continue").click()

--- a/cypress/support/medias.js
+++ b/cypress/support/medias.js
@@ -25,6 +25,7 @@ Cypress.Commands.add(
 Cypress.Commands.add("moveMedia", (mediaTitle, newMediaFolder) => {
   cy.get(`[id^="${mediaTitle}-settings-"]`).click()
   cy.contains("Move to").click()
+  cy.get("[data-cy=menu-dropdown]").children().should("have.length.gt", 3) // assert that "Move to" options have loaded
   if (newMediaFolder) {
     cy.get(`[id^="${newMediaFolder}-1"]`, { timeout: CUSTOM_TIMEOUT })
       .should("have.length.gte", 1)

--- a/cypress/support/medias.js
+++ b/cypress/support/medias.js
@@ -37,7 +37,7 @@ Cypress.Commands.add("moveMedia", (mediaTitle, newMediaFolder) => {
 })
 
 Cypress.Commands.add("deleteMedia", (mediaTitle, disableAction) => {
-  cy.get(`[id^="${mediaTitle}-settings-"]`).click()
+  cy.get(`[id^="${mediaTitle}-settings-"]`).should("exist").click()
   cy.contains("Delete").click()
   if (!disableAction) cy.get("#modal-delete").click()
 })

--- a/cypress/support/medias.js
+++ b/cypress/support/medias.js
@@ -39,5 +39,5 @@ Cypress.Commands.add("moveMedia", (mediaTitle, newMediaFolder) => {
 Cypress.Commands.add("deleteMedia", (mediaTitle, disableAction) => {
   cy.get(`[id^="${mediaTitle}-settings-"]`).click()
   cy.contains("Delete").click()
-  if (!disableAction) cy.get("#delete-confirmation").click()
+  if (!disableAction) cy.get("#modal-delete").click()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7617,6 +7617,12 @@
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.7.tgz",
       "integrity": "sha512-cgWsWx7igxjyyVm9/VJ9ukdy69jL00I7z0lrwUWtXXLPvX4neO+8JAZ054Ax8Xf+mdV9OerenXzb9nqRoafjHA=="
     },
+    "cypress-pipe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-pipe/-/cypress-pipe-2.0.0.tgz",
+      "integrity": "sha512-KW9s+bz4tFLucH3rBGfjW+Q12n7S4QpUSSyxiGrgPOfoHlbYWzAGB3H26MO0VTojqf9NVvfd5Kt0MH5XMgbfyg==",
+      "dev": true
+    },
     "cz-conventional-changelog": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@testing-library/react": "^11.2.6",
     "btoa": "^1.2.1",
     "cypress": "^7.2.0",
+    "cypress-pipe": "^2.0.0",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^7.28.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/src/components/DeleteWarningModal.jsx
+++ b/src/components/DeleteWarningModal.jsx
@@ -18,7 +18,6 @@ const DeleteWarningModal = ({ onDelete, onCancel, type }) => (
             disabledStyle={elementStyles.disabled}
             className={elementStyles.warning}
             callback={onDelete}
-            id="delete-confirmation"
           />
           <button
             id="modal-cancel"

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -107,6 +107,7 @@ const FileMoveMenuDropdown = ({
       ref={dropdownRef}
       tabIndex={1}
       onBlur={onBlur}
+      data-cy="menu-dropdown"
     >
       <MenuItem
         key={`back-${menuIndex}`}

--- a/src/components/MenuDropdown.jsx
+++ b/src/components/MenuDropdown.jsx
@@ -35,6 +35,7 @@ const MenuItem = ({ item, menuIndex, dropdownRef, className }) => {
     <div
       tabIndex={2}
       id={`${itemId}-${menuIndex}`}
+      data-cy={itemId}
       onMouseDown={(e) => {
         e.stopPropagation()
         e.preventDefault()


### PR DESCRIPTION
# Overview
This PR patches some of our failing and flaky E2E tests. It fixes the following tests:
1. Failing delete test for `EditPage`
2. Failing delete tests using the `Folders` and `Media` layouts
3. Failing test for subfolder renaming
4. Flaky file-moving breadcrumbs

Other misc. changes:
- Eliminate extraneous `id` attribute in `DeleteWarningModal`

In the course of testing this PR, issue #526 (cleanup of uploaded assets during testing) was also filed, to be resolved in a subsequent PR.

## 1. Failing delete test for `EditPage`
**Problem**
Previously, the "Edit page should allow user to delete page" test failed because Cypress was unable to click on the delete button in the `DeleteWarningModal`. I suspect that this is because the modal takes some time to appear in the DOM.

**Solution**
To resolve this problem, we wait for the `DeleteWarningModal` to come into existence by using a "should" assertion before attempting to click on it.

## 2. Failing delete tests using the `Folders` and `Media` layouts
**Problem**
Even though the snapshots show images/files being deleted successfully, our subsequent assertions (like `cy.contains(IMAGE_TITLE).should("not.exist")`) fail. This is because `ReactQueryDevTools` maintains a reference to the delete API call and so Cypress can still find a reference to the deleted file. Refer to the image below for details:

<img width="1360" alt="Screenshot 2021-06-17 at 8 49 41 PM" src="https://user-images.githubusercontent.com/31984694/122411541-6a0af580-cfb7-11eb-8fac-1ddfb5ebdba5.png">

**Solution**
~We have a few options:~
- ~When running tests, ensure that the `REACT_APP_ENV` environment variable is set to a value that is NOT `LOCAL_ENV`, so that `ReactQueryDevTools` isn't activated.~
- ~Remove `ReactQueryDevTools` from our codebase since we aren't using it much at this point~

~Either approach works for me - please let me know what you think.~

After some discussion, we will ensure that the `REACT_APP_ENV` environment variable is set to a value that is NOT `LOCAL_ENV`, so that `ReactQueryDevTools` isn't activated when running tests.

## 3. Failing test for `"Should be able to rename a sub-folder"`
**Problem**
Previously, we attempted to assert using a custom timeout, but the test failed to find the renamed subfolder despite the successful HTTP request. 

```
      cy.contains("1 item", { timeout: CUSTOM_TIMEOUT }).should("exist")
      cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE).click() // test fails here
```

This is because the UI takes some time to update and the second contain requires a longer timeout as well.

**Solution**
Instead of waiting for a longer time with `CUSTOM_TIMEOUT`, if we intercept the subfolder renaming request and wait for it, the test passes successfully.

This means we can probably also replace the use of `CUSTOM_TIMEOUT` with interceptors throughout our test suite so that our tests can fail more quickly (#524). This is because the slowest actions in the CMS come from network calls, and DOM changes should not take more than the default of 4 seconds set by Cypress .

## 4. Flaky breadcrumb elements in `FileMoveMenuDropdown` component
**Problem**
Cypress sometimes complains that the breadcrumb element is detached from the DOM, despite already asserting that the element is visible, or exists.

**Solution**
We use the `cypress-pipe` library (on recommendation from the Cypress team) to help to click on the correct DOM element when we're trying to move a file from one directory to another.

Previously, Cypress would complain that the breadcrumb element was detached from the DOM, despite already asserting for visibility. This is a case where the app is slow to react and Cypress was fast to act: see [this blog post](https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/) from the Cypress team which addresses the issue. The problem is probably that the DOM element has been created but the event listeners have not been set up.

`cypress-pipe` solves this problem by continuously retrying until “the assertions that follow pass”.
