### PR TITLE
Vapt/xss

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,3 +9,8 @@ export CYPRESS_BASEURL=''
 export CYPRESS_COOKIE_NAME=''
 export CYPRESS_COOKIE_VALUE=''
 export CYPRESS_TEST_REPO_NAME=''
+
+# Reset e2e-test-repo
+export E2E_COMMIT_HASH=6800d5c2bf40d010e8b2f008ee6abc43df0cd4a2
+export PERSONAL_ACCESS_TOKEN=''
+export USERNAME=''

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Add the following Cypress environment variables:
 - CYPRESS_COOKIE_VALUE (Value of the JWT cookie)
 - CYPRESS_TEST_REPO_NAME (Name of the test repo on GitHub)
 
+Add the following environment variables which we use to reset our test repo:
+
+- E2E_COMMIT_HASH (the commit hash which you would like to reset the `e2e-test-repo` to)
+- PERSONAL_ACCESS_TOKEN (your GitHub personal access token)
+- USERNAME (your GitHub username)
+
 Run the following:
 
 ```

--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -27,7 +27,7 @@ describe("Edit unlinked page", () => {
     TEST_UNLINKED_PAGE_TITLE
   )}.md`
 
-  const DEFAULT_IMAGE_TITLE = "hero-banner.png"
+  const DEFAULT_IMAGE_TITLE = "isomer-logo.svg"
   const ADDED_IMAGE_TITLE = "balloon.png"
   const ADDED_IMAGE_PATH = "images/balloon.png"
 
