### PR TITLE
Chore/component cleanup

### DIFF
--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -94,7 +94,7 @@ describe("Edit unlinked page", () => {
 
   it("Edit page (unlinked) should provide a warning to users when navigating away", () => {
     cy.get(".CodeMirror-scroll").type(TEST_PAGE_CONTENT)
-    cy.contains(":button", "My Workspace").click()
+    cy.contains(":button", "Back to Workspace").click()
 
     cy.contains("Warning")
     cy.contains(":button", "No").click()
@@ -106,7 +106,7 @@ describe("Edit unlinked page", () => {
     )
     cy.contains(TEST_PAGE_CONTENT)
 
-    cy.contains(":button", "My Workspace").click()
+    cy.contains(":button", "Back to Workspace").click()
 
     cy.contains("Warning")
     cy.contains(":button", "Yes").click()

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -83,7 +83,7 @@ describe("Workspace Pages flow", () => {
       cy.contains(TEST_PAGE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist")
 
       // 2. If user goes back to the workspace, they should be able to see that the page exists
-      cy.contains("My Workspace", { timeout: CUSTOM_TIMEOUT })
+      cy.contains("Back to Workspace", { timeout: CUSTOM_TIMEOUT })
         .should("exist")
         .click()
       cy.contains(TEST_PAGE_FILENAME, { timeout: CUSTOM_TIMEOUT }).should(

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,6 +6,8 @@ import useRedirectHook from "../hooks/useRedirectHook"
 import useSiteUrlHook from "../hooks/useSiteUrlHook"
 import elementStyles from "../styles/isomer-cms/Elements.module.scss"
 
+import { getBackButton } from "../utils"
+
 // axios settings
 axios.defaults.withCredentials = true
 
@@ -20,6 +22,7 @@ const Header = ({
   shouldAllowEditPageBackNav,
   backButtonText,
   backButtonUrl,
+  params,
 }) => {
   const { setRedirectToLogout, setRedirectToPage } = useRedirectHook()
   const { retrieveStagingUrl } = useSiteUrlHook()
@@ -28,12 +31,20 @@ const Header = ({
   const [showStagingWarningModal, setShowStagingWarningModal] = useState(false)
   const [stagingUrl, setStagingUrl] = useState()
 
+  const {
+    backButtonLabel: backButtonTextFromParams,
+    backButtonUrl: backButtonUrlFromParams,
+  } = getBackButton(params)
+  const { siteName: siteNameFromParams } = params
+
   useEffect(() => {
     let _isMounted = true
 
     const loadStagingUrl = async () => {
-      if (siteName) {
-        const retrievedStagingUrl = await retrieveStagingUrl(siteName)
+      if (siteNameFromParams || siteName) {
+        const retrievedStagingUrl = await retrieveStagingUrl(
+          siteNameFromParams || siteName
+        )
         if (_isMounted) setStagingUrl(retrievedStagingUrl)
       }
     }
@@ -45,7 +56,7 @@ const Header = ({
   }, [])
 
   const toggleBackNav = () => {
-    setRedirectToPage(backButtonUrl)
+    setRedirectToPage(backButtonUrlFromParams || backButtonUrl)
   }
 
   const handleBackNav = () => {
@@ -55,8 +66,12 @@ const Header = ({
   }
 
   const handleViewPullRequest = () => {
-    const githubUrl = `https://github.com/isomerpages/${siteName}/pulls`
-    window.open(githubUrl, "_blank")
+    if (siteNameFromParams || siteName) {
+      const githubUrl = `https://github.com/isomerpages/${
+        siteNameFromParams || siteName
+      }/pulls`
+      window.open(githubUrl, "_blank")
+    }
   }
 
   const handleViewStaging = () => {
@@ -76,7 +91,7 @@ const Header = ({
               type="button"
             >
               <i className="bx bx-chevron-left" />
-              {backButtonText}
+              {backButtonTextFromParams || backButtonText}
             </button>
           </div>
         )}
@@ -96,7 +111,7 @@ const Header = ({
       </div>
       {/* Right section */}
       <div className={elementStyles.headerRight}>
-        {siteName ? (
+        {siteNameFromParams || siteName ? (
           <>
             <button
               type="button"
@@ -165,6 +180,7 @@ Header.defaultProps = {
   shouldAllowEditPageBackNav: true,
   backButtonText: "Back to Sites",
   backButtonUrl: "/sites",
+  params: {},
 }
 
 Header.propTypes = {
@@ -175,6 +191,12 @@ Header.propTypes = {
   shouldAllowEditPageBackNav: PropTypes.bool,
   backButtonText: PropTypes.string,
   backButtonUrl: PropTypes.string,
+  params: PropTypes.shape({
+    siteName: PropTypes.string,
+    collectionName: PropTypes.string,
+    subCollectionName: PropTypes.string,
+    fileName: PropTypes.string,
+  }),
 }
 
 export default Header

--- a/src/components/MoveModal.jsx
+++ b/src/components/MoveModal.jsx
@@ -9,17 +9,41 @@ import SaveDeleteButtons from "./SaveDeleteButtons"
 
 import { getLastItemType, getNextItemType, deslugifyDirectory } from "../utils"
 
-const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
-  const [moveQuery, setMoveQuery] = useState(
-    (({ fileName, ...p }) => p)(queryParams)
-  )
-  const [moveTo, setMoveTo] = useState(moveQuery)
-
-  const { data: dirData } = useGetDirectoryHook(moveQuery)
-
+const MoveMenu = ({ moveQuery, setMoveQuery, moveTo, setMoveTo, dirData }) => {
   /** ******************************** */
   /*     subcomponents    */
   /** ******************************** */
+
+  const MoveMenuBackButton = () => {
+    const lastItemType = getLastItemType(moveQuery)
+    const isEnabled = Object.keys(moveQuery).length > 1
+    return (
+      <div
+        id="moveModal-backButton"
+        className={`${elementStyles.dropdownHeader}`}
+        onMouseDown={
+          isEnabled
+            ? () => {
+                const newMoveQuery = (({ [lastItemType]: unused, ...p }) => p)(
+                  moveQuery
+                )
+                setMoveQuery(newMoveQuery)
+                setMoveTo(newMoveQuery)
+              }
+            : null
+        }
+      >
+        <i
+          className={`${elementStyles.dropdownIcon} ${
+            lastItemType != "siteName" && "bx bx-sm bx-arrow-back text-white"
+          }`}
+        />
+        {lastItemType === "siteName"
+          ? "Workspace"
+          : deslugifyDirectory(decodeURIComponent(moveQuery[lastItemType]))}
+      </div>
+    )
+  }
 
   const MoveMenuItem = ({ item, id }) => {
     const { name, type } = item
@@ -77,38 +101,7 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
     return null
   }
 
-  const MoveMenuBackButton = () => {
-    const lastItemType = getLastItemType(moveQuery)
-    const isEnabled = Object.keys(moveQuery).length > 1
-    return (
-      <div
-        id="moveModal-backButton"
-        className={`${elementStyles.dropdownHeader}`}
-        onMouseDown={
-          isEnabled
-            ? () => {
-                const newMoveQuery = (({ [lastItemType]: unused, ...p }) => p)(
-                  moveQuery
-                )
-                setMoveQuery(newMoveQuery)
-                setMoveTo(newMoveQuery)
-              }
-            : null
-        }
-      >
-        <i
-          className={`${elementStyles.dropdownIcon} ${
-            lastItemType != "siteName" && "bx bx-sm bx-arrow-back text-white"
-          }`}
-        />
-        {lastItemType === "siteName"
-          ? "Workspace"
-          : deslugifyDirectory(decodeURIComponent(moveQuery[lastItemType]))}
-      </div>
-    )
-  }
-
-  const MoveMenu = () => (
+  return (
     <div className={`${elementStyles.moveModal}`}>
       <MoveMenuBackButton />
       {dirData && dirData.length ? (
@@ -122,7 +115,6 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
           {/* pages */}
           {dirData
             .filter((item) => item.type === "file")
-            .filter((item) => item.name != params.fileName)
             .map((item, itemIndex) => (
               <MoveMenuItem item={item} id={itemIndex} />
             ))}
@@ -142,6 +134,15 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
       )}
     </div>
   )
+}
+
+const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
+  const [moveQuery, setMoveQuery] = useState(
+    (({ fileName, ...p }) => p)(queryParams)
+  )
+  const [moveTo, setMoveTo] = useState(moveQuery)
+
+  const { data: dirData } = useGetDirectoryHook(moveQuery)
 
   return (
     <div className={elementStyles.overlay}>
@@ -160,7 +161,17 @@ const MoveModal = ({ queryParams, params, onProceed, onClose }) => {
             <br />
             Current location of page: <br />
             <Breadcrumb params={params} title={params.fileName} />
-            <MoveMenu />
+            <MoveMenu
+              moveQuery={moveQuery}
+              setMoveQuery={setMoveQuery}
+              moveTo={moveTo}
+              setMoveTo={setMoveTo}
+              dirData={
+                dirData
+                  ? dirData.filter((item) => item.name != params.fileName)
+                  : []
+              }
+            />
             Moving page to: <br />
             <Breadcrumb params={moveTo} title={params.fileName} />
           </div>

--- a/src/components/folders/Breadcrumb.jsx
+++ b/src/components/folders/Breadcrumb.jsx
@@ -1,16 +1,26 @@
 import React from "react"
-
+import { Link } from "react-router-dom"
 import { deslugifyDirectory, isLastItem } from "../../utils"
 
-const BreadcrumbItem = ({ item, isLast }) => (
-  <span>
-    {" > "}
-    {isLast ? <u className="ml-1">{item}</u> : item}
-  </span>
+const BreadcrumbItem = ({ item, isLast, link }) => (
+  <>
+    {link && !isLast ? (
+      <Link to={link}>{item}</Link>
+    ) : !isLast ? (
+      <span>{item}</span>
+    ) : (
+      // underline last item
+      <span>
+        <u className="ml-1">{item}</u>
+      </span>
+    )}
+    {isLast ? "" : " > "}
+  </>
 )
 
-const Breadcrumb = ({ params, title }) => {
+const Breadcrumb = ({ params, title, isLink }) => {
   const {
+    siteName,
     collectionName,
     subCollectionName,
     resourceRoomName,
@@ -19,29 +29,47 @@ const Breadcrumb = ({ params, title }) => {
   const newParams = { ...params, fileName: title }
   return (
     <span>
-      Workspace
+      {
+        <BreadcrumbItem
+          item="Workspace"
+          isLast={isLastItem("siteName", newParams)}
+          link={isLink && `/sites/${siteName}/workspace`}
+        />
+      }
       {collectionName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(collectionName)}
           isLast={isLastItem("collectionName", newParams)}
+          link={isLink && `/sites/${siteName}/folders/${collectionName}`}
         />
       ) : null}
       {subCollectionName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(subCollectionName)}
           isLast={isLastItem("subCollectionName", newParams)}
+          link={
+            isLink &&
+            `/sites/${siteName}/folders/${collectionName}/subfolders/${subCollectionName}`
+          }
         />
       ) : null}
       {resourceRoomName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(resourceRoomName)}
           isLast={isLastItem("resourceRoomName", newParams)}
+          link={
+            isLink && `/sites/${siteName}/resourceRoomName/${resourceRoomName}`
+          }
         />
       ) : null}
       {resourceCategoryName ? (
         <BreadcrumbItem
           item={deslugifyDirectory(resourceCategoryName)}
           isLast={isLastItem("resourceCategoryName", newParams)}
+          link={
+            isLink &&
+            `/sites/${siteName}/resourceRoomName/${resourceRoomName}/resources/${resourceCategoryName}`
+          }
         />
       ) : null}
       {title ? (

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -17,7 +17,7 @@ import { useCspHook, useSiteColorsHook } from "../hooks/settingsHooks"
 import useRedirectHook from "../hooks/useRedirectHook"
 
 // Isomer components
-import { prependImageSrc, extractMetadataFromFilename } from "../utils"
+import { prependImageSrc } from "../utils"
 
 import { createPageStyleSheet } from "../utils/siteColorUtils"
 
@@ -61,9 +61,6 @@ const EditPageV2 = ({ match, history }) => {
 
   const mdeRef = useRef()
 
-  const { title, type: resourceType, date } = extractMetadataFromFilename(
-    decodedParams
-  )
   const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
     onError: () => setRedirectToNotFound(siteName),
   })
@@ -174,7 +171,6 @@ const EditPageV2 = ({ match, history }) => {
           mdeRef={mdeRef}
           onChange={(value) => setEditorValue(value)}
           value={editorValue}
-          isDisabled={resourceType === "file"}
           isLoading={isLoadingPage}
         />
         {/* Preview */}
@@ -195,7 +191,6 @@ const EditPageV2 = ({ match, history }) => {
         saveCallback={() => {
           if (isXSSViolation) setShowXSSWarning(true)
           else {
-            console.log(pageData.sha)
             updatePageHandler({
               frontMatter: pageData.content.frontMatter,
               sha: pageData.sha,

--- a/src/layouts/EditPageV2.jsx
+++ b/src/layouts/EditPageV2.jsx
@@ -17,11 +17,7 @@ import { useCspHook, useSiteColorsHook } from "../hooks/settingsHooks"
 import useRedirectHook from "../hooks/useRedirectHook"
 
 // Isomer components
-import {
-  prependImageSrc,
-  getBackButton,
-  extractMetadataFromFilename,
-} from "../utils"
+import { prependImageSrc, extractMetadataFromFilename } from "../utils"
 
 import { createPageStyleSheet } from "../utils/siteColorUtils"
 
@@ -65,7 +61,6 @@ const EditPageV2 = ({ match, history }) => {
 
   const mdeRef = useRef()
 
-  const { backButtonLabel, backButtonUrl } = getBackButton(decodedParams)
   const { title, type: resourceType, date } = extractMetadataFromFilename(
     decodedParams
   )
@@ -129,12 +124,10 @@ const EditPageV2 = ({ match, history }) => {
   return (
     <>
       <Header
-        siteName={siteName}
         title={pageData?.content?.frontMatter?.title || ""}
         shouldAllowEditPageBackNav={!hasChanges}
         isEditPage
-        backButtonText={backButtonLabel}
-        backButtonUrl={backButtonUrl}
+        params={decodedParams}
       />
       <div className={elementStyles.wrapper}>
         {isXSSViolation &&

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -48,17 +48,7 @@ const Folders = ({ match, location }) => {
 
   return (
     <>
-      <Header
-        siteName={siteName}
-        backButtonText={`Back to ${
-          subCollectionName ? collectionName : "Workspace"
-        }`}
-        backButtonUrl={`/sites/${siteName}/${
-          subCollectionName ? `folders/${collectionName}` : "workspace"
-        }`}
-        shouldAllowEditPageBackNav
-        isEditPage
-      />
+      <Header params={decodedParams} />
       {/* main bottom section */}
       <div className={elementStyles.wrapper}>
         <Sidebar siteName={siteName} currPath={location.pathname} />

--- a/src/layouts/Folders.jsx
+++ b/src/layouts/Folders.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { ReactQueryDevtools } from "react-query/devtools"
-import { Link, Switch, useRouteMatch, useHistory } from "react-router-dom"
+import { Switch, useRouteMatch, useHistory } from "react-router-dom"
 import _ from "lodash"
 
 // Import components
@@ -10,6 +10,7 @@ import Sidebar from "../components/Sidebar"
 
 import FolderOptionButton from "../components/FolderOptionButton"
 import { FolderContent } from "../components/folders/FolderContent"
+import Breadcrumb from "../components/folders/Breadcrumb"
 
 import {
   PageSettingsScreen,
@@ -44,6 +45,7 @@ const Folders = ({ match, location }) => {
   const { data: dirData, isLoading: isLoadingDirectory } = useGetDirectoryHook(
     params
   )
+
   return (
     <>
       <Header
@@ -86,38 +88,7 @@ const Folders = ({ match, location }) => {
           </div>
           {/* Collections title */}
           <div className={contentStyles.segment}>
-            <span>
-              <Link to={`/sites/${siteName}/workspace`}>
-                <strong>Workspace</strong>
-              </Link>
-              &nbsp;
-              {">"}
-              {collectionName ? (
-                subCollectionName ? (
-                  <Link to={`/sites/${siteName}/folders/${collectionName}`}>
-                    <strong className="ml-1">
-                      &nbsp;
-                      {deslugifyDirectory(collectionName)}
-                    </strong>
-                  </Link>
-                ) : (
-                  <strong className="ml-1">
-                    &nbsp;
-                    {deslugifyDirectory(collectionName)}
-                  </strong>
-                )
-              ) : null}
-              {collectionName && subCollectionName ? (
-                <span>
-                  &nbsp;
-                  {">"}
-                  <strong className="ml-1">
-                    &nbsp;
-                    {subCollectionName}
-                  </strong>
-                </span>
-              ) : null}
-            </span>
+            <Breadcrumb params={decodedParams} isLink />
           </div>
           {/* Options */}
           <div className={contentStyles.contentContainerFolderRowMargin}>

--- a/src/utils.js
+++ b/src/utils.js
@@ -474,29 +474,37 @@ export const getBackButton = ({
   collectionName,
   siteName,
   subCollectionName,
+  fileName,
 }) => {
   if (resourceCategory)
     return {
-      backButtonLabel: deslugifyDirectory(resourceCategory),
+      backButtonLabel: `Back to ${deslugifyDirectory(resourceCategory)}`,
       backButtonUrl: `/sites/${siteName}/resources/${resourceCategory}`,
     }
   if (collectionName) {
-    if (subCollectionName)
+    if (subCollectionName && fileName)
       return {
-        backButtonLabel: deslugifyDirectory(subCollectionName),
+        backButtonLabel: `Back to ${deslugifyDirectory(subCollectionName)}`,
         backButtonUrl: `/sites/${siteName}/folders/${collectionName}/subfolders/${encodeURIComponent(
           subCollectionName
         )}`,
       }
+    if (fileName || subCollectionName)
+      return {
+        backButtonLabel: `Back to ${deslugifyDirectory(collectionName)}`,
+        backButtonUrl: `/sites/${siteName}/folders/${collectionName}`,
+      }
     return {
-      backButtonLabel: deslugifyDirectory(collectionName),
-      backButtonUrl: `/sites/${siteName}/folders/${collectionName}`,
+      backButtonLabel: "Back to My Workspace",
+      backButtonUrl: `/sites/${siteName}/workspace`,
     }
   }
-  return {
-    backButtonLabel: "My Workspace",
-    backButtonUrl: `/sites/${siteName}/workspace`,
-  }
+  if (siteName)
+    return {
+      backButtonLabel: "Back to Sites",
+      backButtonUrl: `/sites`,
+    }
+  return {}
 }
 
 export const extractMetadataFromFilename = ({

--- a/src/utils.js
+++ b/src/utils.js
@@ -499,11 +499,17 @@ export const getBackButton = ({
       backButtonUrl: `/sites/${siteName}/workspace`,
     }
   }
-  if (siteName)
+  if (siteName) {
+    if (fileName)
+      return {
+        backButtonLabel: "Back to Workspace",
+        backButtonUrl: `/sites/${siteName}/workspace`,
+      }
     return {
       backButtonLabel: "Back to Sites",
       backButtonUrl: `/sites`,
     }
+  }
   return {}
 }
 


### PR DESCRIPTION
This PR refactors the `Breadcrumb` and `Header` components, and updates the layouts to use the refactored components.

Specifically:
- `Breadcrumb` is refactored to contain optional navigation links, so that it can be reused throughout the `Folders` layout
- `Header` is refactored to contain the logic for parsing page URL params and computing the corresponding `BackButtonText` and `BackButtonUrl` for each page.

## Merge details
As the list of PRs to be merged for release on 14th Oct is fairly large, here's the proposed merging strategy:

`chore/component-cleanup`
-> `refactor/special-characters-tests` 
-> `refactor/special-characters` 
-> `refactor/workspace-tests` 
-> `refactor/workspace` 
-> `refactor/collections-test` 
-> `refactor-collections`
-> `develop`

All commits in the PRs above can be tested by running `npm run cypress:open` on the latest branch `chore/component-cleanup` as this is rebased on the latest version of each branch above. Please run Cypress tests on the e2e commit branch ```export E2E_COMMIT_HASH=c80b66da287adde4424a2b4a28ad3c0db9018ef9```