### PR TITLE
feat: add banner component and identity phase 1 banner

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,0 +1,26 @@
+import { Box, Flex } from "@chakra-ui/react"
+
+export interface BannerProps {
+  children: string
+}
+
+// TODO: Please get rid of this and use the design system instead!!
+const styles = {
+  banner: { color: "white", bg: "#2B5FCE" },
+  item: {
+    display: "flex",
+    justifyContent: "space-between",
+    px: "1rem",
+    py: ["1rem", "1rem", "0.5rem"],
+  },
+}
+
+export const Banner = ({ children }: BannerProps): JSX.Element => {
+  return (
+    <Box __css={styles.banner}>
+      <Flex sx={styles.item}>
+        <Flex>{children}</Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -8,7 +8,6 @@ export interface BannerProps {
 const styles = {
   banner: { color: "white", bg: "#2B5FCE" },
   item: {
-    display: "flex",
     justifyContent: "space-between",
     px: "1rem",
     py: ["1rem", "1rem", "0.5rem"],
@@ -18,9 +17,7 @@ const styles = {
 export const Banner = ({ children }: BannerProps): JSX.Element => {
   return (
     <Box __css={styles.banner}>
-      <Flex sx={styles.item}>
-        <Flex>{children}</Flex>
-      </Flex>
+      <Flex sx={styles.item}>{children}</Flex>
     </Box>
   )
 }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -5,6 +5,7 @@ export interface BannerProps {
 }
 
 // TODO: Please get rid of this and use the design system instead!!
+// Refer to issue: https://github.com/isomerpages/isomercms-frontend/issues/782
 const styles = {
   banner: { color: "white", bg: "#2B5FCE" },
   item: {

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,0 +1,3 @@
+import { Banner } from "./Banner"
+
+export default Banner

--- a/src/layouts/Sites.jsx
+++ b/src/layouts/Sites.jsx
@@ -56,7 +56,8 @@ export default class Sites extends Component {
     const { siteNames } = this.state
     return (
       <>
-        {/* TODO: Move ThemeProvider to root of app during design system refactor */}
+        {/* TODO: Move ThemeProvider to root of app during design system refactor. 
+        Refer to issue: https://github.com/isomerpages/isomercms-frontend/issues/782 */}
         <ThemeProvider>
           <Banner>
             From 31 Mar 2022, all users will have to use an agency-issued email

--- a/src/layouts/Sites.jsx
+++ b/src/layouts/Sites.jsx
@@ -1,9 +1,10 @@
-import { Link } from "@chakra-ui/react"
+import { Link as ChakraLink } from "@chakra-ui/react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
 import axios from "axios"
 import Banner from "components/Banner"
 import Header from "components/Header"
 import React, { Component } from "react"
+import { Link } from "react-router-dom"
 
 import { SITES_IS_PRIVATE_KEY } from "constants/constants"
 
@@ -60,13 +61,13 @@ export default class Sites extends Component {
           <Banner>
             From 31 Mar 2022, all users will have to use an agency-issued email
             to verify their account before making new edits in the CMS. &nbsp;
-            <Link
+            <ChakraLink
               color="white"
               href="https://go.gov.sg/isomer-identity"
               isExternal
             >
               Read more
-            </Link>
+            </ChakraLink>
           </Banner>
         </ThemeProvider>
         <Header showButton={false} />

--- a/src/layouts/Sites.jsx
+++ b/src/layouts/Sites.jsx
@@ -1,7 +1,9 @@
+import { Link } from "@chakra-ui/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
 import axios from "axios"
+import Banner from "components/Banner"
 import Header from "components/Header"
 import React, { Component } from "react"
-import { Link } from "react-router-dom"
 
 import { SITES_IS_PRIVATE_KEY } from "constants/constants"
 
@@ -53,6 +55,20 @@ export default class Sites extends Component {
     const { siteNames } = this.state
     return (
       <>
+        {/* TODO: Move ThemeProvider to root of app during design system refactor */}
+        <ThemeProvider>
+          <Banner>
+            From 31 Mar 2022, all users will have to use an agency-issued email
+            to verify their account before making new edits in the CMS. &nbsp;
+            <Link
+              color="white"
+              href="https://go.gov.sg/isomer-identity"
+              isExternal
+            >
+              Read more
+            </Link>
+          </Banner>
+        </ThemeProvider>
         <Header showButton={false} />
         <div className={elementStyles.wrapper}>
           <div className={siteStyles.sitesContainer}>

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -41,7 +41,6 @@ li {
 .wrapper {
   height: calc(100vh - #{$header-height});
   width: 100%;
-  top: $header-height;
   position: relative;
   display: flex;
   flex-direction: row;

--- a/src/styles/isomer-cms/elements/header.scss
+++ b/src/styles/isomer-cms/elements/header.scss
@@ -1,7 +1,7 @@
 @import "./variable";
 
 .header {
-  position: fixed;
+  position: relative;
   height: $header-height;
   background: $header-background;
   width: 100%;


### PR DESCRIPTION
### Description
This PR adds a new custom banner component, as well as modifies the Sites layout to use the banner for an announcement about identity phase 1. 

Closes https://github.com/isomerpages/isomercms-frontend/issues/772

### Solution

The PR adds a custom banner component - because, unfortunately, the existing CMS styles interfere with those from the design system.

#### Design system styles do not play nicely with the CMS styles because of poor scoping

There are 2 external icon links, and the left icon in the banner is mis-aligned.

<img width="1624" alt="Screenshot 2022-02-16 at 11 12 03 PM" src="https://user-images.githubusercontent.com/19917616/154404757-93ca161a-9e32-45fd-bf15-8b63d32f688d.png">

#### Custom banner

As such, we had to create a very simple custom banner that did not have icons (i.e. no left icon and no close button functionality) just to tide us over for now, while we refactor the styles/components in the CMS. We chose to take this hacky approach because it was crucial to get the announcement banner for identity phase 1 out by this week.

![Screenshot 2022-02-17 at 11 45 22 AM](https://user-images.githubusercontent.com/19917616/154404266-fd20a7dd-5bb7-46e1-a5c2-f9e1e53203a9.png)

#### Breaking Changes

No - this PR is backwards compatible


### Tests
- The banner component can be used in any layout
- The banner should appear on the Sites layout along with the specific announcement message as shown above; clicking on the `Read more` button should open a new tab to the [announcement page](https://guide.isomer.gov.sg/isomer-identity)
