### PR TITLE
refactor(settings): change conflict modal to use WarningModal component 

### DIFF
--- a/src/components/WarningModal/WarningModal.tsx
+++ b/src/components/WarningModal/WarningModal.tsx
@@ -32,7 +32,7 @@ export const WarningModal = ({
       <ModalCloseButton />
       <ModalBody>{displayText}</ModalBody>
       <ModalFooter>
-        <HStack w="100%" spacing={2} justifyContent="flex-end">
+        <HStack w="100%" spacing={4} justifyContent="flex-end">
           {children}
         </HStack>
       </ModalFooter>

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -4,17 +4,11 @@ import {
   VStack,
   Skeleton,
   StackDivider,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
   useDisclosure,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { Footer } from "components/Footer"
+import { WarningModal } from "components/WarningModal"
 import _ from "lodash"
 import { useEffect, useRef } from "react"
 import { useForm, FormProvider } from "react-hook-form"
@@ -190,8 +184,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
               </Button>
             </Footer>
           </VStack>
-
-          <Modal
+          <WarningModal
             isCentered
             // NOTE: The second conditional is required as the wrapped method by react hook form
             // terminates earlier than the actual call to the BE API.
@@ -199,37 +192,38 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
             // and the user still chose to proceed (this only occurs when there is a diff)
             isOpen={isOpen || (hasDiff && isLoading)}
             onClose={onClose}
-          >
-            <ModalOverlay />
-            <ModalContent>
-              <ModalHeader>Override Changes</ModalHeader>
-              <ModalCloseButton />
-              <ModalBody>
+            displayTitle="Override Changes"
+            displayText={
+              <Text>
                 Your site settings have recently been changed by another user.
                 You can choose to either override their changes, or go back to
                 editing.
+                {/*
+                 * NOTE: We have 2 line breaks here because we want a line spacing between the 2 <paragraphs.
+                 * Only have 1 br would cause the second paragraph to begin on a new line but without the line spacing.
+                 */}
+                <br />
                 <br />
                 We recommend you to make a copy of your changes elsewhere, and
                 come back later to reconcile your changes.
-              </ModalBody>
-              <ModalFooter>
-                <Button variant="outline" mr="1rem" onClick={onClose}>
-                  Back to editing
-                </Button>
-                <Button
-                  colorScheme="danger"
-                  type="submit"
-                  isLoading={isLoading}
-                  onClick={async () => {
-                    await onSubmit()
-                    onClose()
-                  }}
-                >
-                  Override
-                </Button>
-              </ModalFooter>
-            </ModalContent>
-          </Modal>
+              </Text>
+            }
+          >
+            <Button variant="outline" onClick={onClose}>
+              Back to editing
+            </Button>
+            <Button
+              colorScheme="danger"
+              type="submit"
+              isLoading={isLoading}
+              onClick={async () => {
+                await onSubmit()
+                onClose()
+              }}
+            >
+              Override
+            </Button>
+          </WarningModal>
         </form>
       </FormProvider>
     </Box>


### PR DESCRIPTION
## Problem
Previously in the v1.5 PR, the `Settings` page uses a newly created `Modal` component rather than using the `WarningModal` component that is used to display warning messages. 

## Solution
This PR changes the `Modal` to use the `WarningModal` component and also, changes the `spacing` in `WarningModal` to 4. This is because the spacing given in figma seems to be 16px, which is `spacing = {4}`.
