### PR TITLE
refactor: backend settings v2

### DIFF
--- a/src/hooks/settingsHooks/useSiteColorsHook.jsx
+++ b/src/hooks/settingsHooks/useSiteColorsHook.jsx
@@ -15,10 +15,9 @@ const getSiteColors = async ({ siteName }) => {
   const settingsResp = await axios.get(
     `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
   )
-  const { settings } = settingsResp.data
   const {
-    configFieldsRequired: { colors },
-  } = settings
+    configSettings: { colors },
+  } = settingsResp.data
 
   return {
     primaryColor: colors?.["primary-color"] || DEFAULT_ISOMER_PRIMARY_COLOR,

--- a/src/hooks/settingsHooks/useSiteColorsHook.jsx
+++ b/src/hooks/settingsHooks/useSiteColorsHook.jsx
@@ -13,7 +13,7 @@ import { DEFAULT_RETRY_MSG } from "../../utils"
 
 const getSiteColors = async ({ siteName }) => {
   const settingsResp = await axios.get(
-    `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
+    `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`
   )
   const {
     configSettings: { colors },

--- a/src/hooks/useSiteUrlHook.jsx
+++ b/src/hooks/useSiteUrlHook.jsx
@@ -34,7 +34,7 @@ const useSiteUrlHook = () => {
         const settingsResp = await axios.get(
           `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
         )
-        url = settingsResp.data.settings.configFieldsRequired.url
+        url = settingsResp.data.configSettings.url
       }
       setSiteUrl(url, siteName, type)
       return url

--- a/src/hooks/useSiteUrlHook.jsx
+++ b/src/hooks/useSiteUrlHook.jsx
@@ -32,7 +32,7 @@ const useSiteUrlHook = () => {
       }
       if (type === "site") {
         const settingsResp = await axios.get(
-          `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
+          `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`
         )
         url = settingsResp.data.configSettings.url
       }

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -142,7 +142,6 @@ const EditContactUs = ({ match }) => {
   const [frontMatterSha, setFrontMatterSha] = useState(null)
   const [footerContent, setFooterContent] = useState({})
   const [originalFooterContent, setOriginalFooterContent] = useState({})
-  const [footerSha, setFooterSha] = useState(null)
   const [displaySections, setDisplaySections] = useState({
     sectionsDisplay: {
       locations: false,
@@ -167,7 +166,6 @@ const EditContactUs = ({ match }) => {
     let content
     let sha
     let footerContent
-    let footerSha
 
     const loadContactUsDetails = async () => {
       // Set page colors
@@ -202,12 +200,8 @@ const EditContactUs = ({ match }) => {
         const settingsResp = await axios.get(
           `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
         )
-        const {
-          footerContent: retrievedContent,
-          footerSha: retrievedSha,
-        } = settingsResp.data.settings
-        footerContent = retrievedContent
-        footerSha = retrievedSha
+        const { footerSettings } = settingsResp.data
+        footerContent = footerSettings
       } catch (err) {
         errorToast(
           `There was a problem trying to load your contact us page. ${DEFAULT_RETRY_MSG}`
@@ -264,7 +258,6 @@ const EditContactUs = ({ match }) => {
         })
         setFooterContent(footerContent)
         setOriginalFooterContent(_.cloneDeep(footerContent))
-        setFooterSha(footerSha)
         setFrontMatter(sanitisedFrontMatter)
         setOriginalFrontMatter(_.cloneDeep(frontMatter))
         setDeletedFrontMatter(deletedFrontMatter)
@@ -726,12 +719,11 @@ const EditContactUs = ({ match }) => {
         )
       }
 
-      // // Update settings
+      // Update settings
       const updatedFooterContents = _.cloneDeep(footerContent)
 
       const footerParams = {
         footerSettings: updatedFooterContents,
-        footerSha,
       }
 
       if (
@@ -898,7 +890,7 @@ const EditContactUs = ({ match }) => {
               disabled={hasErrors()}
               disabledStyle={elementStyles.disabled}
               className={
-                hasErrors() || !(frontMatterSha && footerSha)
+                hasErrors() || !frontMatterSha
                   ? elementStyles.disabled
                   : elementStyles.blue
               }

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -198,7 +198,7 @@ const EditContactUs = ({ match }) => {
 
       try {
         const settingsResp = await axios.get(
-          `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
+          `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`
         )
         const { footerSettings } = settingsResp.data
         footerContent = footerSettings
@@ -730,7 +730,7 @@ const EditContactUs = ({ match }) => {
         JSON.stringify(footerContent) !== JSON.stringify(originalFooterContent)
       ) {
         await axios.post(
-          `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`,
+          `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`,
           footerParams,
           {
             withCredentials: true,

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -139,6 +139,7 @@ export default class Settings extends Component {
         // url: configSettings.url,
         shareicon: configSettings.shareicon,
         title: configSettings.title,
+        description: configSettings.description,
         // footer fields
         otherFooterSettings: {
           contact_us: footerSettings.contact_us,

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -119,7 +119,7 @@ export default class Settings extends Component {
 
       // get settings data from backend
       const resp = await axios.get(
-        `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`,
+        `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`,
         {
           withCredentials: true,
         }
@@ -361,7 +361,7 @@ export default class Settings extends Component {
       }
 
       await axios.post(
-        `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`,
+        `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`,
         params,
         {
           withCredentials: true,

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -124,46 +124,40 @@ export default class Settings extends Component {
           withCredentials: true,
         }
       )
-      const { settings } = resp.data
-      const {
-        configFieldsRequired,
-        footerContent,
-        navigationContent,
-      } = settings
+      const { configSettings, footerSettings, navigationSettings } = resp.data
 
       const originalState = {
         // config fields
         // note: config fields are listed out one-by-one since we do not use all config fields
-        colors: configFieldsRequired.colors,
-        favicon: configFieldsRequired.favicon,
-        google_analytics: configFieldsRequired.google_analytics,
-        facebook_pixel: configFieldsRequired.facebook_pixel,
-        linkedin_insights: configFieldsRequired.linkedin_insights,
-        is_government: configFieldsRequired.is_government,
-        // resources_name: configFieldsRequired.resources_name,
-        // url: configFieldsRequired.url,
-        shareicon: configFieldsRequired.shareicon,
-        title: configFieldsRequired.title,
-        description: configFieldsRequired.description,
+        colors: configSettings.colors,
+        favicon: configSettings.favicon,
+        google_analytics: configSettings.google_analytics,
+        facebook_pixel: configSettings.facebook_pixel,
+        linkedin_insights: configSettings.linkedin_insights,
+        is_government: configSettings.is_government,
+        // resources_name: configSettings.resources_name,
+        // url: configSettings.url,
+        shareicon: configSettings.shareicon,
+        title: configSettings.title,
         // footer fields
         otherFooterSettings: {
-          contact_us: footerContent.contact_us,
-          feedback: footerContent.feedback,
-          faq: footerContent.faq,
-          show_reach: footerContent.show_reach,
+          contact_us: footerSettings.contact_us,
+          feedback: footerSettings.feedback,
+          faq: footerSettings.faq,
+          show_reach: footerSettings.show_reach,
         },
         socialMediaContent: {
-          facebook: footerContent.social_media.facebook,
-          twitter: footerContent.social_media.twitter,
-          youtube: footerContent.social_media.youtube,
-          instagram: footerContent.social_media.instagram,
-          linkedin: footerContent.social_media.linkedin,
-          telegram: footerContent.social_media.telegram,
-          tiktok: footerContent.social_media.tiktok,
+          facebook: footerSettings.social_media.facebook,
+          twitter: footerSettings.social_media.twitter,
+          youtube: footerSettings.social_media.youtube,
+          instagram: footerSettings.social_media.instagram,
+          linkedin: footerSettings.social_media.linkedin,
+          telegram: footerSettings.social_media.telegram,
+          tiktok: footerSettings.social_media.tiktok,
         },
         // navigation fields
         navigationSettings: {
-          ...navigationContent,
+          ...navigationSettings,
         },
       }
 

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -132,7 +132,7 @@ const getSiteColors = async (siteName) => {
   try {
     // get settings data from backend
     const settingsResp = await axios.get(
-      `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
+      `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/settings`
     )
     const {
       configSettings: { colors },

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -134,10 +134,9 @@ const getSiteColors = async (siteName) => {
     const settingsResp = await axios.get(
       `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/settings`
     )
-    const { settings } = settingsResp.data
     const {
-      configFieldsRequired: { colors },
-    } = settings
+      configSettings: { colors },
+    } = settingsResp.data
 
     return {
       primaryColor: colors?.["primary-color"] || DEFAULT_ISOMER_PRIMARY_COLOR,


### PR DESCRIPTION
This PR is modifies frontend components which hit the backend GET `/{siteName}/settings` endpoint in response to changes to the settings response format made in the backend PR #[282](https://github.com/isomerpages/isomercms-backend/pull/282). 

The biggest change to note is the removal of the `footerSha` state variable in the `EditContactUs` layout. The GET `/{siteName}/settings`  endpoint pulls the existing footer file to check for differences in the request footer fields and the current repo value - in doing so, it retrieves the existing footer file sha. Thus, we no longer need to submit a sha value when updating the footer. 

Additional refactoring to bring the settings component in line with our existing refactor is in a future PR : https://github.com/isomerpages/isomercms-frontend/pull/666