### PR TITLE
ref(storybook): refactor folders and add stories

### DIFF
--- a/src/components/folders/FolderItem.jsx
+++ b/src/components/folders/FolderItem.jsx
@@ -23,8 +23,6 @@ import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 
 import { pageFileNameToTitle } from "utils"
 
-// Import styles
-
 const FolderItem = ({ item, isDisabled }) => {
   const { url } = useRouteMatch()
 
@@ -120,32 +118,4 @@ const FolderItem = ({ item, isDisabled }) => {
   )
 }
 
-const FolderContent = ({ dirData }) => {
-  const InnerContent = () => {
-    if (dirData && dirData.length) {
-      return dirData.map((item) => <FolderItem key={item.name} item={item} />)
-    }
-
-    if (dirData) {
-      return (
-        <span className="d-flex justify-content-center">
-          No pages here yet.
-        </span>
-      )
-    }
-
-    return (
-      <div className="d-flex justify-content-center">
-        <div className="spinner-border text-primary" role="status" />
-      </div>
-    )
-  }
-
-  return (
-    <div className={`${contentStyles.contentContainerFolderColumn} mb-5`}>
-      <InnerContent />
-    </div>
-  )
-}
-
-export { FolderContent, FolderItem }
+export { FolderItem }

--- a/src/components/folders/ReorderingModal.jsx
+++ b/src/components/folders/ReorderingModal.jsx
@@ -1,5 +1,5 @@
 import { Breadcrumb } from "components/folders/Breadcrumb"
-import { FolderItem } from "components/folders/FolderContent"
+import { FolderItem } from "components/folders/FolderItem"
 import { Footer } from "components/Footer"
 import { LoadingButton } from "components/LoadingButton"
 import update from "immutability-helper"

--- a/src/hooks/directoryHooks/useGetFolders.ts
+++ b/src/hooks/directoryHooks/useGetFolders.ts
@@ -9,18 +9,21 @@ import * as DirectoryService from "services/DirectoryService/index"
 import { isAxiosError } from "utils/axios"
 import { useErrorToast } from "utils/toasts"
 
