### PR TITLE
fix(e2e): release 0.7.0

### DIFF
--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -219,8 +219,7 @@ describe("Resource category page", () => {
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_RENAMED)
     cy.get('input[id="permalink"]').clear().type(TEST_PAGE_PERMALINK_CHANGED)
     cy.get('input[id="date"]').clear().type(TEST_PAGE_DATE_CHANGED)
-    cy.contains("Save").click()
-    cy.wait(E2E_DEFAULT_WAIT_TIME)
+    cy.contains("Save").click().should("not.exist")
 
     // Asserts
 

--- a/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
@@ -6,6 +6,7 @@ import {
   slugifyLowerFalseRegexTest,
   DIRECTORY_SETTINGS_TITLE_MIN_LENGTH,
   DIRECTORY_SETTINGS_TITLE_MAX_LENGTH,
+  resourceCategoryRegexTest,
 } from "utils/validators"
 
 import { deslugifyDirectory } from "utils"
@@ -38,7 +39,7 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
               (value) => !mediaSpecialCharactersRegexTest.test(value)
             )
         }
-        if (type === "subCollectionName" || type === "resourceRoomName") {
+        if (type === "subCollectionName") {
           return schema
             .transform((value) => deslugifyDirectory(value))
             .test(
@@ -46,6 +47,13 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
               'Title cannot contain any of the following special characters: ~%^*_+-./`;{}[]"<>',
               (value) => !specialCharactersRegexTest.test(value)
             )
+        }
+        if (type === "resourceRoomName") {
+          return schema.test(
+            "Special characters found",
+            "Title cannot contain any symbols",
+            (value) => resourceCategoryRegexTest.test(value)
+          )
         }
         if (type === "collectionName") {
           return schema

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,8 +1,9 @@
 import { extendTheme } from "@chakra-ui/react"
+import { theme as designSystemTheme } from "@opengovsg/design-system-react"
 
 import { colours } from "./foundations/colours"
 
-const theme = extendTheme({
+const theme = extendTheme(designSystemTheme, {
   styles: {
     global: {
       body: {


### PR DESCRIPTION
## Problem
This PR fixes a flaky e2e test in cypress by changing from a fixed wait time to using an assertion to ensure that the element is no longer in the Dom.

This PR also fixes the check for resource category so that special symbols are no longer allowed.

Also fixes our ui theming from design system
## Solution
1. Changed validation for resources to use the same one as originally
2. Changed wait time to assertion
3. Extend them from ogp design system (I mistakenly thought calling`extendTheme` was sufficient but we need to also add the base design system theme
