### PR TITLE
Fix/e2e tests

### DIFF
--- a/cypress/integration/files.spec.js
+++ b/cypress/integration/files.spec.js
@@ -115,7 +115,7 @@ describe("Files", () => {
     it("Should be able to delete file", () => {
       cy.contains("button", OTHER_FILE_TITLE).as("filePreview")
       cy.clickContextMenuItem("@filePreview", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
       // ASSERTS
       cy.contains(OTHER_FILE_TITLE).should("not.exist") // File name should not exist in Files
     })
@@ -163,7 +163,7 @@ describe("Files", () => {
       // User should be able delete directory
       cy.contains("a", OTHER_DIRECTORY_TITLE).should("exist").as("folderItem")
       cy.clickContextMenuItem("@folderItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
       cy.wait(E2E_CHANGE_WAIT_TIME)
       // ASSERTS
       cy.contains(OTHER_DIRECTORY_TITLE).should("not.exist") // Directory name should not be contained in Files
@@ -219,7 +219,7 @@ describe("Files", () => {
     it("Should be able to delete file from file directory", () => {
       cy.contains(OTHER_FILE_TITLE).should("exist").as("fileItem")
       cy.clickContextMenuItem("@fileItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
       // ASSERTS
       cy.contains(OTHER_FILE_TITLE).should("not.exist") // File file name should not exist in Files
     })

--- a/cypress/integration/folders.spec.js
+++ b/cypress/integration/folders.spec.js
@@ -220,7 +220,7 @@ describe("Folders flow", () => {
         .as("folderItem")
         .should("exist")
       cy.clickContextMenuItem("@folderItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
       cy.wait(E2E_DEFAULT_WAIT_TIME)
 
       // Assert
@@ -232,7 +232,7 @@ describe("Folders flow", () => {
     it("Should be able to delete a sub-folder without page", () => {
       cy.contains("a", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE).as("folderItem")
       cy.clickContextMenuItem("@folderItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
 
       // Assert
       cy.contains(PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE).should("not.exist", {
@@ -379,7 +379,7 @@ describe("Folders flow", () => {
       // User should be able to remove the created test page card
       cy.contains("a", EDITED_TEST_PAGE_TITLE_2).as("pageItem").should("exist")
       cy.clickContextMenuItem("@pageItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
 
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
@@ -552,7 +552,7 @@ describe("Folders flow", () => {
       // User should be able to remove the created test page card
       cy.contains("a", EDITED_TEST_PAGE_TITLE_2).as("pageItem")
       cy.clickContextMenuItem("@pageItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
       cy.contains("Successfully deleted page", {
         timeout: E2E_EXTENDED_TIMEOUT,
       }).should("exist")

--- a/cypress/integration/images.spec.js
+++ b/cypress/integration/images.spec.js
@@ -80,7 +80,7 @@ describe("Images", () => {
         .as("imagePreview")
         .should("exist")
       cy.clickContextMenuItem("@imagePreview", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
       // ASSERTS
       cy.contains(OTHER_IMAGE_TITLE, { timeout: E2E_EXTENDED_TIMEOUT }).should(
         "not.exist"

--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -298,7 +298,7 @@ describe("Resource category page", () => {
     cy.contains(`${TEST_PAGE_DATE_CHANGED_PRETTIFIED}/FILE`)
   })
 
-  it.only("Resources category page should allow user to change an existing resource page from file to post", () => {
+  it("Resources category page should allow user to change an existing resource page from file to post", () => {
     cy.contains("button", TEST_PAGE_TITLE_RENAMED, {
       timeout: E2E_EXTENDED_TIMEOUT,
     })

--- a/cypress/integration/resourceCategory.spec.js
+++ b/cypress/integration/resourceCategory.spec.js
@@ -329,7 +329,7 @@ describe("Resource category page", () => {
       .should("exist")
     cy.clickContextMenuItem("@pageCard", "Delete")
 
-    cy.contains("button", "Delete", { timeout: E2E_EXTENDED_TIMEOUT })
+    cy.contains("button", "delete", { timeout: E2E_EXTENDED_TIMEOUT })
       .should("exist")
       .click()
 

--- a/cypress/integration/resources.spec.js
+++ b/cypress/integration/resources.spec.js
@@ -153,7 +153,7 @@ describe("Resources page", () => {
 
     cy.contains("a", TEST_CATEGORY_RENAMED).as("folderCard")
     cy.clickContextMenuItem("@folderCard", "Delete")
-    cy.contains(":button", "Delete").click()
+    cy.contains(":button", "delete").click()
 
     cy.contains("Successfully deleted directory").should("exist")
 

--- a/cypress/integration/workspace.spec.js
+++ b/cypress/integration/workspace.spec.js
@@ -196,7 +196,7 @@ describe("Workspace Pages flow", () => {
       // User should be able to remove the created test page card
       cy.contains("a", EDITED_TEST_PAGE_TITLE_2).as("pageCard").should("exist")
       cy.clickContextMenuItem("@pageCard", "Delete")
-      cy.contains("button", "Delete").should("exist").click()
+      cy.contains("button", "delete").should("exist").click()
 
       // Assert
       cy.contains(EDITED_TEST_PAGE_TITLE_2, {
@@ -334,10 +334,10 @@ describe("Workspace Pages flow", () => {
 
       // Act
       cy.clickContextMenuItem("@emptyFolderItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
 
       cy.clickContextMenuItem("@folderItem", "Delete")
-      cy.contains("button", "Delete").click()
+      cy.contains("button", "delete").click()
 
       // Assert
       cy.contains(PRETTIFIED_FOLDER_NO_PAGES_TITLE, {


### PR DESCRIPTION
## Problem

This PR fixes some lingering issues with our e2e tests:

- As we changed the wording of some of our buttons from `Delete` to `Yes, delete`, we also changed the respective buttons in the tests here
- We also removed the `.only` in our resource category tests.
