### PR TITLE
Fix: do not return layout for unlinked pages

### DIFF
--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -68,7 +68,20 @@ describe("Workspace Pages flow", () => {
         .click()
       cy.get("#title").clear().type(TEST_PAGE_TITLE)
       cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
+      cy.intercept("POST", "/v2/**").as("awaitSave")
       cy.contains("Save").click()
+      cy.wait("@awaitSave")
+        .its("request.body")
+        .should("deep.equal", {
+          content: {
+            frontMatter: {
+              title: TEST_PAGE_TITLE,
+              permalink: TEST_PAGE_PERMALNK,
+              description: "",
+            },
+          },
+          newFileName: `${TEST_PAGE_TITLE}.md`,
+        })
 
       // Asserts
       // 1. User should be redirected to correct EditPage

--- a/src/__tests__/utils.jsx
+++ b/src/__tests__/utils.jsx
@@ -11,9 +11,11 @@ describe("Utils test", () => {
     const resourceCategoryName = "resourceCategory"
     const exampleDate = format(Date.now(), "yyyy-MM-dd")
     const exampleLayout = "post"
+
     it("returns the proper parameters for unlinked pages", async () => {
       const params = {}
       const examplePermalink = "/permalink"
+
       expect(getDefaultFrontMatter(params, [])).toMatchObject({
         title: exampleTitle,
         permalink: examplePermalink,
@@ -24,6 +26,7 @@ describe("Utils test", () => {
       const params = {}
       const examplePermalink = "/permalink"
       const existingTitles = [`${exampleTitle}.md`, `${exampleTitle} 1.md`]
+
       expect(getDefaultFrontMatter(params, existingTitles)).toMatchObject({
         title: `${exampleTitle} 1 1`,
         permalink: examplePermalink,
@@ -35,6 +38,7 @@ describe("Utils test", () => {
         collectionName,
       }
       const examplePermalink = `/${collectionName}/permalink`
+
       expect(getDefaultFrontMatter(params, [])).toMatchObject({
         title: exampleTitle,
         permalink: examplePermalink,
@@ -47,6 +51,7 @@ describe("Utils test", () => {
         subCollectionName,
       }
       const examplePermalink = `/${collectionName}/${subCollectionName}/permalink`
+
       expect(getDefaultFrontMatter(params, [])).toMatchObject({
         title: exampleTitle,
         permalink: examplePermalink,
@@ -58,8 +63,8 @@ describe("Utils test", () => {
         resourceRoomName,
         resourceCategoryName,
       }
-      const exampleResourceTitle = `${exampleDate}-${exampleLayout}-${exampleTitle}.md`
       const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`
+
       expect(getDefaultFrontMatter(params, [])).toMatchObject({
         title: exampleTitle,
         permalink: examplePermalink,
@@ -75,6 +80,7 @@ describe("Utils test", () => {
       }
       const exampleResourceTitle = `${exampleDate}-${exampleLayout}-${exampleTitle}`
       const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`
+
       expect(
         getDefaultFrontMatter(params, [
           `${exampleResourceTitle}.md`,

--- a/src/__tests__/utils.jsx
+++ b/src/__tests__/utils.jsx
@@ -1,0 +1,91 @@
+import { format } from "date-fns-tz"
+
+const { getDefaultFrontMatter } = require("../utils")
+
+describe("Utils test", () => {
+  describe("getDefaultFrontMatter should return the correct parameters", () => {
+    const exampleTitle = "Example Title"
+    const collectionName = "collection"
+    const subCollectionName = "subcollection"
+    const resourceRoomName = "resourceRoom"
+    const resourceCategoryName = "resourceCategory"
+    const exampleDate = format(Date.now(), "yyyy-MM-dd")
+    const exampleLayout = "post"
+    it("returns the proper parameters for unlinked pages", async () => {
+      const params = {}
+      const examplePermalink = "/permalink"
+      expect(getDefaultFrontMatter(params, [])).toMatchObject({
+        title: exampleTitle,
+        permalink: examplePermalink,
+      })
+    })
+
+    it("returns the proper parameters for unlinked pages with an existing title", async () => {
+      const params = {}
+      const examplePermalink = "/permalink"
+      const existingTitles = [`${exampleTitle}.md`, `${exampleTitle} 1.md`]
+      expect(getDefaultFrontMatter(params, existingTitles)).toMatchObject({
+        title: `${exampleTitle} 1 1`,
+        permalink: examplePermalink,
+      })
+    })
+
+    it("returns the proper parameters for collection pages", async () => {
+      const params = {
+        collectionName,
+      }
+      const examplePermalink = `/${collectionName}/permalink`
+      expect(getDefaultFrontMatter(params, [])).toMatchObject({
+        title: exampleTitle,
+        permalink: examplePermalink,
+      })
+    })
+
+    it("returns the proper parameters for subcollection pages", async () => {
+      const params = {
+        collectionName,
+        subCollectionName,
+      }
+      const examplePermalink = `/${collectionName}/${subCollectionName}/permalink`
+      expect(getDefaultFrontMatter(params, [])).toMatchObject({
+        title: exampleTitle,
+        permalink: examplePermalink,
+      })
+    })
+
+    it("returns the proper parameters for resource pages", async () => {
+      const params = {
+        resourceRoomName,
+        resourceCategoryName,
+      }
+      const exampleResourceTitle = `${exampleDate}-${exampleLayout}-${exampleTitle}.md`
+      const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`
+      expect(getDefaultFrontMatter(params, [])).toMatchObject({
+        title: exampleTitle,
+        permalink: examplePermalink,
+        date: exampleDate,
+        layout: exampleLayout,
+      })
+    })
+
+    it("returns the proper parameters for resource pages if example title already used", async () => {
+      const params = {
+        resourceRoomName,
+        resourceCategoryName,
+      }
+      const exampleResourceTitle = `${exampleDate}-${exampleLayout}-${exampleTitle}`
+      const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`
+      expect(
+        getDefaultFrontMatter(params, [
+          `${exampleResourceTitle}.md`,
+          `${exampleResourceTitle} 1.md`,
+        ])
+      ).toMatchObject({
+        title: `${exampleTitle} 1 1`,
+        permalink: examplePermalink,
+        date: exampleDate,
+        layout: exampleLayout,
+      })
+    })
+  })
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -498,7 +498,7 @@ export const getDefaultFrontMatter = (params, existingTitles) => {
     }`
   }
   examplePermalink += `permalink`
-  if (collectionName)
+  if (!resourceRoomName)
     return {
       title: exampleTitle,
       permalink: examplePermalink,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Newly created unlinked pages are created with `layout:post` in the frontmatter. This causes an issue where unlinked pages take on the secondary colour of a repo, instead of the primary colour as expected. These pages also display a date , which is undesired behaviour.

## Solution

<!-- How did you solve the problem? -->

This issue was caused by an incorrect retrieval of default front matter - we relied on collectionName to determine whether the page was a resource page or not, rather than the absence of resourceRoomName.

Resolves #775 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- No - this PR is backwards compatible

## Tests

<!-- What tests should be run to confirm functionality? -->
Attempting to add a new unlinked page will create one without `layout:post` in the front matter

## Notes
Unlinked pages created since the pages refactor prior to this fix will still have the incorrect colours