### PR TITLE
Fix: save sanitised file data

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -155,9 +155,11 @@ const EditPage = ({ match }) => {
                 setIsXSSViolation(false)
                 setShowXSSWarning(false)
                 updatePageHandler({
-                  frontMatter: pageData.content.frontMatter,
-                  sha: currSha,
-                  pageBody: sanitizedEditorValue,
+                  pageData: {
+                    frontMatter: pageData.content.frontMatter,
+                    sha: currSha,
+                    pageBody: sanitizedEditorValue,
+                  },
                 })
               }}
               onCancel={() => {
@@ -175,9 +177,11 @@ const EditPage = ({ match }) => {
             onProceed={() => {
               setShowOverwriteWarning(false)
               updatePageHandler({
-                frontMatter: pageData.content.frontMatter,
-                sha: pageData.sha,
-                pageBody: editorValue,
+                pageData: {
+                  frontMatter: pageData.content.frontMatter,
+                  sha: pageData.sha,
+                  pageBody: editorValue,
+                },
               })
             }}
             onCancel={() => setShowOverwriteWarning(false)}


### PR DESCRIPTION
This PR fixes an issue where users were unable to save sanitised files and file which were overwritten by a later commit. The reason for this was due to the format of the data provided, which has been fixed in this PR.