### PR TITLE
fix(v1.5): concurrent editing displays updates/errors properly

### DIFF
--- a/src/layouts/Settings/ColourSettings.tsx
+++ b/src/layouts/Settings/ColourSettings.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   Modal,
   ModalContent,
+  FormControl,
 } from "@chakra-ui/react"
 import {
   FormLabel,
@@ -16,7 +17,7 @@ import {
 import { upperFirst } from "lodash"
 import { useState } from "react"
 import { SketchPicker } from "react-color"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, Controller } from "react-hook-form"
 
 import { Section, SectionHeader } from "layouts/components"
 
@@ -29,72 +30,92 @@ interface ColourSettingsProp {
 export const ColourSettings = ({
   isError,
 }: ColourSettingsProp): JSX.Element => {
-  const { register } = useFormContext()
   return (
     <Section id="colour-fields">
       <SectionHeader label="Colours" />
-      <VStack spacing="1rem" align="flex-start" w="50%">
-        <FormColourPicker
-          {...register("colours.primaryColour")}
-          label="Primary"
-          isDisabled={isError}
-        />
-        <FormColourPicker
-          {...register("colours.secondaryColour")}
-          label="Secondary"
-          isDisabled={isError}
-        />
-        <FormColourPicker
-          {...register("colours.mediaColours.0")}
-          label="Resource 1"
-          isDisabled={isError}
-        />
-        <FormColourPicker
-          {...register("colours.mediaColours.1")}
-          label="Resource 2"
-          isDisabled={isError}
-        />
-        <FormColourPicker
-          {...register("colours.mediaColours.2")}
-          label="Resource 2"
-          isDisabled={isError}
-        />
-        <FormColourPicker
-          {...register("colours.mediaColours.3")}
-          label="Resource 3"
-          isDisabled={isError}
-        />
-        <FormColourPicker
-          {...register("colours.mediaColours.4")}
-          label="Resource 4"
-          isDisabled={isError}
-        />
-      </VStack>
+      <FormControl isDisabled={isError} isRequired>
+        <VStack spacing="1rem" align="flex-start" w="50%">
+          <FormColourPicker
+            name="colours.primaryColour"
+            label="Primary"
+            isDisabled={isError}
+          />
+          <FormColourPicker
+            name="colours.secondaryColour"
+            label="Secondary"
+            isDisabled={isError}
+          />
+          <FormColourPicker
+            name="colours.mediaColours.0"
+            label="Resource 1"
+            isDisabled={isError}
+          />
+          <FormColourPicker
+            name="colours.mediaColours.1"
+            label="Resource 2"
+            isDisabled={isError}
+          />
+          <FormColourPicker
+            name="colours.mediaColours.2"
+            label="Resource 3"
+            isDisabled={isError}
+          />
+          <FormColourPicker
+            name="colours.mediaColours.3"
+            label="Resource 4"
+            isDisabled={isError}
+          />
+          <FormColourPicker
+            name="colours.mediaColours.4"
+            label="Resource 5"
+            isDisabled={isError}
+          />
+        </VStack>
+      </FormControl>
     </Section>
   )
 }
 
-interface FormColourPickerProps extends InputProps {
+interface FormColourPickerProps extends Omit<InputProps, "onChange" | "value"> {
   name: string
   label: string
   isDisabled?: boolean
+  onChange: (colour: string) => void
+  value: string
 }
 
-const FormColourPicker = forwardRef<FormColourPickerProps, "input">(
+const FormColourPicker = ({
+  name,
+  ...rest
+}: Pick<
+  FormColourPickerProps,
+  "name" | "label" | "isDisabled"
+>): JSX.Element => {
+  const { control } = useFormContext()
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => {
+        return <FormColourPickerBase {...field} {...rest} />
+      }}
+    />
+  )
+}
+
+const FormColourPickerBase = forwardRef<FormColourPickerProps, "input">(
   (
-    { name, label, isDisabled, ...rest }: FormColourPickerProps,
+    { value, onChange, label, isDisabled, ...rest }: FormColourPickerProps,
     ref
   ): JSX.Element => {
     const { isOpen, onOpen, onClose } = useDisclosure()
-    const { setValue, getValues } = useFormContext()
-    const initialColour: string = getValues(name)
-    const [colour, setColour] = useState<string>(initialColour)
+    const [colour, setColour] = useState<string>(value)
     const [hasSelectedColour, setHasSelectedColour] = useState(false)
     // Reset colour if user clicks away without selecting so that the button background
     // will always be in sync with the input hex code
     const resetColour = () => {
       if (!hasSelectedColour) {
-        setColour(initialColour)
+        setColour(value)
       }
     }
 
@@ -106,20 +127,21 @@ const FormColourPicker = forwardRef<FormColourPickerProps, "input">(
             <Input
               disabled
               {...rest}
-              value={initialColour}
+              value={value}
               borderRightRadius={0}
+              ref={ref}
             />
             <Button
               borderLeftRadius={0}
               isDisabled={isDisabled}
               _hover={{
-                backgroundColor: varyHexColor(initialColour, 10),
+                backgroundColor: varyHexColor(value, 10),
               }}
               _active={{
-                backgroundColor: varyHexColor(initialColour, 20),
+                backgroundColor: varyHexColor(value, 20),
               }}
               aria-label="Select colour"
-              bgColor={colour}
+              bgColor={isOpen ? colour : value}
               onClick={onOpen}
             />
           </Flex>
@@ -141,7 +163,7 @@ const FormColourPicker = forwardRef<FormColourPickerProps, "input">(
             <Button
               w="100%"
               onClick={() => {
-                setValue(name, colour)
+                onChange(colour)
                 setHasSelectedColour(true)
                 onClose()
               }}

--- a/src/layouts/Settings/FooterSettings.tsx
+++ b/src/layouts/Settings/FooterSettings.tsx
@@ -1,9 +1,11 @@
-import { VStack, FormControl, Flex, Switch } from "@chakra-ui/react"
+import { VStack, FormControl, Flex } from "@chakra-ui/react"
 import { FormLabel, Input } from "@opengovsg/design-system-react"
 import { upperFirst } from "lodash"
 import { useFormContext } from "react-hook-form"
 
 import { Section, SectionHeader } from "layouts/components"
+
+import { FormToggle } from "./components/FormToggle"
 
 interface FooterSettingsProp {
   isError: boolean
@@ -36,7 +38,7 @@ export const FooterSettings = ({
             <FormLabel>Show REACH</FormLabel>
             {/* NOTE: This should be toggle from design system but the component is 
                 broken and doesn't display a slider */}
-            <Switch {...register("showReach")} />
+            <FormToggle name="showReach" />
           </Flex>
         </FormControl>
       </VStack>

--- a/src/layouts/Settings/GeneralSettings.tsx
+++ b/src/layouts/Settings/GeneralSettings.tsx
@@ -1,10 +1,11 @@
-import { VStack, FormControl, Flex, Switch, Box } from "@chakra-ui/react"
+import { VStack, FormControl, Flex, Box } from "@chakra-ui/react"
 import { FormLabel, Input, Textarea } from "@opengovsg/design-system-react"
 import { FormTitle } from "components/Form"
 import { useFormContext } from "react-hook-form"
 
 import { Section, SectionHeader } from "layouts/components"
 
+import { FormToggle } from "./components/FormToggle"
 import { SettingsFormFieldMedia } from "./components/SettingsFormFieldMedia"
 
 interface GeneralSettingsProp {
@@ -54,7 +55,7 @@ export const GeneralSettings = ({
             <FormLabel>Display government masthead</FormLabel>
             {/* NOTE: This should be toggle from design system 
                 but the component is broken and doesn't display a slider */}
-            <Switch {...register("displayGovMasthead")} />
+            <FormToggle name="displayGovMasthead" />
           </Flex>
         </FormControl>
         <FormControl isDisabled={isError} isRequired>

--- a/src/layouts/Settings/components/FormToggle.tsx
+++ b/src/layouts/Settings/components/FormToggle.tsx
@@ -1,0 +1,18 @@
+import { Switch, SwitchProps } from "@chakra-ui/react"
+import { Controller, useFormContext } from "react-hook-form"
+
+export interface FormToggleProps extends Omit<SwitchProps, "value"> {
+  name: string
+}
+export const FormToggle = ({ name, ...rest }: FormToggleProps): JSX.Element => {
+  const { control } = useFormContext()
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => {
+        return <Switch {...field} {...rest} isChecked={!!field.value} />
+      }}
+    />
+  )
+}

--- a/src/layouts/Settings/components/SettingsFormFieldMedia.tsx
+++ b/src/layouts/Settings/components/SettingsFormFieldMedia.tsx
@@ -8,10 +8,11 @@ import {
   HStack,
 } from "@chakra-ui/react"
 import MediaModal from "components/media/MediaModal"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, Controller } from "react-hook-form"
 import { BiUpload } from "react-icons/bi"
 
-interface FormFieldMediaProps extends Omit<InputProps, "onChange"> {
+interface FormFieldMediaProps extends Omit<InputProps, "onChange" | "name"> {
+  onChange: (value: string) => void
   name: string
 }
 
@@ -19,25 +20,23 @@ interface FormFieldMediaProps extends Omit<InputProps, "onChange"> {
  * @precondition This field MUST be used within a FormProvider from react hook forms
  * @param name When using `{...register(<name>)}`, this prop MUST be set to the same name
  */
-export const SettingsFormFieldMedia = forwardRef<FormFieldMediaProps, "input">(
-  ({ name, ...props }: FormFieldMediaProps, ref): JSX.Element => {
+const SettingsFormFieldMediaBase = forwardRef<FormFieldMediaProps, "input">(
+  ({ onChange, ...props }: FormFieldMediaProps, ref): JSX.Element => {
     const { isOpen, onOpen, onClose } = useDisclosure()
-    const { setValue, getValues } = useFormContext()
-    const selectedMedia: string = getValues(name)
 
     const onMediaSave = ({
       selectedMediaPath,
     }: {
       selectedMediaPath: string
     }) => {
-      setValue(name, selectedMediaPath)
+      onChange(selectedMediaPath)
       onClose()
     }
 
     return (
       <>
         <HStack w="100%" spacing="0.5rem">
-          <Input disabled value={selectedMedia} {...props} ref={ref} />
+          <Input disabled {...props} ref={ref} />
           <Button
             onClick={onOpen}
             leftIcon={<Icon as={BiUpload} fontSize="1.5rem" fill="white" />}
@@ -53,3 +52,19 @@ export const SettingsFormFieldMedia = forwardRef<FormFieldMediaProps, "input">(
     )
   }
 )
+
+export const SettingsFormFieldMedia = ({
+  name,
+  isDisabled,
+}: Pick<FormFieldMediaProps, "name" | "isDisabled">): JSX.Element => {
+  const { control } = useFormContext()
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => {
+        return <SettingsFormFieldMediaBase {...field} isDisabled={isDisabled} />
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Problem
See [here](https://docs.google.com/document/d/1EreGS8X1uIOgMrl7yXDF4jCprsIQ25BTVmyGLpT5P9k/edit#), under settings, for an overview of the concurrent editing issues faced.

## Solution
1. use `controller` which react hook forms provides. rather than managing state from within rhf ourselves, the `controller` simplifies these usage patterns and handles the state of the field for us. Hence, using this component allows us to focus on writing simple components that take in values while deferring the lifecycle etc to rhf