### PR TITLE
Chore: automate release versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ If you would like the Cypress UI, run
 ```
 npm run cypress:open
 ```
+
+### Release
+Run the following on the release branch to tag and push changes automatically:
+```
+npm run release --update=<versionType>
+```
+where versionType corresponds to npm version types. This only works on non-Windows platforms, for Windows, modify the release script to use %npm_config_update% instead of $npm_config_update.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "start": "source .env.development.local && craco start",
     "dev": "source .env && craco start",
     "build": "craco build",
+    "release": "npm version $npm_config_update && git push --tags",
     "test": "craco test",
     "test:ci": "node scripts/run-e2e.js run",
     "test-e2e": "source .env && node scripts/run-e2e.js run",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

This PR automates the release flow to automatically run `npm version` and push tags to github.

Closes #788 

**New scripts**:

- `release --update=<versionType>` : runs `npm version <versionType> && git push --tags` to automate the release process.


Will replicate this on the backend repo after this PR has been approved.