-import { DirectoryData } from "types/directory"
+import { DirectoryData, PageData } from "types/directory"
 import { PageDirectoryParams } from "types/folders"
 import { DEFAULT_RETRY_MSG } from "utils"
 
 export const useGetFolders = (
   params: PageDirectoryParams,
-  queryOptions?: Omit<UseQueryOptions<DirectoryData[]>, "queryFn" | "queryKey">
-): UseQueryResult<DirectoryData[]> => {
+  queryOptions?: Omit<
+    UseQueryOptions<(PageData | DirectoryData)[]>,
+    "queryFn" | "queryKey"
+  >
+): UseQueryResult<(PageData | DirectoryData)[]> => {
   const { setRedirectToNotFound } = useRedirectHook()
   const errorToast = useErrorToast()
 
-  return useQuery<DirectoryData[]>(
+  return useQuery<(PageData | DirectoryData)[]>(
     [DIR_CONTENT_KEY, params],
     () => DirectoryService.getCollection(params),
     {

--- a/src/layouts/Folders/Folders.stories.tsx
+++ b/src/layouts/Folders/Folders.stories.tsx
@@ -1,8 +1,12 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react"
 import { MemoryRouter, Route } from "react-router-dom"
 
-import { MOCK_DIR_DATA, MOCK_FOLDER_NAME } from "mocks/constants"
-import { buildDirData, buildFolderData } from "mocks/utils"
+import {
+  MOCK_DIR_DATA,
+  MOCK_FOLDER_NAME,
+  MOCK_PAGES_DATA,
+} from "mocks/constants"
+import { buildFolderData } from "mocks/utils"
 
 import { handlers } from "../../mocks/handlers"
 
@@ -36,7 +40,10 @@ const Template: ComponentStory<typeof Folders> = Folders
 export const Default = Template.bind({})
 Default.parameters = {
   msw: {
-    handlers: [...handlers, buildFolderData(MOCK_DIR_DATA)],
+    handlers: [
+      ...handlers,
+      buildFolderData([...MOCK_DIR_DATA, ...MOCK_PAGES_DATA]),
+    ],
   },
 }
 
@@ -50,7 +57,10 @@ Empty.parameters = {
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: {
-    handlers: [...handlers, buildFolderData(MOCK_DIR_DATA, "infinite")],
+    handlers: [
+      ...handlers,
+      buildFolderData([...MOCK_DIR_DATA, ...MOCK_PAGES_DATA], "infinite"),
+    ],
   },
 }
 

--- a/src/layouts/Folders/Folders.stories.tsx
+++ b/src/layouts/Folders/Folders.stories.tsx
@@ -1,0 +1,57 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { MOCK_DIR_DATA, MOCK_FOLDER_NAME } from "mocks/constants"
+import { buildDirData, buildFolderData } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { Folders } from "./Folders"
+
+const FoldersMeta = {
+  title: "Pages/Folders",
+  component: Folders,
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[`/sites/storybook/folders/${MOCK_FOLDER_NAME}`]}
+        >
+          <Route path="/sites/:siteName/folders/:collectionName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Folders>
+
+const Template: ComponentStory<typeof Folders> = Folders
+
+export const Default = Template.bind({})
+Default.parameters = {
+  msw: {
+    handlers: [...handlers, buildFolderData(MOCK_DIR_DATA)],
+  },
+}
+
+export const Empty = Template.bind({})
+Empty.parameters = {
+  msw: {
+    handlers: [...handlers, buildFolderData([])],
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [...handlers, buildFolderData(MOCK_DIR_DATA, "infinite")],
+  },
+}
+
+export default FoldersMeta

--- a/src/layouts/Folders/Folders.stories.tsx
+++ b/src/layouts/Folders/Folders.stories.tsx
@@ -16,6 +16,8 @@ const FoldersMeta = {
   title: "Pages/Folders",
   component: Folders,
   parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 300 },
     msw: {
       handlers,
     },

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -7,7 +7,6 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
-import { FolderContent } from "components/folders/FolderContent"
 import { BiBulb, BiSort } from "react-icons/bi"
 import {
   Switch,
@@ -32,12 +31,18 @@ import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 import { getDecodedParams } from "utils/decoding"
 
 import { FolderUrlParams } from "types/folders"
+import { isDirData } from "types/utils"
 import { deslugifyDirectory } from "utils"
 
 import { Section, SectionHeader, SectionCaption } from "../components"
 import { SiteViewLayout } from "../layouts"
 
-import { FolderBreadcrumbs, MenuDropdownButton } from "./components"
+import {
+  FolderBreadcrumbs,
+  MenuDropdownButton,
+  FolderCard,
+  PageCard,
+} from "./components"
 
 export const Folders = (): JSX.Element => {
   const { params } = useRouteMatch<FolderUrlParams>()
@@ -51,6 +56,7 @@ export const Folders = (): JSX.Element => {
   const history = useHistory()
 
   const { data: dirData, isLoading: isLoadingDirectory } = useGetFolders(params)
+  const hasDirContent = dirData && dirData.length
 
   return (
     <>
@@ -60,7 +66,7 @@ export const Folders = (): JSX.Element => {
             <Text as="h2" textStyle="h2">
               {subCollectionName
                 ? deslugifyDirectory(subCollectionName)
-                : collectionName}
+                : deslugifyDirectory(collectionName)}
             </Text>
             <FolderBreadcrumbs />
           </VStack>
@@ -98,8 +104,27 @@ export const Folders = (): JSX.Element => {
               section by creating a subfolder.
             </SectionCaption>
           </Box>
-          <Skeleton isLoaded={!isLoadingDirectory} w="100%">
-            <FolderContent dirData={dirData} />
+          <Skeleton
+            isLoaded={!isLoadingDirectory}
+            w="100%"
+            h={isLoadingDirectory ? "4.5rem" : "fit-content"}
+          >
+            {hasDirContent ? (
+              <VStack spacing="1.5rem" w="full" align="flex-start">
+                {dirData.map((props) => {
+                  return isDirData(props) ? (
+                    <FolderCard
+                      name={props.name}
+                      dirContent={props.children || []}
+                    />
+                  ) : (
+                    <PageCard name={props.name} />
+                  )
+                })}
+              </VStack>
+            ) : (
+              <Text> No pages here yet.</Text>
+            )}
           </Skeleton>
         </Section>
         {/* main section ends here */}

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -16,8 +16,6 @@ import {
   Link as RouterLink,
 } from "react-router-dom"
 
-// Import components
-
 import { useGetFolders } from "hooks/directoryHooks"
 
 import {
@@ -31,6 +29,8 @@ import {
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
+import { getDecodedParams } from "utils/decoding"
+
 import { FolderUrlParams } from "types/folders"
 import { deslugifyDirectory } from "utils"
 
@@ -39,15 +39,9 @@ import { SiteViewLayout } from "../layouts"
 
 import { FolderBreadcrumbs, MenuDropdownButton } from "./components"
 
-interface FoldersProps {
-  match: {
-    params: FolderUrlParams
-    decodedParams: FolderUrlParams
-  }
-}
-
-export const Folders = ({ match }: FoldersProps): JSX.Element => {
-  const { params, decodedParams } = match
+export const Folders = (): JSX.Element => {
+  const { params } = useRouteMatch<FolderUrlParams>()
+  const decodedParams = getDecodedParams({ ...params })
   const { collectionName, subCollectionName } = decodedParams
   // NOTE: As isomer does not support recursively nested folders,
   // the depth of folder creation is 1 (parent -> child).

--- a/src/layouts/Folders/Subfolder.stories.tsx
+++ b/src/layouts/Folders/Subfolder.stories.tsx
@@ -1,0 +1,53 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import {
+  MOCK_DIR_DATA,
+  MOCK_FOLDER_NAME,
+  MOCK_PAGES_DATA,
+  MOCK_SUBFOLDER_NAME,
+} from "mocks/constants"
+import { buildSubfolderData } from "mocks/utils"
+
+import { handlers } from "../../mocks/handlers"
+
+import { Folders } from "./Folders"
+
+const FoldersMeta = {
+  title: "Pages/Folders",
+  component: Folders,
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[
+            `/sites/storybook/folders/${MOCK_FOLDER_NAME}/subfolders/${MOCK_SUBFOLDER_NAME}`,
+          ]}
+        >
+          <Route path="/sites/:siteName/folders/:collectionName/subfolders/:subCollectionName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof Folders>
+
+const Template: ComponentStory<typeof Folders> = Folders
+
+export const Subfolder = Template.bind({})
+Subfolder.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildSubfolderData([...MOCK_DIR_DATA, ...MOCK_PAGES_DATA]),
+    ],
+  },
+}
+
+export default FoldersMeta

--- a/src/layouts/Folders/Subfolder.stories.tsx
+++ b/src/layouts/Folders/Subfolder.stories.tsx
@@ -17,6 +17,8 @@ const FoldersMeta = {
   title: "Pages/Folders",
   component: Folders,
   parameters: {
+    // Set delay so mock API requests will get resolved and the UI will render properly
+    chromatic: { delay: 300 },
     msw: {
       handlers,
     },

--- a/src/layouts/Folders/Subfolder.stories.tsx
+++ b/src/layouts/Folders/Subfolder.stories.tsx
@@ -45,6 +45,7 @@ const Template: ComponentStory<typeof Folders> = Folders
 export const Subfolder = Template.bind({})
 Subfolder.parameters = {
   msw: {
+    // NOTE: Subfolders do not have directories, only pages
     handlers: [...handlers, buildSubfolderData([...MOCK_PAGES_DATA])],
   },
 }

--- a/src/layouts/Folders/Subfolder.stories.tsx
+++ b/src/layouts/Folders/Subfolder.stories.tsx
@@ -2,7 +2,6 @@ import { ComponentStory, ComponentMeta } from "@storybook/react"
 import { MemoryRouter, Route } from "react-router-dom"
 
 import {
-  MOCK_DIR_DATA,
   MOCK_FOLDER_NAME,
   MOCK_PAGES_DATA,
   MOCK_SUBFOLDER_NAME,

--- a/src/layouts/Folders/Subfolder.stories.tsx
+++ b/src/layouts/Folders/Subfolder.stories.tsx
@@ -45,10 +45,7 @@ const Template: ComponentStory<typeof Folders> = Folders
 export const Subfolder = Template.bind({})
 Subfolder.parameters = {
   msw: {
-    handlers: [
-      ...handlers,
-      buildSubfolderData([...MOCK_DIR_DATA, ...MOCK_PAGES_DATA]),
-    ],
+    handlers: [...handlers, buildSubfolderData([...MOCK_PAGES_DATA])],
   },
 }
 

--- a/src/layouts/Folders/components/FolderCard.tsx
+++ b/src/layouts/Folders/components/FolderCard.tsx
@@ -1,0 +1,85 @@
+import {
+  LinkBox,
+  LinkOverlay,
+  Icon,
+  Divider,
+  Text,
+  Spacer,
+  Box,
+} from "@chakra-ui/react"
+import { Card, CardBody } from "components/Card"
+import { ContextMenu } from "components/ContextMenu"
+import { useMemo } from "react"
+import { BiEditAlt, BiWrench, BiFolder, BiTrash } from "react-icons/bi"
+import { useRouteMatch, Link as RouterLink } from "react-router-dom"
+
+import { pageFileNameToTitle } from "utils"
+
+interface FolderCardProps {
+  name: string
+  dirContent: string[]
+}
+
+export const FolderCard = ({
+  name,
+  dirContent,
+}: FolderCardProps): JSX.Element => {
+  const { url } = useRouteMatch()
+
+  const encodedName = encodeURIComponent(name)
+
+  const generatedLink = useMemo(() => {
+    return `${url}/subfolders/${encodedName}`
+  }, [encodedName, url])
+
+  return (
+    <LinkBox position="relative" w="full">
+      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
+        <Card variant="single">
+          <CardBody alignItems="center">
+            <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+              {pageFileNameToTitle(name)}
+            </Text>
+            <Spacer />
+            <Text textStyle="body-2" whiteSpace="nowrap">
+              {`${dirContent.length} item${dirContent.length === 1 ? "" : "s"}`}
+            </Text>
+            {/* 
+            NOTE: This is a workaround as our card component uses a HStack to orient elements with 1 rem spacing.
+            As we require 1.5 rem gap between text and the context menu button, this equates to a box width of 0.5 rem.
+            */}
+            <Box w="0.5rem" />
+          </CardBody>
+        </Card>
+      </LinkOverlay>
+      <ContextMenu>
+        <ContextMenu.Button />
+        <ContextMenu.List>
+          <ContextMenu.Item
+            icon={<BiEditAlt />}
+            as={RouterLink}
+            to={generatedLink}
+          >
+            <Text>Edit</Text>
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            icon={<BiWrench />}
+            as={RouterLink}
+            to={`${url}/editDirectorySettings/${encodedName}`}
+          >
+            Settings
+          </ContextMenu.Item>
+          <Divider />
+          <ContextMenu.Item
+            icon={<BiTrash />}
+            as={RouterLink}
+            to={`${url}/deleteDirectory/${encodedName}`}
+          >
+            Delete
+          </ContextMenu.Item>
+        </ContextMenu.List>
+      </ContextMenu>
+    </LinkBox>
+  )
+}

--- a/src/layouts/Folders/components/PageCard.tsx
+++ b/src/layouts/Folders/components/PageCard.tsx
@@ -1,0 +1,88 @@
+import {
+  LinkBox,
+  LinkOverlay,
+  HStack,
+  Icon,
+  Divider,
+  Text,
+} from "@chakra-ui/react"
+import { Card, CardBody } from "components/Card"
+import { ContextMenu } from "components/ContextMenu"
+import { useMemo } from "react"
+import {
+  BiEditAlt,
+  BiWrench,
+  BiFolder,
+  BiChevronRight,
+  BiTrash,
+  BiFileBlank,
+} from "react-icons/bi"
+import { useRouteMatch, Link as RouterLink } from "react-router-dom"
+
+import { pageFileNameToTitle } from "utils"
+
+interface PageCardProps {
+  name: string
+}
+
+export const PageCard = ({ name }: PageCardProps): JSX.Element => {
+  const { url } = useRouteMatch()
+
+  const encodedName = encodeURIComponent(name)
+
+  const generatedLink = useMemo(() => {
+    return `${url}/editPage/${encodedName}`
+  }, [encodedName, url])
+
+  return (
+    <LinkBox position="relative" w="full">
+      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
+        <Card variant="single">
+          <CardBody alignItems="center">
+            <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
+            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+              {pageFileNameToTitle(name)}
+            </Text>
+          </CardBody>
+        </Card>
+      </LinkOverlay>
+      <ContextMenu>
+        <ContextMenu.Button />
+        <ContextMenu.List>
+          <ContextMenu.Item
+            icon={<BiEditAlt />}
+            as={RouterLink}
+            to={generatedLink}
+          >
+            <Text>Edit</Text>
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            icon={<BiWrench />}
+            as={RouterLink}
+            to={`${url}/editPageSettings/${encodedName}`}
+          >
+            Settings
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            icon={<BiFolder />}
+            as={RouterLink}
+            to={`${url}/movePage/${encodedName}`}
+          >
+            <HStack spacing="4rem" alignItems="center">
+              <Text>Move to</Text>
+              <Icon as={BiChevronRight} fontSize="1.25rem" />
+            </HStack>
+          </ContextMenu.Item>
+          <Divider />
+          <ContextMenu.Item
+            icon={<BiTrash />}
+            as={RouterLink}
+            to={`${url}/deletePage/${encodedName}`}
+          >
+            Delete
+          </ContextMenu.Item>
+        </ContextMenu.List>
+      </ContextMenu>
+    </LinkBox>
+  )
+}

--- a/src/layouts/Folders/components/index.ts
+++ b/src/layouts/Folders/components/index.ts
@@ -1,2 +1,4 @@
 export * from "./FolderBreadcrumb"
 export * from "./MenuDropdownButton"
+export * from "./FolderCard"
+export * from "./PageCard"

--- a/src/layouts/ResourceCategory/components/ResourceCard.tsx
+++ b/src/layouts/ResourceCategory/components/ResourceCard.tsx
@@ -18,17 +18,16 @@ import {
   BiWrench,
 } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
-import type { SetRequired } from "type-fest"
 
 import { BxFileArchiveSolid } from "assets"
-import { PageData } from "types/directory"
+import { ResourcePageData } from "types/directory"
 import { prettifyDate } from "utils"
 
 interface ResourceCardProps {
   name: string
   title: string
   date: string
-  resourceType: SetRequired<PageData, "resourceType">["resourceType"]
+  resourceType: ResourcePageData["resourceType"]
 }
 
 export const ResourceCard = ({

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -126,9 +126,7 @@ export const Workspace = (): JSX.Element => {
                 pagesData.length > 0 &&
                 pagesData
                   .filter((page) => page.name !== "contact-us.md")
-                  .map(({ name, resourceType }) => (
-                    <PageCard title={name} resourceType={resourceType} />
-                  ))}
+                  .map(({ name }) => <PageCard title={name} />)}
             </SimpleGrid>
           </Skeleton>
         </Section>

--- a/src/layouts/Workspace/components/Cards/PageCard.tsx
+++ b/src/layouts/Workspace/components/Cards/PageCard.tsx
@@ -23,32 +23,20 @@ import { pageFileNameToTitle } from "utils"
 
 interface PageCardProps {
   title: string
-  resourceType?: "file" | "post"
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export const PageCard = ({
-  title,
-  resourceType = undefined,
-}: PageCardProps): JSX.Element => {
+export const PageCard = ({ title }: PageCardProps): JSX.Element => {
   const {
     url,
-    params: { siteName, resourceRoomName },
+    params: { siteName },
   } = useRouteMatch<{ siteName: string; resourceRoomName: string }>()
 
   const encodedName = encodeURIComponent(title)
 
   const generatedLink = useMemo(() => {
-    if (resourceType === "file")
-      // TODO: implement file preview on CMS
-      return "#"
-    if (resourceType || resourceRoomName) {
-      // use resourceRoomName in case resourcePage does not have format Date-Type-Name.md
-      // for resourcePages that are not migrated
-      return `${url}/editPage/${encodedName}`
-    }
     return `/sites/${siteName}/editPage/${encodedName}`
-  }, [resourceType, resourceRoomName, siteName, encodedName, url])
+  }, [siteName, encodedName])
 
   return (
     <LinkBox>
@@ -57,7 +45,7 @@ export const PageCard = ({
           <CardBody>
             <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
             <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {pageFileNameToTitle(title, !!resourceType)}
+              {pageFileNameToTitle(title)}
             </Text>
           </CardBody>
         </Card>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -35,3 +35,5 @@ export const MOCK_USER = {
   email: "mockUser@open.gov.sg",
   contactNumber: "98765432",
 }
+
+export const MOCK_FOLDER_NAME = "mock-folder"

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -1,3 +1,5 @@
+import { DirectoryData } from "types/directory"
+
 export const MOCK_PAGES_DATA = [
   {
     name: "some page",
@@ -14,19 +16,27 @@ export const MOCK_PAGES_DATA = [
   },
 ]
 
-export const MOCK_DIR_DATA = [
+export const MOCK_DIR_DATA: DirectoryData[] = [
   {
     name: "A directory",
+    type: "dir",
+    children: [],
   },
   {
     name: "Another directory",
+    type: "dir",
+    children: ["something", "something else"],
   },
   {
     name:
-      "some dir with an extremely long name that cannot fit inside the textbox",
+      "some dir with an extremely long name that cannot fit inside the textbox. in fact, it's so long that it should be a paragraph and perhaps a novel.",
+    type: "dir",
+    children: ["one"],
   },
   {
     name: "why so extra",
+    type: "dir",
+    children: [],
   },
 ]
 

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -1,18 +1,22 @@
-import { DirectoryData } from "types/directory"
+import { DirectoryData, PageData } from "types/directory"
 
-export const MOCK_PAGES_DATA = [
+export const MOCK_PAGES_DATA: PageData[] = [
   {
     name: "some page",
+    type: "file",
   },
   {
     name: "another page",
+    type: "file",
   },
   {
     name:
-      "some page with an extremely long name that cannot fit inside the textbox",
+      "some page with an extremely long name that cannot fit inside the textbox. in fact, it's so long that it should be a paragraph and perhaps a novel.",
+    type: "file",
   },
   {
     name: "extra page",
+    type: "file",
   },
 ]
 
@@ -47,3 +51,5 @@ export const MOCK_USER = {
 }
 
 export const MOCK_FOLDER_NAME = "mock-folder"
+
+export const MOCK_SUBFOLDER_NAME = "mock-subfolder"

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -22,6 +22,10 @@ export const buildDirData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/collections"
 )
 
+export const buildFolderData = apiDataBuilder<DirectoryData[]>(
+  "*/sites/:siteName/collections/:collectionName"
+)
+
 export const buildLoginData = apiDataBuilder<LoggedInUser>("*/auth/whoami")
 
 export const buildLastUpdated = apiDataBuilder<{ lastUpdated: string }>(

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -22,7 +22,7 @@ export const buildDirData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/collections"
 )
 
-export const buildFolderData = apiDataBuilder<DirectoryData[]>(
+export const buildFolderData = apiDataBuilder<(PageData | DirectoryData)[]>(
   "*/sites/:siteName/collections/:collectionName"
 )
 

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -26,6 +26,10 @@ export const buildFolderData = apiDataBuilder<(PageData | DirectoryData)[]>(
   "*/sites/:siteName/collections/:collectionName"
 )
 
+export const buildSubfolderData = apiDataBuilder<(PageData | DirectoryData)[]>(
+  "*/sites/:siteName/collections/:collectionName/subcollections/:subCollectionName"
+)
+
 export const buildLoginData = apiDataBuilder<LoggedInUser>("*/auth/whoami")
 
 export const buildLastUpdated = apiDataBuilder<{ lastUpdated: string }>(

--- a/src/services/DirectoryService/DirectoryService.ts
+++ b/src/services/DirectoryService/DirectoryService.ts
@@ -45,7 +45,7 @@ export const getCollection = ({
   siteName,
   collectionName,
   subCollectionName,
-}: PageDirectoryParams): Promise<DirectoryData[]> => {
+}: PageDirectoryParams): Promise<(PageData | DirectoryData)[]> => {
   let endpoint = `/sites/${siteName}/collections`
   if (collectionName) {
     endpoint += `/${collectionName}`

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -20,7 +20,6 @@ a {
 
   &:hover {
     text-decoration: none;
-    color: $isomer-blue;
   }
 }
 

--- a/src/types/directory.ts
+++ b/src/types/directory.ts
@@ -19,13 +19,17 @@ export interface DirectoryInfoReturn {
 
 export interface DirectoryData {
   name: string
+  type: "dir"
+  children: string[]
 }
 
 export interface PageData {
   name: string
   title?: string
   date?: string
-  resourceType?: "file" | "post"
+  type: "file"
 }
 
-export type ResourcePageData = Required<PageData>
+export type ResourcePageData = Required<Omit<PageData, "pageType">> & {
+  resourceType: "file" | "post"
+}

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,5 @@
+import { DirectoryData } from "./directory"
+
+export const isDirData = (data: unknown): data is DirectoryData => {
+  return (data as DirectoryData).type === "dir"
+}


### PR DESCRIPTION
## Problem
first part of problem can be seen in #980, where writing page level stories helps to ensure design consistency + give our designers an easier life.

second part of problem is that folders previously did not lend itself well to page level stories. this resulted in the card missing a few UI elements in storybook, which meant that a refactor was needed. moreover, the card component here did not fit the designer's vision in v1.5 (the component itself looked visually different). 

## Solution
1. write stories for `Folders`
2. update api of `useGetFolders` and related types (as it can return both folders/pages)
3. write new `PageCard` and `FolderCard` component for use in `Folders`