### PR TITLE
Hotfix to develop: update fonts for span

### DIFF
--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -386,9 +386,7 @@ section {
 }
 
 code,
-code > span,
-pre,
-pre > span {
+pre {
   -moz-osx-font-smoothing: auto;
   -webkit-font-smoothing: auto;
   font-family: monospace;


### PR DESCRIPTION
This PR fixes the font on EditPage. 

Currently, there's a style override that causes the EditPage font to render as `monospace`, and on highlight, render as `Inter`. We remove the style override so that `Inter` is the default font.