### PR TITLE
fix(nav): open external links for header/sidebar in new tab

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -156,14 +156,22 @@ export const Sidebar = (): JSX.Element => {
       <Spacer />
       <Divider color="secondary.100" />
       <LinkBox>
-        <LinkOverlay href="https://go.gov.sg/isomercms-guide/">
+        <LinkOverlay
+          rel="noopener noreferrer"
+          target="_blank"
+          href="https://go.gov.sg/isomercms-guide/"
+        >
           <SidebarButton leftIcon={<Icon as={BiBook} fontSize="1.5rem" />}>
             <Text textStyle="body-1">Guide</Text>
           </SidebarButton>
         </LinkOverlay>
       </LinkBox>
       <LinkBox>
-        <LinkOverlay href="https://go.gov.sg/isomer-cms-help">
+        <LinkOverlay
+          href="https://go.gov.sg/isomer-cms-help"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
           <SidebarButton leftIcon={<Icon as={BiBuoy} fontSize="1.5rem" />}>
             <Text textStyle="body-1">Help</Text>
           </SidebarButton>

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -110,6 +110,8 @@ const ButtonLink = (props: ButtonProps & LinkProps) => {
   return (
     <Button
       as={Link}
+      rel="noopener noreferrer"
+      target="_blank"
       textDecoration="none"
       _hover={{
         textDecoration: "none",


### PR DESCRIPTION
## Problem
previously, links for header and sidebar were opened in the current tab. this pr changes that so that they are now opened in a new tab.

## Solution
1. add `target/rel` props
