### PR TITLE
chore: add mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,9 +1,9 @@
 pull_request_rules:
   - name: Approve and merge non-major version dependabot upgrades
     conditions:
-      - author~=^dependabot(|-preview)\[bot\]$
+      - author~=^dependabot\[bot\]$
       - check-success~=lint
-      - title~=^build\(deps[^)]*\). bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
     actions:
       review:
         type: APPROVE

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,42 @@
+pull_request_rules:
+  - name: Approve and merge non-major version dependabot upgrades
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - check-success~=lint
+      - title~=^build\(deps[^)]*\). bump [^\s]+ from ([\d]+)\..+ to \1\.
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash
+
+  - name: Approve and merge Snyk.io upgrades
+    conditions:
+      - author=snyk-bot
+      - check-success~=lint
+      - title~=^\[Snyk\]
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash
+
+  - name: Close stale PRs (>1 month since last activity)
+    conditions:
+      - updated-at>30 days ago
+    actions:
+      close:
+        message: This pull request has been closed as it has been a month since the most recent activity on it.
+
+  - name: Automatically delete branches after they have been merged
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+
+  - name: Automatically mark a PR as draft if [WIP] is in the title
+    conditions:
+      - title~=(?i)\[wip\]
+    actions:
+      edit:
+        draft: True

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,13 +21,6 @@ pull_request_rules:
       merge:
         method: squash
 
-  - name: Close stale PRs (>1 month since last activity)
-    conditions:
-      - updated-at>30 days ago
-    actions:
-      close:
-        message: This pull request has been closed as it has been a month since the most recent activity on it.
-
   - name: Automatically delete branches after they have been merged
     conditions:
       - merged


### PR DESCRIPTION
## Problem
We should automate some stuff on isomer, which would otherwise either slip by or require man hours. 

## Solution
Add mergify to the repo to automate the boring stuff away. The mergify config is relatively conservative (taken from `ts-template`) with a few added configurations. The added configs are: 

1. close PRs without any recent (>1 month) activity 
2. delete branches after their PR is merged (we can still restore branch so this is not information destroying) 
3. mark a PR as draft if [wip] (case insensitive) is in the title.

## Note
1. the mergify config only runs `lint` and does **not** test to see if the changes pass (for dependabot/snyk). this is due to the extremely long run time for ci tests - we should test them once we have lightweight unit tests up.