### PR TITLE
fix(settings): add warning modal back into settings

### DIFF
--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -5,7 +5,15 @@ import {
   Skeleton,
   StackDivider,
   Flex,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
   FlexProps,
+  useDisclosure,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import _ from "lodash"
@@ -81,6 +89,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   const { siteName } = useParams<{ siteName: string }>()
   // NOTE: Use a ref to persist the initial value between renders
   const initialSettings = useRef(settings)
+  const { isOpen, onOpen, onClose } = useDisclosure()
 
   const methods = useForm({
     mode: "onTouched",
@@ -96,9 +105,15 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
     isSuccess,
   } = useUpdateSettings(siteName)
   const errorToast = useErrorToast()
-  const onSubmit = (data: SiteSettings) => {
+  const onSubmit = methods.handleSubmit((data: SiteSettings) => {
     updateSettings(data)
-  }
+  })
+
+  const dirtyFieldKeys = _.keys(dirtyFields)
+  const hasDiff = !_.isEqual(
+    _.pick(settings, dirtyFieldKeys),
+    _.pick(initialSettings.current, dirtyFieldKeys)
+  )
 
   // NOTE: Because the default values are cached, we need to reset whenever they change
   useEffect(() => {
@@ -108,12 +123,6 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   // Warn on sync mutation on dirty (edited) field
   // this warning should only show for dirty fields
   useEffect(() => {
-    const dirtyFieldKeys = _.keys(dirtyFields)
-    const hasDiff = !_.isEqual(
-      _.pick(settings, dirtyFieldKeys),
-      _.pick(initialSettings.current, dirtyFieldKeys)
-    )
-
     if (hasDiff) {
       errorToast({
         title: "Error",
@@ -121,7 +130,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
           "Your site settings have recently been changed by another user. You can choose to either override their changes, or go back to editing. We recommend you to make a copy of your changes elsewhere, and come back later to reconcile your changes.",
       })
     }
-  }, [errorToast, settings, dirtyFields])
+  }, [errorToast, hasDiff])
 
   // Reset cache on success
   useEffect(() => {
@@ -159,7 +168,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   return (
     <Box w="100%">
       <FormProvider {...methods}>
-        <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <form onSubmit={onSubmit}>
           <VStack
             align="flex-start"
             spacing="2rem"
@@ -172,11 +181,56 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
             <FooterSettings isError={isError} />
             <AnalyticsSettings isError={isError} />
             <SettingsFooter>
-              <Button type="submit" isLoading={isLoading}>
+              <Button
+                isLoading={isLoading}
+                onClick={() => {
+                  hasDiff ? onOpen() : onSubmit()
+                }}
+              >
                 Save
               </Button>
             </SettingsFooter>
           </VStack>
+
+          <Modal
+            isCentered
+            // NOTE: The second conditional is required as the wrapped method by react hook form
+            // terminates earlier than the actual call to the BE API.
+            // Hence, the model is open if it was triggered manually or if the warning in the modal was acknowledged
+            // and the user still chose to proceed (this only occurs when there is a diff)
+            isOpen={isOpen || (hasDiff && isLoading)}
+            onClose={onClose}
+          >
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Override Changes</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                Your site settings have recently been changed by another user.
+                You can choose to either override their changes, or go back to
+                editing.
+                <br />
+                We recommend you to make a copy of your changes elsewhere, and
+                come back later to reconcile your changes.
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="outline" mr="1rem" onClick={onClose}>
+                  Back to editing
+                </Button>
+                <Button
+                  colorScheme="danger"
+                  type="submit"
+                  isLoading={isLoading}
+                  onClick={async () => {
+                    await onSubmit()
+                    onClose()
+                  }}
+                >
+                  Override
+                </Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
         </form>
       </FormProvider>
     </Box>


### PR DESCRIPTION
## Problem
previously, the warning modal was removed for ease of manual testing (sadge) - this PR readds the modal back into settings page. 

related to #941 - tbc if need to rebase and use the generic warning modal

## Solution
1. extract `hasDiff` out from `useEffect`
2. conditionally display modal when `hasDiff`
