### PR TITLE
ref(formFieldColour): refactored to use base form components

### DIFF
--- a/src/components/Form/FormTitle.jsx
+++ b/src/components/Form/FormTitle.jsx
@@ -3,11 +3,12 @@ import React from "react"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
-const FormTitle = ({ children }) => (
-  <p className={elementStyles.formLabel}>{children}</p>
+const FormTitle = ({ className = elementStyles.formLabel, children }) => (
+  <p className={className}>{children}</p>
 )
 
 FormTitle.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node,
 }
 

--- a/src/components/settings/ColorPickerSection.jsx
+++ b/src/components/settings/ColorPickerSection.jsx
@@ -1,5 +1,7 @@
+import FormContext from "components/Form/FormContext"
+import FormTitle from "components/Form/FormTitle"
 import FormFieldColor from "components/settings/FormFieldColor"
-import * as _ from "lodash"
+import _ from "lodash"
 import PropTypes from "prop-types"
 import React from "react"
 
@@ -9,52 +11,63 @@ const ColorPickerSection = ({ colors, saveChanges }) => {
   return (
     <div id="color-fields">
       <p className={elementStyles.formSectionHeader}>Colors</p>
-      <FormFieldColor
-        title="Primary"
-        id="primary-color"
-        value={colors["primary-color"]}
-        isRequired
-        saveChanges={(selectedColor) => {
-          saveChanges({
-            ...colors,
-            "primary-color": selectedColor,
-          })
-        }}
-      />
-      <FormFieldColor
-        title="Secondary"
-        id="secondary-color"
-        value={colors["secondary-color"]}
-        isRequired
-        saveChanges={(selectedColor) => {
-          saveChanges({
-            ...colors,
-            "secondary-color": selectedColor,
-          })
-        }}
-      />
-      <div id="media-color-fields">
-        {colors["media-colors"].map((category, index) => {
-          const { title: mediaColorName, color } = category
-          return (
-            <FormFieldColor
-              title={`Resource ${index + 1}`}
-              id={`media-color@${index}`}
-              value={color}
-              key={mediaColorName}
-              isRequired
-              saveChanges={(selectedColor) => {
-                const newMediaColors = _.cloneDeep(colors["media-colors"])
-                newMediaColors[index].color = selectedColor
-                saveChanges({
-                  ...colors,
-                  "media-colors": newMediaColors,
-                })
-              }}
-            />
-          )
-        })}
-      </div>
+      <FormContext isRequired>
+        <div className={elementStyles.formColor}>
+          <FormTitle className={elementStyles.formColorLabel}>
+            Primary
+          </FormTitle>
+          <FormFieldColor
+            id="primary-color"
+            value={colors["primary-color"]}
+            saveChanges={(selectedColor) => {
+              saveChanges({
+                ...colors,
+                "primary-color": selectedColor,
+              })
+            }}
+          />
+        </div>
+        <div className={elementStyles.formColor}>
+          <FormTitle className={elementStyles.formColorLabel}>
+            Secondary
+          </FormTitle>
+          <FormFieldColor
+            id="secondary-color"
+            value={colors["secondary-color"]}
+            saveChanges={(selectedColor) => {
+              saveChanges({
+                ...colors,
+                "secondary-color": selectedColor,
+              })
+            }}
+          />
+        </div>
+        <div id="media-color-fields">
+          {colors["media-colors"].map((category, index) => {
+            const { title: mediaColorName, color } = category
+            return (
+              <div className={elementStyles.formColor}>
+                <FormTitle className={elementStyles.formColorLabel}>
+                  {`Resource ${index + 1}`}
+                </FormTitle>
+                <FormFieldColor
+                  id={`media-color@${index}`}
+                  value={color}
+                  key={mediaColorName}
+                  saveChanges={(selectedColor) => {
+                    const newMediaColors = _.cloneDeep(colors["media-colors"])
+                    newMediaColors[index].color = selectedColor
+                    saveChanges({
+                      ...colors,
+                      "media-colors": newMediaColors,
+                    })
+                  }}
+                />
+              </div>
+            )
+          })}
+        </div>
+      </FormContext>
     </div>
   )
 }

