### PR TITLE
Test/add helper methods

### DIFF
--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -1,6 +1,5 @@
 import { titleToPageFileName, slugifyCategory } from "../../src/utils"
 import { E2E_EXTENDED_TIMEOUT } from "../fixtures/constants"
-import waitForDom from "../support/waitForDom"
 
 describe("Move flow", () => {
   const CMS_BASEURL = Cypress.env("BASEURL")
@@ -44,18 +43,16 @@ describe("Move flow", () => {
       cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
       window.localStorage.setItem("userId", "test")
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
-      waitForDom()
     })
 
     it("Should be able to navigate from Workspace to subfolder back to Workspace via MoveModal buttons", () => {
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
       cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
 
-      cy.get("button[id^=move-]").first().click()
-      waitForDom()
+      cy.get("button[id^=move-]").first().clickAndWait()
+
       cy.contains(`Move Here`)
 
       cy.get("u")
@@ -76,8 +73,8 @@ describe("Move flow", () => {
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
+
       cy.get("u")
         .first()
         .contains(TITLE_WORKSPACE_TO_FOLDER)
@@ -98,8 +95,10 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
+        force: true,
+      })
+
       cy.get("u")
         .first()
         .contains(TITLE_WORKSPACE_TO_FOLDER)
@@ -124,8 +123,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .first()
         .contains(TITLE_WORKSPACE_TO_FOLDER)
@@ -146,8 +145,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Workspace
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .first()
         .contains(TITLE_WORKSPACE_TO_FOLDER)
@@ -168,14 +167,14 @@ describe("Move flow", () => {
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
       cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
         .should("exist")
-        .click()
-      waitForDom()
-      cy.get("button[id^=move-]").first().click()
-      waitForDom()
+        .clickAndWait()
+
+      cy.get("button[id^=move-]").first().clickAndWait()
+
       cy.contains(`Move Here`)
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -185,10 +184,10 @@ describe("Move flow", () => {
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
       cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
         .should("exist")
-        .click()
-      waitForDom()
-      cy.get("button[id^=move-]").first().click()
-      waitForDom()
+        .clickAndWait()
+
+      cy.get("button[id^=move-]").first().clickAndWait()
+
       cy.contains(`Move Here`)
 
       // Assert
@@ -203,8 +202,7 @@ describe("Move flow", () => {
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
 
       // Assert
       cy.get("u")
@@ -226,8 +224,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -241,7 +239,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}`
       )
-      waitForDom()
+
       cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
     })
 
@@ -251,10 +249,10 @@ describe("Move flow", () => {
         `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_SUBFOLDER}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
-      cy.get("button[id^=move-]").first().click()
-      waitForDom()
+        .clickAndWait()
+
+      cy.get("button[id^=move-]").first().clickAndWait()
+
       cy.contains(`Move Here`)
 
       // Assert
@@ -276,11 +274,12 @@ describe("Move flow", () => {
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
+
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
+        force: true,
+      })
 
       // Assert
       cy.get("u")
@@ -306,8 +305,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -321,7 +320,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_REPO_SUBFOLDER_NAME}`
       )
-      waitForDom()
+
       cy.contains(TITLE_WORKSPACE_TO_SUBFOLDER).should("exist")
     })
   })
@@ -343,7 +342,6 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}`
       )
-      waitForDom()
     })
 
     it("Should be able to navigate from folder to Workspace to subfolder back to folder via MoveModal buttons", () => {
@@ -352,8 +350,8 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -381,8 +379,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Workspace
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .first()
         .contains(TEST_REPO_FOLDER_NAME)
@@ -412,8 +410,8 @@ describe("Move flow", () => {
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
+
       cy.get("u")
         .eq(1)
         .contains(TITLE_FOLDER_TO_WORKSPACE)
@@ -438,8 +436,10 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
+        force: true,
+      })
+
       cy.get("u")
         .last()
         .contains(TITLE_FOLDER_TO_WORKSPACE)
@@ -457,8 +457,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_FOLDER_TO_WORKSPACE)
@@ -478,13 +478,13 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -496,8 +496,8 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -514,8 +514,7 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
 
       // Assert
       cy.get("u")
@@ -526,8 +525,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -539,7 +538,7 @@ describe("Move flow", () => {
       })
       // 2. File is in Workspace
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
-      waitForDom()
+
       cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
     })
 
@@ -549,8 +548,8 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_SUBFOLDER}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -567,8 +566,9 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
+        force: true,
+      })
 
       // Assert
 
