### PR TITLE
fix(mediamodal): fixed infinite rendering bug

### DIFF
--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -56,7 +56,7 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
 
   // Returns the appropriate modal type based on the media mode.
   // This defaults to null if no conditions fit.
-  const Modal = () => {
+  const getModal = () => {
     if (mediaMode === "upload") {
       return (
         <MediaCreationModal
@@ -93,11 +93,7 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
     ) : null
   }
 
-  return (
-    <FormProvider {...methods}>
-      <Modal />
-    </FormProvider>
-  )
+  return <FormProvider {...methods}>{getModal()}</FormProvider>
 }
 
 export default MediaModal


### PR DESCRIPTION
## Problem

The `MediaModal` infinitely renders when creating the modal as a component (introduced in #758).

Closes [insert issue #]

## Solution

Change it to a function invocation. However, still unsure why it works as i always thought components and functions are equal (in React).