--- a/src/components/settings/FormFieldColor.jsx
+++ b/src/components/settings/FormFieldColor.jsx
@@ -101,7 +101,6 @@ const FormFieldColor = ({ value, id, saveChanges }) => {
       <FormInput
         value={value}
         id={id}
-        autoComplete="off"
         // This component is purely presentational.
         // It is used to display the hex code and hence, is alwaysDisabled.
         alwaysDisabled

--- a/src/components/settings/FormFieldColor.jsx
+++ b/src/components/settings/FormFieldColor.jsx
@@ -1,20 +1,18 @@
+import FormInput from "components/Form/FormInput"
 import ColorPickerModal from "components/settings/ColorPickerModal"
 import PropTypes from "prop-types"
 import React, { useCallback, useEffect, useState } from "react"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
-const FormFieldColor = ({
-  title,
-  defaultValue,
-  value,
-  id,
-  isRequired,
-  style,
-  saveChanges,
-}) => {
+const FormFieldColor = ({ value, id, saveChanges }) => {
   const [originalColor, setOriginalColor] = useState()
   const [colorPickerToggle, setColorPickerToggle] = useState(false)
+
+  const setRealTimeColor = (color) => {
+    const hex = color.hex ? color.hex : `#${color}`
+    saveChanges(hex)
+  }
 
   // event listener callback function that resets ColorPicker modal
   // when escape key is pressed while modal is active
@@ -89,11 +87,6 @@ const FormFieldColor = ({
     setColorPickerToggle(false)
   }
 
-  const setRealTimeColor = (color) => {
-    const hex = color.hex ? color.hex : `#${color}`
-    saveChanges(hex)
-  }
-
   return (
     <>
       {/* Color picker modal */}
@@ -105,27 +98,21 @@ const FormFieldColor = ({
           elementId={id}
         />
       )}
-      <div className={elementStyles.formColor}>
-        <p className={elementStyles.formColorLabel}>{title}</p>
-        <input
-          type="text"
-          placeholder={title}
-          value={value}
-          defaultValue={defaultValue}
-          id={id}
-          autoComplete="off"
-          required={isRequired}
-          className={elementStyles.formColorInput}
-          style={style}
-          disabled
-        />
-        <div
-          className={elementStyles.formColorBox}
-          id={`${id}-box`}
-          style={{ background: value }}
-          onClick={activateColorPicker}
-        />
-      </div>
+      <FormInput
+        value={value}
+        id={id}
+        autoComplete="off"
+        // This component is purely presentational.
+        // It is used to display the hex code and hence, is alwaysDisabled.
+        alwaysDisabled
+        className={elementStyles.formColorInput}
+      />
+      <div
+        className={elementStyles.formColorBox}
+        id={`${id}-box`}
+        style={{ background: value }}
+        onClick={activateColorPicker}
+      />
     </>
   )
 }
@@ -133,16 +120,7 @@ const FormFieldColor = ({
 export default FormFieldColor
 
 FormFieldColor.propTypes = {
-  title: PropTypes.string.isRequired,
-  defaultValue: PropTypes.string,
   value: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  isRequired: PropTypes.bool.isRequired,
-  style: PropTypes.string,
   saveChanges: PropTypes.func.isRequired,
-}
-
-FormFieldColor.defaultProps = {
-  defaultValue: undefined,
-  style: undefined,
 }


### PR DESCRIPTION
## Problem
`FormFieldColour` has quite a few components inside. It should only be restricted to the the colour picker and the hex display.

Closes #771

## Solution
1. Shift away wrapper component/`FormTitle` into the wrapping component (`ColorPickerSection`)
2. Use base `FormInput` to simplify internal component logic
