### PR TITLE
test: added e2e test error message if environment variables are not defined.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,6 +5,11 @@ const btoa = require("btoa")
 
 // login credentials
 const { PERSONAL_ACCESS_TOKEN, USERNAME } = process.env
+if (!PERSONAL_ACCESS_TOKEN || !USERNAME) {
+  throw new Error(
+    `E2E tests require env vars PERSONAL_ACCESS_TOKEN (${PERSONAL_ACCESS_TOKEN}) and USERNAME (${USERNAME}) to be set.`
+  )
+}
 
 const CREDENTIALS = `${USERNAME}:${PERSONAL_ACCESS_TOKEN}`
 const headers = {
@@ -23,6 +28,11 @@ const runCypressCommand =
 
 // reset e2e-test-repo
 const { E2E_COMMIT_HASH } = process.env
+if (!E2E_COMMIT_HASH) {
+  throw new Error(
+    `E2E tests require env var E2E_COMMIT_HASH (${E2E_COMMIT_HASH}) to be set.`
+  )
+}
 const GITHUB_ORG_NAME = "isomerpages"
 const REPO_NAME = "e2e-test-repo"
 


### PR DESCRIPTION
## Problem

Cypress tests fail with unhelpful error messages if the required environment variables are not defined.

## Solution

Throw an exception if any variable is undefined (showing the value that was read for each).

**Breaking Changes**

- [x] No - this PR is backwards compatible


## Tests

npm run test-e2e #should give error messages if `PERSONAL_ACCESS_TOKEN` or `USERNAME` are undefined.