### PR TITLE
chore(v1.5): minor UI updates 

### DIFF
--- a/src/layouts/Folders/components/FolderBreadcrumb.tsx
+++ b/src/layouts/Folders/components/FolderBreadcrumb.tsx
@@ -1,5 +1,3 @@
-// NOTE: As Isomer does not have recursively nested folders at present,
-
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from "@chakra-ui/react"
 import { BiChevronRight } from "react-icons/bi"
 import { useRouteMatch, Link as RouterLink } from "react-router-dom"
@@ -14,7 +12,8 @@ interface FolderUrlParams {
   subCollectionName?: string
 }
 
-// NOTE: A folder breadcrumb is dependent solely on whether the sub folder is present
+// NOTE: As Isomer does not have recursively nested folders at present,
+// A folder breadcrumb is dependent solely on whether the sub folder is present
 export const FolderBreadcrumbs = (): JSX.Element => {
   const { params } = useRouteMatch<FolderUrlParams>()
   const { siteName, collectionName, subCollectionName } = getDecodedParams({
@@ -49,7 +48,7 @@ export const FolderBreadcrumbs = (): JSX.Element => {
           <BreadcrumbItem isLastChild={hasModifier} isCurrentPage={hasModifier}>
             <BreadcrumbLink
               textStyle="body-2"
-              color="text.body"
+              color={hasModifier ? "text.link.default" : "text.body"}
               as={RouterLink}
               to={to}
               textDecoration={hasModifier ? "underline" : "inherit"}

--- a/src/layouts/ResourceCategory/components/ResourceCategoryBreadcrumb.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCategoryBreadcrumb.tsx
@@ -1,5 +1,3 @@
-// NOTE: As Isomer does not have recursively nested folders at present,
-
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from "@chakra-ui/react"
 import { BiChevronRight } from "react-icons/bi"
 import { useRouteMatch, Link as RouterLink } from "react-router-dom"
@@ -9,7 +7,8 @@ import { getDecodedParams } from "utils/decoding"
 import { ResourceCategoryRouteParams } from "types/resources"
 import { deslugifyDirectory } from "utils"
 
-// NOTE: A folder breadcrumb is dependent solely on whether the sub folder is present
+// NOTE: As Isomer does not have recursively nested folders at present,
+// A folder breadcrumb is dependent solely on whether the sub folder is present
 export const ResourceCategoryBreadcrumb = (): JSX.Element => {
   const { params } = useRouteMatch<ResourceCategoryRouteParams>()
   const {
@@ -34,6 +33,7 @@ export const ResourceCategoryBreadcrumb = (): JSX.Element => {
           as={RouterLink}
           textStyle="body-2"
           textDecoration="underline"
+          color="text.link.default"
           to={`/sites/${siteName}/resourceRoom/${resourceRoomName}/resourceCategory/`}
         >
           {deslugifyDirectory(resourceCategoryName)}

--- a/src/layouts/ResourceRoom/components/ResourceBreadcrumb.tsx
+++ b/src/layouts/ResourceRoom/components/ResourceBreadcrumb.tsx
@@ -18,6 +18,7 @@ export const ResourceBreadcrumb = (): JSX.Element => {
           as={RouterLink}
           textStyle="body-2"
           textDecoration="underline"
+          color="text.link.default"
           to={`/sites/${siteName}/resourceRoom/${resourceRoomName}`}
         >
           {resourceRoomName && deslugifyDirectory(resourceRoomName)}

--- a/src/layouts/Settings/ColourSettings.tsx
+++ b/src/layouts/Settings/ColourSettings.tsx
@@ -132,6 +132,9 @@ const FormColourPickerBase = forwardRef<FormColourPickerProps, "input">(
               ref={ref}
             />
             <Button
+              border="1px solid"
+              borderColor="neutral.400"
+              borderLeft={0}
               borderLeftRadius={0}
               isDisabled={isDisabled}
               _hover={{

--- a/src/theme/components/Breadcrumb.ts
+++ b/src/theme/components/Breadcrumb.ts
@@ -1,0 +1,9 @@
+export const Breadcrumb = {
+  baseStyle: {
+    link: {
+      _hover: {
+        textDecoration: "inherit",
+      },
+    },
+  },
+}

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,3 +1,4 @@
+import { Breadcrumb } from "./Breadcrumb"
 import { Card, CARD_THEME_KEY } from "./Card"
 import { Tabs } from "./Tabs"
 
@@ -5,4 +6,5 @@ import { Tabs } from "./Tabs"
 export const components = {
   [CARD_THEME_KEY]: Card,
   Tabs,
+  Breadcrumb,
 }


### PR DESCRIPTION
## Problem
Some UI styling differed from what the designers had in mind for v1.5; refer [here](https://docs.google.com/document/d/1EreGS8X1uIOgMrl7yXDF4jCprsIQ25BTVmyGLpT5P9k/edit#) for a comprehensive list of changes. 

This PR addresses the following: 
1. underline on hover for breadcrumbs
2. last breadcrumb colour
3. settings -> colour button's outline colour

## Solution
1. for underline on breadcrumb hover, this is done through overriding the chakra UI styling for breadcrumbs as the `textDecoration` is set by chakra [here](https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/breadcrumb.ts). concretely, this means that all future breadcrumbs will **not** have underline on hover. waiting for designers' response on this but if this is the desired behaviour then it should be ok. 
2. changed colours to fit for settings/breadcrumb