### PR TITLE
feat: add story for formFieldMedia

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,3 @@
-import "@opengovsg/design-system-react/build/fonts/inter.css"
-import { ThemeProvider } from "@opengovsg/design-system-react"
-
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -10,11 +7,3 @@ export const parameters = {
     },
   },
 }
-
-export const decorators = [
-  (Story) => (
-    <ThemeProvider>
-      <Story />
-    </ThemeProvider>
-  ),
-]

--- a/src/components/FormFieldMedia/FormFieldMedia.scss
+++ b/src/components/FormFieldMedia/FormFieldMedia.scss
@@ -1,0 +1,11 @@
+// NOTE: This file is used solely for the component's stories.
+// This is because the base styling for the component is done in bootstrap, which is included in the index.html file.
+// The styles here are obtained by looking at the element in the console and copying the styling there.
+
+.d-flex {
+  display: flex;
+}
+
+.border {
+  border: 1px solid #dee2e6;
+}

--- a/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
@@ -11,12 +11,10 @@ import {
 import FormMediaInput from "./FormMediaInput"
 import "./FormFieldMedia.scss"
 
-import FormFieldMediaComponent from "./index"
-
 const formFieldMeta = {
-  title: "Components/Form Field Media",
-  component: FormFieldMediaComponent,
-} as ComponentMeta<typeof FormFieldMediaComponent>
+  title: "Components/Form Field Media/v1",
+  component: FormMediaInput,
+} as ComponentMeta<typeof FormMediaInput>
 
 interface FormFieldProps {
   hasError: boolean

--- a/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
@@ -1,38 +1,65 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { Story, Meta } from "@storybook/react"
+import {
+  FormContext,
+  FormError,
+  FormTitle,
+  FormDescription,
+} from "components/Form"
 import React from "react"
-import { QueryClient, QueryClientProvider } from "react-query"
-import { BrowserRouter as Router, Route } from "react-router-dom"
+
+import FormMediaInput from "./FormMediaInput"
+import "./FormFieldMedia.scss"
 
 import FormFieldMedia from "./index"
 
 const formFieldMeta = {
   title: "FormFieldMedia",
   component: FormFieldMedia,
-} as ComponentMeta<typeof FormFieldMedia>
+} as Meta<typeof FormFieldMedia>
 
-const queryClient = new QueryClient()
+interface FormFieldProps {
+  hasError: boolean
+  errorMessage: string
+  formTitle: string
+  formDescription: string
+  placeholder: string
+  inlineButtonText: string
+}
 
