### PR TITLE
Refactor/components collection pages

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-export default function LoadingButton(props) {
+export default function Button(props) {
   // extract props
   const {
     label,
@@ -12,7 +12,6 @@ export default function LoadingButton(props) {
     isLoading,
     ...remainingProps
   } = props
-
   return (
     <button
       type="button"
@@ -31,7 +30,7 @@ export default function LoadingButton(props) {
   )
 }
 
-LoadingButton.propTypes = {
+Button.propTypes = {
   label: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   disabledStyle: PropTypes.string.isRequired,
@@ -40,6 +39,6 @@ LoadingButton.propTypes = {
   isLoading: PropTypes.bool.isRequired,
 }
 
-LoadingButton.defaultProps = {
+Button.defaultProps = {
   disabled: false,
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,56 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import editorStyles from "../styles/isomer-cms/pages/Editor.module.scss"
+import elementStyles from "../styles/isomer-cms/Elements.module.scss"
+
+import Button from "./Button"
+
+const Footer = ({
+  keyButtonText,
+  keyCallback,
+  isKeyButtonDisabled,
+  keyButtonIsLoading,
+  optionalButtonText,
+  optionalCallback,
+  isOptionalButtonDisabled,
+  optionalButtonIsLoading,
+}) => (
+  <div className={editorStyles.pageEditorFooter}>
+    {optionalCallback ? (
+      <Button
+        label={optionalButtonText}
+        disabledStyle={elementStyles.disabled}
+        disabled={isOptionalButtonDisabled}
+        className={
+          isOptionalButtonDisabled
+            ? elementStyles.disabled
+            : elementStyles.warning
+        }
+        callback={optionalCallback}
+        isLoading={optionalButtonIsLoading}
+      />
+    ) : null}
+    {keyCallback ? (
+      <Button
+        label={keyButtonText}
+        disabledStyle={elementStyles.disabled}
+        disabled={isKeyButtonDisabled}
+        className={
+          isKeyButtonDisabled ? elementStyles.disabled : elementStyles.blue
+        }
+        callback={keyCallback}
+        isLoading={keyButtonIsLoading}
+      />
+    ) : null}
+  </div>
+)
+
+Footer.propTypes = {
+  isDeleteDisabled: PropTypes.bool,
+  isSaveDisabled: PropTypes.bool,
+  deleteCallback: PropTypes.func,
+  saveCallback: PropTypes.func,
+}
+
+export default Footer

--- a/src/components/pages/EditPageFooter.jsx
+++ b/src/components/pages/EditPageFooter.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react"
+import Footer from "../Footer"
+import DeleteWarningModal from "../DeleteWarningModal"
+
+const EditPageFooter = ({
+  isSaveDisabled,
+  deleteCallback,
+  saveCallback,
+  isSaving,
+}) => {
+  const [showDeleteWarning, setShowDeleteWarning] = useState(false)
+  return (
+    <>
+      {showDeleteWarning && (
+        <DeleteWarningModal
+          onCancel={() => setShowDeleteWarning(false)}
+          onDelete={deleteCallback}
+          type="page"
+        />
+      )}
+      <Footer
+        isKeyButtonDisabled={isSaveDisabled}
+        optionalCallback={() => setShowDeleteWarning(true)}
+        keyCallback={saveCallback}
+        keyButtonIsLoading={isSaving}
+        keyButtonText="Save"
+        optionalButtonText="Delete"
+      />
+    </>
+  )
+}
+
+export default EditPageFooter

--- a/src/components/pages/EditorModals.jsx
+++ b/src/components/pages/EditorModals.jsx
@@ -1,0 +1,141 @@
+import React, { useState } from "react"
+import PropTypes from "prop-types"
+
+import HyperlinkModal from "../HyperlinkModal"
+import MediaModal from "../media/MediaModal"
+import MediaSettingsModal from "../media/MediaSettingsModal"
+
+const MEDIA_PLACEHOLDER_TEXT = {
+  images: "![Alt text for image on Isomer site]",
+  files: "[Example Filename]",
+}
+
+const EditorModals = ({
+  siteName,
+  mdeRef,
+  onSave,
+  modalType,
+  onClose,
+  insertingMediaType,
+}) => {
+  const [isMediaUpload, setIsMediaUpload] = useState(false)
+  const [stagedMediaDetails, setStagedMediaDetails] = useState({})
+  const [uploadPath, setUploadPath] = useState("")
+
+  /** ******************************** */
+  /*         Hyperlink Modal         */
+  /** ******************************** */
+
+  const onHyperlinkSave = (text, link) => {
+    const cm = mdeRef.current.simpleMde.codemirror
+    cm.replaceSelection(`[${text}](${link})`)
+    // set state so that rerender is triggered and path is shown
+    onSave(mdeRef.current.simpleMde.codemirror.getValue())
+    onClose()
+  }
+
+  /** ******************************** */
+  /*           Media Modal           */
+  /*   to be refactored with media   */
+  /** ******************************** */
+
+  const toggleMediaAndSettingsModal = (newFileName) => {
+    const cm = mdeRef.current.simpleMde.codemirror
+    if (newFileName) {
+      cm.replaceSelection(
+        `${
+          MEDIA_PLACEHOLDER_TEXT[insertingMediaType]
+        }${`(/${insertingMediaType}/${
+          uploadPath ? `${uploadPath}/` : ""
+        }${newFileName})`.replaceAll(" ", "%20")}`
+      )
+      // set state so that rerender is triggered and image is shown
+      onSave(mdeRef.current.simpleMde.codemirror.getValue())
+    }
+    onClose()
+    setIsMediaUpload(false)
+  }
+
+  const onMediaSelect = (path) => {
+    const cm = mdeRef.current.simpleMde.codemirror
+    cm.replaceSelection(
+      `${MEDIA_PLACEHOLDER_TEXT[insertingMediaType]}(${path.replaceAll(
+        " ",
+        "%20"
+      )})`
+    )
+    // set state so that rerender is triggered and image is shown
+    onSave(mdeRef.current.simpleMde.codemirror.getValue())
+    onClose()
+  }
+
+  const readMediaToStageUpload = async (event) => {
+    const fileReader = new FileReader()
+    const fileName = event.target.files[0].name
+    fileReader.onload = () => {
+      /** Github only requires the content of the image
+       * fileReader returns  `data:application/pdf;base64, {fileContent}`
+       * hence the split
+       */
+      const fileData = fileReader.result.split(",")[1]
+      setStagedMediaDetails({
+        path: `${insertingMediaType}%2F${fileName}`,
+        content: fileData,
+        fileName,
+      })
+    }
+    fileReader.readAsDataURL(event.target.files[0])
+    setIsMediaUpload(true)
+  }
+
+  return (
+    <>
+      {modalType == "media" && insertingMediaType && !isMediaUpload && (
+        <MediaModal
+          siteName={siteName}
+          onClose={onClose}
+          onMediaSelect={onMediaSelect}
+          type={insertingMediaType}
+          readFileToStageUpload={readMediaToStageUpload}
+          setUploadPath={setUploadPath}
+        />
+      )}
+      {modalType == "media" && insertingMediaType && isMediaUpload && (
+        <MediaSettingsModal
+          type={insertingMediaType}
+          siteName={siteName}
+          customPath={uploadPath}
+          onClose={() => {
+            onClose()
+            setIsMediaUpload(false)
+          }}
+          onSave={toggleMediaAndSettingsModal}
+          media={stagedMediaDetails}
+          isPendingUpload
+        />
+      )}
+      {modalType == "hyperlink" && (
+        <HyperlinkModal
+          text={mdeRef.current.simpleMde.codemirror.getSelection()}
+          onSave={onHyperlinkSave}
+          onClose={onClose}
+        />
+      )}
+    </>
+  )
+}
+
+EditorModals.propTypes = {
+  siteName: PropTypes.string,
+  mdeRef: PropTypes.oneOfType([
+    // https://stackoverflow.com/questions/48007326/what-is-the-correct-proptype-for-a-ref-in-react
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  onSave: PropTypes.func.isRequired,
+  modalType: PropTypes.oneOf(["hyperlink", "media"]).isRequired,
+  onClose: PropTypes.func.isRequired,
+  insertingMediaType: PropTypes.oneOf(["files", "images"]),
+}
+
+export default EditorModals

--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -1,0 +1,94 @@
+import React from "react"
+import SimpleMDE from "react-simplemde-editor"
+import editorStyles from "../../styles/isomer-cms/pages/Editor.module.scss"
+import {
+  boldButton,
+  italicButton,
+  strikethroughButton,
+  headingButton,
+  codeButton,
+  quoteButton,
+  unorderedListButton,
+  orderedListButton,
+  tableButton,
+  guideButton,
+} from "../../utils/markdownToolbar"
+
+const MarkdownEditor = ({
+  mdeRef,
+  onChange,
+  value,
+  customOptions,
+  isDisabled,
+  isLoading,
+}) => {
+  return (
+    <div
+      className={`${editorStyles.pageEditorSidebar} ${
+        isLoading || isDisabled ? editorStyles.pageEditorSidebarLoading : null
+      }`}
+    >
+      {isDisabled ? (
+        <>
+          <div
+            className={`text-center ${editorStyles.pageEditorSidebarDisabled}`}
+          >
+            Editing is disabled for downloadable files.
+          </div>
+        </>
+      ) : isLoading ? (
+        <div
+          className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`}
+        />
+      ) : (
+        ""
+      )}
+      <SimpleMDE
+        id="simplemde-editor"
+        className="h-100"
+        onChange={onChange}
+        ref={mdeRef}
+        value={value}
+        options={{
+          toolbar: [
+            headingButton,
+            boldButton,
+            italicButton,
+            strikethroughButton,
+            "|",
+            codeButton,
+            quoteButton,
+            unorderedListButton,
+            orderedListButton,
+            "|",
+            {
+              name: "image",
+              action: customOptions.imageAction,
+              className: "fa fa-picture-o",
+              title: "Insert Image",
+              default: true,
+            },
+            {
+              name: "file",
+              action: customOptions.fileAction,
+              className: "fa fa-file-pdf-o",
+              title: "Insert File",
+              default: true,
+            },
+            {
+              name: "link",
+              action: customOptions.linkAction,
+              className: "fa fa-link",
+              title: "Insert Link",
+              default: true,
+            },
+            tableButton,
+            guideButton,
+          ],
+        }}
+      />
+    </div>
+  )
+}
+
+export default MarkdownEditor

--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import SimpleMDE from "react-simplemde-editor"
 import editorStyles from "../../styles/isomer-cms/pages/Editor.module.scss"
 import {
@@ -13,81 +13,106 @@ import {
   tableButton,
   guideButton,
 } from "../../utils/markdownToolbar"
+import EditorModals from "./EditorModals"
 
 const MarkdownEditor = ({
+  siteName,
   mdeRef,
   onChange,
   value,
-  customOptions,
   isDisabled,
   isLoading,
 }) => {
+  const [editorModalType, setEditorModalType] = useState("")
+  const [insertingMediaType, setInsertingMediaType] = useState("")
+
   return (
-    <div
-      className={`${editorStyles.pageEditorSidebar} ${
-        isLoading || isDisabled ? editorStyles.pageEditorSidebarLoading : null
-      }`}
-    >
-      {isDisabled ? (
-        <>
-          <div
-            className={`text-center ${editorStyles.pageEditorSidebarDisabled}`}
-          >
-            Editing is disabled for downloadable files.
-          </div>
-        </>
-      ) : isLoading ? (
-        <div
-          className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`}
-        />
-      ) : (
-        ""
-      )}
-      <SimpleMDE
-        id="simplemde-editor"
-        className="h-100"
-        onChange={onChange}
-        ref={mdeRef}
-        value={value}
-        options={{
-          toolbar: [
-            headingButton,
-            boldButton,
-            italicButton,
-            strikethroughButton,
-            "|",
-            codeButton,
-            quoteButton,
-            unorderedListButton,
-            orderedListButton,
-            "|",
-            {
-              name: "image",
-              action: customOptions.imageAction,
-              className: "fa fa-picture-o",
-              title: "Insert Image",
-              default: true,
-            },
-            {
-              name: "file",
-              action: customOptions.fileAction,
-              className: "fa fa-file-pdf-o",
-              title: "Insert File",
-              default: true,
-            },
-            {
-              name: "link",
-              action: customOptions.linkAction,
-              className: "fa fa-link",
-              title: "Insert Link",
-              default: true,
-            },
-            tableButton,
-            guideButton,
-          ],
+    <>
+      <EditorModals
+        siteName={siteName}
+        mdeRef={mdeRef}
+        modalType={editorModalType}
+        onSave={onChange}
+        onClose={() => {
+          setEditorModalType("")
+          setInsertingMediaType("")
         }}
+        insertingMediaType={insertingMediaType}
       />
-    </div>
+      <div
+        className={`${editorStyles.pageEditorSidebar} ${
+          isLoading || isDisabled ? editorStyles.pageEditorSidebarLoading : null
+        }`}
+      >
+        {isDisabled ? (
+          <>
+            <div
+              className={`text-center ${editorStyles.pageEditorSidebarDisabled}`}
+            >
+              Editing is disabled for downloadable files.
+            </div>
+          </>
+        ) : isLoading ? (
+          <div
+            className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`}
+          />
+        ) : (
+          ""
+        )}
+        <SimpleMDE
+          id="simplemde-editor"
+          className="h-100"
+          onChange={onChange}
+          ref={mdeRef}
+          value={value}
+          options={{
+            toolbar: [
+              headingButton,
+              boldButton,
+              italicButton,
+              strikethroughButton,
+              "|",
+              codeButton,
+              quoteButton,
+              unorderedListButton,
+              orderedListButton,
+              "|",
+              {
+                name: "image",
+                action: async () => {
+                  setEditorModalType("media")
+                  setInsertingMediaType("images")
+                },
+                className: "fa fa-picture-o",
+                title: "Insert Image",
+                default: true,
+              },
+              {
+                name: "file",
+                action: async () => {
+                  setEditorModalType("media")
+                  setInsertingMediaType("files")
+                },
+                className: "fa fa-file-pdf-o",
+                title: "Insert File",
+                default: true,
+              },
+              {
+                name: "link",
+                action: async () => {
+                  setEditorModalType("hyperlink")
+                },
+                className: "fa fa-link",
+                title: "Insert Link",
+                default: true,
+              },
+              tableButton,
+              guideButton,
+            ],
+          }}
+        />
+      </div>
+    </>
   )
 }
 

--- a/src/components/pages/PagePreview.jsx
+++ b/src/components/pages/PagePreview.jsx
@@ -1,0 +1,51 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import CollectionPageTemplate from "../../templates/pages/CollectionPageTemplate"
+import ResourcePageTemplate from "../../templates/pages/ResourcePageTemplate"
+import PageTemplate from "../../templates/pages/PageTemplate"
+
+import editorStyles from "../../styles/isomer-cms/pages/Editor.module.scss"
+
+const PagePreview = ({ pageParams, chunk, dirData }) => {
+  const {
+    collectionName,
+    subCollectionName,
+    resourceRoomName,
+    resourceCategoryName,
+    fileName,
+  } = pageParams
+  return (
+    <div className={editorStyles.pageEditorMain}>
+      {collectionName && dirData ? (
+        <CollectionPageTemplate
+          chunk={chunk}
+          dirData={dirData}
+          pageParams={pageParams}
+        />
+      ) : resourceRoomName && resourceCategoryName ? (
+        <ResourcePageTemplate
+          chunk={chunk}
+          fileName={fileName}
+          pageParams={pageParams}
+        />
+      ) : (
+        <PageTemplate chunk={chunk} fileName={fileName} />
+      )}
+    </div>
+  )
+}
+
+PagePreview.propTypes = {
+  pageParams: PropTypes.shape({
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    resourceRoomName: PropTypes.string,
+    resourceCategoryName: PropTypes.string,
+    fileName: PropTypes.string.isRequired,
+  }),
+  chunk: PropTypes.string,
+  dirData: PropTypes.arrayOf(PropTypes.string.isRequired),
+}
+
+export default PagePreview

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -2,12 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import axios from "axios"
 import _ from "lodash"
 import PropTypes from "prop-types"
-import SimpleMDE from "react-simplemde-editor"
 import marked from "marked"
-
-import SimplePage from "../templates/SimplePage"
-import LeftNavPage from "../templates/LeftNavPage"
-
 import checkCSP from "../utils/cspUtils"
 
 import {
@@ -25,7 +20,6 @@ import {
   prependImageSrc,
   getBackButton,
   extractMetadataFromFilename,
-  deslugifyDirectory,
 } from "../utils"
 
 import { createPageStyleSheet } from "../utils/siteColorUtils"
@@ -41,6 +35,7 @@ import HyperlinkModal from "../components/HyperlinkModal"
 import MediaModal from "../components/media/MediaModal"
 import MediaSettingsModal from "../components/media/MediaSettingsModal"
 import MarkdownEditor from "../components/pages/MarkdownEditor"
+import PagePreview from "../components/pages/PagePreview"
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -51,15 +46,7 @@ const MEDIA_PLACEHOLDER_TEXT = {
 }
 
 const EditPageV2 = ({ match, history }) => {
-  const {
-    subCollectionName,
-    collectionName,
-    resourceRoomName,
-    resourceCategoryName,
-    fileName,
-    siteName,
-  } = match.params
-
+  const { siteName } = match.params
   const [editorValue, setEditorValue] = useState("")
   const [canShowDeleteWarningModal, setCanShowDeleteWarningModal] = useState(
     false
@@ -72,7 +59,6 @@ const EditPageV2 = ({ match, history }) => {
   const [stagedFileDetails, setStagedFileDetails] = useState({})
 
   const [uploadPath, setUploadPath] = useState("")
-  const [leftNavPages, setLeftNavPages] = useState([])
   const [isCspViolation, setIsCspViolation] = useState(false)
   const [chunk, setChunk] = useState("")
 
@@ -123,16 +109,6 @@ const EditPageV2 = ({ match, history }) => {
     if (pageData)
       setHasChanges(pageData.content.pageBody.trim() !== editorValue)
   }, [pageData, editorValue])
-
-  useEffect(() => {
-    if (dirData)
-      setLeftNavPages(
-        dirData.map((name) => ({
-          fileName: name.includes("/") ? name.split("/")[1] : name,
-          third_nav_title: name.includes("/") ? name.split("/")[0] : null,
-        }))
-      )
-  }, [dirData])
 
   useEffect(() => {
     async function loadChunk() {
@@ -299,27 +275,12 @@ const EditPageV2 = ({ match, history }) => {
           isDisabled={resourceType === "file"}
           isLoading={isLoadingPage}
         />
-        <div className={editorStyles.pageEditorMain}>
-          {collectionName && leftNavPages.length > 0 ? (
-            <LeftNavPage
-              chunk={chunk}
-              leftNavPages={leftNavPages}
-              fileName={fileName}
-              title={title}
-              collection={deslugifyDirectory(collectionName)}
-            />
-          ) : resourceRoomName && resourceCategoryName ? (
-            <SimplePage
-              chunk={chunk}
-              title={title}
-              date={date}
-              resourceRoomName={deslugifyDirectory(resourceRoomName)}
-              collection={resourceCategoryName}
-            />
-          ) : (
-            <SimplePage chunk={chunk} title={title} date={date} />
-          )}
-        </div>
+        {/* Preview */}
+        <PagePreview
+          pageParams={match.params}
+          chunk={chunk}
+          dirData={dirData}
+        />
       </div>
       <div className={editorStyles.pageEditorFooter}>
         <button

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -27,15 +27,13 @@ import { createPageStyleSheet } from "../utils/siteColorUtils"
 import "easymde/dist/easymde.min.css"
 import "../styles/isomer-template.scss"
 import elementStyles from "../styles/isomer-cms/Elements.module.scss"
-import editorStyles from "../styles/isomer-cms/pages/Editor.module.scss"
 import Header from "../components/Header"
-import DeleteWarningModal from "../components/DeleteWarningModal"
-import LoadingButton from "../components/LoadingButton"
 import HyperlinkModal from "../components/HyperlinkModal"
 import MediaModal from "../components/media/MediaModal"
 import MediaSettingsModal from "../components/media/MediaSettingsModal"
 import MarkdownEditor from "../components/pages/MarkdownEditor"
 import PagePreview from "../components/pages/PagePreview"
+import EditPageFooter from "../components/pages/EditPageFooter"
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -48,9 +46,6 @@ const MEDIA_PLACEHOLDER_TEXT = {
 const EditPageV2 = ({ match, history }) => {
   const { siteName } = match.params
   const [editorValue, setEditorValue] = useState("")
-  const [canShowDeleteWarningModal, setCanShowDeleteWarningModal] = useState(
-    false
-  )
   const [insertingMediaType, setInsertingMediaType] = useState("")
   const [showMediaModal, setShowMediaModal] = useState(false)
   const [isInsertingHyperlink, setIsInsertingHyperlink] = useState(false)
@@ -78,7 +73,10 @@ const EditPageV2 = ({ match, history }) => {
       onError: () => setRedirectToNotFound(siteName),
     }
   )
-  const { mutateAsync: updatePageHandler } = useUpdatePageHook(match.params)
+  const {
+    mutateAsync: updatePageHandler,
+    isLoading: isSavingPage,
+  } = useUpdatePageHook(match.params)
   const { mutateAsync: deletePageHandler } = useDeletePageHook(match.params, {
     onSuccess: () => history.goBack(),
   })
@@ -282,41 +280,22 @@ const EditPageV2 = ({ match, history }) => {
           dirData={dirData}
         />
       </div>
-      <div className={editorStyles.pageEditorFooter}>
-        <button
-          type="button"
-          className={elementStyles.warning}
-          onClick={() => setCanShowDeleteWarningModal(true)}
-        >
-          Delete
-        </button>
-        <LoadingButton
-          label="Save"
-          disabledStyle={elementStyles.disabled}
-          disabled={isCspViolation}
-          className={
-            isCspViolation ? elementStyles.disabled : elementStyles.blue
-          }
-          callback={() =>
-            updatePageHandler({
-              frontMatter: pageData.content.frontMatter,
-              sha: pageData.sha,
-              pageBody: editorValue,
-            })
-          }
-        />
-      </div>
-      {canShowDeleteWarningModal && (
-        <DeleteWarningModal
-          onCancel={() => setCanShowDeleteWarningModal(false)}
-          onDelete={() =>
-            deletePageHandler({
-              sha: pageData.sha,
-            })
-          }
-          type="page"
-        />
-      )}
+      <EditPageFooter
+        isSaveDisabled={isCspViolation}
+        deleteCallback={() =>
+          deletePageHandler({
+            sha: pageData.sha,
+          })
+        }
+        saveCallback={() =>
+          updatePageHandler({
+            frontMatter: pageData.content.frontMatter,
+            sha: pageData.sha,
+            pageBody: editorValue,
+          })
+        }
+        isSaving={isSavingPage}
+      />
     </>
   )
 }

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -27,18 +27,6 @@ import {
   extractMetadataFromFilename,
   deslugifyDirectory,
 } from "../utils"
-import {
-  boldButton,
-  italicButton,
-  strikethroughButton,
-  headingButton,
-  codeButton,
-  quoteButton,
-  unorderedListButton,
-  orderedListButton,
-  tableButton,
-  guideButton,
-} from "../utils/markdownToolbar"
 
 import { createPageStyleSheet } from "../utils/siteColorUtils"
 
@@ -52,6 +40,7 @@ import LoadingButton from "../components/LoadingButton"
 import HyperlinkModal from "../components/HyperlinkModal"
 import MediaModal from "../components/media/MediaModal"
 import MediaSettingsModal from "../components/media/MediaSettingsModal"
+import MarkdownEditor from "../components/pages/MarkdownEditor"
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -290,83 +279,26 @@ const EditPageV2 = ({ match, history }) => {
             onClose={onHyperlinkClose}
           />
         )}
-        {
-          <div
-            className={`${editorStyles.pageEditorSidebar} ${
-              isLoadingPage || resourceType === "file"
-                ? editorStyles.pageEditorSidebarLoading
-                : null
-            }`}
-          >
-            {resourceType === "file" ? (
-              <>
-                <div
-                  className={`text-center ${editorStyles.pageEditorSidebarDisabled}`}
-                >
-                  Editing is disabled for downloadable files.
-                </div>
-              </>
-            ) : isLoadingPage ? (
-              <div
-                className={`spinner-border text-primary ${editorStyles.sidebarLoadingIcon}`}
-              />
-            ) : (
-              ""
-            )}
-            <SimpleMDE
-              id="simplemde-editor"
-              className="h-100"
-              onChange={(value) => setEditorValue(value)}
-              ref={mdeRef}
-              value={editorValue}
-              options={{
-                toolbar: [
-                  headingButton,
-                  boldButton,
-                  italicButton,
-                  strikethroughButton,
-                  "|",
-                  codeButton,
-                  quoteButton,
-                  unorderedListButton,
-                  orderedListButton,
-                  "|",
-                  {
-                    name: "image",
-                    action: async () => {
-                      setShowMediaModal(true)
-                      setInsertingMediaType("images")
-                    },
-                    className: "fa fa-picture-o",
-                    title: "Insert Image",
-                    default: true,
-                  },
-                  {
-                    name: "file",
-                    action: async () => {
-                      setShowMediaModal(true)
-                      setInsertingMediaType("files")
-                    },
-                    className: "fa fa-file-pdf-o",
-                    title: "Insert File",
-                    default: true,
-                  },
-                  {
-                    name: "link",
-                    action: async () => {
-                      onHyperlinkOpen()
-                    },
-                    className: "fa fa-link",
-                    title: "Insert Link",
-                    default: true,
-                  },
-                  tableButton,
-                  guideButton,
-                ],
-              }}
-            />
-          </div>
-        }
+        <MarkdownEditor
+          mdeRef={mdeRef}
+          onChange={(value) => setEditorValue(value)}
+          value={editorValue}
+          customOptions={{
+            imageAction: async () => {
+              setShowMediaModal(true)
+              setInsertingMediaType("images")
+            },
+            fileAction: async () => {
+              setShowMediaModal(true)
+              setInsertingMediaType("files")
+            },
+            linkAction: async () => {
+              onHyperlinkOpen()
+            },
+          }}
+          isDisabled={resourceType === "file"}
+          isLoading={isLoadingPage}
+        />
         <div className={editorStyles.pageEditorMain}>
           {collectionName && leftNavPages.length > 0 ? (
             <LeftNavPage

--- a/src/templates/pageComponentsV2/Breadcrumb.jsx
+++ b/src/templates/pageComponentsV2/Breadcrumb.jsx
@@ -1,0 +1,52 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { deslugifyDirectory } from "../../utils"
+
+const BreadCrumbItem = ({ itemName }) => (
+  <li>
+    <small>
+      <a>{itemName.toUpperCase()}</a>
+    </small>
+  </li>
+)
+
+const Breadcrumb = ({
+  title,
+  pageParams: {
+    collectionName,
+    subCollectionName,
+    resourceRoomName,
+    resourceCategoryName,
+  },
+}) => (
+  <nav className="bp-breadcrumb" aria-label="breadcrumbs">
+    <ul>
+      <BreadCrumbItem itemName="Home" />
+      {resourceRoomName ? (
+        <BreadCrumbItem itemName={deslugifyDirectory(resourceRoomName)} />
+      ) : null}
+      {resourceCategoryName ? (
+        <BreadCrumbItem itemName={deslugifyDirectory(resourceCategoryName)} />
+      ) : null}
+      {collectionName ? (
+        <BreadCrumbItem itemName={deslugifyDirectory(collectionName)} />
+      ) : null}
+      {subCollectionName ? (
+        <BreadCrumbItem itemName={deslugifyDirectory(subCollectionName)} />
+      ) : null}
+      <BreadCrumbItem itemName={title} />
+    </ul>
+  </nav>
+)
+
+Breadcrumb.propTypes = {
+  title: PropTypes.string.isRequired,
+  pageParams: PropTypes.shape({
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    resourceRoomName: PropTypes.string,
+    resourceCategoryName: PropTypes.string,
+  }),
+}
+
+export default Breadcrumb

--- a/src/templates/pageComponentsV2/LeftNav.jsx
+++ b/src/templates/pageComponentsV2/LeftNav.jsx
@@ -1,0 +1,83 @@
+/* eslint-disable arrow-body-style */
+import React, { useEffect, useState } from "react"
+import PropTypes from "prop-types"
+import { generateLeftNav } from "../../utils/leftnavGeneration"
+import "../../styles/isomer-template.scss"
+
+export const LeftNav = ({ dirData, fileName }) => {
+  const [leftNavData, setLeftNavData] = useState()
+  useEffect(() => {
+    setLeftNavData(generateLeftNav(dirData, fileName))
+  }, [dirData])
+  return (
+    <div className="col is-2 is-position-relative has-side-nav is-hidden-touch">
+      <div id="sidenav" className="sidenav">
+        <aside className="bp-menu is-gt sidebar__inner">
+          <ul className="bp-menu-list">{leftNavData}</ul>
+          <div dir="ltr" className="resize resize-sensor">
+            <div className="resize resize-sensor-expand">
+              <div
+                style={{
+                  position: "absolute",
+                  left: "0px",
+                  top: "0px",
+                  transition: "all 0s ease 0s",
+                  width: "174px",
+                  height: "126px",
+                }}
+              />
+            </div>
+            <div className="resize resize-sensor-shrink">
+              <div
+                style={{
+                  position: "absolute",
+                  left: "0px",
+                  top: "0px",
+                  transition: "0s",
+                  width: "200%",
+                  height: "200%",
+                }}
+              />
+            </div>
+          </div>
+        </aside>
+      </div>
+      <div dir="ltr" className="resize resize-sensor">
+        <div className="resize resize-sensor-expand">
+          <div
+            style={{
+              position: "absolute",
+              left: "0px",
+              top: "0px",
+              transition: "all 0s ease 0s",
+              width: "198px",
+              height: "306px",
+            }}
+          />
+        </div>
+        <div className="resize resize-sensor-shrink">
+          <div
+            style={{
+              position: "absolute",
+              left: "0px",
+              top: "0px",
+              transition: "0s",
+              width: "200%",
+              height: "200%",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+LeftNav.propTypes = {
+  leftNavPages: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string,
+      fileName: PropTypes.string,
+    })
+  ).isRequired,
+  fileName: PropTypes.string.isRequired,
+}

--- a/src/templates/pageComponentsV2/PageBody.jsx
+++ b/src/templates/pageComponentsV2/PageBody.jsx
@@ -1,0 +1,12 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export const PageBody = ({ chunk }) => (
+  <div className="col is-8 is-offset-1-desktop is-12-touch print-content page-content-body">
+    <div className="content" dangerouslySetInnerHTML={{ __html: chunk }} />
+  </div>
+)
+
+PageBody.propTypes = {
+  chunk: PropTypes.string,
+}

--- a/src/templates/pageComponentsV2/PageHeader.jsx
+++ b/src/templates/pageComponentsV2/PageHeader.jsx
@@ -1,0 +1,59 @@
+import React from "react"
+import PropTypes from "prop-types"
+import Breadcrumb from "./Breadcrumb"
+
+import { extractMetadataFromFilename } from "../../utils"
+
+export const PageHeader = ({ pageParams }) => {
+  const { resourceCategoryName, fileName } = pageParams
+  const { title, date } = extractMetadataFromFilename({
+    resourceCategoryName,
+    fileName,
+  })
+  return (
+    <>
+      <div className="bp-container page-header-container">
+        <div className="row">
+          <div className="col">
+            <Breadcrumb title={title} pageParams={pageParams} />
+          </div>
+        </div>
+      </div>
+      <div className="bp-container page-header-container">
+        <div className="row">
+          <div className="col">
+            <h1 className="has-text-white">
+              <b>
+                {title
+                  .split(" ")
+                  .map(
+                    (string) => string.charAt(0).toUpperCase() + string.slice(1)
+                  )
+                  .join(" ")}
+              </b>
+            </h1>
+          </div>
+        </div>
+      </div>
+      {date && (
+        <div className="bp-container page-header-container">
+          <div className="row">
+            <div className="col">
+              <p className="has-text-white">{date}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+PageHeader.propTypes = {
+  pageParams: PropTypes.shape({
+    fileName: PropTypes.string,
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    resourceCategoryName: PropTypes.string,
+    resourceRoomName: PropTypes.string,
+  }),
+}

--- a/src/templates/pageComponentsV2/index.js
+++ b/src/templates/pageComponentsV2/index.js
@@ -1,0 +1,3 @@
+export { LeftNav } from "./LeftNav"
+export { PageHeader } from "./PageHeader"
+export { PageBody } from "./PageBody"

--- a/src/templates/pages/CollectionPageTemplate.jsx
+++ b/src/templates/pages/CollectionPageTemplate.jsx
@@ -1,0 +1,37 @@
+import React from "react"
+import PropTypes from "prop-types"
+import _ from "lodash"
+import { PageHeader, PageBody, LeftNav } from "../pageComponentsV2"
+
+const CollectionPageTemplate = ({ chunk, dirData, pageParams }) => {
+  return (
+    <div>
+      <section
+        id="display-header"
+        className="bp-section is-small bp-section-pagetitle"
+      >
+        <PageHeader pageParams={pageParams} />
+      </section>
+      <section className="bp-section page-content-body">
+        <div className="bp-container padding--top--lg padding--bottom--xl">
+          <div className="row">
+            <LeftNav dirData={dirData} fileName={pageParams.fileName} />
+            <PageBody chunk={chunk} />
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+CollectionPageTemplate.propTypes = {
+  chunk: PropTypes.string.isRequired,
+  dirData: PropTypes.arrayOf(PropTypes.string).isRequired,
+  pageParams: {
+    fileName: PropTypes.string.isRequired,
+    collectionName: PropTypes.string.isRequired,
+    subCollectionName: PropTypes.string,
+  },
+}
+
+export default CollectionPageTemplate

--- a/src/templates/pages/PageTemplate.jsx
+++ b/src/templates/pages/PageTemplate.jsx
@@ -1,0 +1,28 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { PageHeader, PageBody } from "../pageComponentsV2"
+
+const PageTemplate = ({ chunk, pageParams }) => (
+  <div>
+    <section
+      id="display-header"
+      className="bp-section is-small bp-section-pagetitle"
+    >
+      <PageHeader pageParams={pageParams} />
+    </section>
+    <section className="bp-section">
+      <div className="bp-container content padding--top--lg padding--bottom--xl">
+        <PageBody chunk={chunk} />
+      </div>
+    </section>
+  </div>
+)
+
+PageTemplate.propTypes = {
+  chunk: PropTypes.string.isRequired,
+  pageParams: PropTypes.shape({
+    fileName: PropTypes.string.isRequired,
+  }),
+}
+
+export default PageTemplate

--- a/src/templates/pages/ResourcePageTemplate.jsx
+++ b/src/templates/pages/ResourcePageTemplate.jsx
@@ -1,0 +1,27 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { PageHeader, PageBody } from "../pageComponentsV2"
+
+const ResourcePageTemplate = ({ chunk, pageParams }) => {
+  return (
+    <div>
+      <section id="display-header" className="bp-section bg-secondary">
+        <PageHeader pageParams={pageParams} />
+      </section>
+      <section className="bp-section">
+        <div className="bp-container content padding--top--lg padding--bottom--xl">
+          <PageBody chunk={chunk} />
+        </div>
+      </section>
+    </div>
+  )
+}
+
+ResourcePageTemplate.propTypes = {
+  chunk: PropTypes.string.isRequired,
+  fileName: PropTypes.string.isRequired,
+  resourceCategoryName: PropTypes.string.isRequired,
+  resourceRoomName: PropTypes.string.isRequired,
+}
+
+export default ResourcePageTemplate

--- a/src/utils/leftnavGeneration.jsx
+++ b/src/utils/leftnavGeneration.jsx
@@ -176,7 +176,12 @@ const generateThirdNavHeader = (
   </li>
 )
 
-export const generateLeftNav = (leftNavPages, fileName) => {
+export const generateLeftNav = (dirData, fileName) => {
+  const leftNavPages = dirData.map((name) => ({
+    fileName: name.includes("/") ? name.split("/")[1] : name,
+    third_nav_title: name.includes("/") ? name.split("/")[0] : null,
+  }))
+
   const currentFileThirdNavTitle = retrieveCurrentFileThirdNavTitle(
     leftNavPages,
     fileName


### PR DESCRIPTION
This PR refactors the component and and state logic in EditPage. This PR supersedes #587, and breaks down #587 into smaller PRs for reviewing.

## Background
This PR breaks down EditPage into 4 key parts (`Header`, `MarkdownEditor`, `PagePreview`, `Footer`) seen in the image below:
<img width="1792" alt="Screenshot 2021-08-16 at 2 56 08 PM" src="https://user-images.githubusercontent.com/39231249/129523832-85cd8497-d49a-43f3-9194-f3d9c17d292d.png">


The logic functions and state associated with each component is moved out of EditPage and into the relevant component, so that EditPage becomes a scaffold to hold the components. The only state held in EditPage is the editor value and the output html. 




