### PR TITLE
fix(ci): prevent chromatic from being triggered by bots

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - check-success~=lint
       - check-success~=build
       - check-success~=test
-      - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - title~=Bump [^\s]+ from ([\d]+)\..+ to \1\.
     actions:
       review:
         type: APPROVE

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,8 @@ jobs:
   chromatic-deployment:
     # Operating System
     runs-on: ubuntu-latest
+    # Only run if the user is not a bot
+    if: ${{!endsWith(github.actor , 'bot')}}
     environment: staging
     # Job steps
     steps:


### PR DESCRIPTION
## Problem
Chromatic workflow is being triggered by bots, which is not needed.

## Solution
add if condition in the chromatic job so that the workflow is only triggered if the username doesn't end with bot. This PR also adds in a fix for mergify (see #770) that got overridden