### PR TITLE
Fix: editpage third nav styling

### DIFF
--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -6408,6 +6408,7 @@ a[href$=".pdf"][target="_blank"]:after {
 
 .bp-menu-list {
   line-height: 1.25;
+  list-style: none;
 }
 
 .has-side-nav {

--- a/src/templates/utils/leftnavGeneration.jsx
+++ b/src/templates/utils/leftnavGeneration.jsx
@@ -47,13 +47,13 @@ const calculateThirdNavHeaderChevronState = (
   elementFileName
 ) => {
   if (currentFileThirdNavTitle !== currentThirdNavTitle) {
-    return "sgds-icon-chevron-down"
+    return "bx bx-chevron-down"
   }
   if (
     fileName === elementFileName ||
     currentThirdNavTitle === currentElementThirdNavTitle
   ) {
-    return "sgds-icon-chevron-up"
+    return "bx bx-chevron-up"
   }
   return undefined
 }
@@ -75,8 +75,8 @@ const calculateThirdNavElementState = (
 }
 
 const accordionIconToggle = (accordionIconClass) => {
-  const upChevronIconClassName = "sgds-icon-chevron-up"
-  const downChevronIconClassName = "sgds-icon-chevron-down"
+  const upChevronIconClassName = "bx bx-chevron-up"
+  const downChevronIconClassName = "bx bx-chevron-down"
 
   if (accordionIconClass.includes(upChevronIconClassName)) {
     return accordionIconClass.replace(

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -123,11 +123,11 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
     0
   )
   customStyleSheet.insertRule(
-    `.sgds-icon-chevron-up:before { color: ${secondaryColor} !important;}`,
+    `.sgds-icon.bx-chevron-up:before { color: ${secondaryColor} !important;}`,
     0
   )
   customStyleSheet.insertRule(
-    `.sgds-icon-chevron-down:before { color: ${secondaryColor} !important;}`,
+    `.sgds-icon.bx-chevron-down:before { color: ${secondaryColor} !important;}`,
     0
   )
 }


### PR DESCRIPTION
## Problem

This PR fixes a minor styling issue with third nav previews. With the release of #895, we mistakenly removed some styling of third navs in the editpage preview, as these styles were attached to the globally imported sgds stylesheet - bullet points were showing up in the list where they should not and the chevrons indicating third nav items were missing. This PR adds those styles back into our codebase.

Note that since we do not import sgds styles globally anymore, I have opted to swap the chevron used in the nav preview to bx-chevron rather than sgds-chevron, since the icons are similar enough, rather than having to refactor all editpage components to use scoped styles.

Current (incorrect) display on CMS:
<img width="1538" alt="Screenshot 2022-07-01 at 11 39 40 AM" src="https://user-images.githubusercontent.com/22111124/176818871-87833ea9-c985-4caa-bf56-63901e51b7e4.png">

Preview on CMS:
<img width="1514" alt="Screenshot 2022-06-28 at 6 02 54 PM" src="https://user-images.githubusercontent.com/22111124/176152993-4e44a734-a1eb-472f-b1cf-e0b467a10734.png">

Preview prior to removal:
<img width="1515" alt="Screenshot 2022-06-28 at 6 08 15 PM" src="https://user-images.githubusercontent.com/22111124/176153731-68d88519-ac8b-4a24-b904-96f2bb231583.png">

Actual site:
<img width="1519" alt="Screenshot 2022-06-28 at 6 03 07 PM" src="https://user-images.githubusercontent.com/22111124/176153062-80dac331-7ce3-415e-91dd-29d65db3d22c.png">

