### PR TITLE
Hotfix to master: unset permalink for files

### DIFF
--- a/src/components/PageSettingsModal/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.jsx
@@ -62,11 +62,15 @@ export const PageSettingsModal = ({
           shouldValidate: true,
         })
       )
-      if (pageData.content.frontMatter.file_url)
+      if (pageData.content.frontMatter.file_url) {
         // backwards compatible with previous resource files
         setValue("layout", "file", {
           shouldValidate: true,
         })
+        setValue("permalink", undefined, {
+          shouldValidate: true,
+        })
+      }
     }
   }, [pageData, setValue])
 

--- a/src/components/PageSettingsModal/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.jsx
@@ -67,9 +67,7 @@ export const PageSettingsModal = ({
         setValue("layout", "file", {
           shouldValidate: true,
         })
-        setValue("permalink", undefined, {
-          shouldValidate: true,
-        })
+        setValue("permalink", undefined)
       }
     }
   }, [pageData, setValue])


### PR DESCRIPTION
This PR fixes the updating of resource files of type `file`.

Currently, a default permalink is erroneously added to these files when updated, causing the links on the actual site to link to 
a page which does not exist, rather than the file. We remove the permalink for these files in this PR.