### PR TITLE
Fix: prevent operating hours from showing up if blank

### DIFF
--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -14,8 +14,6 @@ import PropTypes from "prop-types"
 import { createRef, useEffect, useState } from "react"
 import { DragDropContext } from "react-beautiful-dnd"
 
-import "styles/isomer-template.scss"
-
 // Import hooks
 import useRedirectHook from "hooks/useRedirectHook"
 import useSiteColorsHook from "hooks/useSiteColorsHook"
@@ -701,7 +699,11 @@ const EditContactUs = ({ match }) => {
               newOperatingHours.push(_.cloneDeep(operatingHour))
             }
           })
-          newLocation.operating_hours = newOperatingHours
+          if (newOperatingHours.length > 0) {
+            newLocation.operating_hours = newOperatingHours
+          } else {
+            delete newLocation.operating_hours
+          }
           newLocations.push(newLocation)
         }
       })


### PR DESCRIPTION
This PR fixes a minor bug involving operating hours - we were previously leaving an empty array if there were no operating hours, but this caused an empty operating hours header to show up on the actual site. This PR removes the operating_hours field if no hours are specified.