### PR TITLE
test: reset e2e repo state

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,3 +9,8 @@ export CYPRESS_BASEURL=''
 export CYPRESS_COOKIE_NAME=''
 export CYPRESS_COOKIE_VALUE=''
 export CYPRESS_TEST_REPO_NAME=''
+
+# Reset e2e-test-repo
+export E2E_COMMIT_HASH=6800d5c2bf40d010e8b2f008ee6abc43df0cd4a2
+export PERSONAL_ACCESS_TOKEN=''
+export USERNAME=''

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Add the following Cypress environment variables:
 - CYPRESS_COOKIE_VALUE (Value of the JWT cookie)
 - CYPRESS_TEST_REPO_NAME (Name of the test repo on GitHub)
 
+Add the following environment variables which we use to reset our test repo:
+
+- E2E_COMMIT_HASH (the commit hash which you would like to reset the `e2e-test-repo` to)
+- PERSONAL_ACCESS_TOKEN (your GitHub personal access token)
+- USERNAME (your GitHub username)
+
 Run the following:
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5843,6 +5843,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true
+    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lint-fix": "eslint --ext .js --ext .jsx --ignore-path .gitignore . --fix",
     "format": "npx prettier --check .",
     "format-fix": "npx prettier --write .",
-    "cypress:open": "cypress open",
+    "cypress:open": "node scripts/run-e2e.js",
     "prepare": "husky install"
   },
   "eslintConfig": {
@@ -77,6 +77,7 @@
     "@jest/globals": "^27.0.3",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
+    "btoa": "^1.2.1",
     "cypress": "^7.2.0",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "dev": "source .env && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "test-e2e": "cypress run",
+    "test-e2e": "node scripts/run-e2e.js run",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",
     "lint-fix": "eslint --ext .js --ext .jsx --ignore-path .gitignore . --fix",
     "format": "npx prettier --check .",
     "format-fix": "npx prettier --write .",
-    "cypress:open": "node scripts/run-e2e.js",
+    "cypress:open": "node scripts/run-e2e.js open",
     "prepare": "husky install"
   },
   "eslintConfig": {

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -43,10 +43,10 @@ const resetE2eTestRepo = async () => {
 
       const child = spawn(runCypressCommand, { shell: true })
       child.stderr.on("data", (data) => {
-        console.error(data.toString())
+        console.error(data.toString().trim())
       })
       child.stdout.on("data", (data) => {
-        console.log(data.toString())
+        console.log(data.toString().trim())
       })
       child.on("exit", (exitCode) => {
         console.log(`Child exited with code: ${exitCode}`)

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,6 +1,7 @@
 const axios = require("axios")
 const btoa = require("btoa")
 const { spawn } = require("child_process")
+const cypress = require("cypress")
 const path = require("path")
 
 // login credentials
@@ -13,9 +14,10 @@ const headers = {
 }
 
 // cypress commands
+const cypressCommand = process.argv[2] // either `run` or `open`
 const srcPath = path.resolve(__dirname, "..")
 const envFilePath = `${srcPath}/.env`
-const runCypressOpenCommand = `source ${envFilePath} && npx cypress open`
+const runCypressCommand = `source ${envFilePath} && npx cypress ${cypressCommand}`
 
 // reset e2e-test-repo
 const { E2E_COMMIT_HASH } = process.env
@@ -39,7 +41,7 @@ const resetE2eTestRepo = async () => {
     .then(() => {
       console.log(`Successfully reset e2e-test-repo to ${E2E_COMMIT_HASH}`)
 
-      const child = spawn(runCypressOpenCommand, { shell: true })
+      const child = spawn(runCypressCommand, { shell: true })
       child.stderr.on("data", (data) => {
         console.error(data.toString())
       })

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,0 +1,56 @@
+const axios = require("axios")
+const btoa = require("btoa")
+const { spawn } = require("child_process")
+const path = require("path")
+
+// login credentials
+const { PERSONAL_ACCESS_TOKEN, USERNAME } = process.env
+
+const CREDENTIALS = `${USERNAME}:${PERSONAL_ACCESS_TOKEN}`
+const headers = {
+  authorization: `basic ${btoa(CREDENTIALS)}`,
+  accept: "application/json",
+}
+
+// cypress commands
+const srcPath = path.resolve(__dirname, "..")
+const envFilePath = `${srcPath}/.env`
+const runCypressOpenCommand = `source ${envFilePath} && npx cypress open`
+
+// reset e2e-test-repo
+const { E2E_COMMIT_HASH } = process.env
+const GITHUB_ORG_NAME = "isomerpages"
+const REPO_NAME = "e2e-test-repo"
+
+const resetE2eTestRepo = async () => {
+  const baseRefEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO_NAME}/git/refs`
+  const refEndpoint = `${baseRefEndpoint}/heads/staging`
+  await axios
+    .patch(
+      refEndpoint,
+      {
+        sha: E2E_COMMIT_HASH,
+        force: true,
+      },
+      {
+        headers,
+      }
+    )
+    .then(() => {
+      console.log(`Successfully reset e2e-test-repo to ${E2E_COMMIT_HASH}`)
+
+      const child = spawn(runCypressOpenCommand, { shell: true })
+      child.stderr.on("data", (data) => {
+        console.error(data.toString())
+      })
+      child.stdout.on("data", (data) => {
+        console.log(data.toString())
+      })
+      child.on("exit", (exitCode) => {
+        console.log(`Child exited with code: ${exitCode}`)
+      })
+    })
+    .catch((err) => console.error(err))
+}
+
+resetE2eTestRepo()


### PR DESCRIPTION
## Overview

This PR uses a node script to reset the `e2e-test-repo` state before running our e2e tests so that we don't have to do it manually.

As it stands, the repo is reset once before all e2e tests are run. This should be sufficient since our tests should not be dependent on side effects to pass (i.e. we shouldn't rely on the outputs of one of our tests for a subsequent test to pass).