### PR TITLE
Fix: create modal footer

### DIFF
--- a/src/components/DirectoryCreationModal/DirectoryCreationModal.jsx
+++ b/src/components/DirectoryCreationModal/DirectoryCreationModal.jsx
@@ -152,7 +152,7 @@ export const DirectoryCreationModal = ({
                 </div>
               </div>
             </div>
-            <Footer>
+            <Footer position="fixed">
               <LoadingButton onClick={onClose} variant="outline">
                 Cancel
               </LoadingButton>


### PR DESCRIPTION
## Problem

This PR fixes a display issue with the footer on the creation modal which was introduced with the Footer refactor. As we are working on a refactor for full screen modals, we've opted for a quick temporary fix - `position: fixed` has been added back to the footer in this modal to replicate the previous footer behaviour.
