### PR TITLE
ref(design-system): fix e2e tests 

### DIFF
--- a/cypress/integration/editPage.spec.js
+++ b/cypress/integration/editPage.spec.js
@@ -44,13 +44,22 @@ describe("Edit unlinked page", () => {
   const LINK_TITLE = "link"
   const LINK_URL = "https://www.google.com"
 
+  const E2E_USER = {
+    userId: "test",
+    email: "test@open.gov.sg",
+    contactNumber: "99999999",
+  }
+  const LOCAL_STORAGE_USERID_KEY = "userId"
+  const LOCAL_STORAGE_USER_KEY = "user"
+
   before(() => {
     cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-    window.localStorage.setItem("userId", "test")
+    window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, E2E_USER)
+    window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
 
     // Set colour
     cy.visit(`/sites/${TEST_REPO_NAME}/settings`)
-    cy.contains("p", "Primary").siblings("button").click()
+    cy.get("button[aria-label='Select colour']").first().click()
     cy.contains(/^r/)
       .siblings()
       .clear()
@@ -69,7 +78,7 @@ describe("Edit unlinked page", () => {
 
     // Set up test resource categories
     cy.visit(`/sites/${TEST_REPO_NAME}/workspace`)
-    cy.contains("Add a new page").click()
+    cy.contains("button", "Create page").click()
     cy.get("#title").clear().type(TEST_UNLINKED_PAGE_TITLE)
     cy.contains("Save").click()
     cy.wait(E2E_CHANGE_WAIT_TIME)
@@ -229,7 +238,7 @@ describe("Edit collection page", () => {
 
     // Set up test collection
     cy.visit(`/sites/${TEST_REPO_NAME}/workspace`)
-    cy.contains("Create new folder").should("exist").click()
+    cy.contains("Create folder").should("exist").click()
     cy.get("input#newDirectoryName").clear().type(TEST_FOLDER_TITLE)
     cy.contains("Next").click()
     cy.contains("Skip").click()
@@ -237,7 +246,7 @@ describe("Edit collection page", () => {
 
     // Set up test collection page
     cy.visit(`/sites/${TEST_REPO_NAME}/folders/${TEST_FOLDER_TITLE_SLUGIFIED}`)
-    cy.contains("Create new page").should("exist").click()
+    cy.contains("Create page").should("exist").click()
     cy.get("#title").clear().type(TEST_PAGE_TITLE)
     cy.contains("Save").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
@@ -353,7 +362,7 @@ describe("Edit resource page", () => {
 
     // Set colour
     cy.visit(`/sites/${TEST_REPO_NAME}/settings`)
-    cy.contains("p", "Secondary").siblings("button").click()
+    cy.get("button[aria-label='Select colour']").eq(1).click()
     cy.contains(/^r/)
       .siblings()
       .clear()
@@ -373,8 +382,8 @@ describe("Edit resource page", () => {
     // Set up test resource category
     cy.visit(`/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM}`)
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Create new category").click()
-    cy.get("input").clear().type(TEST_CATEGORY)
+    cy.contains("Create category").click()
+    cy.get('input[placeholder="Title"]').type(TEST_CATEGORY)
     cy.contains("Next").click()
     cy.wait(E2E_CHANGE_WAIT_TIME)
 
@@ -383,7 +392,7 @@ describe("Edit resource page", () => {
       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM}/resourceCategory/${TEST_CATEGORY_SLUGIFIED}`
     )
 
-    cy.contains("Add a new page").click()
+    cy.contains("Create page").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE)

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -9,7 +9,6 @@ describe("Files", () => {
   const COOKIE_NAME = Cypress.env("COOKIE_NAME")
   const COOKIE_VALUE = Cypress.env("COOKIE_VALUE")
   const TEST_REPO_NAME = Cypress.env("TEST_REPO_NAME")
-  const CUSTOM_TIMEOUT = Cypress.env("CUSTOM_TIMEOUT")
 
   const FILE_TITLE = "singapore.pdf"
   const OTHER_FILE_TITLE = "america.pdf"
@@ -49,10 +48,10 @@ describe("Files", () => {
       cy.uploadMedia(FILE_TITLE, TEST_FILE_PATH)
       // ASSERTS
       cy.wait("@createFile") // should intercept POST request
-      cy.contains(FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist") // file should be contained in Files
+      cy.contains(FILE_TITLE).should("exist") // file should be contained in Files
     })
 
-    it("Should be able to edit an file", () => {
+    it("Should be able to edit a file", () => {
       // Set intercept to listen for POST request on server
       cy.intercept({
         method: "POST",
@@ -62,7 +61,7 @@ describe("Files", () => {
       cy.renameMedia(FILE_TITLE, OTHER_FILE_TITLE)
       // ASSERTS
       cy.wait("@renameFile")
-      cy.contains(OTHER_FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist") // file should be contained in Files
+      cy.contains(OTHER_FILE_TITLE).should("exist") // file should be contained in Files
     })
 
     it("Should not be able to create file with invalid title", () => {
@@ -114,11 +113,11 @@ describe("Files", () => {
     })
 
     it("Should be able to delete file", () => {
-      cy.deleteMedia(OTHER_FILE_TITLE)
+      cy.contains("button", OTHER_FILE_TITLE).as("filePreview")
+      cy.clickContextMenuItem("@filePreview", "Delete")
+      cy.contains("button", "Delete").click()
       // ASSERTS
-      cy.contains(OTHER_FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should(
-        "not.exist"
-      ) // File name should not exist in Files
+      cy.contains(OTHER_FILE_TITLE).should("not.exist") // File name should not exist in Files
     })
   })
 
@@ -145,35 +144,25 @@ describe("Files", () => {
 
       // ASSERTS
       cy.wait(E2E_DEFAULT_WAIT_TIME)
-      cy.contains(DIRECTORY_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist") // Directory name should be contained in Files
+      cy.contains(DIRECTORY_TITLE).should("exist") // Directory name should be contained in Files
     })
 
     it("Should be able to edit file directory name", () => {
       // User should be able edit directory details
-      const testDirectoryCard = cy
-        .contains(DIRECTORY_TITLE, { timeout: CUSTOM_TIMEOUT })
-        .should("exist")
-      testDirectoryCard
-        .children()
-        .within(() => cy.get("[id^=settings-]").click())
-      cy.get("div[id^=settings-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
+      cy.contains("a", DIRECTORY_TITLE).should("exist").as("folderItem")
+      cy.clickContextMenuItem("@folderItem", "Settings")
       cy.get("#newDirectoryName").clear().type(OTHER_DIRECTORY_TITLE)
       cy.contains("button", "Save").click()
       cy.wait(E2E_CHANGE_WAIT_TIME)
 
       // ASSERTS
-      cy.contains(OTHER_DIRECTORY_TITLE, { timeout: CUSTOM_TIMEOUT }).should(
-        "exist"
-      ) // New file directory name should be contained in Files
+      cy.contains(OTHER_DIRECTORY_TITLE).should("exist") // New file directory name should be contained in Files
     })
 
     it("Should be able to delete file directory", () => {
       // User should be able delete directory
-      const testDirectoryCard = cy.contains(OTHER_DIRECTORY_TITLE)
-      testDirectoryCard
-        .children()
-        .within(() => cy.get("[id^=settings-]").click())
-      cy.get("div[id^=delete-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
+      cy.contains("a", OTHER_DIRECTORY_TITLE).should("exist").as("folderItem")
+      cy.clickContextMenuItem("@folderItem", "Delete")
       cy.contains("button", "Delete").click()
       cy.wait(E2E_CHANGE_WAIT_TIME)
       // ASSERTS
@@ -199,7 +188,7 @@ describe("Files", () => {
 
       // Assert
       cy.wait(E2E_DEFAULT_WAIT_TIME)
-      cy.contains(DIRECTORY_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist")
+      cy.contains(DIRECTORY_TITLE).should("exist")
     })
 
     beforeEach(() => {
@@ -215,27 +204,24 @@ describe("Files", () => {
       cy.uploadMedia(FILE_TITLE, TEST_FILE_PATH)
       // ASSERTS
       cy.wait(E2E_DEFAULT_WAIT_TIME)
-      cy.contains("Media file successfully uploaded", {
-        timeout: CUSTOM_TIMEOUT,
-      }).should("exist")
-      cy.contains(FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist") // file should be contained in Files
+      cy.contains("Media file successfully uploaded").should("exist")
+      cy.contains(FILE_TITLE).should("exist") // file should be contained in Files
     })
 
     it("Should be able to edit an file in file directory", () => {
-      cy.contains(FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist")
+      cy.contains(FILE_TITLE).should("exist")
       cy.renameMedia(FILE_TITLE, OTHER_FILE_TITLE)
       // ASSERTS
       cy.wait(E2E_DEFAULT_WAIT_TIME)
-      cy.contains(OTHER_FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist") // File should be contained in Files
+      cy.contains(OTHER_FILE_TITLE).should("exist") // File should be contained in Files
     })
 
     it("Should be able to delete file from file directory", () => {
-      cy.contains(OTHER_FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should("exist")
-      cy.deleteMedia(OTHER_FILE_TITLE)
+      cy.contains(OTHER_FILE_TITLE).should("exist").as("fileItem")
+      cy.clickContextMenuItem("@fileItem", "Delete")
+      cy.contains("button", "Delete").click()
       // ASSERTS
-      cy.contains(OTHER_FILE_TITLE, { timeout: CUSTOM_TIMEOUT }).should(
-        "not.exist"
-      ) // File file name should not exist in Files
+      cy.contains(OTHER_FILE_TITLE).should("not.exist") // File file name should not exist in Files
     })
   })
 })

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -150,7 +150,7 @@ describe("Files", () => {
     it("Should be able to edit file directory name", () => {
       // User should be able edit directory details
       cy.contains("a", DIRECTORY_TITLE).should("exist").as("folderItem")
-      cy.clickContextMenuItem("@folderItem", "settings")
+      cy.clickContextMenuItem("@folderItem", "Settings")
       cy.get("#newDirectoryName").clear().type(OTHER_DIRECTORY_TITLE)
       cy.contains("button", "Save").click()
       cy.wait(E2E_CHANGE_WAIT_TIME)

--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -150,7 +150,7 @@ describe("Files", () => {
     it("Should be able to edit file directory name", () => {
       // User should be able edit directory details
       cy.contains("a", DIRECTORY_TITLE).should("exist").as("folderItem")
-      cy.clickContextMenuItem("@folderItem", "Settings")
+      cy.clickContextMenuItem("@folderItem", "settings")
       cy.get("#newDirectoryName").clear().type(OTHER_DIRECTORY_TITLE)
       cy.contains("button", "Save").click()
       cy.wait(E2E_CHANGE_WAIT_TIME)

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -194,7 +194,7 @@ describe("Folders flow", () => {
       }).as("renameSubfolder")
 
       cy.contains("a", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE).as("folderItem")
-      cy.clickContextMenuItem("@folderItem", "settings")
+      cy.clickContextMenuItem("@folderItem", "Settings")
       cy.contains(`Subfolder settings`)
       cy.get("input#newDirectoryName")
         .clear()
@@ -322,7 +322,7 @@ describe("Folders flow", () => {
       cy.contains("a", TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "settings")
+      cy.clickContextMenuItem("@pageItem", "Settings")
 
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
@@ -352,7 +352,7 @@ describe("Folders flow", () => {
       })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "settings")
+      cy.clickContextMenuItem("@pageItem", "Settings")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -496,7 +496,7 @@ describe("Folders flow", () => {
       cy.contains("a", TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "settings")
+      cy.clickContextMenuItem("@pageItem", "Settings")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -525,7 +525,7 @@ describe("Folders flow", () => {
       })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "settings")
+      cy.clickContextMenuItem("@pageItem", "Settings")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -111,7 +111,8 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to create a new sub-folder within a valid folder name with no pages", () => {
-      cy.contains("Create new subfolder").click()
+      cy.get('button[aria-label="Select options"]').as("dropdown").click()
+      cy.clickContextMenuItem("@dropdown", "folder")
       cy.get("input#newDirectoryName")
         .clear()
         .type(TEST_SUBFOLDER_NO_PAGES_TITLE)
@@ -130,7 +131,8 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to create a new sub-folder within a valid folder name with one page", () => {
-      cy.contains("Create new subfolder").click()
+      cy.get('button[aria-label="Select options"]').as("dropdown").click()
+      cy.clickContextMenuItem("@dropdown", "folder")
       cy.get("input#newDirectoryName")
         .clear()
         .type(TEST_SUBFOLDER_WITH_PAGES_TITLE)
@@ -150,7 +152,7 @@ describe("Folders flow", () => {
         "include",
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_SUBFOLDER_WITH_PAGES_TITLE}`
       )
-      cy.contains(PRETTIFIED_DEFAULT_PAGE_TITLE).click()
+      cy.contains("a", PRETTIFIED_DEFAULT_PAGE_TITLE).click()
       cy.get(".CodeMirror-scroll").should("contain", DEFAULT_TEST_PAGE_CONTENT)
     })
 
@@ -159,7 +161,8 @@ describe("Folders flow", () => {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
 
-      cy.contains("Create new subfolder").click()
+      cy.get('button[aria-label="Select options"]').as("dropdown").click()
+      cy.clickContextMenuItem("@dropdown", "folder")
 
       // Cannot use titles shorter than 2 characters or containing symbols ~!@#$%^&*_+-./\`:;~{}()[]"'<>,?
       INVALID_SUBFOLDER_TITLES.forEach((invalidTitle) => {
@@ -180,7 +183,7 @@ describe("Folders flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_SUBFOLDER_NO_PAGES_TITLE}`
       )
-      cy.contains("button", "Create new subfolder").should("be.disabled")
+      cy.get('button[aria-label="Select options"]').should("not.exist")
     })
 
     // Rename
@@ -190,8 +193,8 @@ describe("Folders flow", () => {
         url: `/v2/sites/e2e-test-repo/collections/${DEFAULT_REPO_FOLDER_NAME}/subcollections/${PARSED_TEST_SUBFOLDER_WITH_PAGES_TITLE}`,
       }).as("renameSubfolder")
 
-      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
-      cy.get("button[id^=settings-]").trigger("mousedown")
+      cy.contains("a", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE).as("folderItem")
+      cy.clickContextMenuItem("@folderItem", "Settings")
       cy.contains(`Subfolder settings`)
       cy.get("input#newDirectoryName")
         .clear()
@@ -201,21 +204,23 @@ describe("Folders flow", () => {
       // Assert
       cy.wait("@renameSubfolder")
       cy.contains("1 item").should("exist")
-      cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE).click()
+      cy.contains("a", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE).click()
       cy.contains(PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
       cy.url().should(
         "include",
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}/subfolders/${PARSED_EDITED_TEST_SUBFOLDER_WITH_PAGES_TITLE}`
       )
-      cy.contains(PRETTIFIED_DEFAULT_PAGE_TITLE).click()
+      cy.contains("a", PRETTIFIED_DEFAULT_PAGE_TITLE).click()
       cy.get(".CodeMirror-scroll").should("contain", DEFAULT_TEST_PAGE_CONTENT)
     })
 
     // Delete
     it("Should be able to delete a sub-folder with a page", () => {
-      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
-      cy.get("button[id^=delete-]").first().trigger("mousedown")
-      cy.get("button[id=modal-delete]").click()
+      cy.contains("a", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
+        .as("folderItem")
+        .should("exist")
+      cy.clickContextMenuItem("@folderItem", "Delete")
+      cy.contains("button", "Delete").click()
       cy.wait(E2E_DEFAULT_WAIT_TIME)
 
       // Assert
@@ -225,9 +230,9 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to delete a sub-folder without page", () => {
-      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
-      cy.get("button[id^=delete-]").first().trigger("mousedown")
-      cy.get("button[id=modal-delete]").click()
+      cy.contains("a", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE).as("folderItem")
+      cy.clickContextMenuItem("@folderItem", "Delete")
+      cy.contains("button", "Delete").click()
 
       // Assert
       cy.contains(PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE).should("not.exist", {
@@ -253,7 +258,7 @@ describe("Folders flow", () => {
 
     it("Should be able to create a new page with valid title and permalink", () => {
       const DEFAULT_TEST_PAGE_PERMALINK = `/${DEFAULT_REPO_FOLDER_NAME}/permalink`
-      cy.contains("Create new page", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create page", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
       cy.get("#title").clear().type(TEST_PAGE_TITLE)
@@ -285,7 +290,7 @@ describe("Folders flow", () => {
     })
 
     it("Should not be able to create page with invalid title", () => {
-      cy.contains("Create new page", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create page", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
 
@@ -302,7 +307,7 @@ describe("Folders flow", () => {
     })
 
     it("Should not be able to create page with invalid permalink", () => {
-      cy.contains("Create new page", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create page", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
 
@@ -314,17 +319,11 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
-      cy.contains(TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT }).should(
-        "exist"
-      )
+      cy.contains("a", TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
+        .as("pageItem")
+        .should("exist")
+      cy.clickContextMenuItem("@pageItem", "Settings")
 
-      // User should be able edit page details
-      cy.get("button[id^=folderItem-dropdown-]")
-        .first()
-        .should("exist")
-        .click()
-        .should("exist")
-      cy.get("button[id^=settings-]").first().trigger("mousedown")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -343,22 +342,17 @@ describe("Folders flow", () => {
       }).should("exist")
 
       // 2. Test page content should still be in Edit Page
-      cy.contains(EDITED_TEST_PAGE_TITLE).click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE).should("exist").click()
       cy.get(".CodeMirror-scroll").should("contain", DEFAULT_TEST_PAGE_CONTENT)
     })
 
     it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
-      cy.contains(EDITED_TEST_PAGE_TITLE, {
+      cy.contains("a", EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
-      }).should("exist")
-
-      // User should be able edit page details
-      cy.get("button[id^=folderItem-dropdown-]")
-        .first()
+      })
+        .as("pageItem")
         .should("exist")
-        .click()
-        .should("exist")
-      cy.get("button[id^=settings-]").first().trigger("mousedown")
+      cy.clickContextMenuItem("@pageItem", "Settings")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -377,19 +371,16 @@ describe("Folders flow", () => {
       }).should("exist")
 
       // 2. Test page content should still be in Edit Page
-      cy.contains(EDITED_TEST_PAGE_TITLE_2).click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE_2).should("exist").click()
       cy.get(".CodeMirror-scroll").should("contain", DEFAULT_TEST_PAGE_CONTENT)
     })
 
     it("Should be able to delete existing page in folder", () => {
       // User should be able to remove the created test page card
-      cy.get("button[id^=folderItem-dropdown-]")
-        .first()
-        .should("exist")
-        .click()
-        .should("exist")
-      cy.get("button[data-cy^=delete]").trigger("mousedown")
-      cy.get("button[id^=modal-delete]").click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE_2).as("pageItem").should("exist")
+      cy.clickContextMenuItem("@pageItem", "Delete")
+      cy.contains("button", "Delete").click()
+
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -401,14 +392,15 @@ describe("Folders flow", () => {
     })
   })
 
-  describe("Create page, delete page, edit page settings in subfolder", () => {
+  describe.only("Create page, delete page, edit page settings in subfolder", () => {
     before(() => {
       Cypress.Cookies.preserveOnce(COOKIE_NAME)
       window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
       )
-      cy.contains("Create new subfolder").click()
+      cy.get('button[aria-label="Select options"]').as("dropdown").click()
+      cy.clickContextMenuItem("@dropdown", "folder")
       cy.get("input#newDirectoryName")
         .clear()
         .type(TEST_SUBFOLDER_NO_PAGES_TITLE)
@@ -440,7 +432,7 @@ describe("Folders flow", () => {
     it("Should be able to create a new page with valid title and permalink", () => {
       const DEFAULT_TEST_PAGE_PERMALINK = `/${DEFAULT_REPO_FOLDER_NAME}/${SLUGIFIED_PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE}/permalink`
 
-      cy.contains("Create new page", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create page", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
       cy.get("#title").clear().type(TEST_PAGE_TITLE)
@@ -472,7 +464,7 @@ describe("Folders flow", () => {
     })
 
     it("Should not be able to create page with invalid title", () => {
-      cy.contains("Create new page", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create page", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
 
@@ -489,7 +481,7 @@ describe("Folders flow", () => {
     })
 
     it("Should not be able to create page with invalid permalink", () => {
-      cy.contains("Create new page", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create page", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
 
@@ -501,13 +493,10 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
-      cy.contains(TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT }).should(
-        "exist"
-      )
-
-      // User should be able edit page details
-      cy.get("button[id^=folderItem-dropdown-]").first().click().should("exist")
-      cy.get("button[id^=settings-]").first().trigger("mousedown")
+      cy.contains("a", TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
+        .as("pageItem")
+        .should("exist")
+      cy.clickContextMenuItem("@pageItem", "Settings")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -526,22 +515,17 @@ describe("Folders flow", () => {
       }).should("exist")
 
       // 2. Test page content should still be in Edit Page
-      cy.contains(EDITED_TEST_PAGE_TITLE).click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE).should("exist").click()
       cy.get(".CodeMirror-scroll").should("contain", DEFAULT_TEST_PAGE_CONTENT)
     })
 
     it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
-      cy.contains(EDITED_TEST_PAGE_TITLE, {
+      cy.contains("a", EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
-      }).should("exist")
-
-      // User should be able edit page details
-      cy.get("button[id^=folderItem-dropdown-]")
-        .first()
+      })
+        .as("pageItem")
         .should("exist")
-        .click()
-        .should("exist")
-      cy.get("button[id^=settings-]").first().trigger("mousedown")
+      cy.clickContextMenuItem("@pageItem", "Settings")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -560,19 +544,15 @@ describe("Folders flow", () => {
       }).should("exist")
 
       // 2. Test page content should still be in Edit Page
-      cy.contains(EDITED_TEST_PAGE_TITLE_2).click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE_2).should("exist").click()
       cy.get(".CodeMirror-scroll").should("contain", DEFAULT_TEST_PAGE_CONTENT)
     })
 
     it("Should be able to delete existing page in folder", () => {
       // User should be able to remove the created test page card
-      cy.get("button[id^=folderItem-dropdown-]")
-        .first()
-        .should("exist")
-        .click()
-        .should("exist")
-      cy.get("button[id^=delete-]").first().trigger("mousedown")
-      cy.get("button[id=modal-delete]").click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE_2).as("pageItem")
+      cy.clickContextMenuItem("@pageItem", "Delete")
+      cy.contains("button", "Delete").click()
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -194,7 +194,7 @@ describe("Folders flow", () => {
       }).as("renameSubfolder")
 
       cy.contains("a", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE).as("folderItem")
-      cy.clickContextMenuItem("@folderItem", "Settings")
+      cy.clickContextMenuItem("@folderItem", "settings")
       cy.contains(`Subfolder settings`)
       cy.get("input#newDirectoryName")
         .clear()
@@ -322,7 +322,7 @@ describe("Folders flow", () => {
       cy.contains("a", TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "Settings")
+      cy.clickContextMenuItem("@pageItem", "settings")
 
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
@@ -352,7 +352,7 @@ describe("Folders flow", () => {
       })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "Settings")
+      cy.clickContextMenuItem("@pageItem", "settings")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -496,7 +496,7 @@ describe("Folders flow", () => {
       cy.contains("a", TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "Settings")
+      cy.clickContextMenuItem("@pageItem", "settings")
       cy.get("#title").should("have.value", PRETTIFIED_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -525,7 +525,7 @@ describe("Folders flow", () => {
       })
         .as("pageItem")
         .should("exist")
-      cy.clickContextMenuItem("@pageItem", "Settings")
+      cy.clickContextMenuItem("@pageItem", "settings")
       cy.get("#title").should("have.value", PRETTIFIED_EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -392,7 +392,7 @@ describe("Folders flow", () => {
     })
   })
 
-  describe.only("Create page, delete page, edit page settings in subfolder", () => {
+  describe("Create page, delete page, edit page settings in subfolder", () => {
     before(() => {
       Cypress.Cookies.preserveOnce(COOKIE_NAME)
       window.localStorage.setItem("userId", "test")

--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -5,7 +5,7 @@ describe("Login flow", () => {
 
   it("Home page should have login button", () => {
     cy.visit(CMS_BASEURL)
-    cy.get("button").should("have.text", LOGIN_BUTTON_TEXT)
+    cy.contains("button", LOGIN_BUTTON_TEXT).should("exist")
   })
 
   it("Login button should redirect to GitHub login on click", () => {

--- a/cypress/integration/images.spec.js
+++ b/cypress/integration/images.spec.js
@@ -74,10 +74,13 @@ describe("Images", () => {
     })
 
     it("Should be able to delete image from image album", () => {
-      cy.contains(OTHER_IMAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT }).should(
-        "exist"
-      )
-      cy.deleteMedia(OTHER_IMAGE_TITLE)
+      cy.contains("button", OTHER_IMAGE_TITLE, {
+        timeout: E2E_EXTENDED_TIMEOUT,
+      })
+        .as("imagePreview")
+        .should("exist")
+      cy.clickContextMenuItem("@imagePreview", "Delete")
+      cy.contains("button", "Delete").click()
       // ASSERTS
       cy.contains(OTHER_IMAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT }).should(
         "not.exist"

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -31,7 +31,6 @@ describe("Move flow", () => {
   beforeEach(() => {
     cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
     window.localStorage.setItem("userId", "test")
-    cy.contains("Verify your email").should("not.exist")
     waitForDom()
   })
 
@@ -41,6 +40,7 @@ describe("Move flow", () => {
 
     beforeEach(() => {
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
+      cy.contains("Verify").should("not.exist")
     })
 
     it("Should be able to navigate from Workspace to subfolder back to Workspace via MoveModal buttons", () => {
@@ -259,6 +259,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}`
       )
+      cy.contains("Verify").should("not.exist")
     })
 
     it("Should be able to navigate from folder to Workspace to subfolder back to folder via MoveModal buttons", () => {
@@ -447,6 +448,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_REPO_SUBFOLDER_NAME}`
       )
+      cy.contains("Verify").should("not.exist")
     })
 
     it("Should be able to navigate from subfolder to folder to Workspace back to subfolder via MoveModal buttons", () => {
@@ -634,6 +636,7 @@ describe("Move flow", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${PARSED_TEST_REPO_RESOURCE_ROOM_NAME}/resourceCategory/${PARSED_TEST_REPO_RESOURCE_CATEGORY_NAME}`
       )
+      cy.contains("Verify").should("not.exist")
     })
 
     it("Should be able to navigate from Resource Category to Resource Room back to Resource Category via MoveModal buttons", () => {

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -1,4 +1,4 @@
-import { titleToPageFileName, slugifyCategory } from "../../src/utils"
+import { slugifyCategory } from "../../src/utils"
 import { E2E_EXTENDED_TIMEOUT } from "../fixtures/constants"
 
 describe("Move flow", () => {
@@ -28,14 +28,18 @@ describe("Move flow", () => {
     TEST_REPO_RESOURCE_CATEGORY_NAME_1
   )
 
+  beforeEach(() => {
+    cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+    window.localStorage.setItem("userId", "test")
+    cy.contains("Verify your email").should("not.exist")
+    waitForDom()
+  })
+
   describe("Move pages out of Workspace", () => {
     const TITLE_WORKSPACE_TO_FOLDER = "Move from Workspace to folder"
-
     const TITLE_WORKSPACE_TO_SUBFOLDER = "Move from Workspace to subfolder"
 
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-      window.localStorage.setItem("userId", "test")
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
     })
 
@@ -46,112 +50,78 @@ describe("Move flow", () => {
 
       cy.contains(`Move Here`)
 
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").first().getFirstSiblingAs("currentLocationBreadcrumb")
+      cy.verifyBreadcrumb("@currentLocationBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("movedLocationBreadcrumb")
+      cy.verifyBreadcrumb("@movedLocationBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
 
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .clickAndWait({ force: true })
-
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+        .click({ force: true })
+      waitForDom()
+      cy.get("u").first().getFirstSiblingAs("moveFolderCurrentBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderCurrentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
 
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
-        force: true,
-      })
-
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
+      waitForDom()
+      cy.get("u").first().getFirstSiblingAs("subFolderCurrentBreadcrumb")
+      cy.verifyBreadcrumb("@subFolderCurrentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("subFolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@subFolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
 
       // Navigate to Move folder
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
-
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").first().getFirstSiblingAs("moveFolderCurrentBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderCurrentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb", [])
+      cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
 
       // Navigate to Workspace
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
-
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").first().getFirstSiblingAs("workspaceCurrentBreadcrumb")
+      cy.verifyBreadcrumb("@workspaceCurrentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("workspaceUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@workspaceUpdatedBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
     })
 
     it("Should be able to move page from Workspace to itself and show correct success message", () => {
@@ -174,13 +144,11 @@ describe("Move flow", () => {
       cy.contains(`Move Here`)
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
 
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
@@ -188,24 +156,17 @@ describe("Move flow", () => {
         .clickAndWait({ force: true })
 
       // Assert
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").first().getFirstSiblingAs("moveFolderCurrentBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderCurrentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_WORKSPACE_TO_FOLDER,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -235,20 +196,16 @@ describe("Move flow", () => {
       cy.contains(`Move Here`)
 
       // Assert
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").first().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_SUBFOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("updatedBreadcrumb")
+      cy.verifyBreadcrumb("@updatedBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_SUBFOLDER,
+      ])
 
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
@@ -261,28 +218,18 @@ describe("Move flow", () => {
       })
 
       // Assert
-      cy.get("u")
-        .first()
-        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_WORKSPACE_TO_SUBFOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").first().getFirstSiblingAs("subfolderCurrentBreadcrumb")
+      cy.verifyBreadcrumb("@subfolderCurrentBreadcrumb", [
+        "Workspace",
+        TITLE_WORKSPACE_TO_SUBFOLDER,
+      ])
+      cy.get("u").last().getFirstSiblingAs("subfolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@subfolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_WORKSPACE_TO_SUBFOLDER,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -306,193 +253,126 @@ describe("Move flow", () => {
 
   describe("Move pages out of folder", () => {
     const TITLE_FOLDER_TO_WORKSPACE = "Move from folder to Workspace"
-    const FILENAME_FOLDER_TO_WORKSPACE = titleToPageFileName(
-      TITLE_FOLDER_TO_WORKSPACE
-    )
-
     const TITLE_FOLDER_TO_SUBFOLDER = "Move from folder to subfolder"
-    const FILENAME_FOLDER_TO_SUBFOLDER = titleToPageFileName(
-      TITLE_FOLDER_TO_SUBFOLDER
-    )
 
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-      window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}`
       )
     })
 
-    it.only("Should be able to navigate from folder to Workspace to subfolder back to folder via MoveModal buttons", () => {
+    it("Should be able to navigate from folder to Workspace to subfolder back to folder via MoveModal buttons", () => {
       cy.contains("a", TITLE_FOLDER_TO_WORKSPACE)
         .as("folderItem")
         .should("exist")
       cy.clickContextMenuItem("@folderItem", "Move to")
-      waitForDom()
       cy.contains(`Move Here`)
 
-      cy.get("u")
-        .eq(1)
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").eq(1).getFirstSiblingAs("currentLocationBreadcrumb")
+      cy.verifyBreadcrumb("@currentLocationBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
+
+      cy.get("u").last().getFirstSiblingAs("movedLocationBreadcrumb")
+      cy.verifyBreadcrumb("@movedLocationBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Workspace
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
-
-      cy.get("u")
-        .first()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").first().getFirstSiblingAs("workspaceBreadcrumb")
+      cy.verifyBreadcrumb("@workspaceBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
+      cy.get("u").last().getFirstSiblingAs("folderBreadcrumb")
+      cy.verifyBreadcrumb("@folderBreadcrumb", [
+        "Workspace",
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .clickAndWait({ force: true })
-
-      cy.get("u")
-        .eq(1)
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+        .click({ force: true })
+      waitForDom()
+      cy.get("u").eq(1).getFirstSiblingAs("moveFolderBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
+      cy.get("u").last().parent().getFirstSiblingAs("movedLocationBreadcrumb")
+      cy.verifyBreadcrumb("@movedLocationBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
-        force: true,
-      })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("subFolderBreadcrumb")
+      cy.verifyBreadcrumb("@subFolderBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Move folder
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").last().parent().getFirstSiblingAs("moveBreadcrumb")
+      cy.verifyBreadcrumb("@moveBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
     })
 
     it("Should be able to move page from folder to itself and show correct success message", () => {
-      cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
-      )
+      cy.contains("a", TITLE_FOLDER_TO_WORKSPACE)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
+      cy.clickContextMenuItem("@folderItem", "Move to")
+      cy.contains("button", "Move Here").click()
 
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
-
-      cy.contains("button", "Move Here").clickAndWait()
-
+      waitForDom()
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
     })
 
     it("Should be able to move a page from folder to Workspace", () => {
-      cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
-      )
+      cy.contains("a", TITLE_FOLDER_TO_WORKSPACE)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.clickContextMenuItem("@folderItem", "Move to")
+      cy.contains("button", "Move Here").should("exist")
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("initialLocationBreadcrumb")
+      cy.verifyBreadcrumb("@initialLocationBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
 
       cy.get("#moveModal-backButton").clickAndWait({ force: true })
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("movedLocationBreadcrumb")
+      cy.verifyBreadcrumb("@movedLocationBreadcrumb", [
+        "Workspace",
+        TITLE_FOLDER_TO_WORKSPACE,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -512,50 +392,32 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move a page from folder to subfolder", () => {
-      cy.contains(TITLE_FOLDER_TO_SUBFOLDER).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_SUBFOLDER}"]`
-      )
+      cy.contains("a", TITLE_FOLDER_TO_SUBFOLDER)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.clickContextMenuItem("@folderItem", "Move to")
+      cy.contains("Move Here").should("exist")
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_SUBFOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("currentLocationBreadcrumb")
+      cy.verifyBreadcrumb("@currentLocationBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_FOLDER_TO_SUBFOLDER,
+      ])
 
       cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
         force: true,
       })
 
       // Assert
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_FOLDER_TO_SUBFOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("movedLocationBreadcrumb")
+      cy.verifyBreadcrumb("@movedLocationBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_FOLDER_TO_SUBFOLDER,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -579,125 +441,77 @@ describe("Move flow", () => {
 
   describe("Move pages out from subfolder", () => {
     const TITLE_SUBFOLDER_TO_WORKSPACE = "Move from subfolder to Workspace"
-    const FILENAME_SUBFOLDER_TO_WORKSPACE = titleToPageFileName(
-      TITLE_SUBFOLDER_TO_WORKSPACE
-    )
-
     const TITLE_SUBFOLDER_TO_FOLDER = "Move from subfolder to folder"
-    const FILENAME_SUBFOLDER_TO_FOLDER = titleToPageFileName(
-      TITLE_SUBFOLDER_TO_FOLDER
-    )
 
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-      window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_REPO_SUBFOLDER_NAME}`
       )
     })
 
     it("Should be able to navigate from subfolder to folder to Workspace back to subfolder via MoveModal buttons", () => {
-      cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_WORKSPACE}"]`
-      )
+      cy.contains("a", TITLE_SUBFOLDER_TO_WORKSPACE)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
+      cy.clickContextMenuItem("@folderItem", "Move to")
       cy.contains(`Move Here`)
 
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Move folder
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Workspace
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("workspaceUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@workspaceUpdatedBreadcrumb", [
+        "Workspace",
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Move folder
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .clickAndWait({ force: true })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+        .click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       // Navigate to Move subfolder
-      cy.get("button[id^=moveModal-forwardButton-]").clickAndWait({
-        force: true,
-      })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("moveSubfolderUpdatedBreadcrumb")
+      cy.verifyBreadcrumb("@moveSubfolderUpdatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
     })
 
     it("Should be able to move page from subfolder to itself and show correct success message", () => {
-      cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_WORKSPACE}"]`
-      )
+      cy.contains("a", TITLE_SUBFOLDER_TO_WORKSPACE)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.clickContextMenuItem("@folderItem", "Move to")
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -707,58 +521,47 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move a page from subfolder to Workspace", () => {
-      cy.contains(TITLE_SUBFOLDER_TO_WORKSPACE).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${TITLE_SUBFOLDER_TO_WORKSPACE}"]`
-      )
+      cy.contains("a", TITLE_SUBFOLDER_TO_WORKSPACE)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
+      cy.clickContextMenuItem("@folderItem", "Move to")
+      cy.contains("button", "Move Here")
 
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       cy.get("#moveModal-backButton").clickAndWait({ force: true })
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("folderBreadcrumb")
+      cy.verifyBreadcrumb("@folderBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       cy.get("#moveModal-backButton").clickAndWait({ force: true })
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_WORKSPACE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("workspaceBreadcrumb")
+      cy.verifyBreadcrumb("@workspaceBreadcrumb", [
+        "Workspace",
+        TITLE_SUBFOLDER_TO_WORKSPACE,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -778,46 +581,31 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move a page from subfolder to folder", () => {
-      cy.contains(TITLE_SUBFOLDER_TO_FOLDER).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_SUBFOLDER_TO_FOLDER}"]`
-      )
+      cy.contains("a", TITLE_SUBFOLDER_TO_FOLDER)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.clickContextMenuItem("@folderItem", "Move to")
+      cy.contains("button", "Move Here")
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_SUBFOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TEST_REPO_SUBFOLDER_NAME,
+        TITLE_SUBFOLDER_TO_FOLDER,
+      ])
+
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_SUBFOLDER_TO_FOLDER)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("updatedBreadcrumb")
+      cy.verifyBreadcrumb("@updatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_FOLDER_NAME,
+        TITLE_SUBFOLDER_TO_FOLDER,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 
@@ -843,146 +631,96 @@ describe("Move flow", () => {
     const TITLE_RESOURCE_PAGE = "Move resource page"
 
     beforeEach(() => {
-      cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-      window.localStorage.setItem("userId", "test")
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${PARSED_TEST_REPO_RESOURCE_ROOM_NAME}/resourceCategory/${PARSED_TEST_REPO_RESOURCE_CATEGORY_NAME}`
       )
     })
 
     it("Should be able to navigate from Resource Category to Resource Room back to Resource Category via MoveModal buttons", () => {
-      cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.contains("a", TITLE_RESOURCE_PAGE).as("resourcePage").should("exist")
+      cy.clickContextMenuItem("@resourcePage", "Move to")
+      cy.contains("button", "Move Here")
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_RESOURCE_PAGE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TEST_REPO_RESOURCE_ROOM_NAME,
+        TEST_REPO_RESOURCE_CATEGORY_NAME,
+        TITLE_RESOURCE_PAGE,
+      ])
 
       // Navigate to Resource Room
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("updatedBreadcrumb")
+      cy.verifyBreadcrumb("@updatedBreadcrumb", [
+        "Workspace",
+        TEST_REPO_RESOURCE_ROOM_NAME,
+        TITLE_RESOURCE_PAGE,
+      ])
 
-      cy.get("u")
-        .last()
-        .contains(TITLE_RESOURCE_PAGE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
       // Navigate to Resource Category
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
-        .clickAndWait({ force: true })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_RESOURCE_PAGE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+        .click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("resourceCategoryBreadcrumb")
+      cy.verifyBreadcrumb("@resourceCategoryBreadcrumb", [
+        "Workspace",
+        TEST_REPO_RESOURCE_ROOM_NAME,
+        TEST_REPO_RESOURCE_CATEGORY_NAME,
+        TITLE_RESOURCE_PAGE,
+      ])
     })
 
     it("Should be able to move page from resource category to itself and show correct success message", () => {
-      cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").clickAndWait()
+      cy.contains("a", TITLE_RESOURCE_PAGE).as("resourcePage").should("exist")
+      cy.clickContextMenuItem("@resourcePage", "Move to")
+      cy.contains("button", "Move Here").click()
 
-      cy.get("button[id^=move-]").first().clickAndWait()
-
-      cy.contains(`Move Here`)
-
-      cy.contains("button", "Move Here").clickAndWait()
-
+      waitForDom()
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
     })
 
     it("Should be able to move page from resource category to another resource category", () => {
-      cy.contains(TITLE_RESOURCE_PAGE).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-"]`).should("exist").clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
-      cy.contains(`Move Here`)
+      cy.contains("a", TITLE_RESOURCE_PAGE).as("resourcePage").should("exist")
+      cy.clickContextMenuItem("@resourcePage", "Move to")
+      cy.contains("button", "Move Here")
 
       // Assert
-      cy.get("u")
-        .last()
-        .contains(TITLE_RESOURCE_PAGE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      // Navigate to Resource Room
-      cy.get("#moveModal-backButton").clickAndWait({ force: true })
+      cy.get("u").last().getFirstSiblingAs("currentBreadcrumb")
+      cy.verifyBreadcrumb("@currentBreadcrumb", [
+        "Workspace",
+        TEST_REPO_RESOURCE_ROOM_NAME,
+        TEST_REPO_RESOURCE_CATEGORY_NAME,
+        TITLE_RESOURCE_PAGE,
+      ])
 
-      cy.get("u")
-        .last()
-        .contains(TITLE_RESOURCE_PAGE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+      // Navigate to Resource Room
+      cy.get("#moveModal-backButton").click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("resourceRoomBreadcrumb")
+      cy.verifyBreadcrumb("@resourceRoomBreadcrumb", [
+        "Workspace",
+        TEST_REPO_RESOURCE_ROOM_NAME,
+        TITLE_RESOURCE_PAGE,
+      ])
 
       // Navigate to Resource Category
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(0)
-        .clickAndWait({ force: true })
-
-      cy.get("u")
-        .last()
-        .contains(TITLE_RESOURCE_PAGE)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_CATEGORY_NAME_1)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains(TEST_REPO_RESOURCE_ROOM_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
+        .click({ force: true })
+      waitForDom()
+      cy.get("u").last().getFirstSiblingAs("resourceCategoryBreadcrumb")
+      cy.verifyBreadcrumb("@resourceCategoryBreadcrumb", [
+        "Workspace",
+        TEST_REPO_RESOURCE_ROOM_NAME,
+        TEST_REPO_RESOURCE_CATEGORY_NAME_1,
+        TITLE_RESOURCE_PAGE,
+      ])
 
       cy.contains("button", "Move Here").clickAndWait()
 

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -30,14 +30,8 @@ describe("Move flow", () => {
 
   describe("Move pages out of Workspace", () => {
     const TITLE_WORKSPACE_TO_FOLDER = "Move from Workspace to folder"
-    const FILENAME_WORKSPACE_TO_FOLDER = titleToPageFileName(
-      TITLE_WORKSPACE_TO_FOLDER
-    )
 
     const TITLE_WORKSPACE_TO_SUBFOLDER = "Move from Workspace to subfolder"
-    const FILENAME_WORKSPACE_TO_SUBFOLDER = titleToPageFileName(
-      TITLE_WORKSPACE_TO_SUBFOLDER
-    )
 
     beforeEach(() => {
       cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
@@ -46,12 +40,9 @@ describe("Move flow", () => {
     })
 
     it("Should be able to navigate from Workspace to subfolder back to Workspace via MoveModal buttons", () => {
-      cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
-        .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().clickAndWait()
+      cy.contains("a", TITLE_WORKSPACE_TO_FOLDER).as("pageItem").should("exist")
+      cy.clickContextMenuItem("@pageItem", "Move to")
+      waitForDom()
 
       cy.contains(`Move Here`)
 
@@ -164,13 +155,9 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move page from Workspace to itself and show correct success message", () => {
-      cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
-        .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().clickAndWait()
-
+      cy.contains("a", TITLE_WORKSPACE_TO_FOLDER).as("pageItem").should("exist")
+      cy.clickContextMenuItem("@pageItem", "Move to")
+      waitForDom()
       cy.contains(`Move Here`)
 
       cy.contains("button", "Move Here").clickAndWait()
@@ -181,13 +168,9 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move a page from Workspace to folder", () => {
-      cy.contains(TITLE_WORKSPACE_TO_FOLDER).should("exist")
-      cy.get(`button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_FOLDER}"]`)
-        .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().clickAndWait()
-
+      cy.contains("a", TITLE_WORKSPACE_TO_FOLDER).as("pageItem").should("exist")
+      cy.clickContextMenuItem("@pageItem", "Move to")
+      waitForDom()
       cy.contains(`Move Here`)
 
       // Assert
@@ -244,15 +227,11 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move a page from folder to subfolder", () => {
-      cy.contains(TITLE_WORKSPACE_TO_SUBFOLDER).should("exist")
-      cy.get(
-        `button[id^="pageCard-dropdown-${FILENAME_WORKSPACE_TO_SUBFOLDER}"]`
-      )
+      cy.contains("a", TITLE_WORKSPACE_TO_SUBFOLDER)
+        .as("pageItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().clickAndWait()
-
+      cy.clickContextMenuItem("@pageItem", "Move to")
+      waitForDom()
       cy.contains(`Move Here`)
 
       // Assert
@@ -344,15 +323,12 @@ describe("Move flow", () => {
       )
     })
 
-    it("Should be able to navigate from folder to Workspace to subfolder back to folder via MoveModal buttons", () => {
-      cy.contains(TITLE_FOLDER_TO_WORKSPACE).should("exist")
-      cy.get(
-        `button[id^="folderItem-dropdown-${FILENAME_FOLDER_TO_WORKSPACE}"]`
-      )
+    it.only("Should be able to navigate from folder to Workspace to subfolder back to folder via MoveModal buttons", () => {
+      cy.contains("a", TITLE_FOLDER_TO_WORKSPACE)
+        .as("folderItem")
         .should("exist")
-        .clickAndWait()
-
-      cy.get("button[id^=move-]").first().trigger("mousedown")
+      cy.clickContextMenuItem("@folderItem", "Move to")
+      waitForDom()
       cy.contains(`Move Here`)
 
       cy.get("u")
@@ -383,13 +359,6 @@ describe("Move flow", () => {
 
       cy.get("u")
         .first()
-        .contains(TEST_REPO_FOLDER_NAME)
-        .prev()
-        .contains(">")
-        .prev()
-        .contains("Workspace")
-      cy.get("u")
-        .eq(1)
         .contains(TITLE_FOLDER_TO_WORKSPACE)
         .prev()
         .contains(">")

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -31,7 +31,6 @@ describe("Move flow", () => {
   beforeEach(() => {
     cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
     window.localStorage.setItem("userId", "test")
-    waitForDom()
   })
 
   describe("Move pages out of Workspace", () => {
@@ -46,7 +45,6 @@ describe("Move flow", () => {
     it("Should be able to navigate from Workspace to subfolder back to Workspace via MoveModal buttons", () => {
       cy.contains("a", TITLE_WORKSPACE_TO_FOLDER).as("pageItem").should("exist")
       cy.clickContextMenuItem("@pageItem", "Move to")
-      waitForDom()
 
       cy.contains(`Move Here`)
 
@@ -65,7 +63,7 @@ describe("Move flow", () => {
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
         .click({ force: true })
-      waitForDom()
+
       cy.get("u").first().getFirstSiblingAs("moveFolderCurrentBreadcrumb")
       cy.verifyBreadcrumb("@moveFolderCurrentBreadcrumb", [
         "Workspace",
@@ -80,7 +78,7 @@ describe("Move flow", () => {
 
       // Navigate to Move subfolder
       cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+
       cy.get("u").first().getFirstSiblingAs("subFolderCurrentBreadcrumb")
       cy.verifyBreadcrumb("@subFolderCurrentBreadcrumb", [
         "Workspace",
@@ -96,7 +94,7 @@ describe("Move flow", () => {
 
       // Navigate to Move folder
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").first().getFirstSiblingAs("moveFolderCurrentBreadcrumb")
       cy.verifyBreadcrumb("@moveFolderCurrentBreadcrumb", [
         "Workspace",
@@ -111,7 +109,7 @@ describe("Move flow", () => {
 
       // Navigate to Workspace
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").first().getFirstSiblingAs("workspaceCurrentBreadcrumb")
       cy.verifyBreadcrumb("@workspaceCurrentBreadcrumb", [
         "Workspace",
@@ -127,7 +125,7 @@ describe("Move flow", () => {
     it("Should be able to move page from Workspace to itself and show correct success message", () => {
       cy.contains("a", TITLE_WORKSPACE_TO_FOLDER).as("pageItem").should("exist")
       cy.clickContextMenuItem("@pageItem", "Move to")
-      waitForDom()
+
       cy.contains(`Move Here`)
 
       cy.contains("button", "Move Here").clickAndWait()
@@ -140,7 +138,7 @@ describe("Move flow", () => {
     it("Should be able to move a page from Workspace to folder", () => {
       cy.contains("a", TITLE_WORKSPACE_TO_FOLDER).as("pageItem").should("exist")
       cy.clickContextMenuItem("@pageItem", "Move to")
-      waitForDom()
+
       cy.contains(`Move Here`)
 
       // Assert
@@ -192,7 +190,7 @@ describe("Move flow", () => {
         .as("pageItem")
         .should("exist")
       cy.clickContextMenuItem("@pageItem", "Move to")
-      waitForDom()
+
       cy.contains(`Move Here`)
 
       // Assert
@@ -285,7 +283,7 @@ describe("Move flow", () => {
 
       // Navigate to Workspace
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").first().getFirstSiblingAs("workspaceBreadcrumb")
       cy.verifyBreadcrumb("@workspaceBreadcrumb", [
         "Workspace",
@@ -302,7 +300,7 @@ describe("Move flow", () => {
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
         .click({ force: true })
-      waitForDom()
+
       cy.get("u").eq(1).getFirstSiblingAs("moveFolderBreadcrumb")
       cy.verifyBreadcrumb("@moveFolderBreadcrumb", [
         "Workspace",
@@ -318,7 +316,7 @@ describe("Move flow", () => {
 
       // Navigate to Move subfolder
       cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("subFolderBreadcrumb")
       cy.verifyBreadcrumb("@subFolderBreadcrumb", [
         "Workspace",
@@ -329,7 +327,7 @@ describe("Move flow", () => {
 
       // Navigate to Move folder
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().parent().getFirstSiblingAs("moveBreadcrumb")
       cy.verifyBreadcrumb("@moveBreadcrumb", [
         "Workspace",
@@ -345,7 +343,6 @@ describe("Move flow", () => {
       cy.clickContextMenuItem("@folderItem", "Move to")
       cy.contains("button", "Move Here").click()
 
-      waitForDom()
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -468,7 +465,7 @@ describe("Move flow", () => {
 
       // Navigate to Move folder
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb")
       cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
         "Workspace",
@@ -478,7 +475,7 @@ describe("Move flow", () => {
 
       // Navigate to Workspace
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("workspaceUpdatedBreadcrumb")
       cy.verifyBreadcrumb("@workspaceUpdatedBreadcrumb", [
         "Workspace",
@@ -489,7 +486,7 @@ describe("Move flow", () => {
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
         .click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("moveFolderUpdatedBreadcrumb")
       cy.verifyBreadcrumb("@moveFolderUpdatedBreadcrumb", [
         "Workspace",
@@ -499,7 +496,7 @@ describe("Move flow", () => {
 
       // Navigate to Move subfolder
       cy.get("button[id^=moveModal-forwardButton-]").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("moveSubfolderUpdatedBreadcrumb")
       cy.verifyBreadcrumb("@moveSubfolderUpdatedBreadcrumb", [
         "Workspace",
@@ -599,7 +596,6 @@ describe("Move flow", () => {
       ])
 
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
 
       // Assert
       cy.get("u").last().getFirstSiblingAs("updatedBreadcrumb")
@@ -655,7 +651,7 @@ describe("Move flow", () => {
 
       // Navigate to Resource Room
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("updatedBreadcrumb")
       cy.verifyBreadcrumb("@updatedBreadcrumb", [
         "Workspace",
@@ -667,7 +663,7 @@ describe("Move flow", () => {
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(1)
         .click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("resourceCategoryBreadcrumb")
       cy.verifyBreadcrumb("@resourceCategoryBreadcrumb", [
         "Workspace",
@@ -682,7 +678,6 @@ describe("Move flow", () => {
       cy.clickContextMenuItem("@resourcePage", "Move to")
       cy.contains("button", "Move Here").click()
 
-      waitForDom()
       cy.contains("File is already in this folder", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -704,7 +699,7 @@ describe("Move flow", () => {
 
       // Navigate to Resource Room
       cy.get("#moveModal-backButton").click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("resourceRoomBreadcrumb")
       cy.verifyBreadcrumb("@resourceRoomBreadcrumb", [
         "Workspace",
@@ -716,7 +711,7 @@ describe("Move flow", () => {
       cy.get("button[id^=moveModal-forwardButton-]")
         .eq(0)
         .click({ force: true })
-      waitForDom()
+
       cy.get("u").last().getFirstSiblingAs("resourceCategoryBreadcrumb")
       cy.verifyBreadcrumb("@resourceCategoryBreadcrumb", [
         "Workspace",

--- a/cypress/integration/move.spec.js
+++ b/cypress/integration/move.spec.js
@@ -636,7 +636,10 @@ describe("Move flow", () => {
     })
 
     it("Should be able to navigate from Resource Category to Resource Room back to Resource Category via MoveModal buttons", () => {
-      cy.contains("a", TITLE_RESOURCE_PAGE).as("resourcePage").should("exist")
+      cy.contains("a", TITLE_RESOURCE_PAGE)
+        .parent()
+        .as("resourcePage")
+        .should("exist")
       cy.clickContextMenuItem("@resourcePage", "Move to")
       cy.contains("button", "Move Here")
 
@@ -674,7 +677,10 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move page from resource category to itself and show correct success message", () => {
-      cy.contains("a", TITLE_RESOURCE_PAGE).as("resourcePage").should("exist")
+      cy.contains("a", TITLE_RESOURCE_PAGE)
+        .parent()
+        .as("resourcePage")
+        .should("exist")
       cy.clickContextMenuItem("@resourcePage", "Move to")
       cy.contains("button", "Move Here").click()
 
@@ -684,7 +690,10 @@ describe("Move flow", () => {
     })
 
     it("Should be able to move page from resource category to another resource category", () => {
-      cy.contains("a", TITLE_RESOURCE_PAGE).as("resourcePage").should("exist")
+      cy.contains("a", TITLE_RESOURCE_PAGE)
+        .parent()
+        .as("resourcePage")
+        .should("exist")
       cy.clickContextMenuItem("@resourcePage", "Move to")
       cy.contains("button", "Move Here")
 

--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -237,7 +237,7 @@ describe("Resource category page", () => {
     )
   })
 
-  it.only("Resources category page should allow user to create a new resource page of type file", () => {
+  it("Resources category page should allow user to create a new resource page of type file", () => {
     cy.contains("Create page").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
@@ -271,7 +271,7 @@ describe("Resource category page", () => {
     cy.contains(`${TEST_PAGE_DATE_PRETTIFIED}/FILE`)
   })
 
-  it.only("Resources category page should allow user to change an existing resource page from post to file", () => {
+  it("Resources category page should allow user to change an existing resource page from post to file", () => {
     cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
       .as("pageCard")
       .should("exist")
@@ -293,7 +293,7 @@ describe("Resource category page", () => {
     cy.contains(`${TEST_PAGE_DATE_CHANGED_PRETTIFIED}/FILE`)
   })
 
-  it.only("Resources category page should allow user to change an existing resource page from file to post", () => {
+  it("Resources category page should allow user to change an existing resource page from file to post", () => {
     cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
       .as("pageCard")
       .should("exist")

--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -44,13 +44,13 @@ describe("Resource category page", () => {
     // Set up test resource categories
     cy.visit(`/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}`)
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Create new category").click()
+    cy.contains("a", "Create category").click()
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY)
     cy.contains("Next").click()
 
     cy.visit(`/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}`)
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Create new category").click()
+    cy.contains("a", "Create category").click()
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_2)
     cy.contains("Next").click()
   })
@@ -63,6 +63,7 @@ describe("Resource category page", () => {
     cy.visit(
       `/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}/resourceCategory/${TEST_CATEGORY_SLUGIFIED}`
     )
+    cy.contains("Verify").should("not.exist")
   })
 
   it("Resource category page should have name of resource category in header", () => {
@@ -70,7 +71,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to create a new resource page of type post", () => {
-    cy.contains("Add a new page").click()
+    cy.contains("a", "Create page").click()
 
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
@@ -99,7 +100,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources page should not allow user to create a new resource category with invalid name", () => {
-    cy.contains("Add a new page").click()
+    cy.contains("a", "Create page").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
     // Same name as existing file
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE).blur()
@@ -132,7 +133,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to create a new resource page of type post", () => {
-    cy.contains("Add a new page").click()
+    cy.contains("a", "Create page").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_2)
@@ -160,15 +161,11 @@ describe("Resource category page", () => {
   })
 
   it("Resource category page should not allow user to rename a resource page using invalid parameters", () => {
-    const testPageCard = cy
-      .contains(TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
+    cy.contains("a", TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
+      .as("pageCard")
       .should("exist")
 
-    testPageCard
-      .children()
-      .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-
-    cy.get("div[id^=settings-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
+    cy.clickContextMenuItem("@pageCard", "settings")
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     // Same name as existing file
@@ -205,15 +202,12 @@ describe("Resource category page", () => {
   })
 
   it("Resource category page should allow user to edit a resource page details", () => {
-    const testPageCard = cy
-      .contains(TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
+    cy.contains("a", TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
+      .as("pageCard")
       .should("exist")
 
-    testPageCard
-      .children()
-      .within(() => cy.get("[id^=pageCard-dropdown-]").click())
+    cy.clickContextMenuItem("@pageCard", "settings")
 
-    cy.get("div[id^=settings-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_RENAMED)
@@ -243,8 +237,8 @@ describe("Resource category page", () => {
     )
   })
 
-  it("Resources category page should allow user to create a new resource page of type file", () => {
-    cy.contains("Add a new page").click()
+  it.only("Resources category page should allow user to create a new resource page of type file", () => {
+    cy.contains("Create page").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_FILE)
@@ -277,16 +271,11 @@ describe("Resource category page", () => {
     cy.contains(`${TEST_PAGE_DATE_PRETTIFIED}/FILE`)
   })
 
-  it("Resources category page should allow user to change an existing resource page from post to file", () => {
-    const testPageCard = cy
-      .contains(TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+  it.only("Resources category page should allow user to change an existing resource page from post to file", () => {
+    cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+      .as("pageCard")
       .should("exist")
-
-    testPageCard
-      .children()
-      .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-
-    cy.get("div[id^=settings-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
+    cy.clickContextMenuItem("@pageCard", "settings")
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     cy.get('input[id="radio-file"]').click()
@@ -304,16 +293,12 @@ describe("Resource category page", () => {
     cy.contains(`${TEST_PAGE_DATE_CHANGED_PRETTIFIED}/FILE`)
   })
 
-  it("Resources category page should allow user to change an existing resource page from file to post", () => {
-    const testPageCard = cy
-      .contains(TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+  it.only("Resources category page should allow user to change an existing resource page from file to post", () => {
+    cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+      .as("pageCard")
       .should("exist")
+    cy.clickContextMenuItem("@pageCard", "settings")
 
-    testPageCard
-      .children()
-      .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-
-    cy.get("div[id^=settings-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
     cy.wait(E2E_DEFAULT_WAIT_TIME)
 
     cy.get('input[id="radio-post"]').click()
@@ -321,7 +306,7 @@ describe("Resource category page", () => {
     cy.contains("Save").click()
     cy.contains("Successfully updated page").should("exist")
 
-    // New page should be of type FILE with the correct date
+    // New page should be of type POST with the correct date
     cy.reload()
     cy.contains(TEST_PAGE_TITLE_RENAMED).contains(
       `${TEST_PAGE_DATE_CHANGED_PRETTIFIED}/POST`
@@ -329,15 +314,11 @@ describe("Resource category page", () => {
   })
 
   it("Resource category page should allow user to delete a page", () => {
-    const testPageCard = cy
-      .contains(TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+    cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+      .as("pageCard")
       .should("exist")
+    cy.clickContextMenuItem("@pageCard", "Delete")
 
-    testPageCard
-      .children()
-      .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-
-    cy.get("div[id^=delete-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
     cy.contains("button", "Delete", { timeout: E2E_EXTENDED_TIMEOUT })
       .should("exist")
       .click()

--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -162,6 +162,7 @@ describe("Resource category page", () => {
 
   it("Resource category page should not allow user to rename a resource page using invalid parameters", () => {
     cy.contains("a", TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
+      .parent()
       .as("pageCard")
       .should("exist")
 
@@ -203,6 +204,7 @@ describe("Resource category page", () => {
 
   it("Resource category page should allow user to edit a resource page details", () => {
     cy.contains("a", TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
+      .parent()
       .as("pageCard")
       .should("exist")
 
@@ -272,7 +274,10 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to change an existing resource page from post to file", () => {
-    cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+    cy.contains("a", TEST_PAGE_TITLE_RENAMED, {
+      timeout: E2E_EXTENDED_TIMEOUT,
+    })
+      .parent()
       .as("pageCard")
       .should("exist")
     cy.clickContextMenuItem("@pageCard", "settings")
@@ -293,8 +298,12 @@ describe("Resource category page", () => {
     cy.contains(`${TEST_PAGE_DATE_CHANGED_PRETTIFIED}/FILE`)
   })
 
-  it("Resources category page should allow user to change an existing resource page from file to post", () => {
-    cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+  it.only("Resources category page should allow user to change an existing resource page from file to post", () => {
+    cy.contains("button", TEST_PAGE_TITLE_RENAMED, {
+      timeout: E2E_EXTENDED_TIMEOUT,
+    })
+      .parent()
+      .parent()
       .as("pageCard")
       .should("exist")
     cy.clickContextMenuItem("@pageCard", "settings")
@@ -315,6 +324,7 @@ describe("Resource category page", () => {
 
   it("Resource category page should allow user to delete a page", () => {
     cy.contains("a", TEST_PAGE_TITLE_RENAMED, { timeout: E2E_EXTENDED_TIMEOUT })
+      .parent()
       .as("pageCard")
       .should("exist")
     cy.clickContextMenuItem("@pageCard", "Delete")

--- a/cypress/integration/resources.spec.js
+++ b/cypress/integration/resources.spec.js
@@ -32,6 +32,7 @@ describe("Resources page", () => {
     cy.visit(
       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}`
     )
+    cy.contains("Verify").should("not.exist")
   })
 
   it("Resources page should have resources header", () => {
@@ -40,7 +41,7 @@ describe("Resources page", () => {
 
   it("Resources page should allow user to create a new resource category", () => {
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Create new category").click()
+    cy.contains("a", "Create category").click()
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY)
     cy.contains("Next").click()
 
@@ -54,13 +55,13 @@ describe("Resources page", () => {
     )
 
     // 2. If user goes back to Resources, they should be able to see that the folder exists
-    cy.contains("Back to Resources").click()
+    cy.contains("a", "Resources").click()
     cy.contains(TEST_CATEGORY)
   })
 
   it("Resources page should not allow user to create a new resource category with invalid name", () => {
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Create new category").click()
+    cy.contains("a", "Create category").click()
 
     // Disabled button for special characters
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_SPECIAL).blur()
@@ -81,7 +82,7 @@ describe("Resources page", () => {
 
   it("Resources page should allow user to create another new resource category", () => {
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Create new category").click()
+    cy.contains("a", "Create category").click()
 
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_2)
     cy.contains("Next").click()
@@ -94,14 +95,14 @@ describe("Resources page", () => {
     )
 
     // 2. If user goes back to Resources, they should be able to see that the folder exists
-    cy.contains("Back to Resources").click()
+    cy.contains("a", "Resources").click()
     cy.wait(E2E_DEFAULT_WAIT_TIME)
     cy.contains(TEST_CATEGORY_2)
   })
 
   it("Resources page should not allow user to rename a resource category using an invalid name", () => {
-    cy.contains(TEST_CATEGORY_2).find("[id^=settings-folder]").click()
-    cy.contains(TEST_CATEGORY_2).contains("Edit details").click()
+    cy.contains("a", TEST_CATEGORY_2).as("folderCard")
+    cy.clickContextMenuItem("@folderCard", "settings")
 
     // Disabled button for special characters
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_SPECIAL).blur()
@@ -122,10 +123,10 @@ describe("Resources page", () => {
 
   it("Resources page should allow user to rename a resource category", () => {
     cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains(TEST_CATEGORY_2).find("[id^=settings-folder]").click()
-    cy.contains(TEST_CATEGORY_2).contains("Edit details").click()
+    cy.contains("a", TEST_CATEGORY_2).as("folderCard")
+    cy.clickContextMenuItem("@folderCard", "settings")
 
-    cy.get("input").clear().type(TEST_CATEGORY_RENAMED)
+    cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_RENAMED)
     cy.contains("Save").click()
 
     // Set a wait time because the API takes time
@@ -138,7 +139,7 @@ describe("Resources page", () => {
   })
 
   it("Resources page should allow user to navigate into a resource category", () => {
-    cy.contains(TEST_CATEGORY).click()
+    cy.contains("a", TEST_CATEGORY).click()
     cy.url().should(
       "include",
       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}/resourceCategory/${TEST_CATEGORY_SLUGIFIED}`
@@ -146,17 +147,15 @@ describe("Resources page", () => {
   })
 
   it("Resources page should allow user to delete a resource category", () => {
-    cy.contains(TEST_CATEGORY_RENAMED).find("[id^=settings-folder]").click()
-    cy.contains(TEST_CATEGORY_RENAMED).contains("Delete").click()
+    cy.contains("a", TEST_CATEGORY_RENAMED).as("folderCard")
+    cy.clickContextMenuItem("@folderCard", "Delete")
     cy.contains(":button", "Cancel").click()
 
-    cy.contains(TEST_CATEGORY_RENAMED).find("[id^=settings-folder]").click()
-    cy.contains(TEST_CATEGORY_RENAMED).contains("Delete").click()
+    cy.contains("a", TEST_CATEGORY_RENAMED).as("folderCard")
+    cy.clickContextMenuItem("@folderCard", "Delete")
     cy.contains(":button", "Delete").click()
 
-    // Set a wait time because the API takes time
-    cy.wait(E2E_DEFAULT_WAIT_TIME)
-    cy.contains("Successfully deleted directory")
+    cy.contains("Successfully deleted directory").should("exist")
 
     cy.contains(TEST_CATEGORY_RENAMED).should("not.exist")
   })

--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -28,6 +28,7 @@ describe("Settings page", () => {
   const IMAGE_DIR = "/images/"
   const TEST_FACEBOOK_PIXEL_ID = "12345"
   const TEST_GOOGLE_ANALYTICS_ID = "UA-39345131-3"
+  const TEST_LINKEDIN_INSIGHTS_ID = "1234567"
   const TEST_PRIMARY_COLOR = [255, 0, 0] // ([R, G, B])
   const TEST_SECONDARY_COLOR = [0, 255, 0] // ([R, G, B])
   const TEST_FACEBOOK_LINK = "https://www.facebook.com/testfb"
@@ -47,7 +48,7 @@ describe("Settings page", () => {
 
   // Reusable save command
   Cypress.Commands.add("saveSettings", () => {
-    cy.intercept("POST", "/v2/**").as("awaitSave")
+    cy.intercept("POST", "/v2/sites/e2e-test-repo/settings").as("awaitSave")
     cy.contains("button", "Save").click()
     cy.wait("@awaitSave")
   })
@@ -75,34 +76,54 @@ describe("Settings page", () => {
 
     // Reset page input field states
     cy.get("#title").clear().type(BASE_TITLE)
-    cy.contains("Analytics")
+    cy.contains("div", "Analytics")
       .parent()
       .find("input")
       .each((elem) => cy.wrap(elem).clear())
-    cy.contains("p", "Primary").siblings("[id$=-box]").click()
-    cy.get("[id=colorModal]")
+    cy.contains("label", "Primary")
+      .parent()
+      .find('button[aria-label="Select colour"]')
+      .click()
+    cy.get(".sketch-picker")
       .find("input")
       .first()
       .clear()
       .type(BASE_PRIMARY_COLOR)
-    cy.get("[id=colorModalSubmit]").click()
-    cy.contains("p", "Secondary").siblings("[id$=-box]").click()
-    cy.get("[id=colorModal]")
+    cy.contains("button", "Select Colour").click()
+    cy.contains("label", "Secondary")
+      .parent()
+      .find('button[aria-label="Select colour"]')
+      .click()
+    cy.get(".sketch-picker")
       .find("input")
       .first()
       .clear()
       .type(BASE_SECONDARY_COLOR)
-    cy.get("[id=colorModalSubmit]").click()
-    cy.get("#facebook").clear().type(BASE_FACEBOOK_LINK)
-    cy.get("#linkedin").clear().type(BASE_LINKEDIN_LINK)
-    cy.get("#twitter").clear().type(BASE_TWITTER_LINK)
-    cy.get("#youtube").clear().type(BASE_YOUTUBE_LINK)
-    cy.get("#instagram").clear().type(BASE_INSTAGRAM_LINK)
-    cy.get("#telegram").clear().type(BASE_TELEGRAM_LINK)
-    cy.get("#tiktok").clear().type(BASE_TIKTOK_LINK)
-    cy.get("#contact_us").clear().type(BASE_CONTACT_US)
-    cy.get("#feedback").clear().type(BASE_FEEDBACK)
-    cy.get("#faq").clear().type(BASE_FAQ)
+    cy.contains("button", "Select Colour").click()
+    cy.get("input[name='socialMediaContent.facebook']")
+      .clear()
+      .type(BASE_FACEBOOK_LINK)
+    cy.get("input[name='socialMediaContent.linkedin']")
+      .clear()
+      .type(BASE_LINKEDIN_LINK)
+    cy.get("input[name='socialMediaContent.twitter']")
+      .clear()
+      .type(BASE_TWITTER_LINK)
+    cy.get("input[name='socialMediaContent.youtube']")
+      .clear()
+      .type(BASE_YOUTUBE_LINK)
+    cy.get("input[name='socialMediaContent.instagram']")
+      .clear()
+      .type(BASE_INSTAGRAM_LINK)
+    cy.get("input[name='socialMediaContent.telegram']")
+      .clear()
+      .type(BASE_TELEGRAM_LINK)
+    cy.get("input[name='socialMediaContent.tiktok']")
+      .clear()
+      .type(BASE_TIKTOK_LINK)
+    cy.get("input[name=contact]").clear().type(BASE_CONTACT_US)
+    cy.get("input[name=feedback]").clear().type(BASE_FEEDBACK)
+    cy.get("input[name=faq]").clear().type(BASE_FAQ)
 
     cy.saveSettings()
   })
@@ -114,6 +135,7 @@ describe("Settings page", () => {
     cy.get("#title").should((elem) => {
       expect(elem.val()).to.have.length.greaterThan(0)
     })
+    cy.contains("Verify").should("not.exist")
   })
 
   it("Should change Title and have change reflect correctly on save", () => {
@@ -125,31 +147,32 @@ describe("Settings page", () => {
   })
 
   it("Should toggle Masthead and Show Reach buttons and have change reflect correctly on save", () => {
-    const shouldBeSelectedArr = []
-    // Toggles the Masthead and Show Reach buttons and saves their expected states to reference later
-    cy.get("input[type=checkbox]")
-      .each((element) => {
-        shouldBeSelectedArr.push(`${!(element.val() === "true")}`)
-        cy.wrap(element).parent().click({ force: true })
-      })
-      .then(() => {
-        cy.saveSettings()
+    // Arrange
+    // NOTE: Initial state is display govt masthead off and show reach on
+    cy.contains("label", "Display government masthead")
+      .next()
+      .find("input")
+      .as("displayMasthead")
+      .should("not.be.checked")
+    cy.contains("label", "Show REACH")
+      .next()
+      .find("input")
+      .as("showReach")
+      .should("be.checked")
 
-        cy.contains("Display government masthead:")
-          .parent()
-          .siblings()
-          .find("input[type=checkbox]")
-          .should("have.value", shouldBeSelectedArr[0])
-        cy.contains("Show Reach:")
-          .parent()
-          .siblings()
-          .find("input[type=checkbox]")
-          .should("have.value", shouldBeSelectedArr[1])
-      })
+    // Act
+    // Trigger click event
+    // NOTE: We have to force as chakra uses an invisible input as a checkbox
+    cy.get("@displayMasthead").check({ force: true })
+    cy.get("@showReach").uncheck({ force: true })
+
+    // Assert
+    cy.get("@displayMasthead").should("be.checked")
+    cy.get("@showReach").should("not.be.checked")
   })
 
   it("Should change Logos and have change reflect correctly on save", () => {
-    cy.get("button:contains(Choose Image)").each((el, index) => {
+    cy.get("button:contains(Upload Image)").each((el, index) => {
       cy.wrap(el).click()
       cy.contains(TEST_LOGO_IMAGES[index]).click()
       cy.contains("button", "Select").should("not.be.disabled").click()
@@ -157,19 +180,42 @@ describe("Settings page", () => {
 
     cy.saveSettings() // Save
 
-    cy.get("#shareicon").should("have.value", IMAGE_DIR + TEST_LOGO_IMAGES[0])
-    cy.get("#logo").should("have.value", IMAGE_DIR + TEST_LOGO_IMAGES[1])
-    cy.get("#favicon").should("have.value", IMAGE_DIR + TEST_LOGO_IMAGES[2])
+    cy.contains("p", "Shareicon")
+      .next()
+      .find("input")
+      .should("have.value", IMAGE_DIR + TEST_LOGO_IMAGES[0])
+    cy.contains("p", "Agency logo")
+      .next()
+      .find("input")
+      .should("have.value", IMAGE_DIR + TEST_LOGO_IMAGES[1])
+    cy.contains("p", "Favicon")
+      .next()
+      .find("input")
+      .should("have.value", IMAGE_DIR + TEST_LOGO_IMAGES[2])
   })
 
   it("Should change analytics codes and have change reflect correctly on save", () => {
-    cy.get("#facebook_pixel").type(TEST_FACEBOOK_PIXEL_ID)
-    cy.get("#google_analytics").type(TEST_GOOGLE_ANALYTICS_ID)
+    // Arrange
+    cy.contains("label", "Facebook Pixel")
+      .next()
+      .as("pixel")
+      .type(TEST_FACEBOOK_PIXEL_ID)
+    cy.contains("label", "Google Analytics")
+      .next()
+      .as("ga")
+      .type(TEST_GOOGLE_ANALYTICS_ID)
+    cy.contains("label", "LinkedIn Insights")
+      .next()
+      .as("insights")
+      .type(TEST_LINKEDIN_INSIGHTS_ID)
 
+    // Act
     cy.saveSettings()
 
-    cy.get("#facebook_pixel").should("have.value", TEST_FACEBOOK_PIXEL_ID)
-    cy.get("#google_analytics").should("have.value", TEST_GOOGLE_ANALYTICS_ID)
+    // Assert
+    cy.get("@pixel").should("have.value", TEST_FACEBOOK_PIXEL_ID)
+    cy.get("@ga").should("have.value", TEST_GOOGLE_ANALYTICS_ID)
+    cy.get("@insights").should("have.value", TEST_LINKEDIN_INSIGHTS_ID)
   })
 
   // [r, g, b] -> #RRGGBB
@@ -177,15 +223,21 @@ describe("Settings page", () => {
     // eslint-disable-next-line no-bitwise
     return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
   }
-  it.only("Should change Primary and Secondary colors and have colors reflected on page previews", () => {
+  it("Should change Primary and Secondary colors and have colors reflected on page previews", () => {
     // Enter RGB values for primary and secondary colors
-    cy.contains("p", "Primary").siblings("button").click()
+    cy.contains("label", "Primary")
+      .parent()
+      .find('button[aria-label="Select colour"]')
+      .click()
     cy.contains(/^r/).siblings().clear().type(TEST_PRIMARY_COLOR[0].toString())
     cy.contains(/^g/).siblings().clear().type(TEST_PRIMARY_COLOR[1].toString())
     cy.contains(/^b/).siblings().clear().type(TEST_PRIMARY_COLOR[2].toString())
-    cy.contains("button", "Select").click()
+    cy.contains("button", "Select Colour").click()
 
-    cy.contains("p", "Secondary").siblings("button").click()
+    cy.contains("label", "Secondary")
+      .parent()
+      .find('button[aria-label="Select colour"]')
+      .click()
     cy.contains(/^r/)
       .siblings()
       .clear()
@@ -198,7 +250,7 @@ describe("Settings page", () => {
       .siblings()
       .clear()
       .type(TEST_SECONDARY_COLOR[2].toString())
-    cy.contains("button", "Select").click()
+    cy.contains("button", "Select Colour").click()
 
     cy.saveSettings()
 
@@ -207,18 +259,22 @@ describe("Settings page", () => {
     const hexPrimary = rgbToHex(...TEST_PRIMARY_COLOR)
     const rgbSecondary = `rgb(${TEST_SECONDARY_COLOR.join(", ")})`
     const hexSecondary = rgbToHex(...TEST_SECONDARY_COLOR)
-    cy.contains("p", "Primary")
-      .siblings("input")
+    cy.contains("label", "Primary")
+      .parent()
+      .find("input")
       .should("have.value", hexPrimary)
-    cy.contains("p", "Primary")
-      .siblings("button")
+    cy.contains("label", "Primary")
+      .parent()
+      .find("button")
       .should("have.css", "background-color")
       .and("eq", rgbPrimary)
-    cy.contains("p", "Secondary")
-      .siblings("input")
+    cy.contains("label", "Secondary")
+      .parent()
+      .find("input")
       .should("have.value", hexSecondary)
-    cy.contains("p", "Secondary")
-      .siblings("button")
+    cy.contains("label", "Secondary")
+      .parent()
+      .find("button")
       .should("have.css", "background-color")
       .and("eq", rgbSecondary)
 
@@ -240,34 +296,75 @@ describe("Settings page", () => {
   })
 
   it("Should change Social Media links and have change reflected on save", () => {
-    cy.get("#facebook").clear().type(TEST_FACEBOOK_LINK)
-    cy.get("#linkedin").clear().type(TEST_LINKEDIN_LINK)
-    cy.get("#twitter").clear().type(TEST_TWITTER_LINK)
-    cy.get("#youtube").clear().type(TEST_YOUTUBE_LINK)
-    cy.get("#instagram").clear().type(TEST_INSTAGRAM_LINK)
-    cy.get("#telegram").clear().type(TEST_TELEGRAM_LINK)
-    cy.get("#tiktok").clear().type(TEST_TIKTOK_LINK)
+    // Arrange
+    cy.get("input[name='socialMediaContent.facebook']")
+      .clear()
+      .type(TEST_FACEBOOK_LINK)
+    cy.get("input[name='socialMediaContent.linkedin']")
+      .clear()
+      .type(TEST_LINKEDIN_LINK)
+    cy.get("input[name='socialMediaContent.twitter']")
+      .clear()
+      .type(TEST_TWITTER_LINK)
+    cy.get("input[name='socialMediaContent.youtube']")
+      .clear()
+      .type(TEST_YOUTUBE_LINK)
+    cy.get("input[name='socialMediaContent.instagram']")
+      .clear()
+      .type(TEST_INSTAGRAM_LINK)
+    cy.get("input[name='socialMediaContent.telegram']")
+      .clear()
+      .type(TEST_TELEGRAM_LINK)
+    cy.get("input[name='socialMediaContent.tiktok']")
+      .clear()
+      .type(TEST_TIKTOK_LINK)
 
+    // Act
     cy.saveSettings()
 
-    cy.get("#facebook").should("have.value", TEST_FACEBOOK_LINK)
-    cy.get("#linkedin").should("have.value", TEST_LINKEDIN_LINK)
-    cy.get("#twitter").should("have.value", TEST_TWITTER_LINK)
-    cy.get("#youtube").should("have.value", TEST_YOUTUBE_LINK)
-    cy.get("#instagram").should("have.value", TEST_INSTAGRAM_LINK)
-    cy.get("#telegram").should("have.value", TEST_TELEGRAM_LINK)
-    cy.get("#tiktok").should("have.value", TEST_TIKTOK_LINK)
+    // Assert
+    cy.get("input[name='socialMediaContent.facebook']").should(
+      "have.value",
+      TEST_FACEBOOK_LINK
+    )
+    cy.get("input[name='socialMediaContent.linkedin']").should(
+      "have.value",
+      TEST_LINKEDIN_LINK
+    )
+    cy.get("input[name='socialMediaContent.twitter']").should(
+      "have.value",
+      TEST_TWITTER_LINK
+    )
+    cy.get("input[name='socialMediaContent.youtube']").should(
+      "have.value",
+      TEST_YOUTUBE_LINK
+    )
+    cy.get("input[name='socialMediaContent.instagram']").should(
+      "have.value",
+      TEST_INSTAGRAM_LINK
+    )
+    cy.get("input[name='socialMediaContent.telegram']").should(
+      "have.value",
+      TEST_TELEGRAM_LINK
+    )
+    cy.get("input[name='socialMediaContent.tiktok']").should(
+      "have.value",
+      TEST_TIKTOK_LINK
+    )
   })
 
   it("Should change footer info and have info reflected correctly on save", () => {
-    cy.get("#contact_us").clear().type(TEST_CONTACT_US)
-    cy.get("#feedback").clear().type(TEST_FEEDBACK)
-    cy.get("#faq").clear().type(TEST_FAQ)
+    // Arrange
+    cy.get("input[name=contact]").clear().type(TEST_CONTACT_US)
+    cy.get("input[name=feedback]").clear().type(TEST_FEEDBACK)
+    cy.get("input[name=faq]").clear().type(TEST_FAQ)
 
+    // Act
     cy.saveSettings()
 
-    cy.get("#contact_us").should("have.value", TEST_CONTACT_US)
-    cy.get("#feedback").should("have.value", TEST_FEEDBACK)
-    cy.get("#faq").should("have.value", TEST_FAQ)
+    // Assert
+    cy.get("input[name=contact]").should("have.value", TEST_CONTACT_US)
+    cy.get("input[name=feedback]").should("have.value", TEST_FEEDBACK)
+    cy.get("input[name=faq]").should("have.value", TEST_FAQ)
   })
 })

--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -78,6 +78,7 @@ describe("Settings page", () => {
     cy.get("#title").clear().type(BASE_TITLE)
     cy.contains("div", "Analytics")
       .parent()
+      .parent()
       .find("input")
       .each((elem) => cy.wrap(elem).clear())
     cy.contains("label", "Primary")

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -145,7 +145,7 @@ describe("Workspace Pages flow", () => {
 
       // Act
       // User should be able edit page details
-      cy.clickContextMenuItem("@pageCard", "settings")
+      cy.clickContextMenuItem("@pageCard", "Settings")
       cy.get("#title").should("have.value", TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -167,7 +167,7 @@ describe("Workspace Pages flow", () => {
 
       // Act
       // User should be able edit page details
-      cy.clickContextMenuItem("@pageCard", "settings")
+      cy.clickContextMenuItem("@pageCard", "Settings")
       cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -302,7 +302,7 @@ describe("Workspace Pages flow", () => {
       cy.contains("a", PRETTIFIED_FOLDER_WITH_PAGES_TITLE)
         .as("folderItem")
         .should("exist")
-      cy.clickContextMenuItem("@folderItem", "settings")
+      cy.clickContextMenuItem("@folderItem", "Settings")
       cy.get("input#newDirectoryName")
         .clear()
         .type(EDITED_TEST_FOLDER_WITH_PAGES_TITLE)

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -53,16 +53,16 @@ describe("Workspace Pages flow", () => {
       cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
       window.localStorage.setItem("userId", "test")
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
+      cy.contains("Verify").should("not.exist")
     })
 
     it("Test site workspace page should have unlinked pages section", () => {
-      cy.contains("Add a new page")
+      cy.contains("Create page")
     })
 
     it("Should be able to create a new page with valid title and permalink", () => {
-      cy.get("#settings-NEW", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
+      // Act
+      cy.contains("button", "Create page").click()
       cy.get("#title").clear().type(TEST_PAGE_TITLE)
       cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
       cy.intercept("POST", "/v2/**").as("awaitSave")
@@ -80,7 +80,7 @@ describe("Workspace Pages flow", () => {
           newFileName: `${TEST_PAGE_TITLE}.md`,
         })
 
-      // Asserts
+      // Assert
       // 1. User should be redirected to correct EditPage
       cy.url().should(
         "include",
@@ -91,15 +91,12 @@ describe("Workspace Pages flow", () => {
       )
 
       // 2. If user goes back to the workspace, they should be able to see that the page exists
-      cy.contains("Back to Workspace", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
-      cy.contains(TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT }).should(
-        "exist"
-      )
+      cy.contains("Back to Workspace").should("exist").click()
+      cy.contains("a", TEST_PAGE_TITLE).should("exist")
     })
 
     it("Should not be able to create page with invalid title", () => {
+      // Arrange
       const INVALID_TEST_PAGE_TITLES = [
         "Ab",
         "Lorem Ipsum<",
@@ -112,16 +109,15 @@ describe("Workspace Pages flow", () => {
         "]Lorem Ipsum",
       ]
 
-      cy.get("#settings-NEW", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
-
+      // Act
+      cy.contains("button", "Create page").click()
       // Cannot use titles shorter than 4 characters or containing symbols ~!@#$%^&*_+-./\`:;~{}()[]"'<>,?
       INVALID_TEST_PAGE_TITLES.forEach((invalidTitle) => {
         cy.get("#title").clear().type(invalidTitle).blur()
         cy.contains("button", "Save").should("be.disabled")
       })
 
+      // Assert
       // Page title must not already exist
       cy.get("#title").clear().type(TEST_PAGE_TITLE).blur()
       cy.contains("Title is already in use. Please choose a different title.")
@@ -129,12 +125,13 @@ describe("Workspace Pages flow", () => {
     })
 
     it("Should not be able to create page with invalid permalink", () => {
+      // Arrange
       const INVALID_TEST_PAGE_PERMALINKS = ["/12", "test-", "/abcd?"]
 
-      cy.get("#settings-NEW", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
+      // Act
+      cy.contains("button", "Create page").click()
 
+      // Assert
       // Permalink needs to be longer than 4 characters, should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only
       INVALID_TEST_PAGE_PERMALINKS.forEach((invalidPermalink) => {
         cy.get("#permalink").clear().type(invalidPermalink).blur()
@@ -143,24 +140,20 @@ describe("Workspace Pages flow", () => {
     })
 
     it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
-      const testPageCard = cy
-        .contains(TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
+      // Arrange
+      cy.contains("a", TEST_PAGE_TITLE).as("pageCard").should("exist")
 
+      // Act
       // User should be able edit page details
-      testPageCard
-        .children()
-        .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-      cy.get("div[id^=settings-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
-
+      cy.clickContextMenuItem("@pageCard", "settings")
       cy.get("#title").should("have.value", TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
-
       cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE)
       cy.contains("button", "Save").click()
 
-      // ASSERT: New page title should be reflected in the Workspace
+      // Assert
+      // New page title should be reflected in the Workspace
       cy.contains(EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
@@ -169,53 +162,43 @@ describe("Workspace Pages flow", () => {
     })
 
     it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
-      const testPageCard = cy
-        .contains(EDITED_TEST_PAGE_TITLE, {
-          timeout: E2E_EXTENDED_TIMEOUT,
-        })
-        .should("exist")
+      // Arrange
+      cy.contains("a", EDITED_TEST_PAGE_TITLE).as("pageCard").should("exist")
 
+      // Act
       // User should be able edit page details
-      testPageCard
-        .children()
-        .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-      cy.get("div[id^=settings-]").first().click()
-
+      cy.clickContextMenuItem("@pageCard", "settings")
       cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
-
       cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE_2)
       cy.contains("button", "Save").click()
 
+      // Asserts
+      // Should show modal
       cy.contains("Successfully updated page!", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
-
-      // Asserts
-      // 1. New page title should be reflected in Folders
+      // New page title should be reflected in Folders
       cy.contains(EDITED_TEST_PAGE_TITLE_2, {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")
     })
 
     it("Should be able to delete existing page on workspace", () => {
+      // Arrange
       // Ensure that the frontend has been updated
       cy.contains(EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("not.exist")
 
-      // Assert
+      // Act
       // User should be able to remove the created test page card
-      cy.contains(EDITED_TEST_PAGE_TITLE_2, { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .children()
-        .within(() => cy.get("[id^=pageCard-dropdown-]").click())
-      cy.get("div[id^=delete-]").first().click() // .first() is necessary because the get returns multiple elements (refer to MenuDropdown.jsx)
-      cy.contains("button", "Delete", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
+      cy.contains("a", EDITED_TEST_PAGE_TITLE_2).as("pageCard").should("exist")
+      cy.clickContextMenuItem("@pageCard", "Delete")
+      cy.contains("button", "Delete").should("exist").click()
 
+      // Assert
       cy.contains(EDITED_TEST_PAGE_TITLE_2, {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("not.exist")

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -210,19 +210,19 @@ describe("Workspace Pages flow", () => {
       cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
       window.localStorage.setItem("userId", "test")
       cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
+      cy.contains("Verify").should("not.exist")
     })
 
     it("Test site workspace page should have folders section", () => {
-      cy.contains("Create new folder", {
-        timeout: E2E_EXTENDED_TIMEOUT,
-      }).should("exist")
+      cy.contains("Create folder").should("exist")
     })
 
     // Create
     it("Should be able to create a new folder with valid folder name with no pages", () => {
-      cy.contains("Create new folder", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
+      // Arrange
+      cy.contains("Create folder").should("exist").click()
+
+      // Act
       cy.get("input#newDirectoryName").clear().type(TEST_FOLDER_NO_PAGES_TITLE)
       cy.contains("Next").click()
       cy.contains("Skip").click()
@@ -239,8 +239,8 @@ describe("Workspace Pages flow", () => {
     })
 
     it("Should be able to create a new folder with valid folder name with page", () => {
-      // Create test page
-      cy.get("#settings-NEW").click()
+      // Act
+      cy.contains("Create page").should("exist").click()
       cy.get("#title").clear().type(TEST_PAGE_TITLE)
       cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
       cy.contains("Save").click()
@@ -256,9 +256,7 @@ describe("Workspace Pages flow", () => {
           cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`)
         )
 
-      cy.contains("Create new folder", { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
+      cy.contains("Create folder").should("exist").click()
       cy.get("input#newDirectoryName")
         .clear()
         .type(TEST_FOLDER_WITH_PAGES_TITLE)
@@ -274,9 +272,7 @@ describe("Workspace Pages flow", () => {
         "include",
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_TEST_FOLDER_WITH_PAGES_TITLE}`
       )
-      cy.contains(TEST_PAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT })
-        .should("exist")
-        .click()
+      cy.contains("a", TEST_PAGE_TITLE).should("exist").click()
       cy.get(".CodeMirror-scroll", { timeout: E2E_EXTENDED_TIMEOUT }).should(
         "contain",
         TEST_PAGE_CONTENT
@@ -286,7 +282,7 @@ describe("Workspace Pages flow", () => {
     it("Should not be able to create a new folder with invalid folder name", () => {
       // Title is too short
       const INVALID_FOLDER_TITLE = "t"
-      cy.contains("Create new folder", { timeout: E2E_EXTENDED_TIMEOUT })
+      cy.contains("Create folder", { timeout: E2E_EXTENDED_TIMEOUT })
         .should("exist")
         .click()
       cy.get("input#newDirectoryName").clear().type(INVALID_FOLDER_TITLE).blur()
@@ -303,55 +299,50 @@ describe("Workspace Pages flow", () => {
     })
 
     it("Should be able to rename a folder", () => {
-      cy.contains(PRETTIFIED_FOLDER_WITH_PAGES_TITLE, {
-        timeout: E2E_EXTENDED_TIMEOUT,
-      })
+      cy.contains("a", PRETTIFIED_FOLDER_WITH_PAGES_TITLE)
+        .as("folderItem")
         .should("exist")
-        .within(() => cy.get("[id^=settingsIcon]").click())
-      cy.contains("Edit details").click()
-      cy.contains("Folder settings")
+      cy.clickContextMenuItem("@folderItem", "settings")
       cy.get("input#newDirectoryName")
         .clear()
         .type(EDITED_TEST_FOLDER_WITH_PAGES_TITLE)
       cy.contains("button", "Save").click()
 
       // Assert
-      cy.contains(PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE, {
+      cy.contains("a", PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
         .should("exist")
         .click()
-      cy.contains(PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE, {
-        timeout: E2E_EXTENDED_TIMEOUT,
-      }).should("exist")
       cy.url().should(
         "include",
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${PARSED_EDITED_TEST_FOLDER_WITH_PAGES_TITLE}`
       )
 
-      cy.contains(TEST_PAGE_TITLE).click()
+      cy.contains("a", TEST_PAGE_TITLE).click()
       cy.get(".CodeMirror-scroll").should("contain", TEST_PAGE_CONTENT)
     })
 
     it("Should be able to delete a folder", () => {
-      cy.contains(PRETTIFIED_FOLDER_NO_PAGES_TITLE, {
-        timeout: E2E_EXTENDED_TIMEOUT,
-      })
+      // Arrange
+      cy.contains("a", PRETTIFIED_FOLDER_NO_PAGES_TITLE)
+        .as("emptyFolderItem")
         .should("exist")
-        .within(() => cy.get("[id^=settingsIcon]").click())
-      cy.get("button[id^=delete-]").first().click()
+      cy.contains("a", PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE).as(
+        "folderItem"
+      )
+
+      // Act
+      cy.clickContextMenuItem("@emptyFolderItem", "Delete")
       cy.contains("button", "Delete").click()
 
+      cy.clickContextMenuItem("@folderItem", "Delete")
+      cy.contains("button", "Delete").click()
+
+      // Assert
       cy.contains(PRETTIFIED_FOLDER_NO_PAGES_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("not.exist")
-
-      cy.contains(PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE).within(() =>
-        cy.get("[id^=settingsIcon]").click()
-      )
-      cy.get("button[id^=delete-]").first().click()
-      cy.contains("button", "Delete").click()
-
       cy.contains(PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("not.exist")

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -145,7 +145,7 @@ describe("Workspace Pages flow", () => {
 
       // Act
       // User should be able edit page details
-      cy.clickContextMenuItem("@pageCard", "Settings")
+      cy.clickContextMenuItem("@pageCard", "settings")
       cy.get("#title").should("have.value", TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -167,7 +167,7 @@ describe("Workspace Pages flow", () => {
 
       // Act
       // User should be able edit page details
-      cy.clickContextMenuItem("@pageCard", "Settings")
+      cy.clickContextMenuItem("@pageCard", "settings")
       cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE, {
         timeout: E2E_EXTENDED_TIMEOUT,
       })
@@ -302,7 +302,7 @@ describe("Workspace Pages flow", () => {
       cy.contains("a", PRETTIFIED_FOLDER_WITH_PAGES_TITLE)
         .as("folderItem")
         .should("exist")
-      cy.clickContextMenuItem("@folderItem", "Settings")
+      cy.clickContextMenuItem("@folderItem", "settings")
       cy.get("input#newDirectoryName")
         .clear()
         .type(EDITED_TEST_FOLDER_WITH_PAGES_TITLE)

--- a/cypress/support/files.js
+++ b/cypress/support/files.js
@@ -1,0 +1,18 @@
+import "cypress-pipe"
+/** Uses the immediate sibling of the context menu to retrieve the requested dropdown menu item \
+ * and fire a click event on it
+ * @param {string} alias **NOTE** alias MUST be the full fledged (@...) alias of the IMMEDIATE PRIOR sibling
+ * @param {string} menuItemText The text within the menu item to select
+ */
+Cypress.Commands.add("clickContextMenuItem", (alias, menuItemText) => {
+  // NOTE: Context menu is absolutely positioned so we get the sibling first using the alias
+  cy.get(alias).next().click()
+  // NOTE: Cypress thinks this element is still hidden after it's being clicked
+  // We pass the force option to override this as it has been clicked above
+  // and existence is guaranteed.
+  cy.get(alias)
+    .parent()
+    .find("div")
+    .contains("a", menuItemText)
+    .click({ force: true })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,2 +1,3 @@
 import "./commands"
 import "./medias"
+import "./files"

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,4 @@
 import "./commands"
 import "./medias"
 import "./files"
+import "./move"

--- a/cypress/support/move.js
+++ b/cypress/support/move.js
@@ -1,0 +1,27 @@
+/** Uses the first element in the breadcrumb to verify the structure of the breadcrumb against the provided array. \
+ * The > connector is implicitly assumed and should not be passed in breadcrumb items.
+ * @param {string} alias **NOTE** alias MUST be the full fledged (@...) alias of the first sibling
+ * @param {[]string} breadcrumbItems The items within the breadcrumb - this must be a non-empty array
+ */
+Cypress.Commands.add("verifyBreadcrumb", (alias, breadcrumbItems) => {
+  const lastBreadcrumb = breadcrumbItems.pop()
+  let breadcrumbRef = cy.get(alias)
+  breadcrumbItems.forEach((curItem) => {
+    breadcrumbRef = breadcrumbRef.contains(curItem).next().contains(">").next()
+  })
+  breadcrumbRef.contains(lastBreadcrumb)
+})
+
+/**
+ * Retrives the first sibling of the given element.
+ * This command is to be chained off a previous command that yields an element (eg: cy.get().getFirstSiblingAs(...))
+ * @param {string} as The alias that should be given to the first sibling
+ */
+Cypress.Commands.add(
+  "getFirstSiblingAs",
+  { prevSubject: "element" },
+  (item, as) => {
+    const wrapped = cy.wrap(item)
+    return wrapped.parent().first().as(as)
+  }
+)

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -52,7 +52,7 @@ export const Card = ({ children, ...props }: CardProps): JSX.Element => {
   return (
     <CardContext.Provider value={{ variant, ...buttonBehaviourProps }}>
       <StylesProvider value={styles}>
-        <Box position="relative" h="100%" overflow="auto">
+        <Box position="relative" h="100%">
           <Inner />
         </Box>
       </StylesProvider>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -52,7 +52,7 @@ export const Card = ({ children, ...props }: CardProps): JSX.Element => {
   return (
     <CardContext.Provider value={{ variant, ...buttonBehaviourProps }}>
       <StylesProvider value={styles}>
-        <Box position="relative" h="100%">
+        <Box position="relative" h="100%" overflow="auto">
           <Inner />
         </Box>
       </StylesProvider>

--- a/src/components/FolderCard/FolderCard.jsx
+++ b/src/components/FolderCard/FolderCard.jsx
@@ -106,7 +106,7 @@ export const FolderCard = ({
                   as={RouterLink}
                   to={`${url}/editDirectorySettings/${category}`}
                 >
-                  Folder Settings
+                  Folder settings
                 </ContextMenu.Item>
                 <>
                   <Divider />

--- a/src/components/MediaMoveModal/MediaMoveModal.jsx
+++ b/src/components/MediaMoveModal/MediaMoveModal.jsx
@@ -1,7 +1,7 @@
 import { CloseButton, HStack } from "@chakra-ui/react"
 import { Breadcrumb } from "components/folders/Breadcrumb"
 import { LoadingButton } from "components/LoadingButton"
-import { MoveMenuBackButton, DirMenuItem, FileMenuItem } from "components/move"
+import { MoveMenuHeader, DirMenuItem, FileMenuItem } from "components/move"
 import _ from "lodash"
 import PropTypes from "prop-types"
 import { useState } from "react"
@@ -94,7 +94,7 @@ export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
               )}
             />
             <div className={`${elementStyles.moveModal}`}>
-              <MoveMenuBackButton
+              <MoveMenuHeader
                 onBack={() => {
                   setMoveQuery({
                     ...moveQuery,

--- a/src/components/PageMoveModal/PageMoveModal.jsx
+++ b/src/components/PageMoveModal/PageMoveModal.jsx
@@ -1,7 +1,7 @@
 import { CloseButton, HStack } from "@chakra-ui/react"
 import { Breadcrumb } from "components/folders/Breadcrumb"
 import { LoadingButton } from "components/LoadingButton"
-import { MoveMenuBackButton, DirMenuItem, FileMenuItem } from "components/move"
+import { MoveMenuHeader, DirMenuItem, FileMenuItem } from "components/move"
 import _ from "lodash"
 import { useState } from "react"
 
@@ -91,7 +91,7 @@ export const PageMoveModal = ({ queryParams, params, onProceed, onClose }) => {
               )}
             />
             <div className={`${elementStyles.moveModal}`}>
-              <MoveMenuBackButton
+              <MoveMenuHeader
                 onBack={() => {
                   setMoveQuery(_.omit(moveQuery, lastItemType))
                   setMoveTo(_.omit(moveQuery, lastItemType))

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
   BiBuoy,
   BiCog,
   BiCubeAlt,
-  BiFile,
+  BiFileBlank,
   BiGridAlt,
   BiImage,
   BiLogOutCircle,
@@ -149,7 +149,7 @@ export const Sidebar = (): JSX.Element => {
             to={`/sites/${siteName}/media/files/mediaDirectory/files`}
             isSelected={selectedTab === "files"}
           >
-            <TabLabel icon={BiFile}>Files</TabLabel>
+            <TabLabel icon={BiFileBlank}>Files</TabLabel>
           </Tab>
           <Tab
             as={RouterLink}

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -86,7 +86,7 @@ const MediaCard = ({ type, media, onClick, showSettings = true }) => {
               as={RouterLink}
               to={`${url}/editMediaSettings/${encodedName}`}
             >
-              Image Settings
+              Image settings
             </ContextMenu.Item>
             <ContextMenu.Item
               icon={<BiFolder />}

--- a/src/components/move/MoveMenuHeader.tsx
+++ b/src/components/move/MoveMenuHeader.tsx
@@ -4,18 +4,18 @@ import { MouseEventHandler } from "react"
 import { BxArrowBack } from "assets/icons"
 import { deslugifyDirectory } from "utils"
 
-interface MoveMenuBackButtonProps {
+interface MoveMenuHeaderProps {
   isDisabled: boolean
   backButtonText: string
   onBack: MouseEventHandler<HTMLButtonElement>
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export const MoveMenuBackButton = ({
+export const MoveMenuHeader = ({
   onBack,
   isDisabled,
   backButtonText,
-}: MoveMenuBackButtonProps): JSX.Element => {
+}: MoveMenuHeaderProps): JSX.Element => {
   const backgroundColour = useToken("colors", "primary.500")
   return (
     <Box
@@ -37,7 +37,7 @@ export const MoveMenuBackButton = ({
             onClick={onBack}
             aria-label="back-button"
             size="sm"
-            icon={<Icon as={BxArrowBack} w="24px" h="24px" />}
+            icon={<Icon as={BxArrowBack} fontSize="1.5rem" />}
           />
         )}
         {/* NOTE: index.scss sets p to have margin bottom of 5 */}

--- a/src/components/move/index.ts
+++ b/src/components/move/index.ts
@@ -1,2 +1,2 @@
-export { MoveMenuBackButton } from "./MoveMenuBackButton"
+export { MoveMenuHeader } from "./MoveMenuHeader"
 export * from "./MoveMenuItem"

--- a/src/contexts/LoginContext.jsx
+++ b/src/contexts/LoginContext.jsx
@@ -19,26 +19,28 @@ const LoginConsumer = ({ children }) => {
 }
 
 const LoginProvider = ({ children }) => {
-  const [, setUserId, removeUserId] = useLocalStorage(
-    LOCAL_STORAGE_KEYS.GithubId
+  const [storedUserId, setStoredUserId, removeStoredUserId] = useLocalStorage(
+    LOCAL_STORAGE_KEYS.GithubId,
+    "Unknown user"
+  )
+  const [storedUser, setStoredUser, removeStoredUser] = useLocalStorage(
+    LOCAL_STORAGE_KEYS.User,
+    {}
   )
 
-  const [user, setUser, removeUser] = useLocalStorage(LOCAL_STORAGE_KEYS.User)
   const [, , removeSites] = useLocalStorage(LOCAL_STORAGE_KEYS.SitesIsPrivate)
   const verifyLoginAndSetLocalStorage = async () => {
     const { data } = await axios.get(`${BACKEND_URL}/auth/whoami`)
     const loggedInUser = omitBy(data, isEmpty)
 
-    if (loggedInUser.userId) {
-      setUserId(loggedInUser.userId)
-    }
-    setUser(loggedInUser)
+    setStoredUserId(loggedInUser.userId)
+    setStoredUser(loggedInUser)
   }
 
   const logout = async () => {
     await axios.delete(`${BACKEND_URL}/auth/logout`)
-    removeUserId()
-    removeUser()
+    removeStoredUserId()
+    removeStoredUser()
     removeSites()
   }
 
@@ -60,7 +62,9 @@ const LoginProvider = ({ children }) => {
   }, []) // Run only once
 
   const loginContextData = {
-    ...user,
+    userId: storedUserId,
+    email: storedUser.email,
+    contactNumber: storedUser.contactNumber,
     logout,
     verifyLoginAndSetLocalStorage,
   }

--- a/src/contexts/LoginContext.jsx
+++ b/src/contexts/LoginContext.jsx
@@ -42,6 +42,9 @@ const LoginProvider = ({ children }) => {
     removeStoredUserId()
     removeStoredUser()
     removeSites()
+    // NOTE: This is REQUIRED (emphasis here) for auto-redirect on removal of stored user id.
+    // This is IN ADDITION to removing the value associated with the key.
+    setStoredUserId(null)
   }
 
   // Set interceptors to log users out if an error occurs within the LoginProvider

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,7 +3,6 @@ import { Integrations } from "@sentry/tracing"
 import ReactDOM from "react-dom"
 
 import "styles/index.scss"
-import "styles/isomer-template.scss"
 import App from "App"
 
 if (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,7 @@ import { Integrations } from "@sentry/tracing"
 import ReactDOM from "react-dom"
 
 import "styles/index.scss"
+import "styles/isomer-template.scss"
 import App from "App"
 
 if (

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -81,7 +81,7 @@ export const Folders = ({ match }: FoldersProps): JSX.Element => {
         {/* Info segment */}
         <Section>
           <Box w="100%">
-            <SectionHeader label="Items">
+            <SectionHeader label="Order of items">
               <ButtonGroup variant="outline" spacing="1rem">
                 <Button
                   as={RouterLink}
@@ -108,7 +108,7 @@ export const Folders = ({ match }: FoldersProps): JSX.Element => {
             </SectionHeader>
             <SectionCaption label="PRO TIP: " icon={BiBulb}>
               Subfolders appear as side navigation in pages. Create a new
-              sesction by creating a subfolder.
+              section by creating a subfolder.
             </SectionCaption>
           </Box>
           <Skeleton isLoaded={!isLoadingDirectory} w="100%">

--- a/src/layouts/Folders/components/FolderBreadcrumb.tsx
+++ b/src/layouts/Folders/components/FolderBreadcrumb.tsx
@@ -1,11 +1,6 @@
 // NOTE: As Isomer does not have recursively nested folders at present,
 
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  Text,
-} from "@chakra-ui/react"
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from "@chakra-ui/react"
 import { BiChevronRight } from "react-icons/bi"
 import { useRouteMatch, Link as RouterLink } from "react-router-dom"
 

--- a/src/layouts/Folders/components/MenuDropdownButton.tsx
+++ b/src/layouts/Folders/components/MenuDropdownButton.tsx
@@ -54,7 +54,7 @@ export const MenuDropdownButton = (): JSX.Element => {
                 icon={<BiFileBlank fontSize="1.25rem" fill="icon.alt" />}
               >
                 <Text textStyle="body-1" fill="text.body">
-                  Create Page
+                  Create page
                 </Text>
               </ContextMenu.Item>
               <ContextMenu.Item
@@ -63,7 +63,7 @@ export const MenuDropdownButton = (): JSX.Element => {
                 icon={<BiFolder fontSize="1.25rem" fill="icon.alt" />}
               >
                 <Text textStyle="body-1" fill="text.body">
-                  Create Folder
+                  Create folder
                 </Text>
               </ContextMenu.Item>
             </ContextMenu.List>

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -72,9 +72,10 @@ export const ResourceCategory = (): JSX.Element => {
           <Skeleton isLoaded={!isLoading}>
             <SimpleGrid columns={3} spacing="1.5rem">
               {/* NOTE: need to use multiline cards */}
-              {pagesData.map(({ name, date, resourceType }) => (
+              {pagesData.map(({ name, title, date, resourceType }) => (
                 <ResourceCard
-                  title={name}
+                  name={name}
+                  title={title}
                   date={date}
                   resourceType={resourceType}
                 />

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -62,7 +62,7 @@ export const ResourceCategory = (): JSX.Element => {
           <Box w="full">
             <SectionHeader label="Pages">
               <CreateButton as={RouterLink} to={`${url}/createPage`}>
-                Create Page
+                Create page
               </CreateButton>
             </SectionHeader>
             <SectionCaption icon={BiBulb} label="PRO TIP: ">

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -69,7 +69,7 @@ export const ResourceCategory = (): JSX.Element => {
               Organise your workspace by moving pages into folders
             </SectionCaption>
           </Box>
-          <Skeleton isLoaded={!isLoading}>
+          <Skeleton isLoaded={!isLoading} w="100%">
             <SimpleGrid columns={3} spacing="1.5rem">
               {/* NOTE: need to use multiline cards */}
               {pagesData.map(({ name, title, date, resourceType }) => (

--- a/src/layouts/ResourceCategory/components/ResourceCard.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCard.tsx
@@ -92,7 +92,7 @@ export const ResourceCard = ({
             as={RouterLink}
             to={`${url}/editPageSettings/${encodedTitle}`}
           >
-            Page Settings
+            Page settings
           </ContextMenu.Item>
           <ContextMenu.Item
             icon={<BiFolder />}

--- a/src/layouts/ResourceCategory/components/ResourceCard.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCard.tsx
@@ -12,6 +12,7 @@ import { ContextMenu } from "components/ContextMenu"
 import {
   BiChevronRight,
   BiEditAlt,
+  BiFileBlank,
   BiFolder,
   BiTrash,
   BiWrench,
@@ -24,23 +25,25 @@ import { PageData } from "types/directory"
 import { prettifyDate } from "utils"
 
 interface ResourceCardProps {
+  name: string
   title: string
   date: string
   resourceType: SetRequired<PageData, "resourceType">["resourceType"]
 }
 
 export const ResourceCard = ({
+  name,
   title,
   date,
   resourceType,
 }: ResourceCardProps): JSX.Element => {
   const { url } = useRouteMatch()
-  const encodedTitle = encodeURIComponent(title)
+  const encodedName = encodeURIComponent(name)
   const CardContent = () => (
-    <Card variant="multi" height="100%">
+    <Card variant="multi">
       <CardBody>
         <Icon
-          as={resourceType === "post" ? BiFolder : BxFileArchiveSolid}
+          as={resourceType === "post" ? BiFileBlank : BxFileArchiveSolid}
           fontSize="1.5rem"
           fill="icon.alt"
         />
@@ -65,7 +68,7 @@ export const ResourceCard = ({
       </Box>
     ) : (
       <LinkBox position="relative" h="100%">
-        <LinkOverlay as={RouterLink} to={`${url}/editPage/${encodedTitle}`}>
+        <LinkOverlay as={RouterLink} to={`${url}/editPage/${encodedName}`}>
           <CardContent />
         </LinkOverlay>
       </LinkBox>
@@ -82,7 +85,7 @@ export const ResourceCard = ({
             <ContextMenu.Item
               icon={<BiEditAlt />}
               as={RouterLink}
-              to={`${url}/editPage/${encodedTitle}`}
+              to={`${url}/editPage/${encodedName}`}
             >
               <Text>Edit page</Text>
             </ContextMenu.Item>
@@ -90,14 +93,14 @@ export const ResourceCard = ({
           <ContextMenu.Item
             icon={<BiWrench />}
             as={RouterLink}
-            to={`${url}/editPageSettings/${encodedTitle}`}
+            to={`${url}/editPageSettings/${encodedName}`}
           >
             Page settings
           </ContextMenu.Item>
           <ContextMenu.Item
             icon={<BiFolder />}
             as={RouterLink}
-            to={`${url}/movePage/${encodedTitle}`}
+            to={`${url}/movePage/${encodedName}`}
           >
             <HStack spacing="4rem" alignItems="center">
               <Text>Move to</Text>
@@ -109,7 +112,7 @@ export const ResourceCard = ({
             <ContextMenu.Item
               icon={<BiTrash />}
               as={RouterLink}
-              to={`${url}/deletePage/${encodedTitle}`}
+              to={`${url}/deletePage/${encodedName}`}
             >
               Delete
             </ContextMenu.Item>

--- a/src/layouts/ResourceCategory/components/ResourceCategoryBreadcrumb.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCategoryBreadcrumb.tsx
@@ -33,6 +33,7 @@ export const ResourceCategoryBreadcrumb = (): JSX.Element => {
         <BreadcrumbLink
           as={RouterLink}
           textStyle="body-2"
+          textDecoration="underline"
           to={`/sites/${siteName}/resourceRoom/${resourceRoomName}/resourceCategory/`}
         >
           {deslugifyDirectory(resourceCategoryName)}

--- a/src/layouts/ResourceRoom/components/ResourceBreadcrumb.tsx
+++ b/src/layouts/ResourceRoom/components/ResourceBreadcrumb.tsx
@@ -1,5 +1,3 @@
-// NOTE: As Isomer does not have recursively nested folders at present,
-
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from "@chakra-ui/react"
 import { BiChevronRight } from "react-icons/bi"
 import { useRouteMatch, Link as RouterLink } from "react-router-dom"
@@ -9,7 +7,6 @@ import { getDecodedParams } from "utils/decoding"
 import { ResourceRoomRouteParams } from "types/resources"
 import { deslugifyDirectory } from "utils"
 
-// NOTE: A folder breadcrumb is dependent solely on whether the sub folder is present
 export const ResourceBreadcrumb = (): JSX.Element => {
   const { params } = useRouteMatch<ResourceRoomRouteParams>()
   const { siteName, resourceRoomName } = getDecodedParams({ ...params })
@@ -20,6 +17,7 @@ export const ResourceBreadcrumb = (): JSX.Element => {
         <BreadcrumbLink
           as={RouterLink}
           textStyle="body-2"
+          textDecoration="underline"
           to={`/sites/${siteName}/resourceRoom/${resourceRoomName}`}
         >
           {resourceRoomName && deslugifyDirectory(resourceRoomName)}

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -121,7 +121,7 @@ export const Workspace = (): JSX.Element => {
 
         <Section>
           <Box w="100%">
-            <SectionHeader label="Pages">
+            <SectionHeader label="Ungrouped Pages">
               <CreateButton
                 onClick={() => setRedirectToPage(`${url}/createPage`)}
               >
@@ -129,7 +129,7 @@ export const Workspace = (): JSX.Element => {
               </CreateButton>
             </SectionHeader>
             <SectionCaption label="NOTE: " icon={BiInfoCircle}>
-              Pages here do not belong to any folders
+              Pages here do not belong to any folders.
             </SectionCaption>
           </Box>
           <Skeleton isLoaded={!!pagesData} w="full">

--- a/src/layouts/Workspace/components/Cards/FolderCard.tsx
+++ b/src/layouts/Workspace/components/Cards/FolderCard.tsx
@@ -42,7 +42,7 @@ export const FolderCard = ({
             as={RouterLink}
             to={`${url}/editDirectorySettings/${title}`}
           >
-            Folder Settings
+            Folder settings
           </ContextMenu.Item>
           <>
             <Divider />

--- a/src/layouts/Workspace/components/Cards/FolderCard.tsx
+++ b/src/layouts/Workspace/components/Cards/FolderCard.tsx
@@ -4,6 +4,8 @@ import { ContextMenu } from "components/ContextMenu"
 import { BiEditAlt, BiFolder, BiTrash, BiWrench } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
 
+import { prettifyPageFileName } from "utils"
+
 interface FolderCardProps {
   title: string
   siteName: string
@@ -22,7 +24,7 @@ export const FolderCard = ({
           <CardBody>
             <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
             <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {title}
+              {prettifyPageFileName(title)}
             </Text>
           </CardBody>
         </Card>

--- a/src/layouts/Workspace/components/Cards/PageCard.tsx
+++ b/src/layouts/Workspace/components/Cards/PageCard.tsx
@@ -77,7 +77,7 @@ export const PageCard = ({
             as={RouterLink}
             to={`${url}/editPageSettings/${encodedName}`}
           >
-            Page Settings
+            Page settings
           </ContextMenu.Item>
           <ContextMenu.Item
             icon={<BiFolder />}

--- a/src/layouts/utils.ts
+++ b/src/layouts/utils.ts
@@ -21,6 +21,7 @@ export const isResourcePageData = (
   return (
     isPageData(possiblePage) &&
     possiblePage.date !== undefined &&
-    possiblePage.resourceType !== undefined
+    possiblePage.resourceType !== undefined &&
+    possiblePage.title !== undefined
   )
 }

--- a/src/theme/components/Card.ts
+++ b/src/theme/components/Card.ts
@@ -60,12 +60,13 @@ export const Card: ComponentMultiStyleConfig = {
       },
     },
     body: {
+      height: "full",
+      overflow: "auto",
       justifyContent: "flex-start",
       display: "flex",
       alignItems: "flex-start",
       textAlign: "left",
       gridArea: "body",
-      height: "full",
     },
   },
   variants: {

--- a/src/theme/components/Card.ts
+++ b/src/theme/components/Card.ts
@@ -58,6 +58,7 @@ export const Card: ComponentMultiStyleConfig = {
       _focus: {
         boxShadow: `0 0 0 2px ${borderColour}`,
       },
+      overflow: "auto",
     },
     body: {
       height: "full",

--- a/src/types/directory.ts
+++ b/src/types/directory.ts
@@ -1,5 +1,3 @@
-import type { SetRequired } from "type-fest"
-
 export type DirectoryType =
   | "mediaDirectoryName"
   | "subCollectionName"
@@ -25,6 +23,7 @@ export interface DirectoryData {
 
 export interface PageData {
   name: string
+  title?: string
   date?: string
   resourceType?: "file" | "post"
 }


### PR DESCRIPTION
## Problem
e2e tests were not included in teh previous PRs. This PR as a whole fixes any e2e tests that were failing due to dom changes. This PR also fixes some visual issues surfaced due to the refactor and also refactors some tests for maintability.

## Solution
1. for e2e tests **fixing**, only the dom structure needs to be altered to fit the updated UI. This meant that the selectors were rewritten to be inline with expectations
2. some e2e tests were refactored for maintability (most notably, anything involving `contextMenu` and `breadcrumb`. this involved making a new cypress command as we've done before and shifting the relevant logic there rather than copy-pasting everything in the test (even tho the focus should be on test correctness, it felt extremely tiring to just read through the tests, hence the refactor) 
3. some (visual) bugs were fixed -> e2e tests are useful in catching said bugs but the high cost of running the tests hinder its effectiveness. storybook is a good guarantee of UI correctness but i suspect logical correctness might still require e2e. 

## Notes
1. checkboxes should probably use the API given by cypress of `check/uncheck` 
2. cypress query selectors are actually pretty ergonomic for writing/chaining methods
3. we should probably get ts compat working for cypress but the provided [guide](https://docs.cypress.io/guides/tooling/typescript-support) seems to not work. this might possibly be because our cypress version is 3 major versions behind. JSX docs have been written for custom commands but they don't display on the global cypress object so future devs have to still search by method name ;--; 