### PR TITLE
ref(storybook): adds workspace stories

### DIFF
--- a/src/layouts/Workspace/Workspace.stories.tsx
+++ b/src/layouts/Workspace/Workspace.stories.tsx
@@ -20,6 +20,8 @@ const WorkspaceMeta = {
   title: "Pages/Workspace",
   component: Workspace,
   parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 300 },
     msw: {
       handlers,
     },

--- a/src/layouts/Workspace/Workspace.stories.tsx
+++ b/src/layouts/Workspace/Workspace.stories.tsx
@@ -21,7 +21,7 @@ const WorkspaceMeta = {
   component: Workspace,
   parameters: {
     // Set delay so mock API requests will get resolved and the UI will render properly
-    chromatic: { delay: 300 },
+    chromatic: { delay: 500 },
     msw: {
       handlers,
     },

--- a/src/layouts/Workspace/Workspace.stories.tsx
+++ b/src/layouts/Workspace/Workspace.stories.tsx
@@ -1,0 +1,105 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import axios from "axios"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { ServicesContext } from "contexts/ServicesContext"
+
+import { MOCK_PAGES_DATA, MOCK_DIR_DATA } from "mocks/constants"
+import { buildDirData, buildPagesData } from "mocks/utils"
+
+import { contactUsHandler, handlers } from "../../mocks/handlers"
+
+import { Workspace } from "./Workspace"
+
+const apiClient = axios.create({
+  baseURL: process.env.REACT_APP_BACKEND_URL_V2,
+  timeout: 100000,
+})
+
+const WorkspaceMeta = {
+  title: "Pages/Workspace",
+  component: Workspace,
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <ServicesContext.Provider
+          value={{
+            pageService: {
+              // NOTE: This is a workaround. For reasons unknown, explicitly instantiating a PageService
+              // causes the story to crash as the rule of hooks isn't obeyed.
+              // As the get method of pageService is only used to call the contact-us endpoint,
+              // it is directly inlined here.
+              get: () =>
+                apiClient
+                  .get("/sites/:siteName/pages/contact-us.md")
+                  .then(({ data }) => data),
+            },
+          }}
+        >
+          <MemoryRouter initialEntries={["/sites/storybook/workspace"]}>
+            <Route path="/sites/:siteName/workspace">
+              <Story />
+            </Route>
+          </MemoryRouter>
+        </ServicesContext.Provider>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Workspace>
+
+const Template: ComponentStory<typeof Workspace> = Workspace
+
+export const Default = Template.bind({})
+Default.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData(MOCK_PAGES_DATA),
+      buildDirData(MOCK_DIR_DATA),
+      contactUsHandler(true),
+    ],
+  },
+}
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData([]),
+      buildDirData([]),
+      contactUsHandler(true),
+    ],
+  },
+}
+
+export const WithoutContactUs = Template.bind({})
+WithoutContactUs.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData(MOCK_PAGES_DATA),
+      buildDirData(MOCK_DIR_DATA),
+      contactUsHandler(),
+    ],
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildPagesData(MOCK_PAGES_DATA, "infinite"),
+      buildDirData(MOCK_DIR_DATA, "infinite"),
+      contactUsHandler(true, "infinite"),
+    ],
+  },
+}
+
+export default WorkspaceMeta

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -1,6 +1,5 @@
 // Import components
 import { SimpleGrid, Box, Skeleton, Text } from "@chakra-ui/react"
-import { useEffect, useState } from "react"
 import { BiBulb, BiInfoCircle } from "react-icons/bi"
 import { Switch, useRouteMatch, useHistory } from "react-router-dom"
 
