### PR TITLE
Fix/dompurify a attribute

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -239,10 +239,10 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
 
   // update page data
   const { mutateAsync: saveHandler } = useMutation(
-    () =>
+    (editorValue) =>
       updatePageData(
         match.params,
-        concatFrontMatterMdBody(frontMatter, DOMPurify.sanitize(editorValue)),
+        concatFrontMatterMdBody(frontMatter, editorValue),
         sha
       ),
     {
@@ -472,9 +472,11 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
             <br/><br/>Before saving, the editor input will be automatically sanitised to prevent security vulnerabilities.
             <br/><br/>To save the sanitised editor input, press Acknowledge. To return to the editor without sanitising, press Cancel.`}
             onProceed={() => {
+              const sanitizedEditorValue = DOMPurify.sanitize(editorValue)
+              setEditorValue(sanitizedEditorValue)
               setIsXSSViolation(false)
               setShowXSSWarning(false)
-              saveHandler()
+              saveHandler(sanitizedEditorValue)
             }}
             onCancel={() => {
               setShowXSSWarning(false)
@@ -631,9 +633,9 @@ const EditPage = ({ match, isResourcePage, isCollectionPage, history }) => {
           className={
             isCspViolation ? elementStyles.disabled : elementStyles.blue
           }
-          callback={
-            isXSSViolation ? () => setShowXSSWarning(true) : saveHandler
-          }
+          callback={() => {
+            isXSSViolation ? setShowXSSWarning(true) : saveHandler(editorValue)
+          }}
         />
       </div>
       {canShowDeleteWarningModal && (

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -118,7 +118,6 @@ const EditPageV2 = ({ match, history }) => {
         sanitisedHtml: CSPSanitisedHtml,
       } = checkCSP(csp, html)
       const DOMCSPSanitisedHtml = DOMPurify.sanitize(CSPSanitisedHtml)
-      console.log(DOMPurify.removed)
       const processedChunk = await prependImageSrc(
         siteName,
         DOMCSPSanitisedHtml
@@ -162,12 +161,14 @@ const EditPageV2 = ({ match, history }) => {
             <br/><br/>Before saving, the editor input will be automatically sanitised to prevent security vulnerabilities.
             <br/><br/>To save the sanitised editor input, press Acknowledge. To return to the editor without sanitising, press Cancel.`}
               onProceed={() => {
+                const sanitizedEditorValue = DOMPurify.sanitize(editorValue)
+                setEditorValue(sanitizedEditorValue)
                 setIsXSSViolation(false)
                 setShowXSSWarning(false)
                 updatePageHandler({
                   frontMatter: pageData.content.frontMatter,
                   sha: pageData.sha,
-                  pageBody: DOMPurify.sanitize(editorValue),
+                  pageBody: sanitizedEditorValue,
                 })
               }}
               onCancel={() => {


### PR DESCRIPTION
This PR accomplishes the following three things:
- Adds `target` as an accepted attribute for `DOMPurify`
- Only runs `DOMPurify` on save only when there's XSS violation/ dirty content, as opposed to on every save (see rationale below)
- Updates `editorValue` during sanitisation

### Quirks of `DOMPurify`

The ordering of attributes reverses when `DOMPurify` is run, see below for an example, where the `href` and `target` tag swaps orders.

```
> DOMPurify.setConfig({ADD_ATTR: ["target"]})
> DOMPurify.sanitize('<p><a href="https://www.google.com" target="_blank">Hi!</a></p>')
'<p><a target="_blank" href="https://www.google.com">Hi!</a></p>'
> DOMPurify.sanitize('<p><a target="_blank" href="https://www.google.com">Hi!</a></p>')
'<p><a href="https://www.google.com" target="_blank">Hi!</a></p>'
```

This implies that if we run sanitisation on save and if the user saves the same page multiple times, the order of the attributes will change on every save. 

### Behavior for CMS users
This quirk above will cause a strange behavior for CMS users as they've not made any changes to their content, but the auto-sanitisation causes the content to change, see the attached video:
https://user-images.githubusercontent.com/39231249/130892981-b8c2759e-330a-4705-a2f2-6e9e898f8373.mov


To prevent this behavior from happening, we modify the **sanitisation to run only when there is dirty attributes to be removed**, which will trigger the **warning to users that their content will be sanitised when they Acknowledge and Save**.

