### PR TITLE
chore(.github/templates): adds github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,64 @@
+## Problem
+
+<!-- What problem are you trying to solve? What issue does this close? -->
+
+Closes [insert issue #]
+
+## Solution
+
+<!-- How did you solve the problem? -->
+
+**Breaking Changes**
+
+<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
+
+- [ ] Yes - this PR contains breaking changes
+  - Details ...
+- [ ] No - this PR is backwards compatible
+
+**Features**:
+
+- Details ...
+
+**Improvements**:
+
+- Details ...
+
+**Bug Fixes**:
+
+- Details ...
+
+## Before & After Screenshots
+
+**BEFORE**:
+
+<!-- [insert screenshot here] -->
+
+**AFTER**:
+
+<!-- [insert screenshot here] -->
+
+## Tests
+
+<!-- What tests should be run to confirm functionality? -->
+
+## Deploy Notes
+
+<!-- Notes regarding deployment of the contained body of work.  -->
+<!-- These should note any new dependencies, new scripts, etc. -->
+
+**New environment variables**:
+
+- `env var` : env var details
+
+**New scripts**:
+
+- `script` : script details
+
+**New dependencies**:
+
+- `dependency` : dependency details
+
+**New dev dependencies**:
+
+- `dependency` : dependency details


### PR DESCRIPTION
## Problem
Right now we don't have a structured way of writing PRs. This means that important information might be lost (eg: changing build scripts/env vars/breaking deps upgrade) as the author forgot while writing their PRs. Adding a github template would solve this issue and extra sections can be deleted if unused.

## Solution
1. copy formsg's pr template 

## Note
1. feel free to suggest edits as necessary! i'll make the changes and raise a corresponding PR on BE when this is merged in with the final version of the PR template