### PR TITLE
test: e2e authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm run start
 Add the following Cypress environment variables:
 
 - CYPRESS_BASEURL (CMS frontend baseurl of the environment you want to test)
-- CYPRESS_COOKIE_NAME (Name of the JWT cookie that the CMS frontend sends to the backend)
-- CYPRESS_COOKIE_VALUE (Value of the JWT cookie)
+- CYPRESS_COOKIE_NAME (The name of the specialized cookie used for E2E testing)
+- CYPRESS_COOKIE_VALUE (The value of the above cookie)
 - CYPRESS_TEST_REPO_NAME (Name of the test repo on GitHub)
 
 Add the following environment variables which we use to reset our test repo:

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,11 @@
     X-Frame-Options = "deny"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Content-Security-Policy = "frame-ancestors 'none'"
+[build]
+    [build.environment]
+    CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
+    TERM = "xterm"
+[[plugins]]
+  package = "netlify-plugin-cypress"
+  [plugins.inputs]
+    enable = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,10 +8,11 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Content-Security-Policy = "frame-ancestors 'none'"
 [build]
-    [build.environment]
+  [build.environment]
     CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
     TERM = "xterm"
 [[plugins]]
   package = "netlify-plugin-cypress"
   [plugins.inputs]
-    enable = true
+    enable = false
+


### PR DESCRIPTION
## Actionables 
To test locally, set the following env vars:

```
export CYPRESS_COOKIE_NAME='isomercmsE2E'
export CYPRESS_COOKIE_VALUE='blahblahblah' // this value needs to match the value of the E2E_TEST_SECRET 
// env var in the backend
export CYPRESS_TEST_REPO_NAME='e2e-test-repo'
export CYPRESS_BASEURL="http://localhost:3000" // or whatever port you choose
```

## Overview
This PR is to be reviewed with PR #[270](https://github.com/isomerpages/isomercms-backend/pull/270) on the backend.

This PR is part one of a two-part change which will allow us to automate our E2E tests. 
1. Allow us to run E2E tests locally without having to replace our login token
2. Allow us to automate E2E tests as part of the Netlify build process, using the `cypress-netlify-plugin` library

For more details, refer to this decision document ([link](https://docs.google.com/document/d/13k746vGrdmkdIc_ZSH3rPIspkG5sJ0muZ1CLIdf-xik/edit#)).

## Context
Currently, we need to manually login, extract the cookie value, and place it in our env vars before we can run our E2E tests. This is clunky, and more importantly, in the long-run it prevents us from automating our tests to be part of our deployment flow. 

We cannot use Cypress to authenticate with OAuth providers unless the identity provider actually supports it. IdPs like auth0 provide these features, but GitHub does not. As such we need to create an alternate way of authenticating our E2E test user if we wish to automate our E2E tests (see this [discussion](https://github.com/ory/hydra/discussions/2256)).

## Requirements
- Test code requests must be able to pass verification checks on the backend middleware (`middleware/auth.js`)
- Test code user must not be able to make requests for resources outside of our `e2e-test-repo`

## Proposal
We can use a secret environment variable (the existing `COOKIE_VALUE` Cypress env var) that is known to both the test code and the backend server. The Cypress test code will store the secret as a secure cookie, and the backend server will verify that the cookie value is the secret value.

Typically, this will not work because any secret that is used on the frontend would be part of the build files, which are public. Thankfully, environment variables used by Cypress (environment variables created in the Cypress spec files using `Cypress.env()`) are not bundled together into the deployment package. 

To verify that this is the case, we can push the proposed code changes and download the deployment package after a build. Then, search for the secret environment variables (`CYPRESS_COOKIE_NAME`, `CYPRESS_COOKIE_VALUE`) in the package. If the proposal works, the secret should not show up anywhere in the deployment package.

Note: however, these env vars are published in Netlify build logs. This can be mitigated by making the build logs private.

## Follow-up action
Currently, we have disabled the Cypress Netlify plugin so that we do not run our E2E tests when deploying our package. We need to correctly configure the `cypress-netlify-plugin` to run our E2E tests on the newly-deployed code, so that we can completely automate our testing process. This will be tracked as part of issue #595.