### PR TITLE
Media/refactor services

### DIFF
--- a/src/contexts/ServicesContext.jsx
+++ b/src/contexts/ServicesContext.jsx
@@ -1,9 +1,11 @@
 import React, { createContext } from "react"
+
 import {
   PageService,
   DirectoryService,
   MoverService,
   SettingsService,
+  MediaService,
 } from "services"
 
 const ServicesContext = createContext({}) // holds all services we need
@@ -13,12 +15,14 @@ const ServicesProvider = ({ client, children }) => {
   const directoryService = new DirectoryService({ apiClient: client })
   const moverService = new MoverService({ apiClient: client })
   const settingsService = new SettingsService({ apiClient: client })
+  const mediaService = new MediaService({ apiClient: client })
 
   const services = {
     pageService,
     directoryService,
     moverService,
     settingsService,
+    mediaService,
   }
 
   return (

--- a/src/services/DirectoryService.jsx
+++ b/src/services/DirectoryService.jsx
@@ -1,4 +1,4 @@
-import { getLastItemType } from "../utils"
+import { getLastItemType, getMediaDirectoryName } from "../utils"
 
 export class DirectoryService {
   constructor({ apiClient }) {
@@ -11,11 +11,30 @@ export class DirectoryService {
     subCollectionName,
     resourceRoomName,
     resourceCategoryName,
+    mediaDirectoryName,
     isCreate,
     isReorder,
     isUnlinked,
     isResource,
   }) {
+    // R media room (images)
+    // GET /sites/a-test-v4/media/images/images
+    // C media folder
+    // POST /sites/a-test-v4/media/images
+    // Rename media folder
+    // POST /sites/a-test-v4/media/images/images/:directoryName
+    // D media folder
+    // DELETE /sites/a-test-v4/media/images/images/:directoryName
+
+    if (mediaDirectoryName) {
+      let endpoint = `/sites/${siteName}/media`
+      if (isCreate) return endpoint
+      if (mediaDirectoryName) {
+        endpoint += `/${mediaDirectoryName}`
+      }
+      return endpoint
+    }
+
     if (isUnlinked) {
       // R Unlinked pages
       // /sites/a-test-v4/pages
@@ -83,6 +102,12 @@ export class DirectoryService {
   }
 
   async update(apiParams, { newDirectoryName }) {
+    if (
+      apiParams.mediaDirectoryName &&
+      apiParams.mediaDirectoryName ===
+        getMediaDirectoryName(newDirectoryName, { splitOn: "/", joinOn: "%2F" })
+    )
+      return
     if (apiParams[getLastItemType(apiParams)] === newDirectoryName) return
     const body = {
       newDirectoryName,

--- a/src/services/DirectoryService.jsx
+++ b/src/services/DirectoryService.jsx
@@ -18,13 +18,15 @@ export class DirectoryService {
     isResource,
   }) {
     // R media room (images)
-    // GET /sites/a-test-v4/media/images/images
+    // GET /sites/a-test-v4/media/images
+    // R media room (images folder)
+    // GET /sites/a-test-v4/media/images%2F:directoryName
     // C media folder
-    // POST /sites/a-test-v4/media/images
+    // POST /sites/a-test-v4/media
     // Rename media folder
-    // POST /sites/a-test-v4/media/images/images/:directoryName
+    // POST /sites/a-test-v4/media/images%2F:directoryName
     // D media folder
-    // DELETE /sites/a-test-v4/media/images/images/:directoryName
+    // DELETE /sites/a-test-v4/media/images%2F:directoryName
 
     if (mediaDirectoryName) {
       let endpoint = `/sites/${siteName}/media`

--- a/src/services/MediaService.jsx
+++ b/src/services/MediaService.jsx
@@ -1,0 +1,48 @@
+export class MediaService {
+  constructor({ apiClient }) {
+    this.apiClient = apiClient
+  }
+
+  getMediaEndpoint({ siteName, mediaDirectoryName, fileName }) {
+    let endpoint = `/sites/${siteName}/media`
+    if (mediaDirectoryName) {
+      endpoint += `/${mediaDirectoryName}`
+    }
+    endpoint += `/pages`
+    if (fileName) {
+      endpoint += `/${fileName}`
+    }
+    return endpoint
+  }
+
+  async create(apiParams, { newFileName, content }) {
+    const body = {
+      content,
+      newFileName,
+    }
+    return await this.apiClient.post(this.getMediaEndpoint(apiParams), body)
+  }
+
+  async update(apiParams, { newFileName, sha }) {
+    const body = {
+      newFileName,
+      sha,
+    }
+    return await this.apiClient.post(this.getMediaEndpoint(apiParams), body)
+  }
+
+  async get(apiParams) {
+    return await this.apiClient
+      .get(this.getMediaEndpoint(apiParams))
+      .then((res) => res.data)
+  }
+
+  async delete(apiParams, { sha }) {
+    const body = {
+      sha,
+    }
+    return await this.apiClient
+      .delete(this.getMediaEndpoint(apiParams), { data: body })
+      .then((res) => res.data)
+  }
+}

--- a/src/services/MoverService.jsx
+++ b/src/services/MoverService.jsx
@@ -9,8 +9,13 @@ export class MoverService {
     resourceCategoryName,
     collectionName,
     subCollectionName,
+    mediaRoom,
+    mediaDirectoryName,
   }) {
     let endpoint = `/sites/${siteName}`
+    if (mediaDirectoryName) {
+      endpoint += `/media/${mediaDirectoryName}`
+    }
     if (resourceRoomName) {
       endpoint += `/resourceRoom/${resourceRoomName}`
     }
@@ -27,7 +32,9 @@ export class MoverService {
       !collectionName &&
       !subCollectionName &&
       !resourceCategoryName &&
-      !resourceRoomName
+      !resourceRoomName &&
+      !mediaRoom &&
+      !mediaDirectoryName
     ) {
       endpoint += `/pages`
     }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,4 +1,5 @@
 export { PageService } from "./PageService"
+export { MediaService } from "./MediaService"
 export { DirectoryService } from "./DirectoryService"
 export { MoverService } from "./MoverService"
 export { SettingsService } from "./SettingsService"


### PR DESCRIPTION
Duplicate of #718 , reopened as the earlier PR was merged wrongly into develop. The accidental merge to develop has been rectified, and this PR is reopened to correctly merge to `media/refactor` instead.