@@ -588,8 +588,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -603,7 +603,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_REPO_SUBFOLDER_NAME}`
       )
-      waitForDom()
+
       cy.contains(TITLE_FOLDER_TO_SUBFOLDER).should("exist")
     })
   })
@@ -625,7 +625,6 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_REPO_SUBFOLDER_NAME}`
       )
-      waitForDom()
     })
 
     it("Should be able to navigate from subfolder to folder to Workspace back to subfolder via MoveModal buttons", () => {
@@ -634,8 +633,8 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_WORKSPACE}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -656,8 +655,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Move folder
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
@@ -671,8 +670,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Workspace
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
@@ -684,8 +683,8 @@ describe("Move flow", () => {
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
@@ -699,8 +698,10 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
+        force: true,
+      })
+
       cy.get("u")
         .last()
         .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
@@ -724,13 +725,13 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_WORKSPACE}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -742,8 +743,8 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${TITLE_SUBFOLDER_TO_WORKSPACE}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -764,8 +765,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       // Assert
       cy.get("u")
         .last()
@@ -779,8 +780,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       // Assert
       cy.get("u")
         .last()
@@ -790,8 +791,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -803,7 +804,7 @@ describe("Move flow", () => {
       })
       // 2. File is in Workspace
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
-      waitForDom()
+
       cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
     })
 
