### PR TITLE
Fix/resource category capitalisation

### DIFF
--- a/src/components/DirectoryCreationModal/DirectoryCreationModal.jsx
+++ b/src/components/DirectoryCreationModal/DirectoryCreationModal.jsx
@@ -30,7 +30,12 @@ export const DirectoryCreationModal = ({
   onProceed,
   showSelectPages,
 }) => {
-  const { siteName, collectionName, mediaDirectoryName } = params
+  const {
+    siteName,
+    collectionName,
+    resourceRoomName,
+    mediaDirectoryName,
+  } = params
 
   const [isSelectingPages, setIsSelectingPages] = useState(false)
 
@@ -40,7 +45,11 @@ export const DirectoryCreationModal = ({
     mode: "onBlur",
     resolver: yupResolver(DirectorySettingsSchema(existingTitlesArray)),
     context: {
-      type: getDirectoryCreationType(mediaDirectoryName, collectionName),
+      type: getDirectoryCreationType(
+        mediaDirectoryName,
+        resourceRoomName,
+        collectionName
+      ),
     },
   })
 

--- a/src/components/DirectorySettingsModal/DirectorySettingsModal.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsModal.jsx
@@ -51,7 +51,7 @@ export const DirectorySettingsModal = ({
   onProceed,
   onClose,
 }) => {
-  const { subCollectionName, mediaDirectoryName } = params
+  const { subCollectionName, resourceRoomName, mediaDirectoryName } = params
   const existingDirectoryName = mediaDirectoryName
     ? getMediaDirectoryName(mediaDirectoryName, { start: -1, splitOn: "/" })
     : params[getLastItemType(params)]
@@ -73,7 +73,11 @@ export const DirectorySettingsModal = ({
         newDirectoryName: deslugifyDirectory(existingDirectoryName),
       },
       context: {
-        type: getDirectorySettingsType(mediaDirectoryName, subCollectionName),
+        type: getDirectorySettingsType(
+          mediaDirectoryName,
+          resourceRoomName,
+          subCollectionName
+        ),
       },
     })
 

--- a/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
@@ -27,7 +27,7 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
         existingTitlesArray,
         "Title is already in use. Please choose a different title."
       )
-      // We only have three possible types (passed from context)
+      // We only have four possible types (passed from context)
       .when("$type", (type, schema) => {
         if (type === "mediaDirectoryName") {
           return schema
@@ -38,7 +38,7 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
               (value) => !mediaSpecialCharactersRegexTest.test(value)
             )
         }
-        if (type === "subCollectionName") {
+        if (type === "subCollectionName" || type === "resourceRoomName") {
           return schema
             .transform((value) => deslugifyDirectory(value))
             .test(

--- a/src/hooks/useSiteUrlHook.jsx
+++ b/src/hooks/useSiteUrlHook.jsx
@@ -31,7 +31,7 @@ const useSiteUrlHook = () => {
       let url
       if (type === "staging") {
         const resp = await axios.get(
-          `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/stagingUrl`
+          `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/stagingUrl`
         )
         url = resp.data.stagingUrl
       }

--- a/src/types/directory.ts
+++ b/src/types/directory.ts
@@ -2,3 +2,4 @@ export type DirectoryType =
   | "mediaDirectoryName"
   | "subCollectionName"
   | "collectionName"
+  | "resourceRoomName"

--- a/src/utils/directoryUtils.ts
+++ b/src/utils/directoryUtils.ts
@@ -2,12 +2,17 @@ import { DirectoryType } from "types/directory"
 
 const getDirectoryType = (
   mediaDirectoryName: string,
+  resourceRoomName: string,
   collectionName: string,
   subcollectionName: string,
   isCreation = true
 ): DirectoryType => {
   if (mediaDirectoryName) {
     return "mediaDirectoryName"
+  }
+
+  if (resourceRoomName) {
+    return "resourceRoomName"
   }
 
   // NOTE: Subcollections are created from the collections screen,
@@ -31,9 +36,15 @@ const getDirectoryType = (
  */
 export const getDirectoryCreationType = (
   mediaDirectoryName: string,
+  resourceRoomName: string,
   collectionName: string
 ): DirectoryType => {
-  return getDirectoryType(mediaDirectoryName, collectionName, "")
+  return getDirectoryType(
+    mediaDirectoryName,
+    resourceRoomName,
+    collectionName,
+    ""
+  )
 }
 
 /**
@@ -45,7 +56,14 @@ export const getDirectoryCreationType = (
  */
 export const getDirectorySettingsType = (
   mediaDirectoryName: string,
+  resourceRoomName: string,
   subcollectionName: string
 ): DirectoryType => {
-  return getDirectoryType(mediaDirectoryName, "", subcollectionName, false)
+  return getDirectoryType(
+    mediaDirectoryName,
+    resourceRoomName,
+    "",
+    subcollectionName,
+    false
+  )
 }


### PR DESCRIPTION
## Problem

This PR fixes an issue with our resource category creation - we previously handled resource category creation the same way that we did for collections, which was to slugify the provided name. This resulted in the breadcrumbs of resource categories showing up in their slugified form, as seen in #856. This PR introduces an additional check for resourceRoomName - these directory items should be handled the same way as subcollections in the frontend and only slugified in the backend so that the original desired name can be preserved in the `index.html` file created.

This PR also fixes a minor issue where we were not using the updated v2 endpoint to retrieve the staging url of a site.

Closes #856 
