### PR TITLE
fix(mergify): update PR rule for dependabot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - author~=^dependabot\[bot\]$
       - check-success~=lint
-      - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - title~=Bump [^\s]+ from ([\d]+)\..+ to \1\.
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Problem
previous rule asserted that `Bump` was the start of the PR title due to `^`. Our dependabot titles start with `Chore(deps | dev-deps)`

## Solution
remove `^` 