### PR TITLE
ref(storybook): add page-level stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "react-query"
 import { LoginProvider } from "contexts/LoginContext"
 import theme from "theme"
 import { MINIMAL_VIEWPORTS } from "@storybook/addon-viewport"
+import { handlers } from "../src/mocks/handlers"
 
 const isomerViewports = {
   GSIB: {
@@ -16,6 +17,9 @@ const isomerViewports = {
 }
 
 export const parameters = {
+  msw: {
+    handlers,
+  },
   viewport: {
     viewports: {
       ...MINIMAL_VIEWPORTS,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,7 +18,9 @@ const isomerViewports = {
 
 export const parameters = {
   msw: {
-    handlers,
+    handlers: {
+      default: handlers,
+    },
   },
   viewport: {
     viewports: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,9 @@
-import { ThemeProvider } from "@opengovsg/design-system-react"
+import { ThemeProvider, useToast } from "@opengovsg/design-system-react"
 import { initialize, mswDecorator } from "msw-storybook-addon"
 import { QueryClient, QueryClientProvider } from "react-query"
+import { LoginContext } from "contexts/LoginContext"
 import theme from "theme"
+import { MOCK_USER } from "mocks/constants"
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -18,6 +20,30 @@ export const parameters = {
 
 // Initialize MSW
 initialize()
+
+const withLoginContext = (Story) => {
+  const toast = useToast()
+  return (
+    <LoginContext.Provider
+      value={{
+        logout: async () => {
+          toast({
+            title: "User is logged out",
+            status: "success",
+            duration: 9000,
+            isClosable: true,
+          })
+        },
+        ...MOCK_USER,
+        verifyLoginAndSetLocalStorage: async () => {
+          return undefined
+        },
+      }}
+    >
+      <Story />
+    </LoginContext.Provider>
+  )
+}
 
 const withThemeProvider = (Story) => (
   <ThemeProvider resetCSS theme={theme}>
@@ -41,4 +67,9 @@ const withReactQuery = (Story) => {
   )
 }
 
-export const decorators = [withThemeProvider, withReactQuery, mswDecorator]
+export const decorators = [
+  withLoginContext,
+  withThemeProvider,
+  withReactQuery,
+  mswDecorator,
+]

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,27 @@
 import { ThemeProvider, useToast } from "@opengovsg/design-system-react"
 import { initialize, mswDecorator } from "msw-storybook-addon"
 import { QueryClient, QueryClientProvider } from "react-query"
-import { LoginContext } from "contexts/LoginContext"
+import { LoginProvider } from "contexts/LoginContext"
 import theme from "theme"
-import { MOCK_USER } from "mocks/constants"
+import { MINIMAL_VIEWPORTS } from "@storybook/addon-viewport"
+
+const isomerViewports = {
+  GSIB: {
+    name: "GSIB Laptop",
+    styles: {
+      width: "1920px",
+      height: "1080px",
+    },
+  },
+}
 
 export const parameters = {
+  viewport: {
+    viewports: {
+      ...MINIMAL_VIEWPORTS,
+      ...isomerViewports,
+    },
+  },
   actions: { argTypesRegex: "^on[A-Z].*" },
   docs: {
     inlineStories: true,
@@ -24,24 +40,9 @@ initialize()
 const withLoginContext = (Story) => {
   const toast = useToast()
   return (
-    <LoginContext.Provider
-      value={{
-        logout: async () => {
-          toast({
-            title: "User is logged out",
-            status: "success",
-            duration: 9000,
-            isClosable: true,
-          })
-        },
-        ...MOCK_USER,
-        verifyLoginAndSetLocalStorage: async () => {
-          return undefined
-        },
-      }}
-    >
+    <LoginProvider>
       <Story />
-    </LoginContext.Provider>
+    </LoginProvider>
   )
 }
 

--- a/cypress/e2e/folders.spec.ts
+++ b/cypress/e2e/folders.spec.ts
@@ -174,7 +174,7 @@ describe("Folders flow", () => {
 
     // Rename
     it("Should be able to rename a sub-folder", () => {
-      cy.contains("button", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -199,7 +199,7 @@ describe("Folders flow", () => {
 
     // Delete
     it("Should be able to delete a sub-folder with a page", () => {
-      cy.contains("button", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -214,7 +214,7 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to delete a sub-folder without page", () => {
-      cy.contains("button", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ export const Footer = ({
   ...rest
 }: PropsWithChildren<FlexProps>): JSX.Element => (
   <Flex
-    h="5rem"
+    h="4rem"
     w="100%"
     pr="2rem"
     position="sticky"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,9 +13,8 @@ import { WarningModal } from "components/WarningModal"
 import PropTypes from "prop-types"
 import { useState, useEffect } from "react"
 
-import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
+import { useLoginContext } from "contexts/LoginContext"
 
-import { useLocalStorage } from "hooks/useLocalStorage"
 import useRedirectHook from "hooks/useRedirectHook"
 import useSiteUrlHook from "hooks/useSiteUrlHook"
 
@@ -38,7 +37,7 @@ const Header = ({
 }) => {
   const { setRedirectToLogout, setRedirectToPage } = useRedirectHook()
   const { retrieveStagingUrl } = useSiteUrlHook()
-  const [userId] = useLocalStorage(LOCAL_STORAGE_KEYS.GithubId)
+  const { userId } = useLoginContext()
   const {
     isOpen: isWarningModalOpen,
     onOpen: onWarningModalOpen,

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,6 +1,8 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { rest } from "msw"
 import { MemoryRouter, Route } from "react-router-dom"
+
+import { MOCK_USER } from "mocks/constants"
+import { buildLastUpdated, buildLoginData } from "mocks/utils"
 
 import { handlers } from "../../mocks/handlers"
 
@@ -9,6 +11,11 @@ import { Sidebar } from "./Sidebar"
 const SidebarMeta = {
   title: "Components/Sidebar",
   component: Sidebar,
+  parameters: {
+    chromatic: {
+      delay: 500,
+    },
+  },
   decorators: [
     (Story) => {
       return (
@@ -49,9 +56,17 @@ export const Error = Template.bind({})
 Error.parameters = {
   msw: {
     handlers: [
-      rest.get(`*/sites/:siteName/lastUpdated`, (req, res, ctx) => {
-        return res.networkError("Failed to retrieve user")
-      }),
+      buildLoginData({ userId: "Unknown user", email: "", contactNumber: "" }),
+    ],
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [
+      buildLastUpdated({ lastUpdated: "Last updated today" }, "infinite"),
+      buildLoginData(MOCK_USER),
     ],
   },
 }

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,6 +1,6 @@
 import { useToast } from "@chakra-ui/react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { MemoryRouter, Redirect, Route } from "react-router-dom"
+import { MemoryRouter, Route } from "react-router-dom"
 
 import { LoginContext } from "contexts/LoginContext"
 
@@ -14,8 +14,7 @@ const SidebarMeta = {
   decorators: [
     (Story) => {
       return (
-        <MemoryRouter initialEntries={["/sites/:siteName/"]}>
-          <Redirect to="/sites/storybook/workspace" />
+        <MemoryRouter initialEntries={["/sites/storybook/workspace"]}>
           <Route path="/sites/:siteName/workspace">
             <Story />
           </Route>
@@ -47,31 +46,5 @@ Default.parameters = {
     handlers,
   },
 }
-Default.decorators = [
-  (Story) => {
-    const toast = useToast()
-    return (
-      <LoginContext.Provider
-        value={{
-          logout: async () => {
-            toast({
-              title: "User is logged out",
-              status: "success",
-              duration: 9000,
-              isClosable: true,
-            })
-          },
-          userId: "username",
-          email: "user@open.gov.sg",
-          contactNumber: "98765432",
-          verifyLoginAndSetLocalStorage: async () => {
-            return undefined
-          },
-        }}
-      >
-        <Story />
-      </LoginContext.Provider>
-    )
-  },
-]
+
 export default SidebarMeta

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,8 +1,6 @@
-import { useToast } from "@chakra-ui/react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { rest } from "msw"
 import { MemoryRouter, Route } from "react-router-dom"
-
-import { LoginContext } from "contexts/LoginContext"
 
 import { handlers } from "../../mocks/handlers"
 
@@ -44,6 +42,17 @@ export const Default = Template.bind({})
 Default.parameters = {
   msw: {
     handlers,
+  },
+}
+
+export const Error = Template.bind({})
+Error.parameters = {
+  msw: {
+    handlers: [
+      rest.get(`*/sites/:siteName/lastUpdated`, (req, res, ctx) => {
+        return res.networkError("Failed to retrieve user")
+      }),
+    ],
   },
 }
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -104,7 +104,7 @@ export const Sidebar = (): JSX.Element => {
           </Text>
           <Skeleton isLoaded={!isLoading} w="100%">
             <Text textStyle="caption-2" color="text.description" w="full">
-              {isError ? "Unable to retrieve last updated time" : lastUpdated}
+              {isError ? "Unable to retrieve data" : lastUpdated}
             </Text>
           </Skeleton>
         </VStack>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -29,10 +29,9 @@ import {
 } from "react-icons/bi"
 import { useParams, Link as RouterLink, useLocation } from "react-router-dom"
 
-import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
+import { useLoginContext } from "contexts/LoginContext"
 
 import { useLastUpdated } from "hooks/useLastUpdated"
-import { useLocalStorage } from "hooks/useLocalStorage"
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { TabSection } from "types/sidebar"
@@ -75,10 +74,7 @@ export const Sidebar = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
   const { pathname } = useLocation<{ pathname: string }>()
   const { lastUpdated, isError, isLoading } = useLastUpdated(siteName)
-  const [loggedInUser] = useLocalStorage(
-    LOCAL_STORAGE_KEYS.GithubId,
-    "Unknown user"
-  )
+  const { userId } = useLoginContext()
   // NOTE: As this is a sub-path, there's a leading / which is converted into an empty string
   const selectedTab = getSelectedTab(pathname.split("/").filter(Boolean))
   const { setRedirectToLogout } = useRedirectHook()
@@ -102,7 +98,7 @@ export const Sidebar = (): JSX.Element => {
           >
             {siteName}
           </Text>
-          <Skeleton isLoaded={!isLoading} w="100%">
+          <Skeleton isLoaded={!isLoading} w="100%" h="16px">
             <Text textStyle="caption-2" color="text.description" w="full">
               {isError ? "Unable to retrieve data" : lastUpdated}
             </Text>
@@ -201,7 +197,7 @@ export const Sidebar = (): JSX.Element => {
         </SidebarButton>
         <Box px="1rem" textColor="text.link.disabled" textAlign="left" w="100%">
           <Text textStyle="body-1">Logged in as</Text>
-          <Text textStyle="body-1">@{loggedInUser}</Text>
+          <Text textStyle="body-1">@{userId}</Text>
         </Box>
       </VStack>
     </Flex>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
   BiBuoy,
   BiCog,
   BiCubeAlt,
-  BiFileBlank,
+  BiFile,
   BiGridAlt,
   BiImage,
   BiLogOutCircle,
@@ -147,7 +147,7 @@ export const Sidebar = (): JSX.Element => {
             to={`/sites/${siteName}/media/files/mediaDirectory/files`}
             isSelected={selectedTab === "files"}
           >
-            <TabLabel icon={BiFileBlank}>Files</TabLabel>
+            <TabLabel icon={BiFile}>Files</TabLabel>
           </Tab>
           <Tab
             as={RouterLink}

--- a/src/components/WarningModal/WarningModal.stories.tsx
+++ b/src/components/WarningModal/WarningModal.stories.tsx
@@ -54,7 +54,11 @@ const MultiButtonModalTemplate: Story<MultiButtonModalTemplateArgs> = ({
         displayTitle={displayTitle}
         displayText={displayText}
       >
-        <Button variant="clear" colorScheme="secondary">
+        <Button
+          variant="clear"
+          colorScheme="secondary"
+          textColor="text.title.alt"
+        >
           {buttonText}
         </Button>
         <Button colorScheme="danger">{secondButtonText}</Button>

--- a/src/components/folders/FolderItem.jsx
+++ b/src/components/folders/FolderItem.jsx
@@ -24,8 +24,6 @@ import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 
 import { pageFileNameToTitle } from "utils"
 
-// Import styles
-
 const FolderItem = ({ item, isDisabled }) => {
   const { url } = useRouteMatch()
 
@@ -126,32 +124,4 @@ const FolderItem = ({ item, isDisabled }) => {
   )
 }
 
-const FolderContent = ({ dirData }) => {
-  const InnerContent = () => {
-    if (dirData && dirData.length) {
-      return dirData.map((item) => <FolderItem key={item.name} item={item} />)
-    }
-
-    if (dirData) {
-      return (
-        <span className="d-flex justify-content-center">
-          No pages here yet.
-        </span>
-      )
-    }
-
-    return (
-      <div className="d-flex justify-content-center">
-        <div className="spinner-border text-primary" role="status" />
-      </div>
-    )
-  }
-
-  return (
-    <div className={`${contentStyles.contentContainerFolderColumn} mb-5`}>
-      <InnerContent />
-    </div>
-  )
-}
-
-export { FolderContent, FolderItem }
+export { FolderItem }

--- a/src/components/folders/ReorderingModal.jsx
+++ b/src/components/folders/ReorderingModal.jsx
@@ -1,5 +1,5 @@
 import { Breadcrumb } from "components/folders/Breadcrumb"
-import { FolderItem } from "components/folders/FolderContent"
+import { FolderItem } from "components/folders/FolderItem"
 import { Footer } from "components/Footer"
 import { LoadingButton } from "components/LoadingButton"
 import update from "immutability-helper"

--- a/src/contexts/LoginContext.tsx
+++ b/src/contexts/LoginContext.tsx
@@ -11,13 +11,9 @@ import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
 import { useLocalStorage } from "hooks/useLocalStorage"
 
-const { REACT_APP_BACKEND_URL: BACKEND_URL } = process.env
+import { LoggedInUser } from "types/user"
 
-interface LoggedInUser {
-  userId: string
-  email: string
-  contactNumber: string
-}
+const { REACT_APP_BACKEND_URL: BACKEND_URL } = process.env
 
 interface LoginContextProps extends LoggedInUser {
   logout: () => Promise<void>

--- a/src/hooks/directoryHooks/useGetFolders.ts
+++ b/src/hooks/directoryHooks/useGetFolders.ts
@@ -9,18 +9,21 @@ import * as DirectoryService from "services/DirectoryService/index"
 import { isAxiosError } from "utils/axios"
 import { useErrorToast } from "utils/toasts"
 
-import { DirectoryData } from "types/directory"
+import { DirectoryData, PageData } from "types/directory"
 import { PageDirectoryParams } from "types/folders"
 import { DEFAULT_RETRY_MSG } from "utils"
 
 export const useGetFolders = (
   params: PageDirectoryParams,
-  queryOptions?: Omit<UseQueryOptions<DirectoryData[]>, "queryFn" | "queryKey">
-): UseQueryResult<DirectoryData[]> => {
+  queryOptions?: Omit<
+    UseQueryOptions<(PageData | DirectoryData)[]>,
+    "queryFn" | "queryKey"
+  >
+): UseQueryResult<(PageData | DirectoryData)[]> => {
   const { setRedirectToNotFound } = useRedirectHook()
   const errorToast = useErrorToast()
 
-  return useQuery<DirectoryData[]>(
+  return useQuery<(PageData | DirectoryData)[]>(
     [DIR_CONTENT_KEY, params],
     () => DirectoryService.getCollection(params),
     {

--- a/src/hooks/settingsHooks/useGetResourceRoomName.ts
+++ b/src/hooks/settingsHooks/useGetResourceRoomName.ts
@@ -1,20 +1,13 @@
-import axios from "axios"
 import { useQuery, UseQueryResult } from "react-query"
 
 import { RESOURCE_ROOM_NAME_KEY } from "constants/queryKeys"
 
-const getResourceRoomName = async (siteName: string) => {
-  const resp = await axios.get<{ resourceRoomName: string }>(
-    `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/resourceRoom`
-  )
-  const { resourceRoomName } = resp.data
-  return resourceRoomName
-}
+import * as DirectoryService from "services/DirectoryService/DirectoryService"
 
 export const useGetResourceRoomName = (
   siteName: string
 ): UseQueryResult<string> => {
   return useQuery([RESOURCE_ROOM_NAME_KEY, { siteName }], () =>
-    getResourceRoomName(siteName)
+    DirectoryService.getResourceRoomName(siteName)
   )
 }

--- a/src/layouts/Folders/Folders.stories.tsx
+++ b/src/layouts/Folders/Folders.stories.tsx
@@ -1,0 +1,69 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import {
+  MOCK_DIR_DATA,
+  MOCK_FOLDER_NAME,
+  MOCK_PAGES_DATA,
+} from "mocks/constants"
+import { buildFolderData } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { Folders } from "./Folders"
+
+const FoldersMeta = {
+  title: "Pages/Folders",
+  component: Folders,
+  parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 300 },
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[`/sites/storybook/folders/${MOCK_FOLDER_NAME}`]}
+        >
+          <Route path="/sites/:siteName/folders/:collectionName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Folders>
+
+const Template: ComponentStory<typeof Folders> = Folders
+
+export const Default = Template.bind({})
+Default.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildFolderData([...MOCK_DIR_DATA, ...MOCK_PAGES_DATA]),
+    ],
+  },
+}
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: [...handlers, buildFolderData([])],
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildFolderData([...MOCK_DIR_DATA, ...MOCK_PAGES_DATA], "infinite"),
+    ],
+  },
+}
+
+export default FoldersMeta

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -7,7 +7,6 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
-import { FolderContent } from "components/folders/FolderContent"
 import { BiBulb, BiSort } from "react-icons/bi"
 import {
   Switch,
@@ -15,8 +14,6 @@ import {
   useHistory,
   Link as RouterLink,
 } from "react-router-dom"
-
-// Import components
 
 import { useGetFolders } from "hooks/directoryHooks"
 
@@ -31,23 +28,25 @@ import {
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
+import { getDecodedParams } from "utils/decoding"
+
 import { FolderUrlParams } from "types/folders"
+import { isDirData } from "types/utils"
 import { deslugifyDirectory } from "utils"
 
 import { Section, SectionHeader, SectionCaption } from "../components"
 import { SiteViewLayout } from "../layouts"
 
-import { FolderBreadcrumbs, MenuDropdownButton } from "./components"
+import {
+  FolderBreadcrumbs,
+  MenuDropdownButton,
+  FolderCard,
+  PageCard,
+} from "./components"
 
-interface FoldersProps {
-  match: {
-    params: FolderUrlParams
-    decodedParams: FolderUrlParams
-  }
-}
-
-export const Folders = ({ match }: FoldersProps): JSX.Element => {
-  const { params, decodedParams } = match
+export const Folders = (): JSX.Element => {
+  const { params } = useRouteMatch<FolderUrlParams>()
+  const decodedParams = getDecodedParams({ ...params })
   const { collectionName, subCollectionName } = decodedParams
   // NOTE: As isomer does not support recursively nested folders,
   // the depth of folder creation is 1 (parent -> child).
@@ -57,6 +56,7 @@ export const Folders = ({ match }: FoldersProps): JSX.Element => {
   const history = useHistory()
 
   const { data: dirData, isLoading: isLoadingDirectory } = useGetFolders(params)
+  const hasDirContent = dirData && dirData.length
 
   return (
     <>
@@ -66,7 +66,7 @@ export const Folders = ({ match }: FoldersProps): JSX.Element => {
             <Text as="h2" textStyle="h2">
               {subCollectionName
                 ? deslugifyDirectory(subCollectionName)
-                : collectionName}
+                : deslugifyDirectory(collectionName)}
             </Text>
             <FolderBreadcrumbs />
           </VStack>
@@ -104,8 +104,27 @@ export const Folders = ({ match }: FoldersProps): JSX.Element => {
               section by creating a subfolder.
             </SectionCaption>
           </Box>
-          <Skeleton isLoaded={!isLoadingDirectory} w="100%">
-            <FolderContent dirData={dirData} />
+          <Skeleton
+            isLoaded={!isLoadingDirectory}
+            w="100%"
+            h={isLoadingDirectory ? "4.5rem" : "fit-content"}
+          >
+            {hasDirContent ? (
+              <VStack spacing="1.5rem" w="full" align="flex-start">
+                {dirData.map((props) => {
+                  return isDirData(props) ? (
+                    <FolderCard
+                      name={props.name}
+                      dirContent={props.children || []}
+                    />
+                  ) : (
+                    <PageCard name={props.name} />
+                  )
+                })}
+              </VStack>
+            ) : (
+              <Text> No pages here yet.</Text>
+            )}
           </Skeleton>
         </Section>
         {/* main section ends here */}

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -29,7 +29,7 @@ import {
   DeleteWarningScreen,
 } from "layouts/screens"
 
-import { ProtectedRouteWithProps } from "routing/RouteSelector"
+import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 import { FolderUrlParams } from "types/folders"
 import { deslugifyDirectory } from "utils"

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -34,7 +34,12 @@ import { FolderUrlParams } from "types/folders"
 import { isDirData } from "types/utils"
 import { deslugifyDirectory } from "utils"
 
-import { Section, SectionHeader, SectionCaption } from "../components"
+import {
+  Section,
+  SectionHeader,
+  SectionCaption,
+  CreateButton,
+} from "../components"
 import { SiteViewLayout } from "../layouts"
 
 import {
@@ -89,13 +94,9 @@ export const Folders = (): JSX.Element => {
                 {canCreateFolder ? (
                   <MenuDropdownButton />
                 ) : (
-                  <Button
-                    variant="outline"
-                    as={RouterLink}
-                    to={`${url}/createPage`}
-                  >
+                  <CreateButton as={RouterLink} to={`${url}/createPage`}>
                     Create page
-                  </Button>
+                  </CreateButton>
                 )}
               </ButtonGroup>
             </SectionHeader>

--- a/src/layouts/Folders/Subfolder.stories.tsx
+++ b/src/layouts/Folders/Subfolder.stories.tsx
@@ -1,0 +1,52 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import {
+  MOCK_FOLDER_NAME,
+  MOCK_PAGES_DATA,
+  MOCK_SUBFOLDER_NAME,
+} from "mocks/constants"
+import { buildSubfolderData } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { Folders } from "./Folders"
+
+const FoldersMeta = {
+  title: "Pages/Folders",
+  component: Folders,
+  parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 300 },
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[
+            `/sites/storybook/folders/${MOCK_FOLDER_NAME}/subfolders/${MOCK_SUBFOLDER_NAME}`,
+          ]}
+        >
+          <Route path="/sites/:siteName/folders/:collectionName/subfolders/:subCollectionName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Folders>
+
+const Template: ComponentStory<typeof Folders> = Folders
+
+export const Subfolder = Template.bind({})
+Subfolder.parameters = {
+  msw: {
+    // NOTE: Subfolders do not have directories, only pages
+    handlers: [...handlers, buildSubfolderData([...MOCK_PAGES_DATA])],
+  },
+}
+
+export default FoldersMeta

--- a/src/layouts/Folders/components/FolderCard.tsx
+++ b/src/layouts/Folders/components/FolderCard.tsx
@@ -1,0 +1,85 @@
+import {
+  LinkBox,
+  LinkOverlay,
+  Icon,
+  Divider,
+  Text,
+  Spacer,
+  Box,
+} from "@chakra-ui/react"
+import { Card, CardBody } from "components/Card"
+import { ContextMenu } from "components/ContextMenu"
+import { useMemo } from "react"
+import { BiEditAlt, BiWrench, BiFolder, BiTrash } from "react-icons/bi"
+import { useRouteMatch, Link as RouterLink } from "react-router-dom"
+
+import { pageFileNameToTitle } from "utils"
+
+interface FolderCardProps {
+  name: string
+  dirContent: string[]
+}
+
+export const FolderCard = ({
+  name,
+  dirContent,
+}: FolderCardProps): JSX.Element => {
+  const { url } = useRouteMatch()
+
+  const encodedName = encodeURIComponent(name)
+
+  const generatedLink = useMemo(() => {
+    return `${url}/subfolders/${encodedName}`
+  }, [encodedName, url])
+
+  return (
+    <LinkBox position="relative" w="full">
+      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
+        <Card variant="single">
+          <CardBody alignItems="center">
+            <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+              {pageFileNameToTitle(name)}
+            </Text>
+            <Spacer />
+            <Text textStyle="body-2" whiteSpace="nowrap">
+              {`${dirContent.length} item${dirContent.length === 1 ? "" : "s"}`}
+            </Text>
+            {/* 
+            NOTE: This is a workaround as our card component uses a HStack to orient elements with 1 rem spacing.
+            As we require 1.5 rem gap between text and the context menu button, this equates to a box width of 0.5 rem.
+            */}
+            <Box w="0.5rem" />
+          </CardBody>
+        </Card>
+      </LinkOverlay>
+      <ContextMenu>
+        <ContextMenu.Button />
+        <ContextMenu.List>
+          <ContextMenu.Item
+            icon={<BiEditAlt />}
+            as={RouterLink}
+            to={generatedLink}
+          >
+            <Text>Edit</Text>
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            icon={<BiWrench />}
+            as={RouterLink}
+            to={`${url}/editDirectorySettings/${encodedName}`}
+          >
+            Settings
+          </ContextMenu.Item>
+          <Divider />
+          <ContextMenu.Item
+            icon={<BiTrash />}
+            as={RouterLink}
+            to={`${url}/deleteDirectory/${encodedName}`}
+          >
+            Delete
+          </ContextMenu.Item>
+        </ContextMenu.List>
+      </ContextMenu>
+    </LinkBox>
+  )
+}

--- a/src/layouts/Folders/components/FolderCard.tsx
+++ b/src/layouts/Folders/components/FolderCard.tsx
@@ -33,26 +33,31 @@ export const FolderCard = ({
   }, [encodedName, url])
 
   return (
-    <LinkBox position="relative" w="full">
-      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
-        <Card variant="single">
-          <CardBody alignItems="center">
-            <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
-            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {pageFileNameToTitle(name)}
-            </Text>
-            <Spacer />
-            <Text textStyle="body-2" whiteSpace="nowrap">
-              {`${dirContent.length} item${dirContent.length === 1 ? "" : "s"}`}
-            </Text>
-            {/* 
+    <Box position="relative" w="full">
+      <Card variant="single">
+        <LinkBox>
+          <LinkOverlay as={RouterLink} to={generatedLink}>
+            <CardBody alignItems="center">
+              <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
+              <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+                {pageFileNameToTitle(name)}
+              </Text>
+              <Spacer />
+              <Text textStyle="body-2" whiteSpace="nowrap">
+                {`${dirContent.length} item${
+                  dirContent.length === 1 ? "" : "s"
+                }`}
+              </Text>
+              {/* 
             NOTE: This is a workaround as our card component uses a HStack to orient elements with 1 rem spacing.
             As we require 1.5 rem gap between text and the context menu button, this equates to a box width of 0.5 rem.
             */}
-            <Box w="0.5rem" />
-          </CardBody>
-        </Card>
-      </LinkOverlay>
+              <Box w="0.5rem" />
+            </CardBody>
+          </LinkOverlay>
+        </LinkBox>
+      </Card>
+
       <ContextMenu>
         <ContextMenu.Button />
         <ContextMenu.List>
@@ -80,6 +85,6 @@ export const FolderCard = ({
           </ContextMenu.Item>
         </ContextMenu.List>
       </ContextMenu>
-    </LinkBox>
+    </Box>
   )
 }

--- a/src/layouts/Folders/components/PageCard.tsx
+++ b/src/layouts/Folders/components/PageCard.tsx
@@ -1,56 +1,51 @@
 import {
-  Divider,
-  HStack,
-  Icon,
   LinkBox,
   LinkOverlay,
+  HStack,
+  Icon,
+  Divider,
   Text,
 } from "@chakra-ui/react"
 import { Card, CardBody } from "components/Card"
 import { ContextMenu } from "components/ContextMenu"
 import { useMemo } from "react"
 import {
-  BiChevronRight,
   BiEditAlt,
-  BiFileBlank,
-  BiFolder,
-  BiTrash,
   BiWrench,
+  BiFolder,
+  BiChevronRight,
+  BiTrash,
+  BiFileBlank,
 } from "react-icons/bi"
-import { Link as RouterLink, useRouteMatch } from "react-router-dom"
+import { useRouteMatch, Link as RouterLink } from "react-router-dom"
 
 import { pageFileNameToTitle } from "utils"
 
 interface PageCardProps {
-  title: string
+  name: string
 }
 
-// eslint-disable-next-line import/prefer-default-export
-export const PageCard = ({ title }: PageCardProps): JSX.Element => {
-  const {
-    url,
-    params: { siteName },
-  } = useRouteMatch<{ siteName: string; resourceRoomName: string }>()
+export const PageCard = ({ name }: PageCardProps): JSX.Element => {
+  const { url } = useRouteMatch()
 
-  const encodedName = encodeURIComponent(title)
+  const encodedName = encodeURIComponent(name)
 
   const generatedLink = useMemo(() => {
-    return `/sites/${siteName}/editPage/${encodedName}`
-  }, [siteName, encodedName])
+    return `${url}/editPage/${encodedName}`
+  }, [encodedName, url])
 
   return (
-    <Card variant="single">
-      <LinkBox>
-        <LinkOverlay as={RouterLink} to={generatedLink}>
-          <CardBody>
+    <LinkBox position="relative" w="full">
+      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
+        <Card variant="single">
+          <CardBody alignItems="center">
             <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
             <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {pageFileNameToTitle(title)}
+              {pageFileNameToTitle(name)}
             </Text>
           </CardBody>
-        </LinkOverlay>
-      </LinkBox>
-
+        </Card>
+      </LinkOverlay>
       <ContextMenu>
         <ContextMenu.Button />
         <ContextMenu.List>
@@ -59,14 +54,14 @@ export const PageCard = ({ title }: PageCardProps): JSX.Element => {
             as={RouterLink}
             to={generatedLink}
           >
-            <Text>Edit page</Text>
+            <Text>Edit</Text>
           </ContextMenu.Item>
           <ContextMenu.Item
             icon={<BiWrench />}
             as={RouterLink}
             to={`${url}/editPageSettings/${encodedName}`}
           >
-            Page settings
+            Settings
           </ContextMenu.Item>
           <ContextMenu.Item
             icon={<BiFolder />}
@@ -78,18 +73,16 @@ export const PageCard = ({ title }: PageCardProps): JSX.Element => {
               <Icon as={BiChevronRight} fontSize="1.25rem" />
             </HStack>
           </ContextMenu.Item>
-          <>
-            <Divider />
-            <ContextMenu.Item
-              icon={<BiTrash />}
-              as={RouterLink}
-              to={`${url}/deletePage/${encodedName}`}
-            >
-              Delete
-            </ContextMenu.Item>
-          </>
+          <Divider />
+          <ContextMenu.Item
+            icon={<BiTrash />}
+            as={RouterLink}
+            to={`${url}/deletePage/${encodedName}`}
+          >
+            Delete
+          </ContextMenu.Item>
         </ContextMenu.List>
       </ContextMenu>
-    </Card>
+    </LinkBox>
   )
 }

--- a/src/layouts/Folders/components/PageCard.tsx
+++ b/src/layouts/Folders/components/PageCard.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   Divider,
   Text,
+  Box,
 } from "@chakra-ui/react"
 import { Card, CardBody } from "components/Card"
 import { ContextMenu } from "components/ContextMenu"
@@ -35,54 +36,56 @@ export const PageCard = ({ name }: PageCardProps): JSX.Element => {
   }, [encodedName, url])
 
   return (
-    <LinkBox position="relative" w="full">
-      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
-        <Card variant="single">
-          <CardBody alignItems="center">
-            <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
-            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {pageFileNameToTitle(name)}
-            </Text>
-          </CardBody>
-        </Card>
-      </LinkOverlay>
-      <ContextMenu>
-        <ContextMenu.Button />
-        <ContextMenu.List>
-          <ContextMenu.Item
-            icon={<BiEditAlt />}
-            as={RouterLink}
-            to={generatedLink}
-          >
-            <Text>Edit</Text>
-          </ContextMenu.Item>
-          <ContextMenu.Item
-            icon={<BiWrench />}
-            as={RouterLink}
-            to={`${url}/editPageSettings/${encodedName}`}
-          >
-            Settings
-          </ContextMenu.Item>
-          <ContextMenu.Item
-            icon={<BiFolder />}
-            as={RouterLink}
-            to={`${url}/movePage/${encodedName}`}
-          >
-            <HStack spacing="4rem" alignItems="center">
-              <Text>Move to</Text>
-              <Icon as={BiChevronRight} fontSize="1.25rem" />
-            </HStack>
-          </ContextMenu.Item>
-          <Divider />
-          <ContextMenu.Item
-            icon={<BiTrash />}
-            as={RouterLink}
-            to={`${url}/deletePage/${encodedName}`}
-          >
-            Delete
-          </ContextMenu.Item>
-        </ContextMenu.List>
-      </ContextMenu>
-    </LinkBox>
+    <Box position="relative" w="full">
+      <Card variant="single">
+        <LinkBox position="relative">
+          <LinkOverlay as={RouterLink} to={generatedLink}>
+            <CardBody alignItems="center">
+              <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
+              <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+                {pageFileNameToTitle(name)}
+              </Text>
+            </CardBody>
+          </LinkOverlay>
+        </LinkBox>
+        <ContextMenu>
+          <ContextMenu.Button />
+          <ContextMenu.List>
+            <ContextMenu.Item
+              icon={<BiEditAlt />}
+              as={RouterLink}
+              to={generatedLink}
+            >
+              <Text>Edit</Text>
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              icon={<BiWrench />}
+              as={RouterLink}
+              to={`${url}/editPageSettings/${encodedName}`}
+            >
+              Settings
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              icon={<BiFolder />}
+              as={RouterLink}
+              to={`${url}/movePage/${encodedName}`}
+            >
+              <HStack spacing="4rem" alignItems="center">
+                <Text>Move to</Text>
+                <Icon as={BiChevronRight} fontSize="1.25rem" />
+              </HStack>
+            </ContextMenu.Item>
+            <Divider />
+            <ContextMenu.Item
+              icon={<BiTrash />}
+              as={RouterLink}
+              to={`${url}/deletePage/${encodedName}`}
+            >
+              Delete
+            </ContextMenu.Item>
+          </ContextMenu.List>
+        </ContextMenu>
+      </Card>
+    </Box>
   )
 }

--- a/src/layouts/Folders/components/index.ts
+++ b/src/layouts/Folders/components/index.ts
@@ -1,2 +1,4 @@
 export * from "./FolderBreadcrumb"
 export * from "./MenuDropdownButton"
+export * from "./FolderCard"
+export * from "./PageCard"

--- a/src/layouts/Media.jsx
+++ b/src/layouts/Media.jsx
@@ -17,7 +17,7 @@ import { MediaCreationScreen } from "layouts/screens/MediaCreationScreen"
 import { MediaSettingsScreen } from "layouts/screens/MediaSettingsScreen"
 import { MoveScreen } from "layouts/screens/MoveScreen"
 
-import { ProtectedRouteWithProps } from "routing/RouteSelector"
+import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"

--- a/src/layouts/ResourceCategory/ResourceCategory.stories.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.stories.tsx
@@ -1,0 +1,69 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import {
+  MOCK_RESOURCE_CATEGORY_NAME,
+  MOCK_RESOURCE_CATEGORY_PAGES_DATA,
+  MOCK_RESOURCE_ROOM_NAME,
+} from "mocks/constants"
+import { buildResourceCategoryData } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { ResourceCategory } from "./ResourceCategory"
+
+const ResourceCategoryMeta = {
+  title: "Pages/ResourceCategory",
+  component: ResourceCategory,
+  parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 500 },
+    msw: {
+      handlers: {
+        resourceCategoryData: buildResourceCategoryData(
+          MOCK_RESOURCE_CATEGORY_PAGES_DATA
+        ),
+        rest: handlers,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[
+            `/sites/storybook/resourceRoom/${MOCK_RESOURCE_ROOM_NAME}/resourceCategory/${MOCK_RESOURCE_CATEGORY_NAME}`,
+          ]}
+        >
+          <Route path="/sites/:siteName/resourceRoom/:resourceRoomName/resourceCategory/:resourceCategoryName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof ResourceCategory>
+
+const Template: ComponentStory<typeof ResourceCategory> = ResourceCategory
+
+export const Default = Template.bind({})
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: {
+      resourceCategoryData: buildResourceCategoryData([]),
+    },
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: {
+      resourceCategoryData: buildResourceCategoryData([], "infinite"),
+    },
+  },
+}
+
+export default ResourceCategoryMeta

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -23,7 +23,7 @@ import {
   DeleteWarningScreen,
 } from "layouts/screens"
 
-import { ProtectedRouteWithProps } from "routing/RouteSelector"
+import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 // Import utils
 import { ResourceCategoryRouteParams } from "types/resources"

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -52,16 +52,21 @@ export const ResourceCategory = (): JSX.Element => {
         </Section>
         <Section>
           <Box w="full">
-            <SectionHeader label="Pages">
+            <SectionHeader label="Resource Pages">
               <CreateButton as={RouterLink} to={`${url}/createPage`}>
                 Create page
               </CreateButton>
             </SectionHeader>
-            <SectionCaption icon={BiBulb} label="PRO TIP: ">
-              Organise your workspace by moving pages into folders
+            <SectionCaption icon={BiBulb} label="NOTE: ">
+              Pages are automatically ordered by latest date.
             </SectionCaption>
           </Box>
-          <Skeleton isLoaded={!isLoading} w="100%">
+          <Skeleton
+            isLoaded={!isLoading}
+            w="100%"
+            h={isLoading ? "10rem" : "fit-content"}
+          >
+            {!pagesData || (!pagesData.length && <Text>No content here</Text>)}
             <SimpleGrid columns={3} spacing="1.5rem">
               {/* NOTE: need to use multiline cards */}
               {(pagesData || []).map(({ name, title, date, resourceType }) => (
@@ -75,8 +80,6 @@ export const ResourceCategory = (): JSX.Element => {
             </SimpleGrid>
           </Skeleton>
         </Section>
-        {/* NOTE: This is needed for the divider to show */}
-        <Box display="none" />
       </SiteViewLayout>
       {/* main section ends here */}
       <Switch>

--- a/src/layouts/ResourceCategory/components/ResourceCard.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCard.tsx
@@ -18,17 +18,16 @@ import {
   BiWrench,
 } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
-import type { SetRequired } from "type-fest"
 
 import { BxFileArchiveSolid } from "assets"
-import { PageData } from "types/directory"
+import { ResourcePageData } from "types/directory"
 import { prettifyDate } from "utils"
 
 interface ResourceCardProps {
   name: string
   title: string
   date: string
-  resourceType: SetRequired<PageData, "resourceType">["resourceType"]
+  resourceType: ResourcePageData["resourceType"]
 }
 
 export const ResourceCard = ({

--- a/src/layouts/ResourceCategory/components/ResourceCategoryBreadcrumb.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCategoryBreadcrumb.tsx
@@ -33,6 +33,7 @@ export const ResourceCategoryBreadcrumb = (): JSX.Element => {
           as={RouterLink}
           textStyle="body-2"
           textDecoration="underline"
+          color="text.link.default"
           to={`/sites/${siteName}/resourceRoom/${resourceRoomName}/resourceCategory/${resourceCategoryName}`}
         >
           {deslugifyDirectory(resourceCategoryName)}

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -1,0 +1,70 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { MOCK_DIR_DATA, MOCK_RESOURCE_ROOM_NAME } from "mocks/constants"
+import { buildResourceRoomData, buildResourceRoomName } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { ResourceRoom } from "./ResourceRoom"
+
+const ResourceRoomMeta = {
+  title: "Pages/ResourceRoom",
+  component: ResourceRoom,
+  parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 500 },
+    msw: {
+      handlers: {
+        resourceRoomName: buildResourceRoomName({
+          resourceRoomName: MOCK_RESOURCE_ROOM_NAME,
+        }),
+        resourceRoomData: buildResourceRoomData(MOCK_DIR_DATA),
+        rest: handlers,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[
+            `/sites/storybook/resourceRoom/${MOCK_RESOURCE_ROOM_NAME}`,
+          ]}
+        >
+          <Route path="/sites/:siteName/resourceRoom/:resourceRoomName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof ResourceRoom>
+
+const Template: ComponentStory<typeof ResourceRoom> = ResourceRoom
+
+export const Default = Template.bind({})
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: {
+      resourceRoomData: buildResourceRoomData([]),
+    },
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: {
+      resourceRoomName: buildResourceRoomName(
+        { resourceRoomName: "" },
+        "infinite"
+      ),
+      resourceRoomData: buildResourceRoomData([], "infinite"),
+    },
+  },
+}
+
+export default ResourceRoomMeta

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -10,7 +10,7 @@ import { Button, FormErrorMessage, Input } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { BiInfoCircle } from "react-icons/bi"
+import { BiBulb, BiInfoCircle } from "react-icons/bi"
 import {
   Link as RouterLink,
   Redirect,
@@ -141,7 +141,7 @@ export const ResourceRoom = (): JSX.Element => {
 
   return (
     <Route>
-      {shouldRedirect && (
+      {!isResourceRoomNameLoading && shouldRedirect && (
         <Redirect
           to={`/sites/${siteName}/resourceRoom/${
             queriedResourceRoomName || ""
@@ -199,11 +199,17 @@ const ResourceRoomContent = ({
         </Box>
       </Section>
       <Section>
-        <SectionHeader label="Categories">
-          <CreateButton as={RouterLink} to={`${url}/createDirectory`}>
-            Create category
-          </CreateButton>
-        </SectionHeader>
+        <Box w="full">
+          <SectionHeader label="Resource Categories">
+            <CreateButton as={RouterLink} to={`${url}/createDirectory`}>
+              Create category
+            </CreateButton>
+          </SectionHeader>
+          <SectionCaption icon={BiBulb} label="PRO TIP: ">
+            Categories impact navigation on your site. Organise your resources
+            by creating categories.
+          </SectionCaption>
+        </Box>
         <Skeleton isLoaded={isLoading} w="100%">
           {directoryData.length === 0 ? (
             <Text>No Categories.</Text>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -36,7 +36,7 @@ import {
   DirectorySettingsScreen,
 } from "layouts/screens"
 
-import { ProtectedRouteWithProps } from "routing/RouteSelector"
+import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 import { useErrorToast } from "utils/toasts"
 

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -17,7 +17,7 @@ export const AnalyticsSettings = ({
     <Section id="analytics-fields">
       <VStack align="flex-start" spacing="0.5rem">
         <SectionHeader label="Analytics" />
-        <SectionCaption label="NOTE: " icon={BiInfoCircle}>
+        <SectionCaption label="" icon={BiInfoCircle}>
           For Analytics set up, refer to our guide{" "}
           <Link
             href="https://guide.isomer.gov.sg/analytics-and-tracking/google-analytics"

--- a/src/layouts/Settings/Settings.stories.tsx
+++ b/src/layouts/Settings/Settings.stories.tsx
@@ -1,0 +1,61 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { pick } from "lodash"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { MOCK_BE_SETTINGS } from "mocks/constants"
+import { buildSettingsData } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { Settings } from "./Settings"
+
+const SettingsMeta = {
+  title: "Pages/Settings",
+  component: Settings,
+  parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 500 },
+    msw: {
+      handlers: {
+        settingsData: buildSettingsData(MOCK_BE_SETTINGS),
+        rest: handlers,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter initialEntries={["/sites/storybook/settings"]}>
+          <Route path="/sites/:siteName/settings">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Settings>
+
+const Template: ComponentStory<typeof Settings> = Settings
+
+export const Default = Template.bind({})
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: {
+      // NOTE: Only colors is guaranteed to be returned from the BE
+      settingsData: buildSettingsData(pick(MOCK_BE_SETTINGS, "colors")),
+    },
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: {
+      settingsData: buildSettingsData(MOCK_BE_SETTINGS, "infinite"),
+    },
+  },
+}
+
+export default SettingsMeta

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -64,7 +64,11 @@ export const Settings = (): JSX.Element => {
         </Box>
       </Section>
       {/* General fields */}
-      <Skeleton isLoaded={!isGetSettingsLoading} w="100%">
+      <Skeleton
+        isLoaded={!isGetSettingsLoading}
+        w="100%"
+        h={isGetSettingsLoading ? "full" : "fit-content"}
+      >
         {settingsData && (
           <SettingsForm settings={settingsData} isError={isGetSettingsError} />
         )}
@@ -166,6 +170,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
             align="flex-start"
             spacing="2rem"
             divider={<StackDivider borderColor="border.divider.alt" />}
+            mb="7.125rem"
           >
             <GeneralSettings isError={isError} />
             <LogoSettings isError={isError} />
@@ -173,17 +178,25 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
             <SocialMediaSettings isError={isError} />
             <FooterSettings isError={isError} />
             <AnalyticsSettings isError={isError} />
-            <Footer w="calc(100% + 4rem)" ml="-2rem" mb="-2rem">
-              <Button
-                isLoading={isLoading}
-                onClick={() => {
-                  hasDiff ? onOpen() : onSubmit()
-                }}
-              >
-                Save
-              </Button>
-            </Footer>
           </VStack>
+          <Footer
+            w="calc(100% + 4rem)"
+            ml="-2rem"
+            mb="-2rem"
+            // NOTE: Borders at left/bottom are already provided by sidebar and layout.
+            // Hence, omit the border at those areas to ensure correct border sizing.
+            borderLeft={0}
+            borderBottom={0}
+          >
+            <Button
+              isLoading={isLoading}
+              onClick={() => {
+                hasDiff ? onOpen() : onSubmit()
+              }}
+            >
+              Save
+            </Button>
+          </Footer>
           <WarningModal
             isCentered
             // NOTE: The second conditional is required as the wrapped method by react hook form

--- a/src/layouts/Workspace/Workspace.stories.tsx
+++ b/src/layouts/Workspace/Workspace.stories.tsx
@@ -1,0 +1,107 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import axios from "axios"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { ServicesContext } from "contexts/ServicesContext"
+
+import { MOCK_PAGES_DATA, MOCK_DIR_DATA } from "mocks/constants"
+import { buildDirData, buildPagesData } from "mocks/utils"
+
+import { contactUsHandler, handlers } from "../../mocks/handlers"
+
+import { Workspace } from "./Workspace"
+
+const apiClient = axios.create({
+  baseURL: process.env.REACT_APP_BACKEND_URL_V2,
+  timeout: 100000,
+})
+
+const WorkspaceMeta = {
+  title: "Pages/Workspace",
+  component: Workspace,
+  parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 500 },
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <ServicesContext.Provider
+          value={{
+            pageService: {
+              // NOTE: This is a workaround. For reasons unknown, explicitly instantiating a PageService
+              // causes the story to crash as the rule of hooks isn't obeyed.
+              // As the get method of pageService is only used to call the contact-us endpoint,
+              // it is directly inlined here.
+              get: () =>
+                apiClient
+                  .get("/sites/:siteName/pages/contact-us.md")
+                  .then(({ data }) => data),
+            },
+          }}
+        >
+          <MemoryRouter initialEntries={["/sites/storybook/workspace"]}>
+            <Route path="/sites/:siteName/workspace">
+              <Story />
+            </Route>
+          </MemoryRouter>
+        </ServicesContext.Provider>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Workspace>
+
+const Template: ComponentStory<typeof Workspace> = Workspace
+
+export const Default = Template.bind({})
+Default.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData(MOCK_PAGES_DATA),
+      buildDirData(MOCK_DIR_DATA),
+      contactUsHandler(true),
+    ],
+  },
+}
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData([]),
+      buildDirData([]),
+      contactUsHandler(true),
+    ],
+  },
+}
+
+export const WithoutContactUs = Template.bind({})
+WithoutContactUs.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData(MOCK_PAGES_DATA),
+      buildDirData(MOCK_DIR_DATA),
+      contactUsHandler(),
+    ],
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData(MOCK_PAGES_DATA, "infinite"),
+      buildDirData(MOCK_DIR_DATA, "infinite"),
+      contactUsHandler(true, "infinite"),
+    ],
+  },
+}
+
+export default WorkspaceMeta

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -1,6 +1,5 @@
 // Import components
 import { SimpleGrid, Box, Skeleton, Text } from "@chakra-ui/react"
-import { useEffect, useState } from "react"
 import { BiBulb, BiInfoCircle } from "react-icons/bi"
 import { Switch, useRouteMatch, useHistory } from "react-router-dom"
 
@@ -38,131 +37,152 @@ import {
 
 const CONTACT_US_TEMPLATE_LAYOUT = "contact_us"
 
-export const Workspace = (): JSX.Element => {
+const WorkspacePage = (): JSX.Element => {
   const {
     params: { siteName },
   } = useRouteMatch<{ siteName: string }>()
-  const [contactUsCard, setContactUsCard] = useState<boolean | undefined>()
 
   const { setRedirectToPage } = useRedirectHook()
-  const { path, url } = useRouteMatch()
-  const history = useHistory()
-
-  const { data: _dirsData } = useGetFolders({ siteName })
-  const { data: _pagesData } = useGetWorkspacePages(siteName)
-  const { data: contactUsPage } = useGetPageHook({
+  const { url } = useRouteMatch()
+  const { data: _dirsData, isLoading: isDirLoading } = useGetFolders({
     siteName,
-    fileName: "contact-us.md",
   })
+  const { data: _pagesData, isLoading: isPagesLoading } = useGetWorkspacePages(
+    siteName
+  )
+  const { data: contactUsPage, isLoading: isContactUsLoading } = useGetPageHook(
+    {
+      siteName,
+      fileName: "contact-us.md",
+    }
+  )
+
+  const hasContactUsCard =
+    contactUsPage?.content?.frontMatter?.layout === CONTACT_US_TEMPLATE_LAYOUT
 
   const dirsData = _dirsData || []
   const pagesData = _pagesData || []
 
-  useEffect(() => {
-    if (contactUsPage)
-      setContactUsCard(
-        contactUsPage.content?.frontMatter?.layout ===
-          CONTACT_US_TEMPLATE_LAYOUT
-      )
-  }, [pagesData, contactUsPage])
+  return (
+    <SiteViewLayout overflow="hidden">
+      <Section>
+        <Text as="h2" textStyle="h2">
+          My Workspace
+        </Text>
+        <Skeleton isLoaded={!isContactUsLoading} w="full">
+          <SimpleGrid columns={3} spacing="1.5rem">
+            <HomepageCard siteName={siteName} />
+            <NavigationCard siteName={siteName} />
+            {hasContactUsCard && <ContactCard siteName={siteName} />}
+          </SimpleGrid>
+        </Skeleton>
+      </Section>
+
+      <Section>
+        <Box w="100%">
+          <SectionHeader label="Folders">
+            <CreateButton
+              onClick={() => setRedirectToPage(`${url}/createDirectory`)}
+            >
+              Create folder
+            </CreateButton>
+          </SectionHeader>
+          <SectionCaption label="PRO TIP: " icon={BiBulb}>
+            Folders impact navigation on your site. Organise your workspace by
+            moving pages into folders.
+          </SectionCaption>
+        </Box>
+        <Skeleton
+          isLoaded={!isDirLoading}
+          w="full"
+          h={isDirLoading ? "4.5rem" : "fit-content"}
+        >
+          <SimpleGrid columns={3} spacing="1.5rem">
+            {dirsData &&
+              dirsData.length > 0 &&
+              dirsData.map(({ name }) => (
+                <FolderCard title={name} siteName={siteName} />
+              ))}
+          </SimpleGrid>
+        </Skeleton>
+      </Section>
+
+      <Section>
+        <Box w="100%">
+          <SectionHeader label="Ungrouped Pages">
+            <CreateButton
+              onClick={() => setRedirectToPage(`${url}/createPage`)}
+            >
+              Create page
+            </CreateButton>
+          </SectionHeader>
+          <SectionCaption label="NOTE: " icon={BiInfoCircle}>
+            Pages here do not belong to any folders.
+          </SectionCaption>
+        </Box>
+        <Skeleton
+          isLoaded={!isPagesLoading}
+          w="full"
+          h={isDirLoading ? "4.5rem" : "fit-content"}
+        >
+          <SimpleGrid columns={3} spacing="1.5rem">
+            {pagesData &&
+              pagesData.length > 0 &&
+              pagesData
+                .filter((page) => page.name !== "contact-us.md")
+                .map(({ name, resourceType }) => <PageCard title={name} />)}
+          </SimpleGrid>
+        </Skeleton>
+      </Section>
+    </SiteViewLayout>
+  )
+}
+
+const WorkspaceRouter = (): JSX.Element => {
+  const { path } = useRouteMatch()
+  const history = useHistory()
 
   return (
+    <Switch>
+      <ProtectedRouteWithProps
+        path={[`${path}/createPage`, `${path}/editPageSettings/:fileName`]}
+        component={PageSettingsScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/deletePage/:fileName`]}
+        component={DeleteWarningScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/movePage/:fileName`]}
+        component={MoveScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/createDirectory`]}
+        component={DirectoryCreationScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/deleteDirectory/:collectionName`]}
+        component={DeleteWarningScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/editDirectorySettings/:collectionName`]}
+        component={DirectorySettingsScreen}
+        onClose={() => history.goBack()}
+      />
+    </Switch>
+  )
+}
+
+export const Workspace = (): JSX.Element => {
+  return (
     <>
-      <SiteViewLayout overflow="hidden">
-        <Section>
-          <Text as="h2" textStyle="h2">
-            My Workspace
-          </Text>
-          <Skeleton isLoaded={!!pagesData} w="full">
-            <SimpleGrid columns={3} spacing="1.5rem">
-              <HomepageCard siteName={siteName} />
-              <NavigationCard siteName={siteName} />
-              {contactUsCard && <ContactCard siteName={siteName} />}
-            </SimpleGrid>
-          </Skeleton>
-        </Section>
-
-        <Section>
-          <Box w="100%">
-            <SectionHeader label="Folders">
-              <CreateButton
-                onClick={() => setRedirectToPage(`${url}/createDirectory`)}
-              >
-                Create folder
-              </CreateButton>
-            </SectionHeader>
-            <SectionCaption label="PRO TIP: " icon={BiBulb}>
-              Folders impact navigation on your site. Organise your workspace by
-              moving pages into folders.
-            </SectionCaption>
-          </Box>
-          <Skeleton isLoaded={!!pagesData} w="full">
-            <SimpleGrid columns={3} spacing="1.5rem">
-              {dirsData &&
-                dirsData.length > 0 &&
-                dirsData.map(({ name }) => (
-                  <FolderCard title={name} siteName={siteName} />
-                ))}
-            </SimpleGrid>
-          </Skeleton>
-        </Section>
-
-        <Section>
-          <Box w="100%">
-            <SectionHeader label="Ungrouped Pages">
-              <CreateButton
-                onClick={() => setRedirectToPage(`${url}/createPage`)}
-              >
-                Create page
-              </CreateButton>
-            </SectionHeader>
-            <SectionCaption label="NOTE: " icon={BiInfoCircle}>
-              Pages here do not belong to any folders.
-            </SectionCaption>
-          </Box>
-          <Skeleton isLoaded={!!pagesData} w="full">
-            <SimpleGrid columns={3} spacing="1.5rem">
-              {pagesData &&
-                pagesData.length > 0 &&
-                pagesData
-                  .filter((page) => page.name !== "contact-us.md")
-                  .map(({ name }) => <PageCard title={name} />)}
-            </SimpleGrid>
-          </Skeleton>
-        </Section>
-      </SiteViewLayout>
-      <Switch>
-        <ProtectedRouteWithProps
-          path={[`${path}/createPage`, `${path}/editPageSettings/:fileName`]}
-          component={PageSettingsScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/deletePage/:fileName`]}
-          component={DeleteWarningScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/movePage/:fileName`]}
-          component={MoveScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/createDirectory`]}
-          component={DirectoryCreationScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/deleteDirectory/:collectionName`]}
-          component={DeleteWarningScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/editDirectorySettings/:collectionName`]}
-          component={DirectorySettingsScreen}
-          onClose={() => history.goBack()}
-        />
-      </Switch>
+      <WorkspacePage />
+      <WorkspaceRouter />
     </>
   )
 }

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -130,7 +130,7 @@ const WorkspacePage = (): JSX.Element => {
               pagesData.length > 0 &&
               pagesData
                 .filter((page) => page.name !== "contact-us.md")
-                .map(({ name, resourceType }) => <PageCard title={name} />)}
+                .map(({ name }) => <PageCard title={name} />)}
           </SimpleGrid>
         </Skeleton>
       </Section>

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -18,7 +18,7 @@ import {
   DirectorySettingsScreen,
 } from "layouts/screens"
 
-import { ProtectedRouteWithProps } from "routing/RouteSelector"
+import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 import {
   Section,

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -126,9 +126,7 @@ export const Workspace = (): JSX.Element => {
                 pagesData.length > 0 &&
                 pagesData
                   .filter((page) => page.name !== "contact-us.md")
-                  .map(({ name, resourceType }) => (
-                    <PageCard title={name} resourceType={resourceType} />
-                  ))}
+                  .map(({ name }) => <PageCard title={name} />)}
             </SimpleGrid>
           </Skeleton>
         </Section>

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -19,6 +19,8 @@ import {
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
+import { isDirData } from "types/utils"
+
 import {
   Section,
   SectionHeader,
@@ -60,7 +62,7 @@ const WorkspacePage = (): JSX.Element => {
   const hasContactUsCard =
     contactUsPage?.content?.frontMatter?.layout === CONTACT_US_TEMPLATE_LAYOUT
 
-  const dirsData = _dirsData || []
+  const dirsData = _dirsData?.filter(isDirData) || []
   const pagesData = _pagesData || []
 
   return (

--- a/src/layouts/Workspace/components/Cards/ContactCard.tsx
+++ b/src/layouts/Workspace/components/Cards/ContactCard.tsx
@@ -16,7 +16,7 @@ export const ContactCard = ({ siteName }: ContactCardProps): JSX.Element => {
         <Card variant="single">
           <CardBody>
             <Icon as={BiPhone} fontSize="1.5rem" fill="secondary.400" />
-            <Text textStyle="subhead-1" color="text.label">
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
               Contact us
             </Text>
           </CardBody>

--- a/src/layouts/Workspace/components/Cards/HomepageCard.tsx
+++ b/src/layouts/Workspace/components/Cards/HomepageCard.tsx
@@ -16,7 +16,7 @@ export const HomepageCard = ({ siteName }: HomepageCardProps): JSX.Element => {
         <Card variant="single">
           <CardBody>
             <Icon as={BiHomeAlt} fontSize="1.5rem" fill="secondary.400" />
-            <Text textStyle="subhead-1" color="text.label">
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
               Homepage
             </Text>
           </CardBody>

--- a/src/layouts/Workspace/components/Cards/NavigationCard.tsx
+++ b/src/layouts/Workspace/components/Cards/NavigationCard.tsx
@@ -18,7 +18,7 @@ export const NavigationCard = ({
         <Card variant="single">
           <CardBody>
             <Icon as={BiWorld} fontSize="1.5rem" fill="secondary.400" />
-            <Text textStyle="subhead-1" color="text.label">
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
               Navigation Bar
             </Text>
           </CardBody>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -1,4 +1,5 @@
 import { DirectoryData, PageData, ResourcePageData } from "types/directory"
+import { BackendSiteSettings } from "types/settings"
 
 export const MOCK_PAGES_DATA: PageData[] = [
   {
@@ -76,6 +77,55 @@ export const MOCK_USER = {
   userId: "mockUser",
   email: "mockUser@open.gov.sg",
   contactNumber: "98765432",
+}
+
+export const MOCK_BE_SETTINGS: BackendSiteSettings = {
+  title: "isomer",
+  description: "isomer is a website builder",
+  // NOTE: No shareicon/logo/favicon as no uploaded img within the story
+  facebook_pixel: "many pixel",
+  google_analytics: "some analytics",
+  linkedin_insights: "some insightful comment",
+  is_government: true,
+  colors: {
+    "primary-color": "#261EFF",
+    "secondary-color": "#26342F",
+    "media-colors": [
+      {
+        title: "some colour",
+        color: "#000000",
+      },
+      {
+        title: "some colour",
+        color: "#000000",
+      },
+      {
+        title: "some colour",
+        color: "#000000",
+      },
+      {
+        title: "some colour",
+        color: "#000000",
+      },
+      {
+        title: "some colour",
+        color: "#000000",
+      },
+    ],
+  },
+  contact_us: "/isomie/indomie",
+  feedback: "/feed/me/back",
+  faq: "/no/questions/allowed",
+  show_reach: "true",
+  social_media: {
+    facebook: "https://www.facebook.com/iloveisomer",
+    linkedin: "https://www.linkedin.com/company/isomerites",
+    twitter: "https://www.twitter.com/isotwit",
+    youtube: "https://www.youtube.com/isotubes",
+    instagram: "https://www.instagram.com/isogram/",
+    telegram: "https://t.me/isogram",
+    tiktok: "https://www.tiktok.com/isotok",
+  },
 }
 
 export const MOCK_FOLDER_NAME = "mock-folder"

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -1,4 +1,4 @@
-import { DirectoryData, PageData } from "types/directory"
+import { DirectoryData, PageData, ResourcePageData } from "types/directory"
 
 export const MOCK_PAGES_DATA: PageData[] = [
   {
@@ -17,6 +17,34 @@ export const MOCK_PAGES_DATA: PageData[] = [
   {
     name: "extra page",
     type: "file",
+  },
+]
+export const MOCK_RESOURCE_CATEGORY_PAGES_DATA: ResourcePageData[] = [
+  {
+    name: "some page",
+    title: "i am a title",
+    date: "2022-08-04",
+    resourceType: "post",
+  },
+  {
+    name: "another page",
+    title: "this a random blog post by a random blogger",
+    date: "2012-02-04",
+    resourceType: "post",
+  },
+  {
+    name:
+      "some page with an extremely long name that cannot fit inside the textbox",
+    title:
+      "some page with an extremely long name that cannot fit inside the textbox. in fact, this is so long it should be an essay but whatever",
+    date: "1966-12-03",
+    resourceType: "file",
+  },
+  {
+    name: "extra page",
+    title: "this is an extra page",
+    date: "2000-01-02",
+    resourceType: "file",
   },
 ]
 
@@ -53,3 +81,7 @@ export const MOCK_USER = {
 export const MOCK_FOLDER_NAME = "mock-folder"
 
 export const MOCK_SUBFOLDER_NAME = "mock-subfolder"
+
+export const MOCK_RESOURCE_ROOM_NAME = "mock-resource-room"
+
+export const MOCK_RESOURCE_CATEGORY_NAME = "mock-resource-category"

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -1,0 +1,37 @@
+export const MOCK_PAGES_DATA = [
+  {
+    name: "some page",
+  },
+  {
+    name: "another page",
+  },
+  {
+    name:
+      "some page with an extremely long name that cannot fit inside the textbox",
+  },
+  {
+    name: "extra page",
+  },
+]
+
+export const MOCK_DIR_DATA = [
+  {
+    name: "A directory",
+  },
+  {
+    name: "Another directory",
+  },
+  {
+    name:
+      "some dir with an extremely long name that cannot fit inside the textbox",
+  },
+  {
+    name: "why so extra",
+  },
+]
+
+export const MOCK_USER = {
+  userId: "username",
+  email: "user@open.gov.sg",
+  contactNumber: "98765432",
+}

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -1,32 +1,46 @@
-export const MOCK_PAGES_DATA = [
+import { DirectoryData, PageData } from "types/directory"
+
+export const MOCK_PAGES_DATA: PageData[] = [
   {
     name: "some page",
+    type: "file",
   },
   {
     name: "another page",
+    type: "file",
   },
   {
     name:
-      "some page with an extremely long name that cannot fit inside the textbox",
+      "some page with an extremely long name that cannot fit inside the textbox. in fact, it's so long that it should be a paragraph and perhaps a novel.",
+    type: "file",
   },
   {
     name: "extra page",
+    type: "file",
   },
 ]
 
-export const MOCK_DIR_DATA = [
+export const MOCK_DIR_DATA: DirectoryData[] = [
   {
     name: "A directory",
+    type: "dir",
+    children: [],
   },
   {
     name: "Another directory",
+    type: "dir",
+    children: ["something", "something else"],
   },
   {
     name:
-      "some dir with an extremely long name that cannot fit inside the textbox",
+      "some dir with an extremely long name that cannot fit inside the textbox. in fact, it's so long that it should be a paragraph and perhaps a novel.",
+    type: "dir",
+    children: ["one"],
   },
   {
     name: "why so extra",
+    type: "dir",
+    children: [],
   },
 ]
 
@@ -35,3 +49,7 @@ export const MOCK_USER = {
   email: "mockUser@open.gov.sg",
   contactNumber: "98765432",
 }
+
+export const MOCK_FOLDER_NAME = "mock-folder"
+
+export const MOCK_SUBFOLDER_NAME = "mock-subfolder"

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -31,7 +31,7 @@ export const MOCK_DIR_DATA = [
 ]
 
 export const MOCK_USER = {
-  userId: "username",
-  email: "user@open.gov.sg",
+  userId: "mockUser",
+  email: "mockUser@open.gov.sg",
   contactNumber: "98765432",
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,12 +1,7 @@
 import { rest } from "msw"
 
-// NOTE: redefining this here (and not using .env values) as storybook will override the env values
-// Only env vars prefixed with STORYBOOK_ will exist in the storybook
-// But because this is outside of storybook, will not exist there.
-const BACKEND_URL = "http://localhost:8081/v1"
-
 export const handlers = [
-  rest.get(`${BACKEND_URL}/sites/:siteName/lastUpdated`, (req, res, ctx) => {
+  rest.get(`*/sites/:siteName/lastUpdated`, (req, res, ctx) => {
     return res(
       ctx.json({
         lastUpdated: "Last updated today",
@@ -14,3 +9,23 @@ export const handlers = [
     )
   }),
 ]
+
+export const contactUsHandler = (
+  showContactUs?: boolean,
+  delay?: number | "infinite"
+): ReturnType<typeof rest["get"]> =>
+  rest.get("/sites/:siteName/pages/contact-us.md", (req, res, ctx) => {
+    return res(
+      delay ? ctx.delay(delay) : ctx.delay(0),
+      ctx.json(
+        showContactUs && {
+          name: "contact-us.md",
+          content: {
+            frontMatter: {
+              layout: "contact_us",
+            },
+          },
+        }
+      )
+    )
+  })

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,13 +1,11 @@
 import { rest } from "msw"
 
+import { MOCK_USER } from "./constants"
+import { buildLastUpdated, buildLoginData } from "./utils"
+
 export const handlers = [
-  rest.get(`*/sites/:siteName/lastUpdated`, (req, res, ctx) => {
-    return res(
-      ctx.json({
-        lastUpdated: "Last updated today",
-      })
-    )
-  }),
+  buildLastUpdated({ lastUpdated: "Last updated today" }),
+  buildLoginData(MOCK_USER),
 ]
 
 export const contactUsHandler = (

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,6 +1,7 @@
 import { DefaultBodyType, rest } from "msw"
 
 import { DirectoryData, PageData, ResourcePageData } from "types/directory"
+import { BackendSiteSettings } from "types/settings"
 import { LoggedInUser } from "types/user"
 
 const apiDataBuilder = <T extends DefaultBodyType = DefaultBodyType>(
@@ -28,6 +29,10 @@ export const buildResourceRoomName = apiDataBuilder<{
 
 export const buildResourceRoomData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/resourceRoom/:resourceRoomName"
+)
+
+export const buildSettingsData = apiDataBuilder<BackendSiteSettings>(
+  "*/sites/:siteName/settings"
 )
 
 export const buildFolderData = apiDataBuilder<(PageData | DirectoryData)[]>(

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,6 +1,6 @@
 import { DefaultBodyType, rest } from "msw"
 
-import { DirectoryData, PageData } from "types/directory"
+import { DirectoryData, PageData, ResourcePageData } from "types/directory"
 import { LoggedInUser } from "types/user"
 
 const apiDataBuilder = <T extends DefaultBodyType = DefaultBodyType>(
@@ -22,6 +22,14 @@ export const buildDirData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/collections"
 )
 
+export const buildResourceRoomName = apiDataBuilder<{
+  resourceRoomName: string
+}>("*/sites/:siteName/resourceRoom")
+
+export const buildResourceRoomData = apiDataBuilder<DirectoryData[]>(
+  "*/sites/:siteName/resourceRoom/:resourceRoomName"
+)
+
 export const buildFolderData = apiDataBuilder<(PageData | DirectoryData)[]>(
   "*/sites/:siteName/collections/:collectionName"
 )
@@ -34,4 +42,8 @@ export const buildLoginData = apiDataBuilder<LoggedInUser>("*/auth/whoami")
 
 export const buildLastUpdated = apiDataBuilder<{ lastUpdated: string }>(
   "*/sites/:siteName/lastUpdated"
+)
+
+export const buildResourceCategoryData = apiDataBuilder<ResourcePageData[]>(
+  "/*sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategoryName"
 )

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,0 +1,21 @@
+import { rest } from "msw"
+
+import { DirectoryData, PageData } from "types/directory"
+
+export const buildPagesData = (
+  mockPagesData: PageData[],
+  delay?: number | "infinite"
+): ReturnType<typeof rest["get"]> => {
+  return rest.get(`*/sites/:siteName/pages`, (req, res, ctx) => {
+    return res(delay ? ctx.delay(delay) : ctx.delay(0), ctx.json(mockPagesData))
+  })
+}
+
+export const buildDirData = (
+  mockDirData: DirectoryData[],
+  delay?: number | "infinite"
+): ReturnType<typeof rest["get"]> => {
+  return rest.get(`*/sites/:siteName/collections`, (req, res, ctx) => {
+    return res(delay ? ctx.delay(delay) : ctx.delay(0), ctx.json(mockDirData))
+  })
+}

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -2,8 +2,10 @@ import { DefaultBodyType, rest } from "msw"
 
 import { DirectoryData, PageData } from "types/directory"
 
-const apiDataBuilder = (endpoint: string) => (
-  mockData: DefaultBodyType,
+const apiDataBuilder = <T extends DefaultBodyType = DefaultBodyType>(
+  endpoint: string
+) => (
+  mockData: T,
   delay?: number | "infinite"
 ): ReturnType<typeof rest["get"]> => {
   return rest.get(endpoint, (req, res, ctx) => {
@@ -11,19 +13,10 @@ const apiDataBuilder = (endpoint: string) => (
   })
 }
 
-export const buildPagesData = (
-  mockPagesData: PageData[],
-  delay?: number | "infinite"
-): ReturnType<typeof rest["get"]> => {
-  return apiDataBuilder("*/sites/:siteName/pages")(mockPagesData, delay)
-}
+export const buildPagesData = apiDataBuilder<PageData[]>(
+  "*/sites/:siteName/pages"
+)
 
-export const buildDirData = (
-  mockDirData: DirectoryData[],
-  delay?: number | "infinite"
-): ReturnType<typeof rest["get"]> => {
-  return apiDataBuilder("*/sites/:siteName/collections")(mockDirData, delay)
-  return rest.get(`*/sites/:siteName/collections`, (req, res, ctx) => {
-    return res(delay ? ctx.delay(delay) : ctx.delay(0), ctx.json(mockDirData))
-  })
-}
+export const buildDirData = apiDataBuilder<DirectoryData[]>(
+  "*/sites/:siteName/collections"
+)

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,6 +1,7 @@
 import { DefaultBodyType, rest } from "msw"
 
 import { DirectoryData, PageData } from "types/directory"
+import { LoggedInUser } from "types/user"
 
 const apiDataBuilder = <T extends DefaultBodyType = DefaultBodyType>(
   endpoint: string
@@ -19,4 +20,10 @@ export const buildPagesData = apiDataBuilder<PageData[]>(
 
 export const buildDirData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/collections"
+)
+
+export const buildLoginData = apiDataBuilder<LoggedInUser>("*/auth/whoami")
+
+export const buildLastUpdated = apiDataBuilder<{ lastUpdated: string }>(
+  "*/sites/:siteName/lastUpdated"
 )

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -22,6 +22,14 @@ export const buildDirData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/collections"
 )
 
+export const buildFolderData = apiDataBuilder<(PageData | DirectoryData)[]>(
+  "*/sites/:siteName/collections/:collectionName"
+)
+
+export const buildSubfolderData = apiDataBuilder<(PageData | DirectoryData)[]>(
+  "*/sites/:siteName/collections/:collectionName/subcollections/:subCollectionName"
+)
+
 export const buildLoginData = apiDataBuilder<LoggedInUser>("*/auth/whoami")
 
 export const buildLastUpdated = apiDataBuilder<{ lastUpdated: string }>(

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,20 +1,28 @@
-import { rest } from "msw"
+import { DefaultBodyType, rest } from "msw"
 
 import { DirectoryData, PageData } from "types/directory"
+
+const apiDataBuilder = (endpoint: string) => (
+  mockData: DefaultBodyType,
+  delay?: number | "infinite"
+): ReturnType<typeof rest["get"]> => {
+  return rest.get(endpoint, (req, res, ctx) => {
+    return res(delay ? ctx.delay(delay) : ctx.delay(0), ctx.json(mockData))
+  })
+}
 
 export const buildPagesData = (
   mockPagesData: PageData[],
   delay?: number | "infinite"
 ): ReturnType<typeof rest["get"]> => {
-  return rest.get(`*/sites/:siteName/pages`, (req, res, ctx) => {
-    return res(delay ? ctx.delay(delay) : ctx.delay(0), ctx.json(mockPagesData))
-  })
+  return apiDataBuilder("*/sites/:siteName/pages")(mockPagesData, delay)
 }
 
 export const buildDirData = (
   mockDirData: DirectoryData[],
   delay?: number | "infinite"
 ): ReturnType<typeof rest["get"]> => {
+  return apiDataBuilder("*/sites/:siteName/collections")(mockDirData, delay)
   return rest.get(`*/sites/:siteName/collections`, (req, res, ctx) => {
     return res(delay ? ctx.delay(delay) : ctx.delay(0), ctx.json(mockDirData))
   })

--- a/src/routing/ProtectedRouteWithProps.tsx
+++ b/src/routing/ProtectedRouteWithProps.tsx
@@ -1,0 +1,25 @@
+import * as Sentry from "@sentry/react"
+import FallbackComponent from "components/FallbackComponent"
+import { PropsWithChildren } from "react"
+import { RouteProps as BaseRouteProps } from "react-router-dom"
+
+import ProtectedRoute from "./ProtectedRoute"
+
+type RouteProps = PropsWithChildren<{
+  component: () => JSX.Element
+  onClose: () => void
+}> &
+  BaseRouteProps
+
+export const ProtectedRouteWithProps = ({
+  children,
+  ...rest
+}: RouteProps): JSX.Element => {
+  const routeChildren = children ?? null
+  return (
+    <Sentry.ErrorBoundary fallback={FallbackComponent}>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <ProtectedRoute {...rest}>{routeChildren}</ProtectedRoute>
+    </Sentry.ErrorBoundary>
+  )
+}

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -1,6 +1,4 @@
 import { Banner } from "@opengovsg/design-system-react"
-import * as Sentry from "@sentry/react"
-import FallbackComponent from "components/FallbackComponent"
 import VerifyUserDetailsModal from "components/VerifyUserDetailsModal"
 import { ReactQueryDevtools } from "react-query/devtools"
 import { Switch } from "react-router-dom"
@@ -22,20 +20,11 @@ import Sites from "layouts/Sites"
 import { Workspace } from "layouts/Workspace"
 
 // ProtectedRoute component
-import ProtectedRoute from "routing/ProtectedRoute"
+import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 import RedirectIfLoggedInRoute from "routing/RedirectIfLoggedInRoute"
 
 const { REACT_APP_BANNER_VARIANT: BANNER_VARIANT } = process.env
 const { REACT_APP_BANNER_MESSAGE: BANNER_MESSAGE } = process.env
-
-export const ProtectedRouteWithProps = (props) => {
-  return (
-    <Sentry.ErrorBoundary fallback={FallbackComponent}>
-      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <ProtectedRoute {...props} />
-    </Sentry.ErrorBoundary>
-  )
-}
 
 export const RouteSelector = () => (
   <>

--- a/src/services/DirectoryService/DirectoryService.ts
+++ b/src/services/DirectoryService/DirectoryService.ts
@@ -45,7 +45,7 @@ export const getCollection = ({
   siteName,
   collectionName,
   subCollectionName,
-}: PageDirectoryParams): Promise<DirectoryData[]> => {
+}: PageDirectoryParams): Promise<(PageData | DirectoryData)[]> => {
   let endpoint = `/sites/${siteName}/collections`
   if (collectionName) {
     endpoint += `/${collectionName}`

--- a/src/services/DirectoryService/DirectoryService.ts
+++ b/src/services/DirectoryService/DirectoryService.ts
@@ -68,3 +68,13 @@ export const getMediaFolders = ({
   const endpoint = `/sites/${siteName}/media/${mediaDirectoryName}`
   return apiService.get<DirectoryData[]>(endpoint).then(({ data }) => data)
 }
+
+export const getResourceRoomName = async (
+  siteName: string
+): Promise<string> => {
+  const resp = await apiService.get<{ resourceRoomName: string }>(
+    `/sites/${siteName}/resourceRoom`
+  )
+  const { resourceRoomName } = resp.data
+  return resourceRoomName
+}

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -20,7 +20,6 @@ a {
 
   &:hover {
     text-decoration: none;
-    color: $isomer-blue;
   }
 }
 

--- a/src/types/directory.ts
+++ b/src/types/directory.ts
@@ -19,13 +19,17 @@ export interface DirectoryInfoReturn {
 
 export interface DirectoryData {
   name: string
+  type: "dir"
+  children: string[]
 }
 
 export interface PageData {
   name: string
   title?: string
   date?: string
-  resourceType?: "file" | "post"
+  type: "file"
 }
 
-export type ResourcePageData = Required<PageData>
+export type ResourcePageData = Required<Omit<PageData, "pageType">> & {
+  resourceType: "file" | "post"
+}

--- a/src/types/directory.ts
+++ b/src/types/directory.ts
@@ -30,6 +30,6 @@ export interface PageData {
   type: "file"
 }
 
-export type ResourcePageData = Required<Omit<PageData, "pageType">> & {
+export type ResourcePageData = Required<Omit<PageData, "type">> & {
   resourceType: "file" | "post"
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,5 @@
+export interface LoggedInUser {
+  userId: string
+  email: string
+  contactNumber: string
+}

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,5 @@
+import { DirectoryData } from "./directory"
+
+export const isDirData = (data: unknown): data is DirectoryData => {
+  return (data as DirectoryData).type === "dir"
+}


### PR DESCRIPTION
## Problem
Isomer uses storybook to track component level changes, but we don't have an equivalent for pages. This means that designers always have to go to staging to look at changes to any particular screen and it is unergonomic for them and inefficient (as they cannot measure precisely etc). 

## Solution
This problem could be solved by adding page level stories for the **new and updated** screens. 
