### PR TITLE
ref(storybook): login context for stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,27 @@
 import { ThemeProvider, useToast } from "@opengovsg/design-system-react"
 import { initialize, mswDecorator } from "msw-storybook-addon"
 import { QueryClient, QueryClientProvider } from "react-query"
-import { LoginContext } from "contexts/LoginContext"
+import { LoginProvider } from "contexts/LoginContext"
 import theme from "theme"
-import { MOCK_USER } from "mocks/constants"
+import { MINIMAL_VIEWPORTS } from "@storybook/addon-viewport"
+
+const isomerViewports = {
+  GSIB: {
+    name: "GSIB Laptop",
+    styles: {
+      width: "1920px",
+      height: "1080px",
+    },
+  },
+}
 
 export const parameters = {
+  viewport: {
+    viewports: {
+      ...MINIMAL_VIEWPORTS,
+      ...isomerViewports,
+    },
+  },
   actions: { argTypesRegex: "^on[A-Z].*" },
   docs: {
     inlineStories: true,
@@ -24,24 +40,9 @@ initialize()
 const withLoginContext = (Story) => {
   const toast = useToast()
   return (
-    <LoginContext.Provider
-      value={{
-        logout: async () => {
-          toast({
-            title: "User is logged out",
-            status: "success",
-            duration: 9000,
-            isClosable: true,
-          })
-        },
-        ...MOCK_USER,
-        verifyLoginAndSetLocalStorage: async () => {
-          return undefined
-        },
-      }}
-    >
+    <LoginProvider>
       <Story />
-    </LoginContext.Provider>
+    </LoginProvider>
   )
 }
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,9 +13,8 @@ import { WarningModal } from "components/WarningModal"
 import PropTypes from "prop-types"
 import { useState, useEffect } from "react"
 
-import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
+import { useLoginContext } from "contexts/LoginContext"
 
-import { useLocalStorage } from "hooks/useLocalStorage"
 import useRedirectHook from "hooks/useRedirectHook"
 import useSiteUrlHook from "hooks/useSiteUrlHook"
 
@@ -38,7 +37,7 @@ const Header = ({
 }) => {
   const { setRedirectToLogout, setRedirectToPage } = useRedirectHook()
   const { retrieveStagingUrl } = useSiteUrlHook()
-  const [userId] = useLocalStorage(LOCAL_STORAGE_KEYS.GithubId)
+  const { userId } = useLoginContext()
   const {
     isOpen: isWarningModalOpen,
     onOpen: onWarningModalOpen,

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,6 +1,8 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { rest } from "msw"
 import { MemoryRouter, Route } from "react-router-dom"
+
+import { MOCK_USER } from "mocks/constants"
+import { buildLastUpdated, buildLoginData } from "mocks/utils"
 
 import { handlers } from "../../mocks/handlers"
 
@@ -9,6 +11,11 @@ import { Sidebar } from "./Sidebar"
 const SidebarMeta = {
   title: "Components/Sidebar",
   component: Sidebar,
+  parameters: {
+    chromatic: {
+      delay: 500,
+    },
+  },
   decorators: [
     (Story) => {
       return (
@@ -49,9 +56,17 @@ export const Error = Template.bind({})
 Error.parameters = {
   msw: {
     handlers: [
-      rest.get(`*/sites/:siteName/lastUpdated`, (req, res, ctx) => {
-        return res.networkError("Failed to retrieve user")
-      }),
+      buildLoginData({ userId: "Unknown user", email: "", contactNumber: "" }),
+    ],
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [
+      buildLastUpdated({ lastUpdated: "Last updated today" }, "infinite"),
+      buildLoginData(MOCK_USER),
     ],
   },
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -29,10 +29,9 @@ import {
 } from "react-icons/bi"
 import { useParams, Link as RouterLink, useLocation } from "react-router-dom"
 
-import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
+import { useLoginContext } from "contexts/LoginContext"
 
 import { useLastUpdated } from "hooks/useLastUpdated"
-import { useLocalStorage } from "hooks/useLocalStorage"
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { TabSection } from "types/sidebar"
@@ -75,10 +74,7 @@ export const Sidebar = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
   const { pathname } = useLocation<{ pathname: string }>()
   const { lastUpdated, isError, isLoading } = useLastUpdated(siteName)
-  const [loggedInUser] = useLocalStorage(
-    LOCAL_STORAGE_KEYS.GithubId,
-    "Unknown user"
-  )
+  const { userId } = useLoginContext()
   // NOTE: As this is a sub-path, there's a leading / which is converted into an empty string
   const selectedTab = getSelectedTab(pathname.split("/").filter(Boolean))
   const { setRedirectToLogout } = useRedirectHook()
@@ -102,7 +98,7 @@ export const Sidebar = (): JSX.Element => {
           >
             {siteName}
           </Text>
-          <Skeleton isLoaded={!isLoading} w="100%">
+          <Skeleton isLoaded={!isLoading} w="100%" h="16px">
             <Text textStyle="caption-2" color="text.description" w="full">
               {isError ? "Unable to retrieve last updated time" : lastUpdated}
             </Text>
@@ -201,7 +197,7 @@ export const Sidebar = (): JSX.Element => {
         </SidebarButton>
         <Box px="1rem" textColor="text.link.disabled" textAlign="left" w="100%">
           <Text textStyle="body-1">Logged in as</Text>
-          <Text textStyle="body-1">@{loggedInUser}</Text>
+          <Text textStyle="body-1">@{userId}</Text>
         </Box>
       </VStack>
     </Flex>

--- a/src/contexts/LoginContext.tsx
+++ b/src/contexts/LoginContext.tsx
@@ -11,13 +11,9 @@ import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
 import { useLocalStorage } from "hooks/useLocalStorage"
 
-const { REACT_APP_BACKEND_URL: BACKEND_URL } = process.env
+import { LoggedInUser } from "types/user"
 
-interface LoggedInUser {
-  userId: string
-  email: string
-  contactNumber: string
-}
+const { REACT_APP_BACKEND_URL: BACKEND_URL } = process.env
 
 interface LoginContextProps extends LoggedInUser {
   logout: () => Promise<void>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -31,7 +31,7 @@ export const MOCK_DIR_DATA = [
 ]
 
 export const MOCK_USER = {
-  userId: "username",
-  email: "user@open.gov.sg",
+  userId: "mockUser",
+  email: "mockUser@open.gov.sg",
   contactNumber: "98765432",
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,13 +1,11 @@
 import { rest } from "msw"
 
+import { MOCK_USER } from "./constants"
+import { buildLastUpdated, buildLoginData } from "./utils"
+
 export const handlers = [
-  rest.get(`*/sites/:siteName/lastUpdated`, (req, res, ctx) => {
-    return res(
-      ctx.json({
-        lastUpdated: "Last updated today",
-      })
-    )
-  }),
+  buildLastUpdated({ lastUpdated: "Last updated today" }),
+  buildLoginData(MOCK_USER),
 ]
 
 export const contactUsHandler = (

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,6 +1,7 @@
 import { DefaultBodyType, rest } from "msw"
 
 import { DirectoryData, PageData } from "types/directory"
+import { LoggedInUser } from "types/user"
 
 const apiDataBuilder = <T extends DefaultBodyType = DefaultBodyType>(
   endpoint: string
@@ -19,4 +20,10 @@ export const buildPagesData = apiDataBuilder<PageData[]>(
 
 export const buildDirData = apiDataBuilder<DirectoryData[]>(
   "*/sites/:siteName/collections"
+)
+
+export const buildLoginData = apiDataBuilder<LoggedInUser>("*/auth/whoami")
+
+export const buildLastUpdated = apiDataBuilder<{ lastUpdated: string }>(
+  "*/sites/:siteName/lastUpdated"
 )

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,5 @@
+export interface LoggedInUser {
+  userId: string
+  email: string
+  contactNumber: string
+}


### PR DESCRIPTION
## Problem
Previously, we were relying on a hard-coded `LoginContext` for our stories as `msw` was not implemented in our codebase and we had no way of providing mock data.

This led to components dependent on `LoginContext` to be unable to update their states accurately to reflect the logged in status. 

Moreover, the `LoginContext` was not being used and components were reading from `localStorage`, which is not reactive and doesn't cause a re-render on change. this led to issues on initial login for `Header`.

Also, this PR adds a new GSIB viewport for visual testing (1920 * 1080).

## Solution
1. Remove `LoginContext` from storybook preview and use `LoginProvider` 
2. Add mocks for the routes used by `LoginProvider`
3. For components relying on `userId`, read directly from the context rather than `localStorage`