### PR TITLE
Fix/release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ npm run cypress:open
 ### Release
 Run the following on the release branch to tag and push changes automatically:
 ```
-npm run release --update=<versionType>
+npm run release --isomer_update=<versionType>
 ```
 where versionType corresponds to npm version types. This only works on non-Windows platforms, for Windows, modify the release script to use %npm_config_update% instead of $npm_config_update.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "start": "source .env.development.local && craco start",
     "dev": "source .env && craco start",
     "build": "craco build",
-    "release": "npm version $npm_config_update && git push --tags",
+    "release": "echo $npm_config_isomer_update && echo hi",
     "test": "craco test",
     "test:ci": "node scripts/run-e2e.js run",
     "test-e2e": "source .env && node scripts/run-e2e.js run",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "start": "source .env.development.local && craco start",
     "dev": "source .env && craco start",
     "build": "craco build",
-    "release": "echo $npm_config_isomer_update && echo hi",
+    "release": "npm version $npm_config_isomer_update && git push --tags",
     "test": "craco test",
     "test:ci": "node scripts/run-e2e.js run",
     "test-e2e": "source .env && node scripts/run-e2e.js run",


### PR DESCRIPTION
## Problem

Previously, we were using $npm_config_update to specify the variable used in the npm release script - however, there was a conflict with the npm_config variables used to configure npm itself, causing this script to fail to work as intended. To fix this, we prefix the argument with a unique prefix, converting it to `isomer_update` instead of `update`.

Relevant docs: https://docs.npmjs.com/cli/v7/using-npm/config#environment-variables