### PR TITLE
ref(form field horizontal): replace with simpler API

### DIFF
--- a/src/components/FormFieldHorizontal.jsx
+++ b/src/components/FormFieldHorizontal.jsx
@@ -1,70 +1,20 @@
-import PropTypes from "prop-types"
-import React from "react"
+import React, { forwardRef } from "react"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
-const FormFieldHorizontal = ({
-  title,
-  description,
-  defaultValue,
-  placeholder,
-  value,
-  id,
-  disabled,
-  errorMessage,
-  onFieldChange,
-  isRequired,
-  style,
-  children,
-  register = () => {},
-}) => (
-  <>
-    <p className={elementStyles.formLabel}>{title}</p>
-    {children}
-    <div className={elementStyles.formHorizontal}>
-      <p className={elementStyles.formDescription}>{description}</p>
-      <input
-        type="text"
-        placeholder={placeholder || title}
-        value={value}
-        defaultValue={defaultValue}
-        id={id}
-        autoComplete="off"
-        required={isRequired}
-        disabled={disabled}
-        className={`${elementStyles.formHorizontalInput} ${
-          errorMessage ? `${elementStyles.error}` : null
-        }`}
-        style={style}
-        onChange={onFieldChange}
-        {...register(id, { required: isRequired })}
-      />
-    </div>
-    {errorMessage ? (
-      <>
-        <span className={elementStyles.error}>{errorMessage}</span>
-        <br />
-        <br />
-      </>
-    ) : null}
-  </>
-)
+import FormInput from "./Form/FormInput"
+
+// This component is a thin wrapper over the basic FormInput.
+// It serves to apply additional UI styling over the base FormInput.
+// Because of this, any additional props are forwarded to the base FormInput for consumption
+const FormFieldHorizontal = forwardRef((args, ref) => (
+  <div className={elementStyles.formHorizontal}>
+    <FormInput
+      className={elementStyles.formHorizontalInput}
+      {...args}
+      ref={ref}
+    />
+  </div>
+))
 
 export default FormFieldHorizontal
-
-FormFieldHorizontal.propTypes = {
-  title: PropTypes.string.isRequired,
-  placeholder: PropTypes.string,
-  defaultValue: PropTypes.string,
-  value: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
-  errorMessage: PropTypes.string.isRequired,
-  onFieldChange: PropTypes.func.isRequired,
-  isRequired: PropTypes.bool.isRequired,
-  style: PropTypes.string,
-}
-
-FormFieldHorizontal.defaultProps = {
-  defaultValue: undefined,
-  style: undefined,
-}

--- a/src/components/PageSettingsModal/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.jsx
@@ -12,7 +12,7 @@ import FormFieldHorizontal from "components/FormFieldHorizontal"
 import FormFieldMedia from "components/FormFieldMedia"
 import ResourceFormFields from "components/ResourceFormFields"
 import SaveDeleteButtons from "components/SaveDeleteButtons"
-import * as _ from "lodash"
+import _ from "lodash"
 import PropTypes from "prop-types"
 import React, { useEffect } from "react"
 import { useForm } from "react-hook-form"
@@ -21,7 +21,7 @@ import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
 import { getDefaultFrontMatter, pageFileNameToTitle } from "utils"
 
