### PR TITLE
Fix/media validation

### DIFF
--- a/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
@@ -32,8 +32,8 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
             .transform((value) => deslugifyDirectory(value))
             .test(
               "Special characters found",
-              'Title cannot contain any of the following special characters: ~%^*_+-./`;{}[]"<>',
-              (value) => !specialCharactersRegexTest.test(value)
+              'Title cannot contain any of the following special characters: ~%^*+#?./`;{}[]"<>',
+              (value) => !mediaSpecialCharactersRegexTest.test(value)
             )
         if (type === "subCollectionName")
           return schema

--- a/src/components/MediaMoveModal/MediaMoveModal.jsx
+++ b/src/components/MediaMoveModal/MediaMoveModal.jsx
@@ -59,7 +59,7 @@ export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
                     ...moveQuery,
                     mediaDirectoryName: getMediaDirectoryName(
                       moveQuery.mediaDirectoryName,
-                      { end: -1, joinOn: "/" }
+                      { end: -1, joinOn: "/", decode: true }
                     ),
                   })
                 }}
@@ -68,7 +68,7 @@ export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
                 } // images%2Fdir%2Fdir2
                 backButtonText={getMediaDirectoryName(
                   moveQuery.mediaDirectoryName,
-                  { start: -1 }
+                  { start: -1, decode: true }
                 )}
               />
               {dirData && dirData.length ? (
@@ -91,7 +91,7 @@ export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
                             ...moveQuery,
                             mediaDirectoryName: `${getMediaDirectoryName(
                               moveQuery.mediaDirectoryName,
-                              { joinOn: "/" }
+                              { joinOn: "/", decode: true }
                             )}/${item.name}`,
                           })
                         }
@@ -100,12 +100,14 @@ export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
                             ...moveQuery,
                             mediaDirectoryName: `${getMediaDirectoryName(
                               moveQuery.mediaDirectoryName,
-                              { joinOn: "/" }
+                              { joinOn: "/", decode: true }
                             )}/${item.name}`,
                           })
                           setMoveQuery((prevState) => ({
                             ...prevState,
-                            mediaDirectoryName: `${moveQuery.mediaDirectoryName}%2F${item.name}`,
+                            mediaDirectoryName: `${
+                              moveQuery.mediaDirectoryName
+                            }%2F${encodeURIComponent(item.name)}`,
                           }))
                         }}
                       />

--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -14,7 +14,7 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
       .required("Title is required")
       .test(
         "Special characters found",
-        'Title cannot contain any of the following special characters: ~%^*+#./`;{}[]"<>',
+        'Title cannot contain any of the following special characters: ~%^*+#?./`;{}[]"<>',
         (value) => !mediaSpecialCharactersRegexTest.test(value.split(".")[0])
       )
       .min(

--- a/src/utils.js
+++ b/src/utils.js
@@ -564,12 +564,17 @@ export const getLastItemType = (params) => {
 
 export const getMediaDirectoryName = (
   mediaDirectoryName,
-  { start = 0, end, splitOn = "%2F", joinOn = "%2F" }
+  { start = 0, end, splitOn = "%2F", joinOn = "%2F", decode = false }
 ) => {
   const mediaDirectoryArray = mediaDirectoryName.split(splitOn)
   const selectedMediaDirectoryArray = mediaDirectoryArray.slice(start, end)
-  const newMediaDirectoryName = selectedMediaDirectoryArray.join(joinOn)
-  return newMediaDirectoryName
+  if (decode) {
+    const decodedSelectedMediaDirectoryArray = selectedMediaDirectoryArray.map(
+      (v) => decodeURIComponent(v)
+    )
+    return decodedSelectedMediaDirectoryArray.join(joinOn)
+  }
+  return selectedMediaDirectoryArray.join(joinOn)
 }
 
 export const getNextItemType = (params) => {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -35,7 +35,7 @@ export const RESOURCE_CATEGORY_REGEX = "^([a-zA-Z0-9]*[- ]?)+$"
 export const slugifyLowerFalseRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 export const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX)
 export const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
-export const mediaSpecialCharactersRegexTest = /[~%^*+#./\\`;~{}[\]"<>]/
+export const mediaSpecialCharactersRegexTest = /[~%^?*+#./\\`;~{}[\]"<>]/
 export const imagesSuffixRegexTest = /^.+\.(svg|jpg|jpeg|png|gif|tif|bmp|ico)$/
 export const filesSuffixRegexTest = /^.+\.(pdf)$/
 


### PR DESCRIPTION
## Problem

Media files containing ? and # in their directory file paths were causing Netlify builds to break. This was related to an earlier issue in #752 where media directories with ? and # in their file paths were not correctly being loaded in the EditPage MediaModals, as Github was unable to retrieve the folder correctly.

Closes #752 and #755

## Solution

This PR resolves this issue by preventing ? and # in media directory names and media file names. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] No - this PR is backwards compatible as all media files previously did not allow # and ? in their directory file paths.


**Bug Fixes**:

- Adding # and ? to disallowed characters in media directory and media name validation
- Decoding media directory name for display in MediaMoveModal

## Before & After Screenshots (MediaMoveModal decoding)

**BEFORE**:

![Screenshot 2022-02-09 at 9 43 51 AM](https://user-images.githubusercontent.com/39231249/153105937-9ebb5b29-8741-4698-9467-c79085c71dc7.png)


**AFTER**:

![Screenshot 2022-02-09 at 9 43 07 AM](https://user-images.githubusercontent.com/39231249/153105863-f00a55c6-2aae-4eea-b252-70220dffa033.png)


## Tests

- [x] Verify that special characters ? and # are now disabled in media directory settings and media file settings
- [x] Verify that files containing other special characters in file path can be displayed on Netlify built site (see https://a-test-v4-staging.netlify.app/permalink-special)
- [x] Verify that MediaMoveModal is correctly displaying decoded directory names (see screenshots above)