@@ -38,131 +37,154 @@ import {
 
 const CONTACT_US_TEMPLATE_LAYOUT = "contact_us"
 
-export const Workspace = (): JSX.Element => {
+const WorkspacePage = (): JSX.Element => {
   const {
     params: { siteName },
   } = useRouteMatch<{ siteName: string }>()
-  const [contactUsCard, setContactUsCard] = useState<boolean | undefined>()
 
   const { setRedirectToPage } = useRedirectHook()
-  const { path, url } = useRouteMatch()
-  const history = useHistory()
-
-  const { data: _dirsData } = useGetFolders({ siteName })
-  const { data: _pagesData } = useGetWorkspacePages(siteName)
-  const { data: contactUsPage } = useGetPageHook({
+  const { url } = useRouteMatch()
+  const { data: _dirsData, isLoading: isDirLoading } = useGetFolders({
     siteName,
-    fileName: "contact-us.md",
   })
+  const { data: _pagesData, isLoading: isPagesLoading } = useGetWorkspacePages(
+    siteName
+  )
+  const { data: contactUsPage, isLoading: isContactUsLoading } = useGetPageHook(
+    {
+      siteName,
+      fileName: "contact-us.md",
+    }
+  )
+
+  const hasContactUsCard =
+    contactUsPage?.content?.frontMatter?.layout === CONTACT_US_TEMPLATE_LAYOUT
 
   const dirsData = _dirsData || []
   const pagesData = _pagesData || []
 
-  useEffect(() => {
-    if (contactUsPage)
-      setContactUsCard(
-        contactUsPage.content?.frontMatter?.layout ===
-          CONTACT_US_TEMPLATE_LAYOUT
-      )
-  }, [pagesData, contactUsPage])
+  return (
+    <SiteViewLayout overflow="hidden">
+      <Section>
+        <Text as="h2" textStyle="h2">
+          My Workspace
+        </Text>
+        <Skeleton isLoaded={!isContactUsLoading} w="full">
+          <SimpleGrid columns={3} spacing="1.5rem">
+            <HomepageCard siteName={siteName} />
+            <NavigationCard siteName={siteName} />
+            {hasContactUsCard && <ContactCard siteName={siteName} />}
+          </SimpleGrid>
+        </Skeleton>
+      </Section>
+
+      <Section>
+        <Box w="100%">
+          <SectionHeader label="Folders">
+            <CreateButton
+              onClick={() => setRedirectToPage(`${url}/createDirectory`)}
+            >
+              Create folder
+            </CreateButton>
+          </SectionHeader>
+          <SectionCaption label="PRO TIP: " icon={BiBulb}>
+            Folders impact navigation on your site. Organise your workspace by
+            moving pages into folders.
+          </SectionCaption>
+        </Box>
+        <Skeleton
+          isLoaded={!isDirLoading}
+          w="full"
+          h={isDirLoading ? "4.5rem" : "fit-content"}
+        >
+          <SimpleGrid columns={3} spacing="1.5rem">
+            {dirsData &&
+              dirsData.length > 0 &&
+              dirsData.map(({ name }) => (
+                <FolderCard title={name} siteName={siteName} />
+              ))}
+          </SimpleGrid>
+        </Skeleton>
+      </Section>
+
+      <Section>
+        <Box w="100%">
+          <SectionHeader label="Ungrouped Pages">
+            <CreateButton
+              onClick={() => setRedirectToPage(`${url}/createPage`)}
+            >
+              Create page
+            </CreateButton>
+          </SectionHeader>
+          <SectionCaption label="NOTE: " icon={BiInfoCircle}>
+            Pages here do not belong to any folders.
+          </SectionCaption>
+        </Box>
+        <Skeleton
+          isLoaded={!isPagesLoading}
+          w="full"
+          h={isDirLoading ? "4.5rem" : "fit-content"}
+        >
+          <SimpleGrid columns={3} spacing="1.5rem">
+            {pagesData &&
+              pagesData.length > 0 &&
+              pagesData
+                .filter((page) => page.name !== "contact-us.md")
+                .map(({ name, resourceType }) => (
+                  <PageCard title={name} resourceType={resourceType} />
+                ))}
+          </SimpleGrid>
+        </Skeleton>
+      </Section>
+    </SiteViewLayout>
+  )
+}
+
+const WorkspaceRouter = (): JSX.Element => {
+  const { path } = useRouteMatch()
+  const history = useHistory()
 
   return (
+    <Switch>
+      <ProtectedRouteWithProps
+        path={[`${path}/createPage`, `${path}/editPageSettings/:fileName`]}
+        component={PageSettingsScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/deletePage/:fileName`]}
+        component={DeleteWarningScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/movePage/:fileName`]}
+        component={MoveScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/createDirectory`]}
+        component={DirectoryCreationScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/deleteDirectory/:collectionName`]}
+        component={DeleteWarningScreen}
+        onClose={() => history.goBack()}
+      />
+      <ProtectedRouteWithProps
+        path={[`${path}/editDirectorySettings/:collectionName`]}
+        component={DirectorySettingsScreen}
+        onClose={() => history.goBack()}
+      />
+    </Switch>
+  )
+}
+
+export const Workspace = (): JSX.Element => {
+  return (
     <>
-      <SiteViewLayout overflow="hidden">
-        <Section>
-          <Text as="h2" textStyle="h2">
-            My Workspace
-          </Text>
-          <Skeleton isLoaded={!!pagesData} w="full">
-            <SimpleGrid columns={3} spacing="1.5rem">
-              <HomepageCard siteName={siteName} />
-              <NavigationCard siteName={siteName} />
-              {contactUsCard && <ContactCard siteName={siteName} />}
-            </SimpleGrid>
-          </Skeleton>
-        </Section>
-
-        <Section>
-          <Box w="100%">
-            <SectionHeader label="Folders">
-              <CreateButton
-                onClick={() => setRedirectToPage(`${url}/createDirectory`)}
-              >
-                Create folder
-              </CreateButton>
-            </SectionHeader>
-            <SectionCaption label="PRO TIP: " icon={BiBulb}>
-              Folders impact navigation on your site. Organise your workspace by
-              moving pages into folders.
-            </SectionCaption>
-          </Box>
-          <Skeleton isLoaded={!!pagesData} w="full">
-            <SimpleGrid columns={3} spacing="1.5rem">
-              {dirsData &&
-                dirsData.length > 0 &&
-                dirsData.map(({ name }) => (
-                  <FolderCard title={name} siteName={siteName} />
-                ))}
-            </SimpleGrid>
-          </Skeleton>
-        </Section>
-
-        <Section>
-          <Box w="100%">
-            <SectionHeader label="Ungrouped Pages">
-              <CreateButton
-                onClick={() => setRedirectToPage(`${url}/createPage`)}
-              >
-                Create page
-              </CreateButton>
-            </SectionHeader>
-            <SectionCaption label="NOTE: " icon={BiInfoCircle}>
-              Pages here do not belong to any folders.
-            </SectionCaption>
-          </Box>
-          <Skeleton isLoaded={!!pagesData} w="full">
-            <SimpleGrid columns={3} spacing="1.5rem">
-              {pagesData &&
-                pagesData.length > 0 &&
-                pagesData
-                  .filter((page) => page.name !== "contact-us.md")
-                  .map(({ name }) => <PageCard title={name} />)}
-            </SimpleGrid>
-          </Skeleton>
-        </Section>
-      </SiteViewLayout>
-      <Switch>
-        <ProtectedRouteWithProps
-          path={[`${path}/createPage`, `${path}/editPageSettings/:fileName`]}
-          component={PageSettingsScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/deletePage/:fileName`]}
-          component={DeleteWarningScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/movePage/:fileName`]}
-          component={MoveScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/createDirectory`]}
-          component={DirectoryCreationScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/deleteDirectory/:collectionName`]}
-          component={DeleteWarningScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/editDirectorySettings/:collectionName`]}
-          component={DirectorySettingsScreen}
-          onClose={() => history.goBack()}
-        />
-      </Switch>
+      <WorkspacePage />
+      <WorkspaceRouter />
     </>
   )
 }

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -130,9 +130,7 @@ const WorkspacePage = (): JSX.Element => {
               pagesData.length > 0 &&
               pagesData
                 .filter((page) => page.name !== "contact-us.md")
-                .map(({ name, resourceType }) => (
-                  <PageCard title={name} resourceType={resourceType} />
-                ))}
+                .map(({ name, resourceType }) => <PageCard title={name} />)}
           </SimpleGrid>
         </Skeleton>
       </Section>

--- a/src/layouts/Workspace/components/Cards/ContactCard.tsx
+++ b/src/layouts/Workspace/components/Cards/ContactCard.tsx
@@ -16,7 +16,7 @@ export const ContactCard = ({ siteName }: ContactCardProps): JSX.Element => {
         <Card variant="single">
           <CardBody>
             <Icon as={BiPhone} fontSize="1.5rem" fill="secondary.400" />
-            <Text textStyle="subhead-1" color="text.label">
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
               Contact us
             </Text>
           </CardBody>

--- a/src/layouts/Workspace/components/Cards/HomepageCard.tsx
+++ b/src/layouts/Workspace/components/Cards/HomepageCard.tsx
@@ -16,7 +16,7 @@ export const HomepageCard = ({ siteName }: HomepageCardProps): JSX.Element => {
         <Card variant="single">
           <CardBody>
             <Icon as={BiHomeAlt} fontSize="1.5rem" fill="secondary.400" />
-            <Text textStyle="subhead-1" color="text.label">
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
               Homepage
             </Text>
           </CardBody>

--- a/src/layouts/Workspace/components/Cards/NavigationCard.tsx
+++ b/src/layouts/Workspace/components/Cards/NavigationCard.tsx
@@ -18,7 +18,7 @@ export const NavigationCard = ({
         <Card variant="single">
           <CardBody>
             <Icon as={BiWorld} fontSize="1.5rem" fill="secondary.400" />
-            <Text textStyle="subhead-1" color="text.label">
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
               Navigation Bar
             </Text>
           </CardBody>


### PR DESCRIPTION
## Problem
See #980 for an overview of the problem

## Solution
1. This PR adds stories for `Workspace` - lmk if i missed out any potentially interesting stories
2. This PR also has minor fixes for loading states: previously, we used a skeleton to wrap the component. this is problematic as the skeleton takes the height of the component, which is 0 when there's nothing loading. This prevents the skeleton from being seen and feedback from being given to the user. This was fixed through a conditional height - display a fixed height when it's loading, let the height fit content after. 