### PR TITLE
Fix: delete resource category

### DIFF
--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -21,7 +21,7 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
     ? getMediaDirectoryName(params.mediaDirectoryName, { start: -1 })
     : pageFileNameToTitle(
         decodedParams[getLastItemType(decodedParams)],
-        !!params.resourceRoomName
+        !!(params.resourceRoomName && params.fileName)
       )
 
   if (fileName) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -278,8 +278,8 @@ export function titleToPageFileName(title) {
   return `${title}.md`
 }
 
-export function pageFileNameToTitle(pageFileName, isResource = false) {
-  if (isResource) return retrieveResourceFileMetadata(pageFileName).title
+export function pageFileNameToTitle(pageFileName, isResourcePage = false) {
+  if (isResourcePage) return retrieveResourceFileMetadata(pageFileName).title
   return `${pageFileName.split(".md")[0]}`
 }
 
@@ -545,6 +545,7 @@ export const isLastItem = (type, params) => {
 export const getLastItemType = (params) => {
   const types = Object.keys(params)
   const lastItemType = types.filter((type) => isLastItem(type, params))[0]
+  console.log(lastItemType)
   return lastItemType
 }
 


### PR DESCRIPTION
## Problem

This PR fixes an issue where users were unable to delete resource categories. As the logic for this component is complicated and difficult to debug, we will file an issue to tackle a more permanent fix/refactor in future.


Issue: https://github.com/isomerpages/isomercms-frontend/issues/977