### PR TITLE
chore: position banner link immediately next to text

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -18,7 +18,9 @@ const styles = {
 export const Banner = ({ children }: BannerProps): JSX.Element => {
   return (
     <Box __css={styles.banner}>
-      <Flex sx={styles.item}>{children}</Flex>
+      <Flex sx={styles.item}>
+        <Flex>{children}</Flex>
+      </Flex>
     </Box>
   )
 }


### PR DESCRIPTION
## Problem

This PR positions the banner link immediately next to the banner text; the link currently is flushed to the right of the banner.

## Before & After Screenshots

**BEFORE**:

![Screenshot 2022-02-24 at 8 43 30 AM](https://user-images.githubusercontent.com/19917616/155435579-e875c393-359f-4937-a0fd-b799cc63b969.png)


**AFTER**:
![Screenshot 2022-02-24 at 8 43 10 AM](https://user-images.githubusercontent.com/19917616/155435588-6953637e-50c8-48c2-a73e-5ff05a0cf85a.png)


