### PR TITLE
[hotfix to develop] Allow iframe objects in EditPage

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -115,6 +115,18 @@ const MEDIA_PLACEHOLDER_TEXT = {
   files: "[Example Filename]",
 }
 
+DOMPurify.setConfig({
+  ADD_TAGS: ["iframe", "#comment"],
+  ADD_ATTR: [
+    "allow",
+    "allowfullscreen",
+    "frameborder",
+    "scrolling",
+    "marginheight",
+    "marginwidth",
+  ],
+})
+
 const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
   // Instantiate queryClient
   const queryClient = useQueryClient()


### PR DESCRIPTION
This PR is a hotfix to modify the configurations on DOMPurify to allow for iframes in EditPage. 

Currently, users are unable to insert Youtube videos and other embedded frames in EditPage as `iframes` are sanitised and removed by `DOMPurify.sanitize`.

This PR also applies `DOMPurify` to the refactored collectionPages flow as `DOMPurify` was accidentally removed during the refactor.