-const Template: ComponentStory<typeof FormFieldMedia> = (args) => (
-  <Router>
-    <QueryClientProvider client={queryClient}>
-      {/* NOTE: This is required as we nest the modal within the FormFieldMedia */}
-      <Route path="/:siteName" component={() => <FormFieldMedia {...args} />} />
-    </QueryClientProvider>
-  </Router>
+const Template: Story<FormFieldProps> = ({
+  hasError,
+  errorMessage,
+  formTitle,
+  formDescription,
+  placeholder,
+  inlineButtonText,
+}: FormFieldProps) => (
+  <FormContext
+    hasError={hasError}
+    onFieldChange={(e) => console.log(e.target.value)}
+  >
+    <FormTitle>{formTitle}</FormTitle>
+    <FormDescription>{formDescription}</FormDescription>
+    <FormMediaInput
+      register={() => {}}
+      placeholder={placeholder}
+      id="image"
+      inlineButtonText={inlineButtonText}
+      value=""
+    />
+    <FormError>{errorMessage}</FormError>
+  </FormContext>
 )
 
 export const ImageFormField = Template.bind({})
 
 ImageFormField.args = {
-  title: "Image Form Field",
-  id: "primary",
-  value: "some default value",
   errorMessage: "something went wrong",
-  isRequired: true,
-  onFieldChange: () => console.log("success!"),
-  inlineButtonText: "Click me",
-  placeholder: "this is a placeholder",
-  type: "images",
+  formTitle: "some title",
+  formDescription: "hello world",
+  placeholder: "some placeholder",
+  inlineButtonText: "select",
+  hasError: false,
 }
 
 export default formFieldMeta

--- a/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
@@ -1,21 +1,22 @@
-import { Story, Meta } from "@storybook/react"
+import "@opengovsg/design-system-react/build/fonts/inter.css"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { ComponentStory, ComponentMeta } from "@storybook/react"
 import {
   FormContext,
   FormError,
   FormTitle,
   FormDescription,
 } from "components/Form"
-import React from "react"
 
 import FormMediaInput from "./FormMediaInput"
 import "./FormFieldMedia.scss"
 
-import FormFieldMedia from "./index"
+import FormFieldMediaComponent from "./index"
 
 const formFieldMeta = {
-  title: "FormFieldMedia",
-  component: FormFieldMedia,
-} as Meta<typeof FormFieldMedia>
+  title: "Components/Form Field Media",
+  component: FormFieldMediaComponent,
+} as ComponentMeta<typeof FormFieldMediaComponent>
 
 interface FormFieldProps {
   hasError: boolean
@@ -26,7 +27,16 @@ interface FormFieldProps {
   inlineButtonText: string
 }
 
-const Template: Story<FormFieldProps> = ({
+const defaultArgs = {
+  errorMessage: "something went wrong",
+  formTitle: "some title",
+  formDescription: "hello world",
+  placeholder: "some placeholder",
+  inlineButtonText: "select",
+  hasError: false,
+}
+
+const BaseComponent = ({
   hasError,
   errorMessage,
   formTitle,
@@ -51,15 +61,21 @@ const Template: Story<FormFieldProps> = ({
   </FormContext>
 )
 
-export const ImageFormField = Template.bind({})
+const Template: ComponentStory<typeof BaseComponent> = (args) => (
+  <BaseComponent {...args} />
+)
 
-ImageFormField.args = {
-  errorMessage: "something went wrong",
-  formTitle: "some title",
-  formDescription: "hello world",
-  placeholder: "some placeholder",
-  inlineButtonText: "select",
-  hasError: false,
-}
+export const FormFieldMedia = Template.bind({})
+export const FormFieldMediaWithTheming = Template.bind({})
 
+FormFieldMediaWithTheming.decorators = [
+  (Story) => (
+    <ThemeProvider>
+      <Story />
+    </ThemeProvider>
+  ),
+]
+
+FormFieldMedia.args = defaultArgs
+FormFieldMediaWithTheming.args = defaultArgs
 export default formFieldMeta

--- a/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import React from "react"
+import { QueryClient, QueryClientProvider } from "react-query"
+import { BrowserRouter as Router, Route } from "react-router-dom"
+
+import FormFieldMedia from "./index"
+
+const formFieldMeta = {
+  title: "FormFieldMedia",
+  component: FormFieldMedia,
+} as ComponentMeta<typeof FormFieldMedia>
+
+const queryClient = new QueryClient()
+
+const Template: ComponentStory<typeof FormFieldMedia> = (args) => (
+  <Router>
+    <QueryClientProvider client={queryClient}>
+      {/* NOTE: This is required as we nest the modal within the FormFieldMedia */}
+      <Route path="/:siteName" component={() => <FormFieldMedia {...args} />} />
+    </QueryClientProvider>
+  </Router>
+)
+
+export const ImageFormField = Template.bind({})
+
+ImageFormField.args = {
+  title: "Image Form Field",
+  id: "primary",
+  value: "some default value",
+  errorMessage: "something went wrong",
+  isRequired: true,
+  onFieldChange: () => console.log("success!"),
+  inlineButtonText: "Click me",
+  placeholder: "this is a placeholder",
+  type: "images",
+}
+
+export default formFieldMeta

--- a/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/FormFieldMedia.stories.tsx
@@ -23,6 +23,7 @@ interface FormFieldProps {
   formDescription: string
   placeholder: string
   inlineButtonText: string
+  isDisabled: boolean
 }
 
 const defaultArgs = {
@@ -32,6 +33,7 @@ const defaultArgs = {
   placeholder: "some placeholder",
   inlineButtonText: "select",
   hasError: false,
+  isDisabled: false,
 }
 
 const BaseComponent = ({
@@ -41,9 +43,11 @@ const BaseComponent = ({
   formDescription,
   placeholder,
   inlineButtonText,
+  isDisabled,
 }: FormFieldProps) => (
   <FormContext
     hasError={hasError}
+    isDisabled={isDisabled}
     onFieldChange={(e) => console.log(e.target.value)}
   >
     <FormTitle>{formTitle}</FormTitle>

--- a/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
@@ -1,5 +1,5 @@
 import "@opengovsg/design-system-react/build/fonts/inter.css"
-import { FormControl, FormHelperText } from "@chakra-ui/react"
+import { FormControl } from "@chakra-ui/react"
 import {
   FormErrorMessage,
   FormFieldMessage,
@@ -8,7 +8,7 @@ import {
 } from "@opengovsg/design-system-react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
 
-import FormMediaInput from "./FormMediaInput"
+import { FormMediaInput } from "./FormMediaInput"
 import V2Input from "./FormMediaInput.v2"
 
 const formFieldMeta = {
@@ -31,6 +31,7 @@ interface FormFieldProps {
   formDescription: string
   placeholder: string
   inlineButtonText: string
+  isDisabled: boolean
   useV2: boolean
 }
 
@@ -42,6 +43,7 @@ const defaultArgs = {
   inlineButtonText: "select",
   hasError: false,
   isRequired: false,
+  isDisabled: false,
   useV2: false,
 }
 
@@ -53,12 +55,17 @@ const BaseComponent = ({
   placeholder,
   inlineButtonText,
   isRequired,
+  isDisabled,
   useV2,
 }: FormFieldProps) => {
   const MediaComponent = useV2 ? V2Input : FormMediaInput
 
   return (
-    <FormControl isRequired={isRequired} isInvalid={hasError}>
+    <FormControl
+      isRequired={isRequired}
+      isInvalid={hasError}
+      isDisabled={isDisabled}
+    >
       <FormLabel>{formTitle}</FormLabel>
       <FormFieldMessage>{formDescription}</FormFieldMessage>
       <MediaComponent
@@ -82,4 +89,5 @@ export const DesignSystemFormFieldMedia = Template.bind({})
 
 FormFieldMedia.args = defaultArgs
 DesignSystemFormFieldMedia.args = { ...defaultArgs, useV2: true }
+
 export default formFieldMeta

--- a/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
@@ -38,7 +38,7 @@ interface FormFieldProps {
 const defaultArgs = {
   errorMessage: "something went wrong",
   formTitle: "some title",
-  formDescription: "hello world",
+  formDescription: "some description",
   placeholder: "some placeholder",
   inlineButtonText: "select",
   hasError: false,

--- a/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
@@ -1,0 +1,75 @@
+import "@opengovsg/design-system-react/build/fonts/inter.css"
+import { FormControl, FormHelperText } from "@chakra-ui/react"
+import {
+  FormErrorMessage,
+  FormFieldMessage,
+  FormLabel,
+  ThemeProvider,
+} from "@opengovsg/design-system-react"
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+
+import FormMediaInput from "./FormMediaInput"
+
+const formFieldMeta = {
+  title: "Components/Form Field Media/v2",
+  component: FormMediaInput,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} as ComponentMeta<typeof FormMediaInput>
+
+interface FormFieldProps {
+  isRequired: boolean
+  hasError: boolean
+  errorMessage: string
+  formTitle: string
+  formDescription: string
+  placeholder: string
+  inlineButtonText: string
+}
+
+const defaultArgs = {
+  errorMessage: "something went wrong",
+  formTitle: "some title",
+  formDescription: "hello world",
+  placeholder: "some placeholder",
+  inlineButtonText: "select",
+  hasError: false,
+  isRequired: false,
+}
+
+const BaseComponent = ({
+  hasError,
+  errorMessage,
+  formTitle,
+  formDescription,
+  placeholder,
+  inlineButtonText,
+  isRequired,
+}: FormFieldProps) => (
+  <FormControl isRequired={isRequired} isInvalid={hasError}>
+    <FormLabel>{formTitle}</FormLabel>
+    <FormFieldMessage>{formDescription}</FormFieldMessage>
+    <FormMediaInput
+      register={() => {}}
+      placeholder={placeholder}
+      id="image"
+      inlineButtonText={inlineButtonText}
+      value=""
+    />
+    <FormErrorMessage>{errorMessage}</FormErrorMessage>
+  </FormControl>
+)
+
+const Template: ComponentStory<typeof BaseComponent> = (args) => (
+  <BaseComponent {...args} />
+)
+
+export const FormFieldMedia = Template.bind({})
+
+FormFieldMedia.args = defaultArgs
+export default formFieldMeta

--- a/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
+++ b/src/components/FormFieldMedia/v2/FormFieldMedia.stories.tsx
@@ -9,6 +9,7 @@ import {
 import { ComponentStory, ComponentMeta } from "@storybook/react"
 
 import FormMediaInput from "./FormMediaInput"
+import V2Input from "./FormMediaInput.v2"
 
 const formFieldMeta = {
   title: "Components/Form Field Media/v2",
@@ -30,6 +31,7 @@ interface FormFieldProps {
   formDescription: string
   placeholder: string
   inlineButtonText: string
+  useV2: boolean
 }
 
 const defaultArgs = {
@@ -40,6 +42,7 @@ const defaultArgs = {
   inlineButtonText: "select",
   hasError: false,
   isRequired: false,
+  useV2: false,
 }
 
 const BaseComponent = ({
@@ -50,26 +53,33 @@ const BaseComponent = ({
   placeholder,
   inlineButtonText,
   isRequired,
-}: FormFieldProps) => (
-  <FormControl isRequired={isRequired} isInvalid={hasError}>
-    <FormLabel>{formTitle}</FormLabel>
-    <FormFieldMessage>{formDescription}</FormFieldMessage>
-    <FormMediaInput
-      register={() => {}}
-      placeholder={placeholder}
-      id="image"
-      inlineButtonText={inlineButtonText}
-      value=""
-    />
-    <FormErrorMessage>{errorMessage}</FormErrorMessage>
-  </FormControl>
-)
+  useV2,
+}: FormFieldProps) => {
+  const MediaComponent = useV2 ? V2Input : FormMediaInput
+
+  return (
+    <FormControl isRequired={isRequired} isInvalid={hasError}>
+      <FormLabel>{formTitle}</FormLabel>
+      <FormFieldMessage>{formDescription}</FormFieldMessage>
+      <MediaComponent
+        register={() => {}}
+        placeholder={placeholder}
+        id="image"
+        inlineButtonText={inlineButtonText}
+        value=""
+      />
+      <FormErrorMessage>{errorMessage}</FormErrorMessage>
+    </FormControl>
+  )
+}
 
 const Template: ComponentStory<typeof BaseComponent> = (args) => (
   <BaseComponent {...args} />
 )
 
 export const FormFieldMedia = Template.bind({})
+export const DesignSystemFormFieldMedia = Template.bind({})
 
 FormFieldMedia.args = defaultArgs
+DesignSystemFormFieldMedia.args = { ...defaultArgs, useV2: true }
 export default formFieldMeta

--- a/src/components/FormFieldMedia/v2/FormFieldMedia.tsx
+++ b/src/components/FormFieldMedia/v2/FormFieldMedia.tsx
@@ -1,0 +1,68 @@
+import MediaModal from "components/media/MediaModal"
+import { useState } from "react"
+
+import FormMediaInput, { FormMediaInputProps } from "./FormMediaInput"
+
+interface MediaSaveEvent {
+  target: {
+    id: string
+    value: string
+  }
+}
+
+export interface FormFieldMediaProps
+  extends Omit<FormMediaInputProps, "onClick"> {
+  onFieldChange: (event: MediaSaveEvent) => void
+  type: "images" | "files"
+}
+
+// This component wraps the input so that the modal can be composed alongside the input and the button
+// This component controls the rendering logic for both underlying components
+const FormFieldMedia = ({
+  value,
+  id,
+  onFieldChange,
+  placeholder = "",
+  type = "images",
+  inlineButtonText = "Choose Item",
+  register = () => {},
+}: FormFieldMediaProps) => {
+  const [isSelectingItem, setIsSelectingItem] = useState(false)
+
+  const onMediaSave = ({
+    selectedMediaPath,
+  }: {
+    selectedMediaPath: string
+  }) => {
+    const event = {
+      target: {
+        id,
+        value: selectedMediaPath,
+      },
+    }
+    onFieldChange(event)
+    setIsSelectingItem(false)
+  }
+
+  return (
+    <>
+      <FormMediaInput
+        placeholder={placeholder}
+        value={value}
+        register={register}
+        id={id}
+        onClick={() => setIsSelectingItem(true)}
+        inlineButtonText={inlineButtonText}
+      />
+      {isSelectingItem && (
+        <MediaModal
+          onClose={() => setIsSelectingItem(false)}
+          type={type}
+          onProceed={onMediaSave}
+        />
+      )}
+    </>
+  )
+}
+
+export default FormFieldMedia

--- a/src/components/FormFieldMedia/v2/FormMediaInput.tsx
+++ b/src/components/FormFieldMedia/v2/FormMediaInput.tsx
@@ -1,0 +1,61 @@
+import { useFormControlContext } from "@chakra-ui/react"
+import { MouseEventHandler } from "react"
+import { RegisterFunc } from "types/forms"
+
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+export interface FormMediaInputProps {
+  value: string
+  id: string
+  placeholder?: string
+  // NOTE: The second type is allowed because we want to default it to that type
+  // when consumers don't pass in a register prop
+  register?: RegisterFunc | (() => void)
+  onClick?: MouseEventHandler<HTMLButtonElement>
+  inlineButtonText?: string
+}
+
+export const FormMediaInput = ({
+  placeholder = "",
+  value,
+  register = () => {},
+  id,
+  onClick = () => {},
+  inlineButtonText = "Choose Item",
+}: FormMediaInputProps): JSX.Element => {
+  const {
+    isRequired,
+    isInvalid: hasError,
+    isDisabled,
+  } = useFormControlContext()
+
+  return (
+    <div className="d-flex border">
+      <input
+        type="text"
+        placeholder={placeholder}
+        value={value}
+        id={id}
+        autoComplete="off"
+        required={isRequired}
+        className={hasError ? `${elementStyles.error}` : "border-0"}
+        disabled
+        {...register(id, { required: isRequired })}
+      />
+      {inlineButtonText && (
+        <button
+          type="button"
+          className={`${
+            isDisabled ? elementStyles.disabled : elementStyles.blue
+          } text-nowrap`}
+          onClick={onClick}
+          disabled={isDisabled}
+        >
+          {inlineButtonText}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default FormMediaInput

--- a/src/components/FormFieldMedia/v2/FormMediaInput.v2.tsx
+++ b/src/components/FormFieldMedia/v2/FormMediaInput.v2.tsx
@@ -1,0 +1,51 @@
+import { Flex, useFormControlContext } from "@chakra-ui/react"
+import { Button, Input } from "@opengovsg/design-system-react"
+import { MouseEventHandler } from "react"
+import { RegisterFunc } from "types/forms"
+
+export interface FormMediaInputProps {
+  value: string
+  id: string
+  placeholder?: string
+  // NOTE: The second type is allowed because we want to default it to that type
+  // when consumers don't pass in a register prop
+  register?: RegisterFunc | (() => void)
+  onClick?: MouseEventHandler<HTMLButtonElement>
+  inlineButtonText?: string
+}
+
+export const FormMediaInput = ({
+  placeholder = "",
+  value,
+  register = () => {},
+  id,
+  onClick = () => {},
+  inlineButtonText = "Choose Item",
+}: FormMediaInputProps): JSX.Element => {
+  const {
+    isRequired,
+    isInvalid: hasError,
+    isDisabled,
+  } = useFormControlContext()
+
+  return (
+    <Flex>
+      <Input
+        placeholder={placeholder}
+        value={value}
+        id={id}
+        autoComplete="off"
+        required={isRequired}
+        disabled
+        {...register(id, { required: isRequired })}
+      />
+      {inlineButtonText && (
+        <Button onClick={onClick} disabled={isDisabled}>
+          {inlineButtonText}
+        </Button>
+      )}
+    </Flex>
+  )
+}
+
+export default FormMediaInput

--- a/src/components/FormFieldMedia/v2/FormMediaInput.v2.tsx
+++ b/src/components/FormFieldMedia/v2/FormMediaInput.v2.tsx
@@ -1,6 +1,7 @@
 import { Flex, useFormControlContext } from "@chakra-ui/react"
 import { Button, Input } from "@opengovsg/design-system-react"
 import { MouseEventHandler } from "react"
+
 import { RegisterFunc } from "types/forms"
 
 export interface FormMediaInputProps {
@@ -22,21 +23,18 @@ export const FormMediaInput = ({
   onClick = () => {},
   inlineButtonText = "Choose Item",
 }: FormMediaInputProps): JSX.Element => {
-  const {
-    isRequired,
-    isInvalid: hasError,
-    isDisabled,
-  } = useFormControlContext()
+  const { isRequired, isDisabled } = useFormControlContext()
 
   return (
     <Flex>
       <Input
+        // This is disabled because we want to disallow users from typing here.
+        // This is meant as a visual display to users, not an interface
+        isDisabled
         placeholder={placeholder}
         value={value}
         id={id}
         autoComplete="off"
-        required={isRequired}
-        disabled
         {...register(id, { required: isRequired })}
       />
       {inlineButtonText && (

--- a/src/components/FormFieldMedia/v2/index.ts
+++ b/src/components/FormFieldMedia/v2/index.ts
@@ -1,0 +1,3 @@
+import FormFieldMedia from "./FormFieldMedia"
+
+export default FormFieldMedia

--- a/src/types/forms.ts
+++ b/src/types/forms.ts
@@ -1,0 +1,12 @@
+import { ChangeHandler, RegisterOptions } from "react-hook-form"
+
+// NOTE: Taken from the react-hook-forms docs located here: https://react-hook-form.com/api/useform/register
+export type RegisterFunc = (
+  name: string,
+  rest?: RegisterOptions
+) => {
+  onChange: ChangeHandler
+  onBlur: ChangeHandler
+  ref: React.Ref<any>
+  name: string
+}


### PR DESCRIPTION
## Problem
`FormFieldMedia` does not have an associated story. It is also written in javascript, which lacks static typing.

Closes #746

## Solution
This PR has more stories than normal. This is because isomer has not decided on a direction for the migration strategy and the stories laid out here are meant to provide context and information on what migration strategy might best suit us.

1. `v1/Form Field Media` is the component as-is.
2. `v1/Form Field Media With Theming` is the component as-is but with an arbitrary `ThemeProvider`. This is the config that would be adopted if we were to adopt the design system gradually (ie, minor UI changes but no functionality changes) 
3. `v2/Form Field Media` is the component with mixed usage of our (themed) components and unthemed portions swapping to design system (here, the `input` and the `div` and `button` is from isomer).
4. `v2/Design System Form Field Media` is a fully design system based `FormFieldMedia`.

Note that this component has been refactored also in a prior PR, which aided in the shift to ts + the design system. this cost has to be kept in mind as the design system components are purely visual, whereas our components might have non-UI logic baked into them. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
