### PR TITLE
fix(preview): revert leftnav changes

### DIFF
--- a/src/templates/pageComponents/LeftNav.jsx
+++ b/src/templates/pageComponents/LeftNav.jsx
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types"
 import { useEffect, useState } from "react"
 
-import { generateLeftNav } from "utils/leftnavGeneration"
+import { generateLeftNav } from "templates/utils/leftnavGeneration"
 import "styles/isomer-template.scss"
 
 const LeftNav = ({ leftNavPages, fileName }) => {

--- a/src/templates/pageComponentsV2/LeftNav.jsx
+++ b/src/templates/pageComponentsV2/LeftNav.jsx
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types"
 import { useEffect, useState } from "react"
 
-import { generateLeftNav } from "utils/leftnavGeneration"
+import { generateLeftNav } from "templates/utils/leftnavGeneration"
 import "styles/isomer-template.scss"
 
 export const LeftNav = ({ dirData, fileName }) => {

--- a/src/templates/utils/leftnavGeneration.jsx
+++ b/src/templates/utils/leftnavGeneration.jsx
@@ -1,6 +1,8 @@
 // NOTE: jsx-ally is disabled for this file as the output of this
 // should match jekyll output as closely as possible.
 // As jekyll outputs an <a /> tag like so, this behaviour is preserved here.
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
 import _ from "lodash"
@@ -152,34 +154,33 @@ const generateThirdNavHeader = (
   fileName,
   elementFileName
 ) => (
-  <button type="button" onClick={accordionHandler}>
-    <li
-      className="third-level-nav-header"
-      key={`${currentThirdNavTitle}-header`}
+  <li
+    className="third-level-nav-header"
+    key={`${currentThirdNavTitle}-header`}
+    onClick={accordionHandler}
+  >
+    <a
+      className={`third-level-nav-header ${calculateThirdNavHeaderState(
+        currentFileThirdNavTitle,
+        currentThirdNavTitle,
+        elementThirdNavTitle,
+        fileName,
+        elementFileName
+      )}`}
     >
-      <span
-        className={`third-level-nav-header ${calculateThirdNavHeaderState(
+      {deslugify(currentThirdNavTitle)}
+      <i
+        className={`sgds-icon is-pulled-right is-size-4 ${calculateThirdNavHeaderChevronState(
           currentFileThirdNavTitle,
           currentThirdNavTitle,
           elementThirdNavTitle,
           fileName,
           elementFileName
         )}`}
-      >
-        {deslugify(currentThirdNavTitle)}
-        <i
-          className={`sgds-icon is-pulled-right is-size-4 ${calculateThirdNavHeaderChevronState(
-            currentFileThirdNavTitle,
-            currentThirdNavTitle,
-            elementThirdNavTitle,
-            fileName,
-            elementFileName
-          )}`}
-          aria-hidden="true"
-        />
-      </span>
-    </li>
-  </button>
+        aria-hidden="true"
+      />
+    </a>
+  </li>
 )
 
 export const generateLeftNav = (dirData, fileName) => {


### PR DESCRIPTION
## Problem
Previously in #819, this file was refactored to remove eslint errors. however, templates are a special portion of our codebase and should adhere **as closely as possible** to jekyll output.

This change resulted in some stylistic changes, which has been fixed since.

## Solution
1. revert changes to `leftnavGeneration`
2. shift the file to `template/utils` so future devs won't accidentally alter it
3. update call sites

## Pictures 

### Prod 
![image](https://user-images.githubusercontent.com/44049504/164158339-dc4c482a-5c6d-4054-ba0c-b406daa49b04.png)

### Before fix
![image](https://user-images.githubusercontent.com/44049504/164158380-9c416b5d-8af1-4d51-beee-21fb99424f77.png)

### After fix 
![image](https://user-images.githubusercontent.com/44049504/164158399-c36d101b-643b-4db4-8def-125be235bf3d.png)
