### PR TITLE
Fix: disable manual user input for colours

### DIFF
--- a/src/components/FormFieldColor.jsx
+++ b/src/components/FormFieldColor.jsx
@@ -26,6 +26,7 @@ const FormFieldColor = ({
         className={elementStyles.formColorInput}
         style={style}
         onChange={onFieldChange}
+        disabled
       />
       <div
         className={elementStyles.formColorBox}


### PR DESCRIPTION
This PR resolves #646. It fixes an issue which allowed users to manually modify the site colours, which could result in the site breaking if the colours were not specified properly. The input has been disabled in this PR, such that users can only use the colour picker to enforce correct colours being chosen.