### PR TITLE
fix(test): update e2e tests

### DIFF
--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -50,7 +50,7 @@ describe("Edit unlinked page", () => {
 
     // Set colour
     cy.visit(`/sites/${TEST_REPO_NAME}/settings`)
-    cy.contains("p", "Primary").siblings("div").click()
+    cy.contains("p", "Primary").siblings("button").click()
     cy.contains(/^r/)
       .siblings()
       .clear()
@@ -393,7 +393,7 @@ describe("Edit resource page", () => {
 
     // Set colour
     cy.visit(`/sites/${TEST_REPO_NAME}/settings`)
-    cy.contains("p", "Secondary").siblings("div").click()
+    cy.contains("p", "Secondary").siblings("button").click()
     cy.contains(/^r/)
       .siblings()
       .clear()

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -11,9 +11,14 @@ import {
 } from "../fixtures/constants"
 
 describe("Folders flow", () => {
-  const CMS_BASEURL = Cypress.env("BASEURL")
   const COOKIE_NAME = Cypress.env("COOKIE_NAME")
   const COOKIE_VALUE = Cypress.env("COOKIE_VALUE")
+
+  before(() => {
+    cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+  })
+
+  const CMS_BASEURL = Cypress.env("BASEURL")
   const TEST_REPO_NAME = Cypress.env("TEST_REPO_NAME")
   const DEFAULT_REPO_FOLDER_NAME = "default"
   const PRETTIFIED_DEFAULT_REPO_FOLDER_NAME = deslugifyDirectory(
@@ -95,11 +100,14 @@ describe("Folders flow", () => {
 
   describe("Create subfolder, rename subfolder, delete subfolder from Folders", () => {
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+      Cypress.Cookies.preserveOnce(COOKIE_NAME)
       window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
       )
+      // Wait for 1s for page to become stable.
+      // This is because there's a modal on first paint that gets removed on second paint
+      cy.wait(1 * 1000)
     })
 
     it("Should be able to create a new sub-folder within a valid folder name with no pages", () => {
@@ -182,7 +190,7 @@ describe("Folders flow", () => {
         url: `/v2/sites/e2e-test-repo/collections/${DEFAULT_REPO_FOLDER_NAME}/subcollections/${PARSED_TEST_SUBFOLDER_WITH_PAGES_TITLE}`,
       }).as("renameSubfolder")
 
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
+      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
       cy.get("button[id^=settings-]").trigger("mousedown")
       cy.contains(`Subfolder settings`)
       cy.get("input#newDirectoryName")
@@ -205,7 +213,7 @@ describe("Folders flow", () => {
 
     // Delete
     it("Should be able to delete a sub-folder with a page", () => {
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
+      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
       cy.get("button[id^=delete-]").first().trigger("mousedown")
       cy.get("button[id=modal-delete]").click()
       cy.wait(E2E_DEFAULT_WAIT_TIME)
@@ -217,7 +225,7 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to delete a sub-folder without page", () => {
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
+      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
       cy.get("button[id^=delete-]").first().trigger("mousedown")
       cy.get("button[id=modal-delete]").click()
 
@@ -233,11 +241,14 @@ describe("Folders flow", () => {
 
   describe("Create page, delete page, edit page settings in folder", () => {
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+      Cypress.Cookies.preserveOnce(COOKIE_NAME)
       window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
       )
+      // Wait for 1s for page to become stable.
+      // This is because there's a modal on first paint that gets removed on second paint
+      cy.wait(1 * 1000)
     })
 
     it("Should be able to create a new page with valid title and permalink", () => {
@@ -308,8 +319,12 @@ describe("Folders flow", () => {
       )
 
       // User should be able edit page details
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("button[id^=settings-]").trigger("mousedown")
+      cy.get("button[id^=folderItem-dropdown-]")
+        .first()
+        .should("exist")
+        .click()
+        .should("exist")
+      cy.get("button[id^=settings-]").first().trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -338,8 +353,12 @@ describe("Folders flow", () => {
       }).should("exist")
 
       // User should be able edit page details
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("button[id^=settings-]").trigger("mousedown")
+      cy.get("button[id^=folderItem-dropdown-]")
+        .first()
+        .should("exist")
+        .click()
+        .should("exist")
+      cy.get("button[id^=settings-]").first().trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -364,9 +383,13 @@ describe("Folders flow", () => {
 
     it("Should be able to delete existing page in folder", () => {
       // User should be able to remove the created test page card
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("button[id^=delete-]").first().click()
-      cy.contains("button", "Delete").click()
+      cy.get("button[id^=folderItem-dropdown-]")
+        .first()
+        .should("exist")
+        .click()
+        .should("exist")
+      cy.get("button[data-cy^=delete]").trigger("mousedown")
+      cy.get("button[id^=modal-delete]").click()
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -380,7 +403,7 @@ describe("Folders flow", () => {
 
   describe("Create page, delete page, edit page settings in subfolder", () => {
     before(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+      Cypress.Cookies.preserveOnce(COOKIE_NAME)
       window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
@@ -404,11 +427,14 @@ describe("Folders flow", () => {
     })
 
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+      Cypress.Cookies.preserveOnce(COOKIE_NAME)
       window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_SUBFOLDER_NO_PAGES_TITLE}`
       )
+      // Wait for 1s for page to become stable.
+      // This is because there's a modal on first paint that gets removed on second paint
+      cy.wait(1 * 1000)
     })
 
     it("Should be able to create a new page with valid title and permalink", () => {
@@ -480,8 +506,8 @@ describe("Folders flow", () => {
       )
 
       // User should be able edit page details
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=settings-]").first().click()
+      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
+      cy.get("button[id^=settings-]").first().trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -510,8 +536,12 @@ describe("Folders flow", () => {
       }).should("exist")
 
       // User should be able edit page details
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=settings-]").first().click()
+      cy.get("button[id^=folderItem-dropdown-]")
+        .first()
+        .should("exist")
+        .click()
+        .should("exist")
+      cy.get("button[id^=settings-]").first().trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -536,9 +566,13 @@ describe("Folders flow", () => {
 
     it("Should be able to delete existing page in folder", () => {
       // User should be able to remove the created test page card
-      cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("button[id^=delete-]").first().click()
-      cy.contains("button", "Delete").click()
+      cy.get("button[id^=folderItem-dropdown-]")
+        .first()
+        .should("exist")
+        .click()
+        .should("exist")
+      cy.get("button[id^=delete-]").first().trigger("mousedown")
+      cy.get("button[id=modal-delete]").click()
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -129,7 +129,7 @@ describe("Folders flow", () => {
         .blur()
       cy.contains("Next").click()
 
-      cy.get("div[id^=folderCard-small]")
+      cy.get("button[id^=folderCard-small]")
         .contains(PRETTIFIED_DEFAULT_PAGE_TITLE)
         .click()
       cy.contains("Done").click()
@@ -183,7 +183,7 @@ describe("Folders flow", () => {
       }).as("renameSubfolder")
 
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=settings-]").first().click()
+      cy.get("button[id^=settings-]").trigger("mousedown")
       cy.contains(`Subfolder settings`)
       cy.get("input#newDirectoryName")
         .clear()
@@ -206,9 +206,10 @@ describe("Folders flow", () => {
     // Delete
     it("Should be able to delete a sub-folder with a page", () => {
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=delete-]").first().click()
-      cy.contains("button", "Delete").click()
+      cy.get("button[id^=delete-]").first().trigger("mousedown")
+      cy.get("button[id=modal-delete]").click()
       cy.wait(E2E_DEFAULT_WAIT_TIME)
+
       // Assert
       cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE).should(
         "not.exist"
@@ -217,8 +218,8 @@ describe("Folders flow", () => {
 
     it("Should be able to delete a sub-folder without page", () => {
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=delete-]").first().click()
-      cy.contains("button", "Delete").click()
+      cy.get("button[id^=delete-]").first().trigger("mousedown")
+      cy.get("button[id=modal-delete]").click()
 
       // Assert
       cy.contains(PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE).should("not.exist", {
@@ -308,7 +309,7 @@ describe("Folders flow", () => {
 
       // User should be able edit page details
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=settings-]").first().click()
+      cy.get("button[id^=settings-]").trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -338,7 +339,7 @@ describe("Folders flow", () => {
 
       // User should be able edit page details
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=settings-]").first().click()
+      cy.get("button[id^=settings-]").trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -364,7 +365,7 @@ describe("Folders flow", () => {
     it("Should be able to delete existing page in folder", () => {
       // User should be able to remove the created test page card
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=delete-]").first().click()
+      cy.get("button[id^=delete-]").first().click()
       cy.contains("button", "Delete").click()
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
@@ -536,7 +537,7 @@ describe("Folders flow", () => {
     it("Should be able to delete existing page in folder", () => {
       // User should be able to remove the created test page card
       cy.get(".bx-dots-vertical-rounded").parent().first().click()
-      cy.get("div[id^=delete-]").first().click()
+      cy.get("button[id^=delete-]").first().click()
       cy.contains("button", "Delete").click()
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -47,43 +47,121 @@ describe("Move flow", () => {
 
     it("Should be able to navigate from Workspace to subfolder back to Workspace via MoveModal buttons", () => {
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
-      cy.get(
-        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
+        .should("exist")
+        .click()
+
+      cy.get("button[id^=move-]").first().click()
       cy.contains(`Move Here`)
 
-      cy.contains(`Workspace > ${TITLE_WORKSPACE_TO_FOLDER}`).should("exist")
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("i[id^=moveModal-forwardButton-]").eq(1).click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_WORKSPACE_TO_FOLDER}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(1)
+        .click({ force: true })
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move subfolder
-      cy.get("i[id^=moveModal-forwardButton-]").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_WORKSPACE_TO_FOLDER}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_WORKSPACE_TO_FOLDER}`
-      ).should("exist")
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Workspace
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(`Workspace > ${TITLE_WORKSPACE_TO_FOLDER}`).should("exist")
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
     })
 
     it("Should be able to move page from Workspace to itself and show correct success message", () => {
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
-      cy.get(
-        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().click()
       cy.contains(`Move Here`)
 
       cy.contains("button", "Move Here").click()
@@ -94,22 +172,45 @@ describe("Move flow", () => {
 
     it("Should be able to move a page from Workspace to folder", () => {
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
-      cy.get(
-        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().click()
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(`Workspace > ${TITLE_WORKSPACE_TO_FOLDER}`)
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("i[id^=moveModal-forwardButton-]").eq(1).click({ force: true })
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(1)
+        .click({ force: true })
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_WORKSPACE_TO_FOLDER}`
-      )
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {
@@ -132,22 +233,58 @@ describe("Move flow", () => {
       cy.contains(TITLE_WORKSPACE_TO_SUBFOLDER).should("exist")
       cy.get(
         `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_SUBFOLDER}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().click()
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(`Workspace > ${TITLE_WORKSPACE_TO_SUBFOLDER}`)
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("i[id^=moveModal-forwardButton-]").eq(1).click({ force: true })
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(1)
+        .click({ force: true })
       // Navigate to Move subfolder
-      cy.get("i[id^=moveModal-forwardButton-]").click({ force: true })
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_WORKSPACE_TO_SUBFOLDER}`
-      )
+      cy.get("u")
+        .first()
+        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {
@@ -190,43 +327,131 @@ describe("Move flow", () => {
       cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_FOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("u")
+        .eq(1)
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Workspace
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(`Workspace > ${TEST_REPO_FOLDER_NAME}`).should("exist")
+      cy.get("u")
+        .first()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .eq(1)
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("i[id^=moveModal-forwardButton-]").eq(1).click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_FOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(1)
+        .click({ force: true })
+      cy.get("u")
+        .eq(1)
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move subfolder
-      cy.get("i[id^=moveModal-forwardButton-]").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_FOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_FOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
     })
 
     it("Should be able to move page from folder to itself and show correct success message", () => {
       cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       cy.contains("button", "Move Here").click()
@@ -239,19 +464,35 @@ describe("Move flow", () => {
       cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_FOLDER_TO_WORKSPACE}`
-      )
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.get("#moveModal-backButton").click({ force: true })
 
       // Assert
-      cy.contains(`Workspace > ${TITLE_FOLDER_TO_WORKSPACE}`)
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {
@@ -272,21 +513,44 @@ describe("Move flow", () => {
       cy.contains(TITLE_FOLDER_TO_SUBFOLDER).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_SUBFOLDER}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_FOLDER_TO_SUBFOLDER}`
-      )
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_SUBFOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
-      cy.get("i[id^=moveModal-forwardButton-]").click({ force: true })
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_FOLDER_TO_SUBFOLDER}`
-      )
+
+      cy.get("u")
+        .last()
+        .contains(TITLE_FOLDER_TO_SUBFOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {
@@ -329,43 +593,95 @@ describe("Move flow", () => {
       cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_WORKSPACE}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_SUBFOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_SUBFOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Workspace
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(`Workspace > ${TEST_REPO_FOLDER_NAME}`).should("exist")
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("i[id^=moveModal-forwardButton-]").eq(1).click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_SUBFOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(1)
+        .click({ force: true })
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Move subfolder
-      cy.get("i[id^=moveModal-forwardButton-]").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_SUBFOLDER_TO_WORKSPACE}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
     })
 
     it("Should be able to move page from subfolder to itself and show correct success message", () => {
       cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_WORKSPACE}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       cy.contains("button", "Move Here").click()
@@ -378,24 +694,52 @@ describe("Move flow", () => {
       cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${TITLE_SUBFOLDER_TO_WORKSPACE}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_SUBFOLDER_TO_WORKSPACE}`
-      )
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.get("#moveModal-backButton").click({ force: true })
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_SUBFOLDER_TO_WORKSPACE}`
-      )
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.get("#moveModal-backButton").click({ force: true })
       // Assert
-      cy.contains(`Workspace > ${TITLE_SUBFOLDER_TO_WORKSPACE}`)
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {
@@ -416,20 +760,42 @@ describe("Move flow", () => {
       cy.contains(TITLE_SUBFOLDER_TO_FOLDER).should("exist")
       cy.get(
         `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_FOLDER}"]`
-      ).click()
-      cy.get("div[id^=move-]").first().click()
+      )
+        .should("exist")
+        .click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TEST_REPO_SUBFOLDER_NAME} > ${TITLE_SUBFOLDER_TO_FOLDER}`
-      )
-
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_SUBFOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
       cy.get("#moveModal-backButton").click({ force: true })
+
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_FOLDER_NAME} > ${TITLE_SUBFOLDER_TO_FOLDER}`
-      )
+      cy.get("u")
+        .last()
+        .contains(TITLE_SUBFOLDER_TO_FOLDER)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_FOLDER_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {
@@ -462,32 +828,65 @@ describe("Move flow", () => {
 
     it("Should be able to navigate from Resource Category to Resource Room back to Resource Category via MoveModal buttons", () => {
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).click()
-      cy.get("div[id^=move-]").first().click()
+      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_RESOURCE_ROOM_NAME} > ${TEST_REPO_RESOURCE_CATEGORY_NAME} > ${TITLE_RESOURCE_PAGE}`
-      ).should("exist")
+      cy.get("u")
+        .last()
+        .contains(TITLE_RESOURCE_PAGE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Resource Room
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_RESOURCE_ROOM_NAME} > ${TITLE_RESOURCE_PAGE}`
-      ).should("exist")
-
+      cy.get("u")
+        .last()
+        .contains(TITLE_RESOURCE_PAGE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
       // Navigate to Resource Category
-      cy.get("i[id^=moveModal-forwardButton-]").eq(1).click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_RESOURCE_ROOM_NAME} > ${TEST_REPO_RESOURCE_CATEGORY_NAME} > ${TITLE_RESOURCE_PAGE}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(1)
+        .click({ force: true })
+      cy.get("u")
+        .last()
+        .contains(TITLE_RESOURCE_PAGE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
     })
 
     it("Should be able to move page from resource category to itself and show correct success message", () => {
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).click()
-      cy.get("div[id^=move-]").first().click()
+      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").click()
+      cy.get("button[id^=move-]").first().click()
       cy.contains(`Move Here`)
 
       cy.contains("button", "Move Here").click()
@@ -498,26 +897,59 @@ describe("Move flow", () => {
 
     it("Should be able to move page from resource category to another resource category", () => {
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).click()
-      cy.get("div[id^=move-]").first().click()
+      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").click()
+      cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
       // Assert
-      cy.contains(
-        `Workspace > ${TEST_REPO_RESOURCE_ROOM_NAME} > ${TEST_REPO_RESOURCE_CATEGORY_NAME} > ${TITLE_RESOURCE_PAGE}`
-      ).should("exist")
-
+      cy.get("u")
+        .last()
+        .contains(TITLE_RESOURCE_PAGE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
       // Navigate to Resource Room
       cy.get("#moveModal-backButton").click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_RESOURCE_ROOM_NAME} > ${TITLE_RESOURCE_PAGE}`
-      ).should("exist")
+      cy.get("u")
+        .last()
+        .contains(TITLE_RESOURCE_PAGE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       // Navigate to Resource Category
-      cy.get("i[id^=moveModal-forwardButton-]").eq(0).click({ force: true })
-      cy.contains(
-        `Workspace > ${TEST_REPO_RESOURCE_ROOM_NAME} > ${TEST_REPO_RESOURCE_CATEGORY_NAME_1} > ${TITLE_RESOURCE_PAGE}`
-      ).should("exist")
+      cy.get("button[id^=moveModal-forwardButton-]")
+        .eq(0)
+        .click({ force: true })
+      cy.get("u")
+        .last()
+        .contains(TITLE_RESOURCE_PAGE)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME_1)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
+        .prev()
+        .contains(">")
+        .prev()
+        .contains("Workspace")
 
       cy.contains("button", "Move Here").click()
       cy.contains("Successfully moved file", {

--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -179,13 +179,13 @@ describe("Settings page", () => {
   }
   it("Should change Primary and Secondary colors and have colors reflected on page previews", () => {
     // Enter RGB values for primary and secondary colors
-    cy.contains("p", "Primary").siblings("div").click()
+    cy.contains("p", "Primary").siblings("button").click()
     cy.contains(/^r/).siblings().clear().type(TEST_PRIMARY_COLOR[0].toString())
     cy.contains(/^g/).siblings().clear().type(TEST_PRIMARY_COLOR[1].toString())
     cy.contains(/^b/).siblings().clear().type(TEST_PRIMARY_COLOR[2].toString())
     cy.contains("button", "Select").click()
 
-    cy.contains("p", "Secondary").siblings("div").click()
+    cy.contains("p", "Secondary").siblings("button").click()
     cy.contains(/^r/)
       .siblings()
       .clear()
@@ -211,13 +211,13 @@ describe("Settings page", () => {
       .siblings("input")
       .should("have.value", hexPrimary)
     cy.contains("p", "Primary")
-      .siblings("div")
+      .siblings("button")
       .should("have.attr", "style", `background: ${rgbPrimary};`)
     cy.contains("p", "Secondary")
       .siblings("input")
       .should("have.value", hexSecondary)
     cy.contains("p", "Secondary")
-      .siblings("div")
+      .siblings("button")
       .should("have.attr", "style", `background: ${rgbSecondary};`)
 
     // Check if page previews reflect color change

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -280,7 +280,7 @@ describe("Workspace Pages flow", () => {
         .clear()
         .type(TEST_FOLDER_WITH_PAGES_TITLE)
       cy.contains("Next").click()
-      cy.get("div[id^=folderCard-small]").contains(TEST_PAGE_TITLE).click()
+      cy.get("button[id^=folderCard-small]").contains(TEST_PAGE_TITLE).click()
       cy.contains("Done").click()
 
       // Assert
@@ -325,7 +325,7 @@ describe("Workspace Pages flow", () => {
       })
         .should("exist")
         .within(() => cy.get("[id^=settingsIcon]").click())
-      cy.get("div[id^=settings-]").first().click()
+      cy.contains("Edit details").click()
       cy.contains("Folder settings")
       cy.get("input#newDirectoryName")
         .clear()
@@ -356,7 +356,7 @@ describe("Workspace Pages flow", () => {
       })
         .should("exist")
         .within(() => cy.get("[id^=settingsIcon]").click())
-      cy.get("div[id^=delete-]").first().click()
+      cy.get("button[id^=delete-]").first().click()
       cy.contains("button", "Delete").click()
 
       cy.contains(PRETTIFIED_FOLDER_NO_PAGES_TITLE, {
@@ -366,7 +366,7 @@ describe("Workspace Pages flow", () => {
       cy.contains(PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE).within(() =>
         cy.get("[id^=settingsIcon]").click()
       )
-      cy.get("div[id^=delete-]").first().click()
+      cy.get("button[id^=delete-]").first().click()
       cy.contains("button", "Delete").click()
 
       cy.contains(PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE, {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test": "craco test",
     "test:ci": "node scripts/run-e2e.js run",
     "test-e2e": "source .env && node scripts/run-e2e.js run",
+    "reset-e2e": "source .env && node scripts/reset-e2e.js",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",
     "lint-fix": "eslint --ext .js --ext .jsx --ignore-path .gitignore . --fix",
     "format": "npx prettier --check .",

--- a/scripts/reset-e2e.js
+++ b/scripts/reset-e2e.js
@@ -1,0 +1,3 @@
+const { resetE2eTestRepo } = require("./build")
+
+resetE2eTestRepo()


### PR DESCRIPTION
## Problem
Previously, in #819, there was work done to rewrite components in semantic html and this resulted in the html types of elements being changed from `div` to `button` as well as a minor rewrite of some components (most notably, `BreadCrumb` to make them more declarative). 

As a result of this, our e2e tests broke because they were written using selectors for those specific html tags/certain specific text.

This PR fixes the failing e2e tests
## Solution
1. rewrite e2e-tests to use selectors for the new html tags
2. for tests checking the `breadcrumb` component, the cypress tests were updated to check for the _siblings_ rather than the raw text content (as previously it was a string like `Workspace > Something > Some other thing`.) 
3. For certain tests, we require an assertion to guard against re-renders (caused by perhaps `useState`), which remove the element from the dom. To do this, an existential check has been added after the selector and prior to the event trigger. 
For more details, refer [here](https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-element-you-are-chaining-off-of-has-become-detached-or-removed-from-the-dom)
4. similar to the above, the identity modal pops up on first paint, which then gets removed later. This causes a UI re-render, which might take place between cypress commands. This leads to flakiness in our tests, whicfh is partially resolved by waiting for 1s before tests start (so that the UI stabilizes) 