-import { PageSettingsSchema } from "."
+import { PageSettingsSchema } from "./PageSettingsSchema"
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -135,16 +135,20 @@ export const PageSettingsModal = ({
                   {/* Permalink */}
                   {watch("layout") !== "file" && (
                     <>
-                      <FormFieldHorizontal
-                        register={register}
-                        disabled={watch("layout") === "file"}
-                        title="Page URL"
-                        description={siteUrl}
-                        id="permalink"
-                        errorMessage={errors.permalink?.message}
+                      <FormContext
+                        hasError={!!errors.permalink?.message}
                         isRequired
-                        placeholder=""
-                      />
+                        isDisabled={watch("layout") === "file"}
+                      >
+                        <FormTitle>Page URL</FormTitle>
+                        <FormDescription>{siteUrl}</FormDescription>
+                        <FormFieldHorizontal
+                          {...register("permalink", { required: true })}
+                          id="permalink"
+                          placeholder="Page URL"
+                        />
+                        <FormError>{errors.permalink?.message}</FormError>
+                      </FormContext>
                       <br />
                     </>
                   )}

--- a/src/components/Spacing/Spacing.jsx
+++ b/src/components/Spacing/Spacing.jsx
@@ -1,4 +1,3 @@
-import cx from "classnames"
 import { PropTypes } from "prop-types"
 import React from "react"
 
@@ -16,7 +15,7 @@ const Spacing = ({ direction = "column", shouldWrap = true, children }) => {
   return (
     <div
       id="spacing"
-      className={cx(elementStyles.spacing, elementStyles[direction])}
+      className={`${elementStyles.spacing} ${elementStyles[direction]}`}
     >
       {React.Children.map(children, (child) =>
         shouldWrap ? <div>{child}</div> : child

--- a/src/components/Spacing/Spacing.jsx
+++ b/src/components/Spacing/Spacing.jsx
@@ -1,0 +1,34 @@
+import cx from "classnames"
+import { PropTypes } from "prop-types"
+import React from "react"
+
+import elementStyles from "./Spacing.module.scss"
+
+/**
+ * TODO [#790] Remove this component and replace calls with Chakra's Stack
+ * This is a utility class to ensure that
+ * the children components are all evenly spaced.
+ *
+ * This is a simplified version of the Chakra stack component with some assumptions made.
+ * @returns Spacing
+ */
+const Spacing = ({ direction = "column", shouldWrap = true, children }) => {
+  return (
+    <div
+      id="spacing"
+      className={cx(elementStyles.spacing, elementStyles[direction])}
+    >
+      {React.Children.map(children, (child) =>
+        shouldWrap ? <div>{child}</div> : child
+      )}
+    </div>
+  )
+}
+
+Spacing.propTypes = {
+  direction: PropTypes.string,
+  shouldWrap: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+export default Spacing

--- a/src/components/Spacing/Spacing.module.scss
+++ b/src/components/Spacing/Spacing.module.scss
@@ -1,0 +1,25 @@
+.spacing {
+  display: flex;
+}
+
+.row {
+  flex-direction: row;
+  // Refer here for a detailed explation of this: https://emmenko.medium.com/patching-lobotomized-owl-selector-for-emotion-ssr-5a582a3c424c
+  // It selects all elements a preceding sibling
+  > * ~ * {
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-inline-end: 0;
+    margin-inline-start: 24px;
+  }
+}
+
+.column {
+  flex-direction: column;
+  > * ~ * {
+    margin-top: 24px;
+    margin-bottom: 0px;
+    margin-inline-end: 0;
+    margin-inline-start: 0;
+  }
+}

--- a/src/components/Spacing/index.js
+++ b/src/components/Spacing/index.js
@@ -1,0 +1,3 @@
+import Spacing from "./Spacing"
+
+export default Spacing

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -141,7 +141,6 @@ const Settings = ({ match, location }) => {
   const changeHandler = (event) => {
     const { id, value, parentElement } = event.target
     const grandparentElementId = parentElement?.parentElement?.id
-    // const errorMessage = validateSettings(id, value);
 
     // although show_reach is a part of footer-fields, the CreatableSelect dropdown handler does not
     // return a normal event, so we need to handle the case separately

--- a/src/layouts/Settings.jsx
+++ b/src/layouts/Settings.jsx
@@ -7,7 +7,8 @@ import GenericWarningModal from "components/GenericWarningModal"
 import Header from "components/Header"
 import ColorPickerSection from "components/settings/ColorPickerSection"
 import Sidebar from "components/Sidebar"
-import * as _ from "lodash"
+import Spacing from "components/Spacing/Spacing"
+import _ from "lodash"
 import PropTypes from "prop-types"
 import React, { useEffect, useState } from "react"
 
@@ -73,6 +74,12 @@ const stateFields = {
 }
 
 const OTHER_FOOTER_SETTINGS = ["contact_us", "feedback", "faq", "show_reach"]
+
+const getTitle = (unprocessedTitle) =>
+  unprocessedTitle
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
 
 const Settings = ({ match, location }) => {
   const { params, decodedParams } = match
@@ -140,16 +147,17 @@ const Settings = ({ match, location }) => {
 
   const changeHandler = (event) => {
     const { id, value, parentElement } = event.target
-    const grandparentElementId = parentElement?.parentElement?.id
+    const ancesterElementId =
+      parentElement?.parentElement?.parentElement?.parentElement?.id
 
     // although show_reach is a part of footer-fields, the CreatableSelect dropdown handler does not
     // return a normal event, so we need to handle the case separately
-    if (id === "show_reach" || grandparentElementId === "footer-fields") {
+    if (id === "show_reach" || ancesterElementId === "footer-fields") {
       setCurrState({
         ...currState,
         [id]: value,
       })
-    } else if (grandparentElementId === "social-media-fields") {
+    } else if (ancesterElementId === "social-media-fields") {
       const errorMessage = validateSocialMedia(value, id)
       setCurrState({
         ...currState,
@@ -165,7 +173,7 @@ const Settings = ({ match, location }) => {
           [id]: errorMessage,
         },
       })
-    } else if (grandparentElementId === "color-fields") {
+    } else if (ancesterElementId === "color-fields") {
       setCurrState({
         ...currState,
         colors: {
@@ -173,7 +181,7 @@ const Settings = ({ match, location }) => {
           [id]: value,
         },
       })
-    } else if (grandparentElementId === "media-color-fields") {
+    } else if (ancesterElementId === "media-color-fields") {
       const index = id.split("@")[id.split("@").length - 1]
       const { colors } = currState
 
@@ -245,35 +253,41 @@ const Settings = ({ match, location }) => {
               {/* General fields */}
               <div id="general-fields">
                 <p className={elementStyles.formSectionHeader}>General</p>
-                <FormFieldHorizontal
-                  title="Title"
-                  id="title"
-                  value={currState.title}
-                  errorMessage={errors.title}
-                  isRequired={false}
-                  onFieldChange={changeHandler}
-                />
-                <FormFieldHorizontal
-                  title="Description"
-                  id="description"
-                  value={currState.description}
-                  errorMessage={errors.description}
-                  isRequired={false}
-                  onFieldChange={changeHandler}
-                />
-                <FormContext
-                  hasError={!!errors.shareicon}
-                  onFieldChange={changeHandler}
-                  isRequired
-                >
-                  <FormTitle>Shareicon</FormTitle>
-                  <FormFieldMedia
-                    value={currState.shareicon}
-                    id="shareicon"
-                    inlineButtonText="Choose Image"
-                  />
-                  <FormError>{errors.shareicon}</FormError>
-                </FormContext>
+                <Spacing>
+                  <FormContext hasError={!!errors.title}>
+                    <FormTitle>Title</FormTitle>
+                    <FormFieldHorizontal
+                      placeholder="Title"
+                      id="title"
+                      value={currState.title}
+                      onChange={changeHandler}
+                    />
+                    <FormError>{errors.title}</FormError>
+                  </FormContext>
+                  <FormContext hasError={!!errors.description}>
+                    <FormTitle>Description</FormTitle>
+                    <FormFieldHorizontal
+                      placeholder="Description"
+                      id="description"
+                      value={currState.description}
+                      onChange={changeHandler}
+                    />
+                    <FormError>{errors.description}</FormError>
+                  </FormContext>
+                  <FormContext
+                    hasError={!!errors.shareicon}
+                    onFieldChange={changeHandler}
+                    isRequired
+                  >
+                    <FormTitle>Shareicon</FormTitle>
+                    <FormFieldMedia
+                      value={currState.shareicon}
+                      id="shareicon"
+                      inlineButtonText="Choose Image"
+                    />
+                    <FormError>{errors.shareicon}</FormError>
+                  </FormContext>
+                </Spacing>
                 <FormFieldToggle
                   title="Display government masthead"
                   id="is_government"
@@ -284,64 +298,71 @@ const Settings = ({ match, location }) => {
               {/* Logo fields */}
               <div id="logo-fields">
                 <p className={elementStyles.formSectionHeader}>Logos</p>
-                <FormContext
-                  hasError={!!errors.logo}
-                  onFieldChange={changeHandler}
-                  isRequired
-                >
-                  <FormTitle>Agency logo</FormTitle>
-                  <FormFieldMedia
-                    value={currState.logo}
-                    id="logo"
-                    inlineButtonText="Choose Image"
-                  />
-                  <FormError>{errors.logo}</FormError>
-                </FormContext>
+                <Spacing>
+                  <FormContext
+                    hasError={!!errors.logo}
+                    onFieldChange={changeHandler}
+                    isRequired
+                  >
+                    <FormTitle>Agency logo</FormTitle>
+                    <FormFieldMedia
+                      value={currState.logo}
+                      id="logo"
+                      inlineButtonText="Choose Image"
+                    />
+                    <FormError>{errors.logo}</FormError>
+                  </FormContext>
 
-                <FormContext
-                  hasError={!!errors.favicon}
-                  onFieldChange={changeHandler}
-                  isRequired
-                >
-                  <FormTitle>Favicon</FormTitle>
-                  <FormFieldMedia
-                    value={currState.favicon}
-                    id="favicon"
-                    inlineButtonText="Choose Image"
-                  />
-                  <FormError>{errors.favicon}</FormError>
-                </FormContext>
+                  <FormContext
+                    hasError={!!errors.favicon}
+                    onFieldChange={changeHandler}
+                    isRequired
+                  >
+                    <FormTitle>Favicon</FormTitle>
+                    <FormFieldMedia
+                      value={currState.favicon}
+                      id="favicon"
+                      inlineButtonText="Choose Image"
+                    />
+                    <FormError>{errors.favicon}</FormError>
+                  </FormContext>
+                </Spacing>
               </div>
               {/* Analytics fields */}
               <div id="analytics-fields">
                 <p className={elementStyles.formSectionHeader}>Analytics</p>
-                <FormFieldHorizontal
-                  title="Facebook Pixel"
-                  placeholder="Facebook Pixel ID"
-                  id="facebook_pixel"
-                  value={currState.facebook_pixel}
-                  errorMessage={errors.facebook_pixel}
-                  isRequired={false}
-                  onFieldChange={changeHandler}
-                />
-                <FormFieldHorizontal
-                  title="Google Analytics"
-                  placeholder="Google Analytics ID"
-                  id="google_analytics"
-                  value={currState.google_analytics}
-                  errorMessage={errors.google_analytics}
-                  isRequired={false}
-                  onFieldChange={changeHandler}
-                />
-                <FormFieldHorizontal
-                  title="Linkedin Insights"
-                  placeholder="Linkedin Insights ID"
-                  id="linkedin_insights"
-                  value={currState.linkedin_insights}
-                  errorMessage={errors.linkedin_insights}
-                  isRequired={false}
-                  onFieldChange={changeHandler}
-                />
+                <Spacing>
+                  <FormContext hasError={!!errors.facebook_pixel}>
+                    <FormTitle>Facebook Pixel</FormTitle>
+                    <FormFieldHorizontal
+                      placeholder="Facebook Pixel ID"
+                      id="facebook_pixel"
+                      value={currState.facebook_pixel}
+                      onChange={changeHandler}
+                    />
+                    <FormError>{errors.facebook_pixel}</FormError>
+                  </FormContext>
+                  <FormContext hasError={!!errors.google_analytics}>
+                    <FormTitle>Google Analytics</FormTitle>
+                    <FormFieldHorizontal
+                      placeholder="Google Analytics ID"
+                      id="google_analytics"
+                      value={currState.google_analytics}
+                      onChange={changeHandler}
+                    />
+                    <FormError>{errors.google_analytics}</FormError>
+                  </FormContext>
+                  <FormContext hasError={!!errors.linkedin_insights}>
+                    <FormTitle>Linkedin Insights</FormTitle>
+                    <FormFieldHorizontal
+                      placeholder="Linkedin Insights ID"
+                      id="linkedin_insights"
+                      value={currState.linkedin_insights}
+                      onChange={changeHandler}
+                    />
+                    <FormError>{errors.linkedin_insights}</FormError>
+                  </FormContext>
+                </Spacing>
               </div>
               {/* Color fields */}
               <ColorPickerSection
@@ -356,58 +377,76 @@ const Settings = ({ match, location }) => {
               {/* Social media fields */}
               <div id="social-media-fields">
                 <p className={elementStyles.formSectionHeader}>Social Media</p>
-                {Object.keys(currState.socialMediaContent).map(
-                  (socialMediaPage) => (
-                    <FormFieldHorizontal
-                      title={
+                <Spacing>
+                  {_.keys(currState.socialMediaContent).map(
+                    (socialMediaPage) => {
+                      const formTitle =
                         socialMediaPage.charAt(0).toUpperCase() +
                         socialMediaPage.slice(1)
-                      }
-                      id={socialMediaPage}
-                      value={currState.socialMediaContent[socialMediaPage]}
-                      key={`${socialMediaPage}-form`}
-                      errorMessage={errors.socialMediaContent[socialMediaPage]}
-                      isRequired={false}
-                      onFieldChange={changeHandler}
-                    />
-                  )
-                )}
+
+                      return (
+                        // NOTE: The FormContext has to be here because the error is tied to
+                        // the object's keys, which is local to the FormField
+                        <FormContext
+                          hasError={
+                            !!errors.socialMediaContent[socialMediaPage]
+                          }
+                        >
+                          <FormTitle>{formTitle}</FormTitle>
+                          <FormFieldHorizontal
+                            placeholder={formTitle}
+                            id={socialMediaPage}
+                            value={_.get(
+                              currState,
+                              `socialMediaContent.${socialMediaPage}`
+                            )}
+                            key={`${socialMediaPage}-form`}
+                            onChange={changeHandler}
+                          />
+                          <FormError>
+                            {errors.socialMediaContent[socialMediaPage]}
+                          </FormError>
+                        </FormContext>
+                      )
+                    }
+                  )}
+                </Spacing>
               </div>
               {/* Footer fields */}
               <div id="footer-fields">
                 <p className={elementStyles.formSectionHeader}>Footer</p>
-                {OTHER_FOOTER_SETTINGS.map((footerSetting) => {
-                  const title = footerSetting
-                    .split("_")
-                    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-                    .join(" ")
+                <Spacing>
+                  {_.without(OTHER_FOOTER_SETTINGS, "show_reach").map(
+                    (footerSetting) => {
+                      const title = getTitle(footerSetting)
 
-                  if (footerSetting === "show_reach") {
-                    return (
-                      <FormFieldToggle
-                        title={title}
-                        id={footerSetting}
-                        value={currState[footerSetting]}
-                        key={`${footerSetting}-form`}
-                        errorMessage={errors[footerSetting]}
-                        isRequired={false}
-                        onFieldChange={changeHandler}
-                      />
-                    )
-                  }
-
-                  return (
-                    <FormFieldHorizontal
-                      title={title}
-                      id={footerSetting}
-                      value={currState[footerSetting]}
-                      key={`${footerSetting}-form`}
-                      errorMessage={errors[footerSetting]}
-                      isRequired={false}
-                      onFieldChange={changeHandler}
-                    />
-                  )
-                })}
+                      return (
+                        <FormContext hasError={!!errors[footerSetting]}>
+                          <FormTitle>{title}</FormTitle>
+                          <FormFieldHorizontal
+                            placeholder={title}
+                            id={footerSetting}
+                            value={currState[footerSetting]}
+                            key={`${footerSetting}-form`}
+                            onChange={changeHandler}
+                          />
+                          <FormError>{errors[footerSetting]}</FormError>
+                        </FormContext>
+                      )
+                    }
+                  )}
+                </Spacing>
+                {["show_reach"].map((footerSetting) => (
+                  <FormFieldToggle
+                    title={getTitle(footerSetting)}
+                    id={footerSetting}
+                    value={currState[footerSetting]}
+                    key={`${footerSetting}-form`}
+                    errorMessage={errors[footerSetting]}
+                    isRequired={false}
+                    onFieldChange={changeHandler}
+                  />
+                ))}
               </div>
               <br />
               <br />

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -41,13 +41,6 @@ p {
   margin-bottom: 5px;
   margin-top: 5px;
 
-  .formHorizontalLabel {
-    @extend .formLabel;
-    padding-right: 5px;
-    min-width: min-content;
-    width: 20%;
-  }
-
   .formHorizontalInput {
     max-width: 80%;
   }


### PR DESCRIPTION
This PR builds on #774 and is part of #771 

## Problem
The `FormFieldHorizontal` component is extremely similar to `FormField` but has alot of repeated code within it. This PR uses the new `FormInput` component introduced in #774 to refactor this component and make it simpler.

The `FormFieldHorizontal` component additionally had 2 line breaks on error, which it used for formatting. This made it difficult to compose as it now had layout logic in addition to just being a UI input.

## Solution
1. utilized `FormInput` component as a base and pass customized props to it.
2. created a new `Spacing` component (inspired by Chakra's [Stack](https://chakra-ui.com/docs/layout/stack)) that handles layout and removes this concern from `FormInput`. I've checked with Nat on this and the spacing is a constant 24px between fields

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Tests 
**page settings modal**
- [ ] Go to workspace and create a page. you should be able to do so successfully. click on a page and then edit details. you should be able to modify the page URL successfully.
- [ ] Go to resources, create a resource category, then create a page. you should be able to do so successfully. click on a page and then edit details. you should be able to modify the page URL successfully.
- [ ] Go to workspace, create a folder, then create a page. you should be able to do so successfully. click on a page and then edit details. you should be able to modify the page URL successfully.

**settings**
- [ ] go to settings. you should be able to edit and save every form field there.


**notes**
1. `pageSettingsModal` has a `siteUrl` prop, which is used to render a description displaying the site url. i couldn't get this behaviour working on prod and when testing on local, `siteUrl` is blank. i've kept the prop in as it might be defined in certain edge cases but ideally we can remove it if everyone is onboard.