@@ -187,10 +187,12 @@ describe("Edit unlinked page", () => {
 
     // Cancel works properly in modal
     cy.get("#modal-cancel").click()
+    cy.get("#modal-cancel").should("not.exist")
 
     cy.contains(":button", "Delete").click()
 
     // Test delete in modal
+    cy.get("#modal-delete").should("exist")
     cy.get("#modal-delete").click()
 
     // Assert: page no longer exists

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -117,6 +117,7 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
 
       // title should not allow for names without extensions
       cy.renameMedia(FILE_TITLE, MISSING_EXTENSION, ACTION_DISABLED)
@@ -128,6 +129,7 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
 
       // should not be able to save if no change
       cy.renameMedia(FILE_TITLE, FILE_TITLE, ACTION_DISABLED)
@@ -136,6 +138,7 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
 
       // users should not be able to create file with duplicated filename in folder (NOT SUPPORTED YET)
       cy.uploadMedia(OTHER_FILE_TITLE, TEST_FILE_PATH)
@@ -148,6 +151,8 @@ describe("Files", () => {
         .contains(/^Save$/)
         .should("be.disabled") // necessary as multiple buttons containing Upload on page
       cy.get("#closeMediaSettingsModal").click()
+      cy.get("#closeMediaSettingsModal").should("not.exist")
+
       cy.deleteMedia(OTHER_FILE_TITLE) // clean up
     })
 
@@ -358,7 +363,12 @@ describe("Files", () => {
       cy.visit(`/sites/${TEST_REPO_NAME}/documents`)
       cy.contains(FILE_TITLE) // file should be contained in directory
 
-      cy.deleteMedia(FILE_TITLE) // cleanup
+      cy.intercept({
+        method: "DELETE",
+        url: `/v1/sites/${TEST_REPO_NAME}/documents/${FILE_TITLE}`,
+      }).as("deleteFile")
+      cy.deleteMedia(FILE_TITLE)
+      cy.wait("@deleteFile")
     })
 
     it("Should be able to move file from Files to file directory", () => {
@@ -385,8 +395,6 @@ describe("Files", () => {
         `/sites/${TEST_REPO_NAME}/documents/${SLUGIFIED_DIRECTORY_TITLE}`
       )
       cy.contains(FILE_TITLE) // file should be contained in directory
-
-      cy.deleteMedia(FILE_TITLE) // cleanup
     })
 
     after(() => {

--- a/cypress/integration/images.spec.js
+++ b/cypress/integration/images.spec.js
@@ -350,7 +350,12 @@ describe("Images", () => {
       cy.visit(`/sites/${TEST_REPO_NAME}/images`)
       cy.contains(IMAGE_TITLE) // image should be contained in album
 
-      cy.deleteMedia(IMAGE_TITLE) // cleanup
+      cy.intercept({
+        method: "DELETE",
+        url: `/v1/sites/${TEST_REPO_NAME}/images/${IMAGE_TITLE}`,
+      }).as("deleteFile")
+      cy.deleteMedia(IMAGE_TITLE)
+      cy.wait("@deleteFile")
     })
 
     it("Should be able to move image from Images to image album", () => {
@@ -375,8 +380,6 @@ describe("Images", () => {
       cy.wait("@moveImage") // should intercept POST request
       cy.visit(`/sites/${TEST_REPO_NAME}/images/${SLUGIFIED_ALBUM_TITLE}`)
       cy.contains(IMAGE_TITLE) // image should be contained in album
-
-      cy.deleteMedia(IMAGE_TITLE) // cleanup
     })
 
     after(() => {

--- a/cypress/integration/pages.spec.js
+++ b/cypress/integration/pages.spec.js
@@ -364,6 +364,11 @@ describe("Pages flow", () => {
 
     // Rename
     it("Should be able to rename a sub-folder", () => {
+      cy.intercept({
+        method: "POST",
+        url: `/v1/sites/e2e-test-repo/folders/${PARSED_TEST_FOLDER_WITH_PAGES_TITLE}/subfolder/${PARSED_TEST_SUBFOLDER_NO_PAGES_TITLE}/rename/${PARSED_EDITED_TEST_SUBFOLDER_WITH_PAGES_TITLE}`,
+      }).as("renameSubfolder")
+
       cy.contains(PRETTIFIED_FOLDER_WITH_PAGES_TITLE, {
         timeout: CUSTOM_TIMEOUT,
       })
@@ -378,7 +383,8 @@ describe("Pages flow", () => {
       cy.contains("button", "Save").click()
 
       // Assert
-      cy.contains("1 item", { timeout: CUSTOM_TIMEOUT }).should("exist")
+      cy.wait("@renameSubfolder")
+      cy.contains("1 item").should("exist")
       cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE).click()
       cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
       cy.url().should(

--- a/cypress/support/medias.js
+++ b/cypress/support/medias.js
@@ -1,3 +1,6 @@
+import "cypress-pipe"
+
+const click = ($el) => $el.click()
 const CUSTOM_TIMEOUT = 30000 // 30 seconds
 
 Cypress.Commands.add("uploadMedia", (mediaTitle, mediaPath, disableAction) => {
@@ -22,22 +25,29 @@ Cypress.Commands.add(
 Cypress.Commands.add("moveMedia", (mediaTitle, newMediaFolder) => {
   cy.get(`[id^="${mediaTitle}-settings-"]`).click()
   cy.contains("Move to").click()
+  cy.get("[data-cy=menu-dropdown]").children().should("have.length.gt", 3) // assert that "Move to" options have loaded
   if (newMediaFolder) {
-    cy.get(`[id^="${newMediaFolder}"]`, { timeout: CUSTOM_TIMEOUT })
-      .should("exist")
+    cy.get(`[data-cy=${newMediaFolder}]`, { timeout: CUSTOM_TIMEOUT })
+      .should("have.length.gte", 1)
+      .should("be.visible")
       .first()
       .click()
   } else {
     cy.get(`[id^="breadcrumbItem-0"]`, { timeout: CUSTOM_TIMEOUT })
-      .should("exist")
-      .click()
+      .should("be.visible")
+      // breadcrumb elements in FileMoveMenuDropdown are flaky, so we need to
+      // use cypress-pipe
+      .pipe(click)
+      .should(($el) => {
+        expect($el).to.not.exist
+      })
   }
   cy.contains("button", "Move Here").click({ scrollBehavior: false }) // necessary because it will otherwise scroll to top of page
   cy.contains("button", "Continue").click()
 })
 
 Cypress.Commands.add("deleteMedia", (mediaTitle, disableAction) => {
-  cy.get(`[id^="${mediaTitle}-settings-"]`).click()
+  cy.get(`[id^="${mediaTitle}-settings-"]`).should("exist").click()
   cy.contains("Delete").click()
-  if (!disableAction) cy.get("#delete-confirmation").click()
+  if (!disableAction) cy.get("#modal-delete").click()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7617,6 +7617,12 @@
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.7.tgz",
       "integrity": "sha512-cgWsWx7igxjyyVm9/VJ9ukdy69jL00I7z0lrwUWtXXLPvX4neO+8JAZ054Ax8Xf+mdV9OerenXzb9nqRoafjHA=="
     },
+    "cypress-pipe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-pipe/-/cypress-pipe-2.0.0.tgz",
+      "integrity": "sha512-KW9s+bz4tFLucH3rBGfjW+Q12n7S4QpUSSyxiGrgPOfoHlbYWzAGB3H26MO0VTojqf9NVvfd5Kt0MH5XMgbfyg==",
+      "dev": true
+    },
     "cz-conventional-changelog": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5843,6 +5843,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true
+    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8133,9 +8133,9 @@
       }
     },
     "dompurify": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.2.tgz",
-      "integrity": "sha512-BsGR4nDLaC5CNBnyT5I+d5pOeaoWvgVeg6Gq/aqmKYWMPR07131u60I80BvExLAJ0FQEIBQ1BTicw+C5+jOyrg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
+      "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
     },
     "domutils": {
       "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,6 +1673,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@braintree/sanitize-url": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz",
+      "integrity": "sha512-NBEJlHWrhQucLhZGHtSxM2loSaNUMajC7KOYJLyfcdW/6goVoff2HoYI3bz8YCDN0wKGbxtUL0gx2dvHpvnWlw=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cheerio": "^1.0.0-rc.3",
     "csp-parse": "0.0.2",
     "cypress-file-upload": "^5.0.7",
-    "dompurify": "^2.2.2",
+    "dompurify": "^2.3.0",
     "easymde": "^2.8.0",
     "escape-string-regexp": "^4.0.0",
     "eslint-plugin-only-warn": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@testing-library/react": "^11.2.6",
     "btoa": "^1.2.1",
     "cypress": "^7.2.0",
+    "cypress-pipe": "^2.0.0",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^7.28.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@atlaskit/tree": "^7.0.2",
+    "@braintree/sanitize-url": "^5.0.2",
     "@sentry/react": "^5.27.6",
     "@sentry/tracing": "^5.27.6",
     "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "dev": "source .env && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "test-e2e": "cypress run",
+    "test-e2e": "node scripts/run-e2e.js run",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",
     "lint-fix": "eslint --ext .js --ext .jsx --ignore-path .gitignore . --fix",
     "format": "npx prettier --check .",
     "format-fix": "npx prettier --write .",
-    "cypress:open": "cypress open",
+    "cypress:open": "node scripts/run-e2e.js open",
     "prepare": "husky install"
   },
   "eslintConfig": {
@@ -77,6 +77,7 @@
     "@jest/globals": "^27.0.3",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
+    "btoa": "^1.2.1",
     "cypress": "^7.2.0",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^7.28.0",

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,0 +1,58 @@
+const axios = require("axios")
+const btoa = require("btoa")
+const { spawn } = require("child_process")
+const cypress = require("cypress")
+const path = require("path")
+
+// login credentials
+const { PERSONAL_ACCESS_TOKEN, USERNAME } = process.env
+
+const CREDENTIALS = `${USERNAME}:${PERSONAL_ACCESS_TOKEN}`
+const headers = {
+  authorization: `basic ${btoa(CREDENTIALS)}`,
+  accept: "application/json",
+}
+
+// cypress commands
+const cypressCommand = process.argv[2] // either `run` or `open`
+const srcPath = path.resolve(__dirname, "..")
+const envFilePath = `${srcPath}/.env`
+const runCypressCommand = `source ${envFilePath} && npx cypress ${cypressCommand}`
+
+// reset e2e-test-repo
+const { E2E_COMMIT_HASH } = process.env
+const GITHUB_ORG_NAME = "isomerpages"
+const REPO_NAME = "e2e-test-repo"
+
+const resetE2eTestRepo = async () => {
+  const baseRefEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO_NAME}/git/refs`
+  const refEndpoint = `${baseRefEndpoint}/heads/staging`
+  await axios
+    .patch(
+      refEndpoint,
+      {
+        sha: E2E_COMMIT_HASH,
+        force: true,
+      },
+      {
+        headers,
+      }
+    )
+    .then(() => {
+      console.log(`Successfully reset e2e-test-repo to ${E2E_COMMIT_HASH}`)
+
+      const child = spawn(runCypressCommand, { shell: true })
+      child.stderr.on("data", (data) => {
+        console.error(data.toString().trim())
+      })
+      child.stdout.on("data", (data) => {
+        console.log(data.toString().trim())
+      })
+      child.on("exit", (exitCode) => {
+        console.log(`Child exited with code: ${exitCode}`)
+      })
+    })
+    .catch((err) => console.error(err))
+}
+
+resetE2eTestRepo()

--- a/src/components/DeleteWarningModal.jsx
+++ b/src/components/DeleteWarningModal.jsx
@@ -18,7 +18,6 @@ const DeleteWarningModal = ({ onDelete, onCancel, type }) => (
             disabledStyle={elementStyles.disabled}
             className={elementStyles.warning}
             callback={onDelete}
-            id="delete-confirmation"
           />
           <button
             id="modal-cancel"

--- a/src/components/FileMoveMenuDropdown.jsx
+++ b/src/components/FileMoveMenuDropdown.jsx
@@ -107,6 +107,7 @@ const FileMoveMenuDropdown = ({
       ref={dropdownRef}
       tabIndex={1}
       onBlur={onBlur}
+      data-cy="menu-dropdown"
     >
       <MenuItem
         key={`back-${menuIndex}`}

--- a/src/components/MenuDropdown.jsx
+++ b/src/components/MenuDropdown.jsx
@@ -35,6 +35,7 @@ const MenuItem = ({ item, menuIndex, dropdownRef, className }) => {
     <div
       tabIndex={2}
       id={`${itemId}-${menuIndex}`}
+      data-cy={itemId}
       onMouseDown={(e) => {
         e.stopPropagation()
         e.preventDefault()

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -446,8 +446,14 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
               DOMPurify.removed.length > 1 ? "s" : ""
             }:
             ${DOMPurify.removed.map(
-              ({ attribute }, i) =>
-                `<br/><code>${i}</code>: <code>${attribute.textContent}</code>`
+              (elem, i) =>
+                `<br/><code>${i}</code>: <code>${
+                  elem.attribute?.textContent || elem.element?.textContent
+                    ? (
+                        elem.attribute?.textContent || elem.element?.textContent
+                      ).replace("<", "&lt;")
+                    : elem
+                }</code>`
             )}
             <br/><br/>Before saving, the editor input will be automatically sanitised to prevent security vulnerabilities.
             <br/><br/>To save the sanitised editor input, press Acknowledge. To return to the editor without sanitising, press Cancel.`}

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -442,6 +442,7 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
         {isXSSViolation && showXSSWarning && (
           <GenericWarningModal
             displayTitle="Warning"
+            // DOMPurify removed object format taken from https://github.com/cure53/DOMPurify/blob/dd63379e6354f66d4689bb80b30cb43a6d8727c2/src/purify.js
             displayText={`There is unauthorised JS detected in the following snippet${
               DOMPurify.removed.length > 1 ? "s" : ""
             }:

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -7,6 +7,7 @@ import SimpleMDE from "react-simplemde-editor"
 import marked from "marked"
 import Policy from "csp-parse"
 
+import DOMPurify from "dompurify"
 import SimplePage from "../templates/SimplePage"
 import LeftNavPage from "../templates/LeftNavPage"
 
@@ -325,15 +326,12 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
   useEffect(() => {
     async function loadChunk() {
       const html = marked(editorValue)
-      const {
-        isCspViolation: checkedIsCspViolation,
-        sanitisedHtml: processedSanitisedHtml,
-      } = checkCSP(csp, html)
-      const processedChunk = await prependImageSrc(
-        siteName,
-        processedSanitisedHtml
+      const { isCspViolation, sanitisedHtml: CSPSanitisedHtml } = checkCSP(
+        csp,
+        html
       )
-      setIsCspViolation(checkedIsCspViolation)
+      const cleanedHtml = DOMPurify.sanitize(CSPSanitisedHtml)
+      const processedChunk = await prependImageSrc(siteName, cleanedHtml)
       setChunk(processedChunk)
     }
     loadChunk()

--- a/src/templates/contact-us/ContactsSection.jsx
+++ b/src/templates/contact-us/ContactsSection.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import DOMPurify from "dompurify"
+import { sanitizeUrl } from "@braintree/sanitize-url"
 
 const Contact = React.forwardRef(({ contact }, ref) => (
   <div className="col is-6" ref={ref}>
@@ -13,7 +14,10 @@ const Contact = React.forwardRef(({ contact }, ref) => (
         case "phone": {
           return (
             <p className="margin--top--none margin--bottom--none" key={i}>
-              <a href={`tel:${d[key].replace(/\s/g, "")}`}>
+              <a
+                href={sanitizeUrl(`tel:${d[key].replace(/\s/g, "")}`)}
+                onClick={(event) => event.preventDefault()}
+              >
                 <u>{d[key]}</u>
               </a>
             </p>
@@ -22,7 +26,10 @@ const Contact = React.forwardRef(({ contact }, ref) => (
         case "email": {
           return (
             <p className="margin--top--none margin--bottom--none" key={i}>
-              <a href={`mailto:${d[key]}`}>
+              <a
+                href={sanitizeUrl(`mailto:${d[key]}`)}
+                onClick={(event) => event.preventDefault()}
+              >
                 <u>{d[key]}</u>
               </a>
             </p>

--- a/src/templates/contact-us/FeedbackSection.jsx
+++ b/src/templates/contact-us/FeedbackSection.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { sanitizeUrl } from "@braintree/sanitize-url"
 
 const TemplateFeedbackSection = React.forwardRef(({ feedback }, ref) => (
   <div ref={ref}>
@@ -15,7 +16,12 @@ const TemplateFeedbackSection = React.forwardRef(({ feedback }, ref) => (
           <p>
             If you have a query, feedback or wish to report a problem related to
             this website, please fill in the{" "}
-            <a href={feedback} rel="noopener noreferrer" target="_blank">
+            <a
+              href={sanitizeUrl(feedback)}
+              rel="noopener noreferrer"
+              target="_blank"
+              onClick={(event) => event.preventDefault()}
+            >
               <u>online form</u>
             </a>
             .

--- a/src/templates/contact-us/LocationsSection.jsx
+++ b/src/templates/contact-us/LocationsSection.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { sanitizeUrl } from "@braintree/sanitize-url"
 
 const LocationHours = ({ operatingHours }) => (
   <div className="col is-6">
@@ -26,11 +27,15 @@ const LocationAddress = ({ location }) => (
       ))}
       <a
         href={
-          location.maps_link ||
-          `https://maps.google.com/?q=${location.address
-            .join("+")
-            .replace(/\s/g, "+")}`
+          location.maps_link
+            ? sanitizeUrl(location.maps_link)
+            : sanitizeUrl(
+                `https://maps.google.com/?q=${location.address
+                  .join("+")
+                  .replace(/\s/g, "+")}`
+              )
         }
+        onClick={(event) => event.preventDefault()}
         className="bp-sec-button has-text-secondary margin--top"
         rel="noopener noreferrer"
         target="_blank"


### PR DESCRIPTION
This PR addresses [isomer-product/issues/7](https://github.com/isomerpages/isomer-product/issues/7).

The following fixes were implemented in this PR:
- Upgrading `DOMPurify`, installing `@braintree/sanitize-url`
- Sanitize before preview:
  - Sanitizing user input before EditPage preview
  - Sanitizing user input for URLs before EditContactUs preview
  - Disabling URL click-throughs in EditContactUs preview (to standardize with behavior on the rest of the sites)
- Sanitizing user input before Save:
  - Sanitizing user input upon Save for Edit Page 
 

However, this means that the behavior on our site will be slightly inconsistent as we will not be sanitising user input on other pages before saving the pages to Github. This has no security implications on Isomer sites as we do not enable inline scripts on Isomer sites.

To standardize the behavior across the site, we should create a reusable component that will help with sanitising user input before Saving. This will be tackled as part of our refactor and is documented here [isomer-product/issues/20](https://github.com/isomerpages/isomer-product/issues/20). 

This PR addresses GTA-03-002 WP1 and GTA-03-014 WP1.