### PR TITLE
fix(marked): fixed import

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -5,7 +5,7 @@ import EditPageFooter from "components/pages/EditPageFooter"
 import MarkdownEditor from "components/pages/MarkdownEditor"
 import PagePreview from "components/pages/PagePreview"
 import DOMPurify from "dompurify"
-import marked from "marked"
+import { marked } from "marked"
 import PropTypes from "prop-types"
 import { useEffect, useRef, useState } from "react"
 


### PR DESCRIPTION
## Problem
#838 changed `marked` to use a new major version and updated teh API but missed out on the import. this resulted in a bug where we are unable to use the edit page as it will crash.

## Solution
fixes the import (see [here](https://marked.js.org/) under the nodeJS section)
