### PR TITLE
refactor(identity): button and input styling

### DIFF
--- a/src/components/Link/Link.module.scss
+++ b/src/components/Link/Link.module.scss
@@ -1,0 +1,14 @@
+.link {
+  text-decoration: none;
+  font-size: 16px;
+  // This is $isomer-blue, inlined here for clarity during migration
+  color: #2b5fce;
+  padding: 0;
+  margin: 0;
+  font-family: "Inter", sans-serif;
+
+  &:hover {
+    text-decoration: none;
+    color: #2b5fce;
+  }
+}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,0 +1,11 @@
+import { ReactNode, HTMLAttributes } from "react"
+
+import elementStyles from "./Link.module.scss"
+
+export interface LinkProps extends HTMLAttributes<HTMLAnchorElement> {
+  children: ReactNode
+}
+
+export const Link = (props: LinkProps): JSX.Element => {
+  return <a className={elementStyles.link} {...props} />
+}

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,0 +1,3 @@
+import { Link } from "./Link"
+
+export default Link

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -187,7 +187,7 @@ const VerifyUserDetailsModal = () => {
           <>
             <div>
               In order to improve security, a verified email is now required for
-              all users of Isomer CMS. Only .gov.sg or{" "}
+              all users of Isomer CMS. Only <b>.gov.sg</b> or{" "}
               <b>whitelisted email addresses</b> will be accepted. You must
               verify your email before proceeding.{" "}
               <Link target="_blank" href="https://go.gov.sg/isomer-identity">

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -12,6 +12,7 @@ import useRedirectHook from "../hooks/useRedirectHook"
 import elementStyles from "../styles/isomer-cms/Elements.module.scss"
 
 import InputWithButton from "./InputWithButton"
+import Link from "./Link"
 
 const VerificationStep = {
   GET_EMAIL_OTP: "GET_EMAIL_OTP",
@@ -186,8 +187,12 @@ const VerifyUserDetailsModal = () => {
           <>
             <div>
               In order to improve security, a verified email is now required for
-              all users of Isomer CMS. Only .gov.sg or whitelisted email
-              addresses will be accepted.
+              all users of Isomer CMS. Only .gov.sg or{" "}
+              <b>whitelisted email addresses</b> will be accepted. You must
+              verify your email before proceeding.{" "}
+              <Link target="_blank" href="https://go.gov.sg/isomer-identity">
+                Read more.
+              </Link>
             </div>
             <form onSubmit={handleGetEmailOtp}>
               <InputWithButton

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -1,5 +1,6 @@
-import React, { useContext, useEffect, useState } from "react"
-import elementStyles from "../styles/isomer-cms/Elements.module.scss"
+import Button from "components/Button"
+import { useContext, useEffect, useState } from "react"
+
 import {
   getEmailOtp,
   verifyEmailOtp,
@@ -8,6 +9,8 @@ import {
 } from "../api"
 import { LoginContext } from "../contexts/LoginContext"
 import useRedirectHook from "../hooks/useRedirectHook"
+import elementStyles from "../styles/isomer-cms/Elements.module.scss"
+
 import InputWithButton from "./InputWithButton"
 
 const VerificationStep = {
@@ -214,9 +217,12 @@ const VerifyUserDetailsModal = () => {
           {renderVerificationStep()}
         </div>
         <div className={elementStyles.footer}>
-          <button onClick={setRedirectToLogout} type="button">
-            Logout
-          </button>
+          <Button
+            onClick={setRedirectToLogout}
+            type="button"
+            label="Logout"
+            className={elementStyles.blue}
+          />
         </div>
       </div>
     </div>

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -199,6 +199,7 @@ input[type="radio"] {
   input {
     flex: 1;
     padding-right: 26px;
+    padding-left: 8px;
   }
 
   button {


### PR DESCRIPTION
## Problem
Some styling in #559 does not adhere to isomer styling and hence looked awkward. This PR made minor stylistic fixes to those portions 

## Solution
1. add padding on input to avoid congestion
2. use isomer button styling

## Before & After Screenshots

**BEFORE**:

<img width="607" alt="image" src="https://user-images.githubusercontent.com/44049504/158738188-f1cba1d4-f584-45d1-b0ec-343b04b9c8d0.png">

**AFTER**:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/44049504/158737993-2073f0a2-c4d4-4aad-ad18-ccaacc4b78a4.png">