@@ -813,8 +814,8 @@ describe("Move flow", () => {
         `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_FOLDER}"]`
       )
         .should("exist")
-        .click()
-      waitForDom()
+        .clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -834,8 +835,7 @@ describe("Move flow", () => {
         .contains(">")
         .prev()
         .contains("Workspace")
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
 
       // Assert
       cy.get("u")
@@ -850,8 +850,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -865,7 +865,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}`
       )
-      waitForDom()
+
       cy.contains(TITLE_SUBFOLDER_TO_FOLDER).should("exist")
     })
   })
@@ -879,13 +879,12 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${PARSED_TEST_REPO_RESOURCE_ROOM_NAME}/resourceCategory/${PARSED_TEST_REPO_RESOURCE_CATEGORY_NAME}`
       )
-      waitForDom()
     })
 
     it("Should be able to navigate from Resource Category to Resource Room back to Resource Category via MoveModal buttons", () => {
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").click()
-      waitForDom()
+      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -907,8 +906,8 @@ describe("Move flow", () => {
         .contains("Workspace")
 
       // Navigate to Resource Room
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_RESOURCE_PAGE)
@@ -923,8 +922,8 @@ describe("Move flow", () => {
       // Navigate to Resource Category
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_RESOURCE_PAGE)
@@ -944,14 +943,14 @@ describe("Move flow", () => {
 
     it("Should be able to move page from resource category to itself and show correct success message", () => {
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").click()
-      waitForDom()
-      cy.get("button[id^=move-]").first().click()
-      waitForDom()
+      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").clickAndWait()
+
+      cy.get("button[id^=move-]").first().clickAndWait()
+
       cy.contains(`Move Here`)
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -959,8 +958,8 @@ describe("Move flow", () => {
 
     it("Should be able to move page from resource category to another resource category", () => {
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").click()
-      waitForDom()
+      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").clickAndWait()
+
       cy.get("button[id^=move-]").first().trigger("mousedown")
       cy.contains(`Move Here`)
 
@@ -981,8 +980,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
       // Navigate to Resource Room
-      cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_RESOURCE_PAGE)
@@ -998,8 +997,8 @@ describe("Move flow", () => {
       // Navigate to Resource Category
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(0)
-        .click({ force: true })
-      waitForDom()
+        .clickAndWait({ force: true })
+
       cy.get("u")
         .last()
         .contains(TITLE_RESOURCE_PAGE)
@@ -1016,8 +1015,8 @@ describe("Move flow", () => {
         .prev()
         .contains("Workspace")
 
-      cy.contains("button", "Move Here").click()
-      waitForDom()
+      cy.contains("button", "Move Here").clickAndWait()
+
       cy.contains("Successfully moved file", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -1031,7 +1030,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${PARSED_TEST_REPO_RESOURCE_ROOM_NAME}/resourceCategory/${PARSED_TEST_REPO_RESOURCE_CATEGORY_NAME_1}`
       )
-      waitForDom()
+
       cy.contains(TITLE_RESOURCE_PAGE).should("exist")
     })
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,32 @@
+import waitForDom from "./waitForDom"
+
+Cypress.Commands.overwrite("visit", (originalFn, url, options) => {
+  // originalFn is the existing `visit` command that you need to call
+  // and it will receive whatever you pass in here.
+  //
+  // make sure to add a return here!
+  originalFn(url, options)
+  cy.wait(2 * 1000)
+  return cy.get(`[data-testid="verify-user-modal"]`).should("not.exist")
+})
+
+Cypress.Commands.add(
+  "clickAndWait",
+  {
+    prevSubject: true,
+  },
+  (subject, options) => {
+    // the previous subject is automatically received
+    // and the commands arguments are shifted
+
+    // allow us to change the console method used
+    cy.wrap(subject).click(options)
+    waitForDom()
+
+    // whatever we return becomes the new subject
+    //
+    // we don't want to change the subject so
+    // we return whatever was passed in
+    return cy.wrap(subject)
+  }
+)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,7 +7,7 @@ Cypress.Commands.overwrite("visit", (originalFn, url, options) => {
   // make sure to add a return here!
   originalFn(url, options)
   cy.wait(2 * 1000)
-  return cy.get(`[data-testid="verify-user-modal"]`).should("not.exist")
+  return cy.get(`[data-cy="verify-user-modal"]`).should("not.exist")
 })
 
 Cypress.Commands.add(

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,15 +1,5 @@
 import waitForDom from "./waitForDom"
 
-Cypress.Commands.overwrite("visit", (originalFn, url, options) => {
-  // originalFn is the existing `visit` command that you need to call
-  // and it will receive whatever you pass in here.
-  //
-  // make sure to add a return here!
-  originalFn(url, options)
-  cy.wait(2 * 1000)
-  return cy.get(`[data-cy="verify-user-modal"]`).should("not.exist")
-})
-
 Cypress.Commands.add(
   "clickAndWait",
   {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,1 +1,2 @@
+import "./commands"
 import "./medias"

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -213,7 +213,7 @@ const VerifyUserDetailsModal = () => {
   }
 
   return userId && (!loggedInEmail || !loggedInContactNumber) ? (
-    <div data-cy="verify-user-modal" className={elementStyles.overlay}>
+    <div className={elementStyles.overlay}>
       <div className={elementStyles["modal-verify-user-details"]}>
         <div className={elementStyles.modalHeader}>
           <h1>Verify your {isEmailStep() ? "email" : "mobile number"}</h1>

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -213,7 +213,7 @@ const VerifyUserDetailsModal = () => {
   }
 
   return userId && (!loggedInEmail || !loggedInContactNumber) ? (
-    <div data-testid="verify-user-modal" className={elementStyles.overlay}>
+    <div data-cy="verify-user-modal" className={elementStyles.overlay}>
       <div className={elementStyles["modal-verify-user-details"]}>
         <div className={elementStyles.modalHeader}>
           <h1>Verify your {isEmailStep() ? "email" : "mobile number"}</h1>

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -213,7 +213,7 @@ const VerifyUserDetailsModal = () => {
   }
 
   return userId && (!loggedInEmail || !loggedInContactNumber) ? (
-    <div className={elementStyles.overlay}>
+    <div data-testid="verify-user-modal" className={elementStyles.overlay}>
       <div className={elementStyles["modal-verify-user-details"]}>
         <div className={elementStyles.modalHeader}>
           <h1>Verify your {isEmailStep() ? "email" : "mobile number"}</h1>


### PR DESCRIPTION
This PR introduces helper methods for our cypress tests, by adding a new `clickAndWait` command which makes use of `waitForDom`. We also override the existing visit method to ensure that the verify user modal has disappeared before any actions are taken. Only the existing move tests, which already contain waitForDom, have been replaced with the new `clickAndWait` command, as this action should only be taken if we need to wait for DOM changes to take effect.