### PR TITLE
Refactor/special characters

### DIFF
--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -94,7 +94,7 @@ describe("Edit unlinked page", () => {
 
   it("Edit page (unlinked) should provide a warning to users when navigating away", () => {
     cy.get(".CodeMirror-scroll").type(TEST_PAGE_CONTENT)
-    cy.contains(":button", "My Workspace").click()
+    cy.contains(":button", "Back to Workspace").click()
 
     cy.contains("Warning")
     cy.contains(":button", "No").click()
@@ -106,7 +106,7 @@ describe("Edit unlinked page", () => {
     )
     cy.contains(TEST_PAGE_CONTENT)
 
-    cy.contains(":button", "My Workspace").click()
+    cy.contains(":button", "Back to Workspace").click()
 
     cy.contains("Warning")
     cy.contains(":button", "Yes").click()
@@ -197,6 +197,7 @@ describe("Edit unlinked page", () => {
     // Test delete in modal
     cy.get("#modal-delete").should("exist")
     cy.get("#modal-delete").click()
+    cy.wait(2000)
 
     // Assert: page no longer exists
     cy.visit(`/sites/${TEST_REPO_NAME}/editPage/${TEST_PAGE_TITLE_ENCODED}`)

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -55,15 +55,25 @@ describe("Folders flow", () => {
 
   const INVALID_TEST_PAGE_TITLES = [
     "Ab",
-    "Lorem Ipsum-",
-    "?Lorem Ipsum",
-    "#Lorem Ipsum",
-    "@Lorem Ipsum",
-    "&Lorem Ipsum",
+    "Lorem Ipsum<",
+    "^Lorem Ipsum",
+    "~%Lorem Ipsum",
+    "/Lorem Ipsum",
+    ";Lorem Ipsum",
+    ">Lorem Ipsum",
+    "[Lorem Ipsum",
+    "]Lorem Ipsum",
   ]
   const INVALID_TEST_PAGE_PERMALINKS = ["/12", "test-", "/abcd?"]
 
-  const INVALID_SUBFOLDER_TITLES = ["t", "!abc"]
+  const INVALID_SUBFOLDER_TITLES = [
+    "t",
+    "/abc",
+    "%abc",
+    "[abc]",
+    "~abc",
+    "<abc>",
+  ]
 
   const TEST_SUBFOLDER_NO_PAGES_TITLE = "test subfolder title no pages"
   const PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE = deslugifyDirectory(

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -36,7 +36,7 @@ describe("Move flow", () => {
     it("Should be able to navigate from Workspace to subfolder back to Workspace via MoveModal buttons", () => {
       cy.contains(FILENAME_WORKSPACE_TO_FOLDER).should("exist")
       cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
+        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
       ).click()
       cy.get("div[id^=move-]").first().click()
       cy.contains(`Move Page`)
@@ -69,7 +69,7 @@ describe("Move flow", () => {
     it("Should be able to move page from Workspace to itself and show correct success message", () => {
       cy.contains(FILENAME_WORKSPACE_TO_FOLDER).should("exist")
       cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
+        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
       ).click()
       cy.get("div[id^=move-]").first().click()
       cy.contains(`Move Page`)
@@ -83,7 +83,7 @@ describe("Move flow", () => {
     it("Should be able to move a page from Workspace to folder", () => {
       cy.contains(FILENAME_WORKSPACE_TO_FOLDER).should("exist")
       cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
+        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
       ).click()
       cy.get("div[id^=move-]").first().click()
       cy.contains(`Move Page`)
@@ -119,7 +119,7 @@ describe("Move flow", () => {
     it("Should be able to move a page from folder to subfolder", () => {
       cy.contains(FILENAME_WORKSPACE_TO_SUBFOLDER).should("exist")
       cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_WORKSPACE_TO_SUBFOLDER}"]`
+        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_SUBFOLDER}"]`
       ).click()
       cy.get("div[id^=move-]").first().click()
       cy.contains(`Move Page`)

--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -8,7 +8,7 @@ describe("Resource category page", () => {
   const COOKIE_NAME = Cypress.env("COOKIE_NAME")
   const COOKIE_VALUE = Cypress.env("COOKIE_VALUE")
   const TEST_REPO_NAME = Cypress.env("TEST_REPO_NAME")
-  Cypress.config("baseUrl", `${CMS_BASEURL}/sites/${TEST_REPO_NAME}`)
+  Cypress.config("baseUrl", Cypress.env("BASEURL"))
 
   const TEST_CATEGORY = "Test Page Folder"
   const TEST_CATEGORY_2 = "Another Page Folder"
@@ -37,12 +37,12 @@ describe("Resource category page", () => {
     window.localStorage.setItem("userId", "test")
 
     // Set up test resource categories
-    cy.visit(`/resources`)
+    cy.visit(`/sites/${TEST_REPO_NAME}/resources`)
     cy.contains("Create new category").click()
     cy.get("input").clear().type(TEST_CATEGORY)
     cy.contains("Save").click()
     cy.wait(3000)
-    cy.visit(`/resources`)
+    cy.visit(`/sites/${TEST_REPO_NAME}/resources`)
     cy.contains("Create new category").click()
     cy.get("input").clear().type(TEST_CATEGORY_2)
     cy.contains("Save").click()
@@ -54,7 +54,7 @@ describe("Resource category page", () => {
     // This means it will not be cleared before the NEXT test starts.
     cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
     window.localStorage.setItem("userId", "test")
-    cy.visit(`/resources/${TEST_CATEGORY_SLUGIFIED}`)
+    cy.visit(`/sites/${TEST_REPO_NAME}/resources/${TEST_CATEGORY_SLUGIFIED}`)
   })
 
   it("Resource category page should have name of resource category in header", () => {

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -83,7 +83,7 @@ describe("Workspace Pages flow", () => {
       cy.contains(TEST_PAGE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist")
 
       // 2. If user goes back to the workspace, they should be able to see that the page exists
-      cy.contains("My Workspace", { timeout: CUSTOM_TIMEOUT })
+      cy.contains("Back to Workspace", { timeout: CUSTOM_TIMEOUT })
         .should("exist")
         .click()
       cy.contains(TEST_PAGE_FILENAME, { timeout: CUSTOM_TIMEOUT }).should(
@@ -94,11 +94,14 @@ describe("Workspace Pages flow", () => {
     it("Should not be able to create page with invalid title", () => {
       const INVALID_TEST_PAGE_TITLES = [
         "Ab",
-        "Lorem Ipsum-",
-        "?Lorem Ipsum",
-        "#Lorem Ipsum",
-        "@Lorem Ipsum",
-        "&Lorem Ipsum",
+        "Lorem Ipsum<",
+        "^Lorem Ipsum",
+        "~%Lorem Ipsum",
+        "/Lorem Ipsum",
+        ";Lorem Ipsum",
+        ">Lorem Ipsum",
+        "[Lorem Ipsum",
+        "]Lorem Ipsum",
       ]
 
       cy.get("#settings-NEW", { timeout: CUSTOM_TIMEOUT })

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,6 +6,8 @@ import useRedirectHook from "../hooks/useRedirectHook"
 import useSiteUrlHook from "../hooks/useSiteUrlHook"
 import elementStyles from "../styles/isomer-cms/Elements.module.scss"
 
+import { getBackButton } from "../utils"
+
 // axios settings
 axios.defaults.withCredentials = true
 
@@ -20,6 +22,7 @@ const Header = ({
   shouldAllowEditPageBackNav,
   backButtonText,
   backButtonUrl,
+  params,
 }) => {
   const { setRedirectToLogout, setRedirectToPage } = useRedirectHook()
   const { retrieveStagingUrl } = useSiteUrlHook()
@@ -28,12 +31,20 @@ const Header = ({
   const [showStagingWarningModal, setShowStagingWarningModal] = useState(false)
   const [stagingUrl, setStagingUrl] = useState()
 
+  const {
+    backButtonLabel: backButtonTextFromParams,
+    backButtonUrl: backButtonUrlFromParams,
+  } = getBackButton(params)
+  const { siteName: siteNameFromParams } = params
+
   useEffect(() => {
     let _isMounted = true
 
     const loadStagingUrl = async () => {
-      if (siteName) {
-        const retrievedStagingUrl = await retrieveStagingUrl(siteName)
+      if (siteNameFromParams || siteName) {
+        const retrievedStagingUrl = await retrieveStagingUrl(
+          siteNameFromParams || siteName
+        )
         if (_isMounted) setStagingUrl(retrievedStagingUrl)
       }
     }
@@ -45,7 +56,7 @@ const Header = ({
   }, [])
 
   const toggleBackNav = () => {
-    setRedirectToPage(backButtonUrl)
+    setRedirectToPage(backButtonUrlFromParams || backButtonUrl)
   }
 
   const handleBackNav = () => {
@@ -55,8 +66,12 @@ const Header = ({
   }
 
   const handleViewPullRequest = () => {
-    const githubUrl = `https://github.com/isomerpages/${siteName}/pulls`
-    window.open(githubUrl, "_blank")
+    if (siteNameFromParams || siteName) {
+      const githubUrl = `https://github.com/isomerpages/${
+        siteNameFromParams || siteName
+      }/pulls`
+      window.open(githubUrl, "_blank")
+    }
   }
 
   const handleViewStaging = () => {
@@ -76,7 +91,7 @@ const Header = ({
               type="button"
             >
               <i className="bx bx-chevron-left" />
-              {backButtonText}
+              {backButtonTextFromParams || backButtonText}
             </button>
           </div>
         )}
@@ -96,7 +111,7 @@ const Header = ({
       </div>
       {/* Right section */}
       <div className={elementStyles.headerRight}>
-        {siteName ? (
+        {siteNameFromParams || siteName ? (
           <>
             <button
               type="button"
@@ -165,6 +180,7 @@ Header.defaultProps = {
   shouldAllowEditPageBackNav: true,
   backButtonText: "Back to Sites",
   backButtonUrl: "/sites",
+  params: {},
 }
 
 Header.propTypes = {
@@ -175,6 +191,12 @@ Header.propTypes = {
   shouldAllowEditPageBackNav: PropTypes.bool,
   backButtonText: PropTypes.string,
   backButtonUrl: PropTypes.string,
+  params: PropTypes.shape({
+    siteName: PropTypes.string,
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    fileName: PropTypes.string,
+  }),
 }
 
 export default Header

--- a/src/components/MoveModal.jsx
+++ b/src/components/MoveModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import PropTypes from "prop-types"
 import Breadcrumb from "./folders/Breadcrumb"
 
 import elementStyles from "../styles/isomer-cms/Elements.module.scss"
@@ -8,9 +9,9 @@ import SaveDeleteButtons from "./SaveDeleteButtons"
 
 import { getLastItemType, getNextItemType, deslugifyDirectory } from "../utils"
 
-const MoveModal = ({ params, onProceed, onClose }) => {
+const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
   const [moveQuery, setMoveQuery] = useState(
-    (({ fileName, ...p }) => p)(params)
+    (({ fileName, ...p }) => p)(queryParams)
   )
   const [moveTo, setMoveTo] = useState(moveQuery)
 
@@ -67,7 +68,7 @@ const MoveModal = ({ params, onProceed, onClose }) => {
               }))
               setMoveQuery((prevState) => ({
                 ...prevState,
-                [nextItemType]: name,
+                [nextItemType]: encodeURIComponent(name),
               }))
             }}
           />
@@ -76,9 +77,9 @@ const MoveModal = ({ params, onProceed, onClose }) => {
     return null
   }
 
-  const MoveMenuBackButton = ({ params }) => {
-    const lastItemType = getLastItemType(params)
-    const isEnabled = Object.keys(params).length > 1
+  const MoveMenuBackButton = () => {
+    const lastItemType = getLastItemType(moveQuery)
+    const isEnabled = Object.keys(moveQuery).length > 1
     return (
       <div
         id="moveModal-backButton"
@@ -102,14 +103,14 @@ const MoveModal = ({ params, onProceed, onClose }) => {
         />
         {lastItemType === "siteName"
           ? "Workspace"
-          : deslugifyDirectory(params[lastItemType])}
+          : deslugifyDirectory(decodeURIComponent(moveQuery[lastItemType]))}
       </div>
     )
   }
 
-  const MoveMenu = ({ dirData }) => (
+  const MoveMenu = () => (
     <div className={`${elementStyles.moveModal}`}>
-      <MoveMenuBackButton params={moveQuery} />
+      <MoveMenuBackButton />
       {dirData && dirData.length ? (
         <>
           {/* directories */}
@@ -159,7 +160,7 @@ const MoveModal = ({ params, onProceed, onClose }) => {
             <br />
             Current location of page: <br />
             <Breadcrumb params={params} title={params.fileName} />
-            <MoveMenu dirData={dirData} />
+            <MoveMenu />
             Moving page to: <br />
             <Breadcrumb params={moveTo} title={params.fileName} />
           </div>
@@ -181,18 +182,19 @@ const MoveModal = ({ params, onProceed, onClose }) => {
 
 export default MoveModal
 
-// MoveModal.propTypes = {
-//   dropdownItems: PropTypes.arrayOf(PropTypes.string.isRequired),
-//   menuIndex: PropTypes.number.isRequired,
-//   dropdownRef: PropTypes.oneOfType([
-//     PropTypes.func,
-//     PropTypes.shape({ current: PropTypes.any }),
-//   ]).isRequired,
-//   onBlur: PropTypes.func,
-//   rootName: PropTypes.string.isRequired,
-//   moveDropdownQuery: PropTypes.string.isRequired,
-//   setMoveDropdownQuery: PropTypes.func.isRequired,
-//   backHandler: PropTypes.func.isRequired,
-//   moveHandler: PropTypes.func,
-//   moveDisabled: PropTypes.bool,
-// }
+MoveModal.propTypes = {
+  queryParams: PropTypes.shape({
+    siteName: PropTypes.string,
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    fileName: PropTypes.string,
+  }).isRequired,
+  params: PropTypes.shape({
+    siteName: PropTypes.string,
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    fileName: PropTypes.string,
+  }).isRequired,
+  onProceed: PropTypes.func,
+  onClose: PropTypes.func,
+}

--- a/src/components/MoveModal.jsx
+++ b/src/components/MoveModal.jsx
@@ -9,17 +9,41 @@ import SaveDeleteButtons from "./SaveDeleteButtons"
 
 import { getLastItemType, getNextItemType, deslugifyDirectory } from "../utils"
 
-const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
-  const [moveQuery, setMoveQuery] = useState(
-    (({ fileName, ...p }) => p)(queryParams)
-  )
-  const [moveTo, setMoveTo] = useState(moveQuery)
-
-  const { data: dirData } = useGetDirectoryHook(moveQuery)
-
+const MoveMenu = ({ moveQuery, setMoveQuery, moveTo, setMoveTo, dirData }) => {
   /** ******************************** */
   /*     subcomponents    */
   /** ******************************** */
+
+  const MoveMenuBackButton = () => {
+    const lastItemType = getLastItemType(moveQuery)
+    const isEnabled = Object.keys(moveQuery).length > 1
+    return (
+      <div
+        id="moveModal-backButton"
+        className={`${elementStyles.dropdownHeader}`}
+        onMouseDown={
+          isEnabled
+            ? () => {
+                const newMoveQuery = (({ [lastItemType]: unused, ...p }) => p)(
+                  moveQuery
+                )
+                setMoveQuery(newMoveQuery)
+                setMoveTo(newMoveQuery)
+              }
+            : null
+        }
+      >
+        <i
+          className={`${elementStyles.dropdownIcon} ${
+            lastItemType != "siteName" && "bx bx-sm bx-arrow-back text-white"
+          }`}
+        />
+        {lastItemType === "siteName"
+          ? "Workspace"
+          : deslugifyDirectory(decodeURIComponent(moveQuery[lastItemType]))}
+      </div>
+    )
+  }
 
   const MoveMenuItem = ({ item, id }) => {
     const { name, type } = item
@@ -77,38 +101,7 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
     return null
   }
 
-  const MoveMenuBackButton = () => {
-    const lastItemType = getLastItemType(moveQuery)
-    const isEnabled = Object.keys(moveQuery).length > 1
-    return (
-      <div
-        id="moveModal-backButton"
-        className={`${elementStyles.dropdownHeader}`}
-        onMouseDown={
-          isEnabled
-            ? () => {
-                const newMoveQuery = (({ [lastItemType]: unused, ...p }) => p)(
-                  moveQuery
-                )
-                setMoveQuery(newMoveQuery)
-                setMoveTo(newMoveQuery)
-              }
-            : null
-        }
-      >
-        <i
-          className={`${elementStyles.dropdownIcon} ${
-            lastItemType != "siteName" && "bx bx-sm bx-arrow-back text-white"
-          }`}
-        />
-        {lastItemType === "siteName"
-          ? "Workspace"
-          : deslugifyDirectory(decodeURIComponent(moveQuery[lastItemType]))}
-      </div>
-    )
-  }
-
-  const MoveMenu = () => (
+  return (
     <div className={`${elementStyles.moveModal}`}>
       <MoveMenuBackButton />
       {dirData && dirData.length ? (
@@ -122,7 +115,6 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
           {/* pages */}
           {dirData
             .filter((item) => item.type === "file")
-            .filter((item) => item.name != params.fileName)
             .map((item, itemIndex) => (
               <MoveMenuItem item={item} id={itemIndex} />
             ))}
@@ -142,6 +134,15 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
       )}
     </div>
   )
+}
+
+const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
+  const [moveQuery, setMoveQuery] = useState(
+    (({ fileName, ...p }) => p)(queryParams)
+  )
+  const [moveTo, setMoveTo] = useState(moveQuery)
+
+  const { data: dirData } = useGetDirectoryHook(moveQuery)
 
   return (
     <div className={elementStyles.overlay}>
@@ -160,7 +161,17 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
             <br />
             Current location of page: <br />
             <Breadcrumb params={params} title={params.fileName} />
-            <MoveMenu />
+            <MoveMenu
+              moveQuery={moveQuery}
+              setMoveQuery={setMoveQuery}
+              moveTo={moveTo}
+              setMoveTo={setMoveTo}
+              dirData={
+                dirData
+                  ? dirData.filter((item) => item.name != params.fileName)
+                  : []
+              }
+            />
             Moving page to: <br />
             <Breadcrumb params={moveTo} title={params.fileName} />
           </div>

--- a/src/components/PageCard.jsx
+++ b/src/components/PageCard.jsx
@@ -34,10 +34,11 @@ const PageCard = ({ item, itemIndex, isDisabled }) => {
   const { setRedirectToPage } = useRedirectHook()
 
   const generateLink = () => {
+    const encodedName = encodeURIComponent(name)
     if (resourceRoomName) {
-      return `/sites/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategoryName}/${name}`
+      return `/sites/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategoryName}/${encodedName}`
     }
-    return `/sites/${siteName}/editPage/${name}`
+    return `/sites/${siteName}/editPage/${encodedName}`
   }
 
   useEffect(() => {
@@ -45,18 +46,20 @@ const PageCard = ({ item, itemIndex, isDisabled }) => {
   }, [showDropdown])
 
   const generateDropdownItems = ({ name }, url) => {
+    const encodedName = encodeURIComponent(name)
     return [
       {
         type: "edit",
-        handler: () => setRedirectToPage(`${url}/editPageSettings/${name}`),
+        handler: () =>
+          setRedirectToPage(`${url}/editPageSettings/${encodedName}`),
       },
       {
         type: "move",
-        handler: () => setRedirectToPage(`${url}/movePage/${name}`),
+        handler: () => setRedirectToPage(`${url}/movePage/${encodedName}`),
       },
       {
         type: "delete",
-        handler: () => setRedirectToPage(`${url}/deletePage/${name}`),
+        handler: () => setRedirectToPage(`${url}/deletePage/${encodedName}`),
       },
     ]
   }

--- a/src/components/PageSettingsModalV2.jsx
+++ b/src/components/PageSettingsModalV2.jsx
@@ -53,6 +53,16 @@ const PageSettingsModalV2 = ({
     if (fileName && pageData && !hasChanges && pageData.content) {
       setTitle(pageData.content.frontMatter.title)
       setPermalink(pageData.content.frontMatter.permalink)
+      setErrors({
+        title: validatePageSettings(
+          "title",
+          pageData.content.frontMatter.title
+        ),
+        permalink: validatePageSettings(
+          "permalink",
+          pageData.content.frontMatter.permalink
+        ),
+      })
     }
   }, [pageData])
 

--- a/src/components/folders/Breadcrumb.jsx
+++ b/src/components/folders/Breadcrumb.jsx
@@ -1,16 +1,26 @@
 import React from "react"
-
+import { Link } from "react-router-dom"
 import { deslugifyDirectory, isLastItem } from "../../utils"
 
-const BreadcrumbItem = ({ item, isLast }) => (
-  <span>
-    {" > "}
-    {isLast ? <u className="ml-1">{item}</u> : item}
-  </span>
+const BreadcrumbItem = ({ item, isLast, link }) => (
+  <>
+    {link && !isLast ? (
+      <Link to={link}>{item}</Link>
+    ) : !isLast ? (
+      <span>{item}</span>
+    ) : (
+      // underline last item
+      <span>
+        <u className="ml-1">{item}</u>
+      </span>
+    )}
+    {isLast ? "" : " > "}
+  </>
 )
 
-const Breadcrumb = ({ params, title }) => {
+const Breadcrumb = ({ params, title, isLink }) => {
   const {
+    siteName,
     collectionName,
     subCollectionName,
     resourceRoomName,
@@ -19,29 +29,47 @@ const Breadcrumb = ({ params, title }) => {
   const newParams = { ...params, fileName: title }
   return (
     <span>
-      Workspace
+      {
+        <BreadcrumbItem
+          item="Workspace"
+          isLast={isLastItem("siteName", newParams)}
+          link={isLink && `/sites/${siteName}/workspace`}
+        />
+      }
       {collectionName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(collectionName)}
           isLast={isLastItem("collectionName", newParams)}
+          link={isLink && `/sites/${siteName}/folders/${collectionName}`}
         />
       ) : null}
       {subCollectionName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(subCollectionName)}
           isLast={isLastItem("subCollectionName", newParams)}
+          link={
+            isLink &&
+            `/sites/${siteName}/folders/${collectionName}/subfolders/${subCollectionName}`
+          }
         />
       ) : null}
       {resourceRoomName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(resourceRoomName)}
           isLast={isLastItem("resourceRoomName", newParams)}
+          link={
+            isLink && `/sites/${siteName}/resourceRoomName/${resourceRoomName}`
+          }
         />
       ) : null}
       {resourceCategoryName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(resourceCategoryName)}
           isLast={isLastItem("resourceCategoryName", newParams)}
+          link={
+            isLink &&
+            `/sites/${siteName}/resourceRoomName/${resourceRoomName}/resources/${resourceCategoryName}`
+          }
         />
       ) : null}
       {title ? (

--- a/src/components/folders/FolderContent.jsx
+++ b/src/components/folders/FolderContent.jsx
@@ -18,29 +18,34 @@ const FolderItem = ({ item, itemIndex, isDisabled }) => {
   const dropdownRef = useRef(null)
   const [showDropdown, setShowDropdown] = useState(false)
 
-  const generateLink = ({ type, name }, url) =>
-    type === "dir" ? `${url}/subfolders/${name}` : `${url}/editPage/${name}`
+  const generateLink = ({ type, name }, url) => {
+    const encodedName = encodeURIComponent(name)
+    return type === "dir"
+      ? `${url}/subfolders/${encodedName}`
+      : `${url}/editPage/${encodedName}`
+  }
 
   const generateDropdownItems = ({ type, name }, url) => {
+    const encodedName = encodeURIComponent(name)
     const dropdownItems = [
       {
         type: "edit",
         handler: () => {
           type === "dir"
-            ? setRedirectToPage(`${url}/editSubfolderSettings/${name}`)
-            : setRedirectToPage(`${url}/editPageSettings/${name}`)
+            ? setRedirectToPage(`${url}/editSubfolderSettings/${encodedName}`)
+            : setRedirectToPage(`${url}/editPageSettings/${encodedName}`)
         },
       },
       {
         type: "move",
-        handler: () => setRedirectToPage(`${url}/movePage/${name}`),
+        handler: () => setRedirectToPage(`${url}/movePage/${encodedName}`),
       },
       {
         type: "delete",
         handler: () => {
           type === "dir"
-            ? setRedirectToPage(`${url}/deleteSubfolder/${name}`)
-            : setRedirectToPage(`${url}/deletePage/${name}`)
+            ? setRedirectToPage(`${url}/deleteSubfolder/${encodedName}`)
+            : setRedirectToPage(`${url}/deletePage/${encodedName}`)
         },
       },
     ]

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -50,7 +50,8 @@ DOMPurify.setConfig({
 })
 
 const EditPageV2 = ({ match, history }) => {
-  const { siteName } = match.params
+  const { params, decodedParams } = match
+  const { siteName } = decodedParams
 
   const [editorValue, setEditorValue] = useState("")
   const [htmlChunk, setHtmlChunk] = useState("")
@@ -64,28 +65,24 @@ const EditPageV2 = ({ match, history }) => {
 
   const mdeRef = useRef()
 
-  const { backButtonLabel, backButtonUrl } = getBackButton(match.params)
+  const { backButtonLabel, backButtonUrl } = getBackButton(decodedParams)
   const { title, type: resourceType, date } = extractMetadataFromFilename(
-    match.params
+    decodedParams
   )
-
-  const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(
-    match.params,
-    {
-      onError: () => setRedirectToNotFound(siteName),
-    }
-  )
+  const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
+    onError: () => setRedirectToNotFound(siteName),
+  })
   const {
     mutateAsync: updatePageHandler,
     isLoading: isSavingPage,
-  } = useUpdatePageHook(match.params)
-  const { mutateAsync: deletePageHandler } = useDeletePageHook(match.params, {
+  } = useUpdatePageHook(params)
+  const { mutateAsync: deletePageHandler } = useDeletePageHook(params, {
     onSuccess: () => history.goBack(),
   })
 
-  const { data: csp } = useCspHook(match.params)
-  const { data: dirData } = useCollectionHook(match.params)
-  const { data: siteColorsData } = useSiteColorsHook(match.params)
+  const { data: csp } = useCspHook(params)
+  const { data: dirData } = useCollectionHook(params)
+  const { data: siteColorsData } = useSiteColorsHook(params)
 
   /** ******************************** */
   /*     useEffects to load data     */
@@ -189,7 +186,7 @@ const EditPageV2 = ({ match, history }) => {
         />
         {/* Preview */}
         <PagePreview
-          pageParams={match.params}
+          pageParams={decodedParams}
           title={pageData?.content?.frontMatter?.title || ""}
           chunk={htmlChunk}
           dirData={dirData}

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -17,11 +17,7 @@ import { useCspHook, useSiteColorsHook } from "../hooks/settingsHooks"
 import useRedirectHook from "../hooks/useRedirectHook"
 
 // Isomer components
-import {
-  prependImageSrc,
-  getBackButton,
-  extractMetadataFromFilename,
-} from "../utils"
+import { prependImageSrc } from "../utils"
 
 import { createPageStyleSheet } from "../utils/siteColorUtils"
 
@@ -65,10 +61,6 @@ const EditPageV2 = ({ match, history }) => {
 
   const mdeRef = useRef()
 
-  const { backButtonLabel, backButtonUrl } = getBackButton(decodedParams)
-  const { title, type: resourceType, date } = extractMetadataFromFilename(
-    decodedParams
-  )
   const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
     onError: () => setRedirectToNotFound(siteName),
   })
@@ -129,12 +121,10 @@ const EditPageV2 = ({ match, history }) => {
   return (
     <>
       <Header
-        siteName={siteName}
         title={pageData?.content?.frontMatter?.title || ""}
         shouldAllowEditPageBackNav={!hasChanges}
         isEditPage
-        backButtonText={backButtonLabel}
-        backButtonUrl={backButtonUrl}
+        params={decodedParams}
       />
       <div className={elementStyles.wrapper}>
         {isXSSViolation &&
@@ -181,7 +171,6 @@ const EditPageV2 = ({ match, history }) => {
           mdeRef={mdeRef}
           onChange={(value) => setEditorValue(value)}
           value={editorValue}
-          isDisabled={resourceType === "file"}
           isLoading={isLoadingPage}
         />
         {/* Preview */}
@@ -202,7 +191,6 @@ const EditPageV2 = ({ match, history }) => {
         saveCallback={() => {
           if (isXSSViolation) setShowXSSWarning(true)
           else {
-            console.log(pageData.sha)
             updatePageHandler({
               frontMatter: pageData.content.frontMatter,
               sha: pageData.sha,

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { ReactQueryDevtools } from "react-query/devtools"
-import { Link, Switch, useRouteMatch, useHistory } from "react-router-dom"
+import { Switch, useRouteMatch, useHistory } from "react-router-dom"
 import _ from "lodash"
 
 // Import components
@@ -10,6 +10,7 @@ import Sidebar from "../components/Sidebar"
 
 import FolderOptionButton from "../components/FolderOptionButton"
 import { FolderContent } from "../components/folders/FolderContent"
+import Breadcrumb from "../components/folders/Breadcrumb"
 
 import {
   PageSettingsScreen,
@@ -44,19 +45,10 @@ const Folders = ({ match, location }) => {
   const { data: dirData, isLoading: isLoadingDirectory } = useGetDirectoryHook(
     params
   )
+
   return (
     <>
-      <Header
-        siteName={siteName}
-        backButtonText={`Back to ${
-          subCollectionName ? collectionName : "Workspace"
-        }`}
-        backButtonUrl={`/sites/${siteName}/${
-          subCollectionName ? `folders/${collectionName}` : "workspace"
-        }`}
-        shouldAllowEditPageBackNav
-        isEditPage
-      />
+      <Header params={decodedParams} />
       {/* main bottom section */}
       <div className={elementStyles.wrapper}>
         <Sidebar siteName={siteName} currPath={location.pathname} />
@@ -86,38 +78,7 @@ const Folders = ({ match, location }) => {
           </div>
           {/* Collections title */}
           <div className={contentStyles.segment}>
-            <span>
-              <Link to={`/sites/${siteName}/workspace`}>
-                <strong>Workspace</strong>
-              </Link>
-              &nbsp;
-              {">"}
-              {collectionName ? (
-                subCollectionName ? (
-                  <Link to={`/sites/${siteName}/folders/${collectionName}`}>
-                    <strong className="ml-1">
-                      &nbsp;
-                      {deslugifyDirectory(collectionName)}
-                    </strong>
-                  </Link>
-                ) : (
-                  <strong className="ml-1">
-                    &nbsp;
-                    {deslugifyDirectory(collectionName)}
-                  </strong>
-                )
-              ) : null}
-              {collectionName && subCollectionName ? (
-                <span>
-                  &nbsp;
-                  {">"}
-                  <strong className="ml-1">
-                    &nbsp;
-                    {subCollectionName}
-                  </strong>
-                </span>
-              ) : null}
-            </span>
+            <Breadcrumb params={decodedParams} isLink />
           </div>
           {/* Options */}
           <div className={contentStyles.contentContainerFolderRowMargin}>

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -36,6 +36,8 @@ import contentStyles from "../styles/isomer-cms/pages/Content.module.scss"
 
 import { useGetDirectoryHook } from "../hooks/directoryHooks"
 
+import { ProtectedRouteWithProps } from "../routing/RouteSelector"
+
 const Folders = ({ match, location }) => {
   const { siteName, subCollectionName, collectionName } = match.params
 
@@ -152,38 +154,38 @@ const Folders = ({ match, location }) => {
         )}
       </div>
       <Switch>
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/createFolder`]}
-          render={() => (
-            <DirectoryCreationScreen onClose={() => history.goBack()} />
-          )}
+          component={DirectoryCreationScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/createPage`, `${path}/editPageSettings/:fileName`]}
-          render={() => <PageSettingsScreen onClose={() => history.goBack()} />}
+          component={PageSettingsScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[
             `${path}/deletePage/:fileName`,
             `${path}/deleteSubfolder/:subCollectionName`,
           ]}
-          render={() => (
-            <DeleteWarningScreen onClose={() => history.goBack()} />
-          )}
+          component={DeleteWarningScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/rearrange`]}
-          render={() => <ReorderingScreen onClose={() => history.goBack()} />}
+          component={ReorderingScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/editSubfolderSettings/:subCollectionName`]}
-          render={() => (
-            <DirectorySettingsScreen onClose={() => history.goBack()} />
-          )}
+          component={DirectorySettingsScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/movePage/:fileName`]}
-          render={() => <PageMoveScreen onClose={() => history.goBack()} />}
+          component={PageMoveScreen}
+          onClose={() => history.goBack()}
         />
       </Switch>
     </>

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -1,13 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { ReactQueryDevtools } from "react-query/devtools"
-import {
-  Link,
-  Route,
-  Switch,
-  useRouteMatch,
-  useHistory,
-} from "react-router-dom"
+import { Link, Switch, useRouteMatch, useHistory } from "react-router-dom"
 import _ from "lodash"
 
 // Import components
@@ -39,7 +33,8 @@ import { useGetDirectoryHook } from "../hooks/directoryHooks"
 import { ProtectedRouteWithProps } from "../routing/RouteSelector"
 
 const Folders = ({ match, location }) => {
-  const { siteName, subCollectionName, collectionName } = match.params
+  const { params, decodedParams } = match
+  const { siteName, subCollectionName, collectionName } = decodedParams
 
   const { path, url } = useRouteMatch()
   const history = useHistory()
@@ -47,7 +42,7 @@ const Folders = ({ match, location }) => {
   const { setRedirectToPage } = useRedirectHook()
 
   const { data: dirData, isLoading: isLoadingDirectory } = useGetDirectoryHook(
-    match.params
+    params
   )
   return (
     <>
@@ -70,11 +65,11 @@ const Folders = ({ match, location }) => {
           {/* Page title */}
           <div className={contentStyles.sectionHeader}>
             <h1 className={contentStyles.sectionTitle}>
-              {getLastItemType(match.params) === "collectionName"
+              {getLastItemType(decodedParams) === "collectionName"
                 ? deslugifyDirectory(
-                    match.params[getLastItemType(match.params)]
+                    decodedParams[getLastItemType(decodedParams)]
                   )
-                : match.params[getLastItemType(match.params)]}
+                : decodedParams[getLastItemType(decodedParams)]}
             </h1>
           </div>
           {/* Info segment */}

--- a/src/layouts/Workspace.jsx
+++ b/src/layouts/Workspace.jsx
@@ -20,6 +20,7 @@ import {
 import elementStyles from "../styles/isomer-cms/Elements.module.scss"
 import contentStyles from "../styles/isomer-cms/pages/Content.module.scss"
 
+import { ProtectedRouteWithProps } from "../routing/RouteSelector"
 // Import utils
 import { prettifyPageFileName } from "../utils"
 
@@ -205,19 +206,20 @@ const Workspace = ({ match, location }) => {
         {/* main section ends here */}
       </div>
       <Switch>
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/createPage`, `${path}/editPageSettings/:fileName`]}
-          render={() => <PageSettingsScreen onClose={() => history.goBack()} />}
+          component={PageSettingsScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/deletePage/:fileName`]}
-          render={() => (
-            <DeleteWarningScreen onClose={() => history.goBack()} />
-          )}
+          component={DeleteWarningScreen}
+          onClose={() => history.goBack()}
         />
-        <Route
+        <ProtectedRouteWithProps
           path={[`${path}/movePage/:fileName`]}
-          render={() => <PageMoveScreen onClose={() => history.goBack()} />}
+          component={PageMoveScreen}
+          onClose={() => history.goBack()}
         />
       </Switch>
     </>

--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -1,15 +1,15 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { useParams } from "react-router-dom"
+
 import DeleteWarningModal from "../../components/DeleteWarningModal"
 import { useDeleteDirectoryHook } from "../../hooks/directoryHooks"
 import { useGetPageHook, useDeletePageHook } from "../../hooks/pageHooks"
 import { getLastItemType } from "../../utils"
 
-export const DeleteWarningScreen = ({ onClose }) => {
-  const params = useParams()
+export const DeleteWarningScreen = ({ match, onClose }) => {
+  const { params, decodedParams } = match
   const { fileName } = params
-  const deleteItemType = params[getLastItemType(params)]
+  const deleteItemName = decodedParams[getLastItemType(decodedParams)]
 
   if (fileName) {
     const { data: pageData } = useGetPageHook(params)
@@ -21,7 +21,7 @@ export const DeleteWarningScreen = ({ onClose }) => {
       <DeleteWarningModal
         onDelete={() => deleteHandler({ sha: pageData.sha })}
         onCancel={() => onClose()}
-        type={deleteItemType}
+        type={deleteItemName}
       />
     ) : null
   }
@@ -33,7 +33,7 @@ export const DeleteWarningScreen = ({ onClose }) => {
     <DeleteWarningModal
       onDelete={deleteHandler}
       onCancel={() => onClose()}
-      type={deleteItemType}
+      type={deleteItemName}
     />
   )
 }

--- a/src/layouts/screens/DirectoryCreationScreen.jsx
+++ b/src/layouts/screens/DirectoryCreationScreen.jsx
@@ -3,8 +3,6 @@ import axios from "axios"
 import PropTypes from "prop-types"
 import * as _ from "lodash"
 
-import { useParams } from "react-router-dom"
-
 import {
   useGetDirectoryHook,
   useCreateDirectoryHook,
@@ -15,8 +13,8 @@ import DirectoryCreationModal from "../../components/DirectoryCreationModal"
 // axios settings
 axios.defaults.withCredentials = true
 
-export const DirectoryCreationScreen = ({ onClose }) => {
-  const params = useParams()
+export const DirectoryCreationScreen = ({ match, onClose }) => {
+  const { params, decodedParams } = match
 
   const { data: dirData } = useGetDirectoryHook(params, { initialData: [] })
   const { mutateAsync: saveHandler } = useCreateDirectoryHook(params)
@@ -24,7 +22,7 @@ export const DirectoryCreationScreen = ({ onClose }) => {
   return (
     <DirectoryCreationModal
       dirData={dirData}
-      params={params}
+      params={decodedParams}
       onProceed={saveHandler}
       onClose={onClose}
     />

--- a/src/layouts/screens/DirectorySettingsScreen.jsx
+++ b/src/layouts/screens/DirectorySettingsScreen.jsx
@@ -1,7 +1,6 @@
 import React from "react"
 import axios from "axios"
 import PropTypes from "prop-types"
-import { useParams } from "react-router-dom"
 
 import { getLastItemType } from "../../utils"
 
@@ -15,8 +14,8 @@ import DirectorySettingsModal from "../../components/DirectorySettingsModal"
 // axios settings
 axios.defaults.withCredentials = true
 
-export const DirectorySettingsScreen = ({ onClose }) => {
-  const params = useParams()
+export const DirectorySettingsScreen = ({ match, onClose }) => {
+  const { params, decodedParams } = match
 
   const { mutateAsync: renameDir } = useUpdateDirectoryHook(params, {
     onSuccess: () => onClose(),
@@ -30,7 +29,7 @@ export const DirectorySettingsScreen = ({ onClose }) => {
     <DirectorySettingsModal
       onProceed={renameDir}
       onClose={onClose}
-      params={params}
+      params={decodedParams}
       dirData={dirData}
     />
   )

--- a/src/layouts/screens/PageMoveScreen.jsx
+++ b/src/layouts/screens/PageMoveScreen.jsx
@@ -1,13 +1,12 @@
 import React from "react"
-import { useParams } from "react-router-dom"
 import PropTypes from "prop-types"
 
 import { useMoveHook } from "../../hooks/moveHooks"
 
 import MoveModal from "../../components/MoveModal"
 
-export const PageMoveScreen = ({ onClose }) => {
-  const params = useParams()
+export const PageMoveScreen = ({ match, onClose }) => {
+  const { params, decodedParams } = match
 
   const { mutateAsync: moveHandler } = useMoveHook(
     (({ fileName, ...p }) => p)(params),
@@ -16,7 +15,14 @@ export const PageMoveScreen = ({ onClose }) => {
     }
   )
 
-  return <MoveModal params={params} onProceed={moveHandler} onClose={onClose} />
+  return (
+    <MoveModal
+      queryParams={params}
+      params={decodedParams}
+      onProceed={moveHandler}
+      onClose={onClose}
+    />
+  )
 }
 
 PageMoveScreen.propTypes = {

--- a/src/layouts/screens/PageSettingsScreen.jsx
+++ b/src/layouts/screens/PageSettingsScreen.jsx
@@ -1,6 +1,5 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { useParams } from "react-router-dom"
 import PageSettingsModalV2 from "../../components/PageSettingsModalV2"
 
 import {
@@ -11,8 +10,8 @@ import {
 import { useSiteUrlHook } from "../../hooks/settingsHooks"
 import { useGetDirectoryHook } from "../../hooks/directoryHooks"
 
-export const PageSettingsScreen = ({ onClose }) => {
-  const params = useParams()
+export const PageSettingsScreen = ({ match, onClose }) => {
+  const { params, decodedParams } = match
 
   const { fileName } = params
   const { data: pageData } = useGetPageHook(params, { enabled: !!fileName })
@@ -28,7 +27,7 @@ export const PageSettingsScreen = ({ onClose }) => {
 
   return (
     <PageSettingsModalV2
-      params={params}
+      params={decodedParams}
       onClose={onClose}
       pageData={pageData}
       onProceed={fileName ? updateHandler : createHandler}

--- a/src/layouts/screens/ReorderingScreen.jsx
+++ b/src/layouts/screens/ReorderingScreen.jsx
@@ -1,8 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import { useParams } from "react-router-dom"
-
 import ReorderingModal from "../../components/folders/ReorderingModal"
 
 import {
@@ -10,8 +8,8 @@ import {
   useReorderDirectoryHook,
 } from "../../hooks/directoryHooks"
 
-export const ReorderingScreen = ({ onClose }) => {
-  const params = useParams()
+export const ReorderingScreen = ({ match, onClose }) => {
+  const { params, decodedParams } = match
   const { data: dirData } = useGetDirectoryHook(params, { initialData: [] })
   const { mutateAsync: reorderHandler } = useReorderDirectoryHook(params, {
     onSettled: onClose,
@@ -21,7 +19,7 @@ export const ReorderingScreen = ({ onClose }) => {
     <ReorderingModal
       dirData={dirData}
       onProceed={reorderHandler}
-      params={params}
+      params={decodedParams}
       onClose={onClose}
     />
   )

--- a/src/routing/ProtectedRoute.jsx
+++ b/src/routing/ProtectedRoute.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Redirect, Route } from "react-router-dom"
 import axios from "axios"
+import { getDecodedParams } from "../utils"
 
 // Import contexts
 import { LoginConsumer } from "../contexts/LoginContext"
@@ -17,7 +18,17 @@ const ProtectedRoute = ({ children, component: WrappedComponent, ...rest }) => {
           (WrappedComponent && (
             <Route
               {...rest}
-              render={(props) => <WrappedComponent {...rest} {...props} />}
+              render={(props) => {
+                const { match } = props
+                const { params } = match
+                const newMatch = {
+                  ...match,
+                  decodedParams: getDecodedParams(params),
+                }
+                return (
+                  <WrappedComponent {...rest} {...props} match={newMatch} />
+                )
+              }}
             />
           ))
         ) : (

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -23,7 +23,7 @@ import FallbackComponent from "../components/FallbackComponent"
 import ProtectedRoute from "./ProtectedRoute"
 import RedirectIfLoggedInRoute from "./RedirectIfLoggedInRoute"
 
-const ProtectedRouteWithProps = (props) => {
+export const ProtectedRouteWithProps = (props) => {
   return (
     <Sentry.ErrorBoundary fallback={FallbackComponent}>
       <ProtectedRoute {...props} />

--- a/src/services/DirectoryService.jsx
+++ b/src/services/DirectoryService.jsx
@@ -38,7 +38,7 @@ export class DirectoryService {
       endpoint += `/subcollections`
     }
     if (subCollectionName) {
-      endpoint += `/subcollections/${encodeURIComponent(subCollectionName)}`
+      endpoint += `/subcollections/${subCollectionName}`
     }
     if (isReorder) {
       endpoint += `/reorder`

--- a/src/services/MoverService.jsx
+++ b/src/services/MoverService.jsx
@@ -9,7 +9,7 @@ export class MoverService {
       endpoint += `/collections/${collectionName}`
     }
     if (subCollectionName) {
-      endpoint += `/subcollections/${encodeURIComponent(subCollectionName)}`
+      endpoint += `/subcollections/${subCollectionName}`
     }
     if (!collectionName && !subCollectionName) {
       endpoint += `/pages`

--- a/src/services/PageService.jsx
+++ b/src/services/PageService.jsx
@@ -16,7 +16,7 @@ export class PageService {
       endpoint += `/collections/${collectionName}`
     }
     if (subCollectionName) {
-      endpoint += `/subcollections/${encodeURIComponent(subCollectionName)}`
+      endpoint += `/subcollections/${subCollectionName}`
     }
     if (resourceRoomName) {
       endpoint += `/resourceRoom/${resourceRoomName}`
@@ -35,7 +35,7 @@ export class PageService {
     }
     endpoint += `/pages`
     if (fileName) {
-      endpoint += `/${encodeURIComponent(fileName)}`
+      endpoint += `/${fileName}`
     }
     return endpoint
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -613,3 +613,11 @@ export const getNextItemType = (params) => {
     return False
   }
 }
+
+export const getDecodedParams = (params) =>
+  Object.entries(params).reduce((acc, [key, value]) => {
+    if (!acc[key]) {
+      acc[key] = decodeURIComponent(value)
+    }
+    return acc
+  }, {})

--- a/src/utils.js
+++ b/src/utils.js
@@ -474,29 +474,43 @@ export const getBackButton = ({
   collectionName,
   siteName,
   subCollectionName,
+  fileName,
 }) => {
   if (resourceCategory)
     return {
-      backButtonLabel: deslugifyDirectory(resourceCategory),
+      backButtonLabel: `Back to ${deslugifyDirectory(resourceCategory)}`,
       backButtonUrl: `/sites/${siteName}/resources/${resourceCategory}`,
     }
   if (collectionName) {
-    if (subCollectionName)
+    if (subCollectionName && fileName)
       return {
-        backButtonLabel: deslugifyDirectory(subCollectionName),
+        backButtonLabel: `Back to ${deslugifyDirectory(subCollectionName)}`,
         backButtonUrl: `/sites/${siteName}/folders/${collectionName}/subfolders/${encodeURIComponent(
           subCollectionName
         )}`,
       }
+    if (fileName || subCollectionName)
+      return {
+        backButtonLabel: `Back to ${deslugifyDirectory(collectionName)}`,
+        backButtonUrl: `/sites/${siteName}/folders/${collectionName}`,
+      }
     return {
-      backButtonLabel: deslugifyDirectory(collectionName),
-      backButtonUrl: `/sites/${siteName}/folders/${collectionName}`,
+      backButtonLabel: "Back to My Workspace",
+      backButtonUrl: `/sites/${siteName}/workspace`,
     }
   }
-  return {
-    backButtonLabel: "My Workspace",
-    backButtonUrl: `/sites/${siteName}/workspace`,
+  if (siteName) {
+    if (fileName)
+      return {
+        backButtonLabel: "Back to Workspace",
+        backButtonUrl: `/sites/${siteName}/workspace`,
+      }
+    return {
+      backButtonLabel: "Back to Sites",
+      backButtonUrl: `/sites`,
+    }
   }
+  return {}
 }
 
 export const extractMetadataFromFilename = ({

--- a/src/utils.js
+++ b/src/utils.js
@@ -451,14 +451,16 @@ export const getRedirectUrl = ({
   if (!fileName) {
     if (collectionName) {
       return `/sites/${siteName}/folders/${collectionName}/${
-        subCollectionName ? `subfolders/${subCollectionName}` : "" // V2
+        subCollectionName
+          ? `subfolders/${encodeURIComponent(subCollectionName)}`
+          : "" // V2
       }`
     }
   } else {
     if (collectionName) {
       return `/sites/${siteName}/folders/${collectionName}/${
         subCollectionName ? `subfolders/${subCollectionName}/` : ""
-      }editPage/${fileName}` // V2
+      }editPage/${encodeURIComponent(fileName)}` // V2
     }
     if (resourceCategoryName) {
       return `/sites/${siteName}/resources/${resourceCategoryName}/${fileName}` // V1
@@ -482,7 +484,9 @@ export const getBackButton = ({
     if (subCollectionName)
       return {
         backButtonLabel: deslugifyDirectory(subCollectionName),
-        backButtonUrl: `/sites/${siteName}/folders/${collectionName}/subfolders/${subCollectionName}`,
+        backButtonUrl: `/sites/${siteName}/folders/${collectionName}/subfolders/${encodeURIComponent(
+          subCollectionName
+        )}`,
       }
     return {
       backButtonLabel: deslugifyDirectory(collectionName),

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -32,7 +32,7 @@ const fileNameExtensionRegexTest = /^[a-zA-z]{3,4}$/
 const RESOURCE_CATEGORY_REGEX = "^([a-zA-Z0-9]*[- ]?)+$"
 const resourceRoomNameRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX)
-const specialCharactersRegexTest = /[~!@#$%^&*_+\-./\\\`:;~{}()[\]"'<>,?]/
+const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 
 const ISOMER_TEMPLATE_PROTECTED_DIRS = [
   "data",
@@ -717,7 +717,7 @@ const validatePageSettings = (id, value, folderOrderArray) => {
         errorMessage = `The title should be shorter than ${PAGE_SETTINGS_TITLE_MAX_LENGTH} characters.`
       }
       if (specialCharactersRegexTest.test(value)) {
-        errorMessage = `The title cannot contain any of the following special characters: ~!@#$%^&*_+\-./\\\`:;~{}()[\]"'<>,?`
+        errorMessage = `The title cannot contain any of the following special characters: ~%^*_+-./\\\`;~{}[]"<>`
       }
       if (
         folderOrderArray !== undefined &&
@@ -937,7 +937,7 @@ const validateSubfolderName = (value, existingNames) => {
     errorMessage = `The subfolder name should be shorter than ${RESOURCE_CATEGORY_MAX_LENGTH} characters.`
   }
   if (specialCharactersRegexTest.test(value)) {
-    errorMessage = `The subfolder name cannot contain any of the following special characters: ~!@#$%^&*_+\-./\\\`:;~{}()[\]"'<>,?`
+    errorMessage = `The subfolder name cannot contain any of the following special characters: ~%^*_+-./\\\`;~{}[]"<>`
   }
   return errorMessage
 }


### PR DESCRIPTION
This PR accomplishes the following things:
- modifies the frontend `ProtectedRouteWithProps` React router component to hold a new parameter `decodedParams`
- modifies the refactored layouts and screens to use the new parameter `decodedParams`
- modifies the current validation rules to broaden the list of accepted special characters
- runs validation on page settings when the user first opens the settings page (for backwards compatibility)

## Technical Details

Currently, we use React Router DOM to handle the routing in the frontend. The [React router](https://reactrouter.com/web/api/match) gives us access to the `match` object, which contains `params`, which are the key/value pairs parsed from the URL corresponding to the dynamic segments of the path. For example, for the following path-url pair,

```
path = `/sites/:siteName/folders/:collectionName/subfolders/:subCollectionName/editPage/:fileName`
url = `/sites/a-test-v4/folders/test/subfolders/!%40!%40!%40%20hello/editPage/Example%20Title%40%40%40%40%40%40%40%20helo.md`
```

The parsed params are:
```
params: {
  siteName: 'a-test-v4', 
  collectionName: 'test', 
  subCollectionName: '!%40!%40!%40 hello', 
  fileName: 'Example Title%40%40%40%40%40%40%40 helo.md'
}
```

We propose adding a new parameter, `decodedParams`. `decodedParams` is the decoded URI version of `params`. 

If `params` has the following shape:
```
params: {
  siteName: 'a-test-v4', 
  collectionName: 'test', 
  subCollectionName: '!%40!%40!%40 hello', 
  fileName: 'Example Title%40%40%40%40%40%40%40 helo.md'
}
```

Then `decodedParams` has the following shape:

```
decodedParams: {
  siteName: 'a-test-v4', 
  collectionName: 'test', 
  subCollectionName: '!@!@!@ hello', 
  fileName: 'Example Title@@@@@@@ helo.md'
}
```
where each key-value pair in `decodedParams` is formed by running the corresponding value from `params` through `decodeURIComponent`.

The `decodedParams` can be accessed the same way `params` are used for any `ProtectedRouteWithProps`, for example through:

```
const { decodedParams, params } = match
```

## Context
 As we use our `filename` and `subCollectionName` in our frontend URL params, and we want to support special characters in `filename` and `subCollectionName`, this means that we have to encode our `filename` and `subCollectionName` in the url. To avoid decoding and encoding it repeatedly in every component (decoded URIs are used for UX display, encoded URIs are used for API calls and URL params), we can pass `params` (encoded by default) into the Router layer, have that compute the `decodedParams` and have both `params` and `decodedParams` accessible by the routes. 

## Others
Move Modal (to be added)

