### PR TITLE
Fix: return correct directory type and update comments

### DIFF
--- a/src/utils/directoryUtils.ts
+++ b/src/utils/directoryUtils.ts
@@ -3,32 +3,49 @@ import { DirectoryType } from "types/directory"
 const getDirectoryType = (
   mediaDirectoryName: string,
   collectionName: string,
+  subcollectionName: string,
   isCreation = true
 ): DirectoryType => {
   if (mediaDirectoryName) {
     return "mediaDirectoryName"
   }
 
-  // NOTE: If we are creating a directory and there is a collection name,
-  // this implies that we are creating a subdirectory.
+  // NOTE: Subcollections are created from the collections screen,
+  // so if there is a collection name, this implies that we are creating a subdirectory.
   if (isCreation) {
     return collectionName ? "subCollectionName" : "collectionName"
   }
 
-  return collectionName ? "collectionName" : "subCollectionName"
+  // Otherwise, we look for subCollectionName to determine
+  // if we are renaming a collection or subcollection.
+  return subcollectionName ? "subCollectionName" : "collectionName"
 }
 
 // The below 2 utility functions are re-exported to hide the isCreation parameter
+/**
+ * Returns the type of directory being created. If mediaDirectoryName is specified, returns "mediaDirectoryName",
+ * otherwise, the presence of collectionName indicates that a subcollection is being created.
+ * @param mediaDirectoryName
+ * @param collectionName
+ * @returns
+ */
 export const getDirectoryCreationType = (
   mediaDirectoryName: string,
   collectionName: string
 ): DirectoryType => {
-  return getDirectoryType(mediaDirectoryName, collectionName)
+  return getDirectoryType(mediaDirectoryName, collectionName, "")
 }
 
+/**
+ * Returns the type of directory being modified. If mediaDirectoryName is specified, returns "mediaDirectoryName",
+ * otherwise, the presence of subcollectionName indicates that a subcollection is being modified.
+ * @param mediaDirectoryName
+ * @param subcollectionName
+ * @returns
+ */
 export const getDirectorySettingsType = (
   mediaDirectoryName: string,
-  collectionName: string
+  subcollectionName: string
 ): DirectoryType => {
-  return getDirectoryType(mediaDirectoryName, collectionName, false)
+  return getDirectoryType(mediaDirectoryName, "", subcollectionName, false)
 }


### PR DESCRIPTION
## Problem

This PR fixes an issue when renaming subcollections - getDirectoryType was returning the incorrect type, which was causing the subcollection title to be incorrectly slugified. This PR fixes this issue and adds additional comments to explain the functionality.
