### PR TITLE
feat(resource-room): empty state for empty resource room

### DIFF
--- a/cypress/e2e/resourceCategory.spec.ts
+++ b/cypress/e2e/resourceCategory.spec.ts
@@ -58,7 +58,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to create a new resource page of type post", () => {
-    cy.contains("a", "Create page").click()
+    cy.contains("a", "Create page").should("be.visible").click()
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE)
     cy.get('input[id="permalink"]').clear().type(TEST_PAGE_PERMALINK)
@@ -81,11 +81,11 @@ describe("Resource category page", () => {
     cy.contains(TEST_PAGE_TITLE)
 
     // 3. New page should be of type POST with the correct date
-    cy.contains(TEST_PAGE_TITLE).contains(`${TEST_PAGE_DATE_PRETTIFIED}/POST`)
+    cy.contains("button",TEST_PAGE_TITLE).contains(`${TEST_PAGE_DATE_PRETTIFIED}/POST`)
   })
 
   it("Resources page should not allow user to create a new resource category with invalid name", () => {
-    cy.contains("a", "Create page").click()
+    cy.contains("a", "Create page").should("be.visible").click()
     // Same name as existing file
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE).blur()
     cy.contains("Save").should("be.disabled")
@@ -117,7 +117,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to create a new resource page of type post", () => {
-    cy.contains("a", "Create page").click()
+    cy.contains("a", "Create page").should("be.visible").click()
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_2)
     cy.get('input[id="permalink"]').clear().type(TEST_PAGE_PERMALINK)
@@ -214,7 +214,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to create a new resource page of type file", () => {
-    cy.contains("Create page").click()
+    cy.contains("Create page").should("be.visible").click()
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_FILE)
     cy.get('input[id="date"]').clear().type(TEST_PAGE_DATE)

--- a/src/assets/images/EmptyBoxImage.tsx
+++ b/src/assets/images/EmptyBoxImage.tsx
@@ -1,6 +1,4 @@
-export const EmptyBoxImage = (
-  props: React.SVGProps<SVGSVGElement>
-): JSX.Element => {
+export const EmptyBoxImage = (): JSX.Element => {
   return (
     <svg
       width="256"

--- a/src/assets/images/EmptyBoxImage.tsx
+++ b/src/assets/images/EmptyBoxImage.tsx
@@ -1,4 +1,6 @@
-export const EmptyBoxImage = (): JSX.Element => {
+export const EmptyBoxImage = (
+  props: React.SVGProps<SVGSVGElement>
+): JSX.Element => {
   return (
     <svg
       width="256"
@@ -6,7 +8,6 @@ export const EmptyBoxImage = (): JSX.Element => {
       viewBox="0 0 256 120"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
       <path

--- a/src/assets/images/EmptyBoxImage.tsx
+++ b/src/assets/images/EmptyBoxImage.tsx
@@ -8,6 +8,7 @@ export const EmptyBoxImage = (
       viewBox="0 0 256 120"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
       <path

--- a/src/components/EmptyArea.tsx
+++ b/src/components/EmptyArea.tsx
@@ -1,11 +1,10 @@
 import { Box, Center, VStack, Text, HTMLChakraProps } from "@chakra-ui/react"
-import { ReactFragment } from "react"
 
 import { EmptyBoxImage } from "assets"
 
-export interface EmptyAreaOption extends HTMLChakraProps<"div"> {
+export interface EmptyAreaProps extends HTMLChakraProps<"div"> {
   isItemEmpty: boolean
-  actionButton: ReactFragment
+  actionButton: JSX.Element
   mainText?: string
   subText?: string
 }
@@ -16,13 +15,14 @@ export const EmptyArea = ({
   actionButton,
   children,
   isItemEmpty,
-}: EmptyAreaOption): JSX.Element => {
+  ...rest
+}: EmptyAreaProps): JSX.Element => {
   return (
     <>
       {isItemEmpty ? (
-        <Box as="form" w="full">
+        <Box w="full">
           {/* Resource Room does not exist */}
-          <VStack spacing={5}>
+          <VStack spacing={5} {...rest}>
             <EmptyBoxImage />
             <Center>
               <VStack spacing={0}>

--- a/src/components/LoadingButton/LoadingButton.tsx
+++ b/src/components/LoadingButton/LoadingButton.tsx
@@ -1,6 +1,9 @@
 import { Button, ButtonProps } from "@opengovsg/design-system-react"
 import { useState } from "react"
 
+/**
+ * @deprecated This is legacy code, use chakraUI's button and pass in the isLoading prop instead
+ */
 // eslint-disable-next-line import/prefer-default-export
 export const LoadingButton = ({
   onClick,

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -50,7 +50,7 @@ const DEFAULT_COLOUR_SETTINGS: SiteColourSettings = {
 
 const TOGGLED_VALUES = ["is_government", "show_reach"]
 
-const convertfromBe = (backendSettings: BackendSiteSettings): SiteSettings => {
+const convertFromBe = (backendSettings: BackendSiteSettings): SiteSettings => {
   const toggledValues: Pick<
     SiteSettings,
     "displayGovMasthead" | "showReach"
@@ -120,7 +120,7 @@ export const useGetSettings = (
 ): UseQueryResult<SiteSettings> => {
   return useQuery<SiteSettings>(
     [SETTINGS_CONTENT_KEY, siteName],
-    () => SettingsService.get({ siteName }).then(convertfromBe),
+    () => SettingsService.get({ siteName }).then(convertFromBe),
     {
       retry: false,
     }

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -62,7 +62,7 @@ export const ResourceCategory = (): JSX.Element => {
         </Section>
         <Section>
           {/* 
-              There is no loading state for this as '!arePagesEmpty' will only evulate to 
+              There is no loading state for this as '!arePagesEmpty' will only evaluate to 
               true after we have received data from the API call.
            */}
           {!arePagesEmpty && (

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -81,7 +81,7 @@ export const ResourceCategory = (): JSX.Element => {
                   to={`${url}/createPage`}
                   leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
                 >
-                  Create Page
+                  Create page
                 </Button>
               }
               subText="Create a resource page to get started."

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -1,13 +1,5 @@
-import {
-  Box,
-  Text,
-  Skeleton,
-  SimpleGrid,
-  Button,
-  Center,
-  Icon,
-  VStack,
-} from "@chakra-ui/react"
+import { Box, Text, Skeleton, SimpleGrid, Button, Icon } from "@chakra-ui/react"
+import { EmptyArea } from "components/EmptyArea"
 import { BiBulb, BiPlus } from "react-icons/bi"
 import {
   Switch,
@@ -35,7 +27,6 @@ import {
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 // Import utils
-import { EmptyBoxImage } from "assets"
 import { ResourceCategoryRouteParams } from "types/resources"
 import { deslugifyDirectory } from "utils"
 
@@ -82,19 +73,9 @@ export const ResourceCategory = (): JSX.Element => {
             w="100%"
             h={isLoading ? "10rem" : "fit-content"}
           >
-            {arePagesEmpty && (
-              <VStack spacing={5}>
-                <EmptyBoxImage />
-                <Center>
-                  <VStack spacing={0}>
-                    <Text textStyle="subhead-1">
-                      There&apos;s nothing here yet.
-                    </Text>
-                    <Text textStyle="body-2">
-                      Create a resource page to get started.
-                    </Text>
-                  </VStack>
-                </Center>
+            <EmptyArea
+              isItemEmpty={arePagesEmpty}
+              actionButton={
                 <Button
                   as={RouterLink}
                   to={`${url}/createPage`}
@@ -102,8 +83,10 @@ export const ResourceCategory = (): JSX.Element => {
                 >
                   Create Page
                 </Button>
-              </VStack>
-            )}
+              }
+              subText="Create a resource page to get started."
+            />
+
             <SimpleGrid columns={3} spacing="1.5rem">
               {/* NOTE: need to use multiline cards */}
               {(pagesData || []).map(({ name, title, date, resourceType }) => (

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -1,5 +1,14 @@
-import { Box, Text, Skeleton, SimpleGrid } from "@chakra-ui/react"
-import { BiBulb } from "react-icons/bi"
+import {
+  Box,
+  Text,
+  Skeleton,
+  SimpleGrid,
+  Button,
+  Center,
+  Icon,
+  VStack,
+} from "@chakra-ui/react"
+import { BiBulb, BiPlus } from "react-icons/bi"
 import {
   Switch,
   useRouteMatch,
@@ -26,6 +35,7 @@ import {
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 // Import utils
+import { EmptyBoxImage } from "assets"
 import { ResourceCategoryRouteParams } from "types/resources"
 import { deslugifyDirectory } from "utils"
 
@@ -66,7 +76,30 @@ export const ResourceCategory = (): JSX.Element => {
             w="100%"
             h={isLoading ? "10rem" : "fit-content"}
           >
-            {!pagesData || (!pagesData.length && <Text>No content here</Text>)}
+            {!pagesData ||
+              (!pagesData.length && (
+                <VStack spacing={5}>
+                  <EmptyBoxImage />
+                  <VStack spacing={0}>
+                    <Center textStyle="subhead-1">
+                      There&apos;s nothing here yet.
+                    </Center>
+                    <Center textStyle="body-2">
+                      Create a page to get started.
+                    </Center>
+                  </VStack>
+                  <Button
+                    variant="solid"
+                    as={RouterLink}
+                    to={`${url}/createPage`}
+                    leftIcon={
+                      <Icon as={BiPlus} fontSize="1.5rem" fill="white" />
+                    }
+                  >
+                    Create Resource Page
+                  </Button>
+                </VStack>
+              ))}
             <SimpleGrid columns={3} spacing="1.5rem">
               {/* NOTE: need to use multiline cards */}
               {(pagesData || []).map(({ name, title, date, resourceType }) => (

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -48,7 +48,7 @@ export const ResourceCategory = (): JSX.Element => {
   const history = useHistory()
 
   const { data: pagesData, isLoading } = useGetResourceCategory(params)
-  const isPagesEmpty = !pagesData?.length
+  const arePagesEmpty = !pagesData?.length
   return (
     <>
       <SiteViewLayout>
@@ -61,7 +61,11 @@ export const ResourceCategory = (): JSX.Element => {
           </Box>
         </Section>
         <Section>
-          {!isPagesEmpty && (
+          {/* 
+              There is no loading state for this as '!arePagesEmpty' will only evulate to 
+              true after we have received data from the API call.
+           */}
+          {!arePagesEmpty && (
             <Box w="full">
               <SectionHeader label="Resource Pages">
                 <CreateButton as={RouterLink} to={`${url}/createPage`}>
@@ -78,19 +82,20 @@ export const ResourceCategory = (): JSX.Element => {
             w="100%"
             h={isLoading ? "10rem" : "fit-content"}
           >
-            {isPagesEmpty && (
+            {arePagesEmpty && (
               <VStack spacing={5}>
                 <EmptyBoxImage />
-                <VStack spacing={0}>
-                  <Center textStyle="subhead-1">
-                    There&apos;s nothing here yet.
-                  </Center>
-                  <Center textStyle="body-2">
-                    Create a resource page to get started.
-                  </Center>
-                </VStack>
+                <Center>
+                  <VStack spacing={0}>
+                    <Text textStyle="subhead-1">
+                      There&apos;s nothing here yet.
+                    </Text>
+                    <Text textStyle="body-2">
+                      Create a resource page to get started.
+                    </Text>
+                  </VStack>
+                </Center>
                 <Button
-                  variant="solid"
                   as={RouterLink}
                   to={`${url}/createPage`}
                   leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -48,7 +48,7 @@ export const ResourceCategory = (): JSX.Element => {
   const history = useHistory()
 
   const { data: pagesData, isLoading } = useGetResourceCategory(params)
-
+  const isPagesEmpty = !pagesData?.length
   return (
     <>
       <SiteViewLayout>
@@ -61,45 +61,44 @@ export const ResourceCategory = (): JSX.Element => {
           </Box>
         </Section>
         <Section>
-          <Box w="full">
-            <SectionHeader label="Resource Pages">
-              <CreateButton as={RouterLink} to={`${url}/createPage`}>
-                Create page
-              </CreateButton>
-            </SectionHeader>
-            <SectionCaption icon={BiBulb} label="NOTE: ">
-              Pages are automatically ordered by latest date.
-            </SectionCaption>
-          </Box>
+          {!isPagesEmpty && (
+            <Box w="full">
+              <SectionHeader label="Resource Pages">
+                <CreateButton as={RouterLink} to={`${url}/createPage`}>
+                  Create page
+                </CreateButton>
+              </SectionHeader>
+              <SectionCaption icon={BiBulb} label="NOTE: ">
+                Pages are automatically ordered by latest date.
+              </SectionCaption>
+            </Box>
+          )}
           <Skeleton
             isLoaded={!isLoading}
             w="100%"
             h={isLoading ? "10rem" : "fit-content"}
           >
-            {!pagesData ||
-              (!pagesData.length && (
-                <VStack spacing={5}>
-                  <EmptyBoxImage />
-                  <VStack spacing={0}>
-                    <Center textStyle="subhead-1">
-                      There&apos;s nothing here yet.
-                    </Center>
-                    <Center textStyle="body-2">
-                      Create a page to get started.
-                    </Center>
-                  </VStack>
-                  <Button
-                    variant="solid"
-                    as={RouterLink}
-                    to={`${url}/createPage`}
-                    leftIcon={
-                      <Icon as={BiPlus} fontSize="1.5rem" fill="white" />
-                    }
-                  >
-                    Create Resource Page
-                  </Button>
+            {isPagesEmpty && (
+              <VStack spacing={5}>
+                <EmptyBoxImage />
+                <VStack spacing={0}>
+                  <Center textStyle="subhead-1">
+                    There&apos;s nothing here yet.
+                  </Center>
+                  <Center textStyle="body-2">
+                    Create a resource page to get started.
+                  </Center>
                 </VStack>
-              ))}
+                <Button
+                  variant="solid"
+                  as={RouterLink}
+                  to={`${url}/createPage`}
+                  leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
+                >
+                  Create Page
+                </Button>
+              </VStack>
+            )}
             <SimpleGrid columns={3} spacing="1.5rem">
               {/* NOTE: need to use multiline cards */}
               {(pagesData || []).map(({ name, title, date, resourceType }) => (

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -60,8 +60,8 @@ Empty.parameters = {
   },
 }
 
-export const EmptyResoruceCategory = Template.bind({})
-EmptyResoruceCategory.parameters = {
+export const EmptyResourceCategory = Template.bind({})
+EmptyResourceCategory.parameters = {
   msw: {
     handlers: {
       resourceRoomData: buildResourceRoomData([]),

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -60,8 +60,8 @@ Empty.parameters = {
   },
 }
 
-export const EmptyCategory = Template.bind({})
-EmptyCategory.parameters = {
+export const EmptyResoruceCategory = Template.bind({})
+EmptyResoruceCategory.parameters = {
   msw: {
     handlers: {
       resourceRoomData: buildResourceRoomData([]),

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { MemoryRouter, Route } from "react-router-dom"
+import { MemoryRouter, Route, Switch } from "react-router-dom"
 
 import { MOCK_DIR_DATA, MOCK_RESOURCE_ROOM_NAME } from "mocks/constants"
 import { buildResourceRoomData, buildResourceRoomName } from "mocks/utils"
@@ -32,10 +32,14 @@ const ResourceRoomMeta = {
             `/sites/storybook/resourceRoom/${MOCK_RESOURCE_ROOM_NAME}`,
           ]}
         >
-          <Route path="/sites/:siteName/resourceRoom/:resourceRoomName">
-            <Story />
-          </Route>
-          )
+          <Switch>
+            <Route path="/sites/:siteName/resourceRoom/:resourceRoomName">
+              <Story />
+            </Route>
+            <Route path="/sites/:siteName/resourceRoom/">
+              <Story />
+            </Route>
+          </Switch>
         </MemoryRouter>
       )
     },
@@ -55,21 +59,6 @@ Empty.parameters = {
     },
   },
 }
-Empty.decorators = [
-  (Story) => {
-    return (
-      <MemoryRouter
-        initialEntries={[
-          `/sites/storybook/resourceRoom/${MOCK_RESOURCE_ROOM_NAME}`,
-        ]}
-      >
-        <Route path="/sites/:siteName/resourceRoom/">
-          <Story />
-        </Route>
-      </MemoryRouter>
-    )
-  },
-]
 
 export const EmptyCategory = Template.bind({})
 EmptyCategory.parameters = {

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -35,9 +35,7 @@ const ResourceRoomMeta = {
           <Route path="/sites/:siteName/resourceRoom/:resourceRoomName">
             <Story />
           </Route>
-          <Route path="/sites/:siteName/resourceRoom/">
-            <Story />
-          </Route>
+          )
         </MemoryRouter>
       )
     },
@@ -57,6 +55,21 @@ Empty.parameters = {
     },
   },
 }
+Empty.decorators = [
+  (Story) => {
+    return (
+      <MemoryRouter
+        initialEntries={[
+          `/sites/storybook/resourceRoom/${MOCK_RESOURCE_ROOM_NAME}`,
+        ]}
+      >
+        <Route path="/sites/:siteName/resourceRoom/">
+          <Story />
+        </Route>
+      </MemoryRouter>
+    )
+  },
+]
 
 export const EmptyCategory = Template.bind({})
 EmptyCategory.parameters = {
@@ -83,15 +96,4 @@ Loading.parameters = {
   },
 }
 
-export const LoadingResourceRoomContent = Template.bind({})
-LoadingResourceRoomContent.parameters = {
-  msw: {
-    handlers: {
-      resourceRoomName: buildResourceRoomName({
-        resourceRoomName: "storybook",
-      }),
-      resourceRoomData: buildResourceRoomData([], "infinite"),
-    },
-  },
-}
 export default ResourceRoomMeta

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -58,12 +58,14 @@ Empty.parameters = {
   },
 }
 
-export const NoResourceRoom = Template.bind({})
-NoResourceRoom.parameters = {
+export const EmptyCategory = Template.bind({})
+EmptyCategory.parameters = {
   msw: {
     handlers: {
       resourceRoomData: buildResourceRoomData([]),
-      resourceRoomName: buildResourceRoomName({ resourceRoomName: "" }),
+      resourceRoomName: buildResourceRoomName({
+        resourceRoomName: MOCK_RESOURCE_ROOM_NAME,
+      }),
     },
   },
 }

--- a/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.stories.tsx
@@ -53,6 +53,7 @@ Empty.parameters = {
   msw: {
     handlers: {
       resourceRoomData: buildResourceRoomData([]),
+      resourceRoomName: buildResourceRoomName({ resourceRoomName: "" }),
     },
   },
 }

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -139,6 +139,7 @@ const EmptyResourceRoom = () => {
               <Input
                 marginTop={5}
                 placeholder="Resource room name"
+                // eslint-disable-next-line react/jsx-props-no-spreading
                 {...register("newDirectoryName", {
                   required: "Please enter resource room name",
                 })}

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -20,7 +20,6 @@ import {
 import { Button, FormLabel, Input } from "@opengovsg/design-system-react"
 import { ContextMenu } from "components/ContextMenu"
 import { EmptyArea } from "components/EmptyArea"
-import { LoadingButton } from "components/LoadingButton"
 import _ from "lodash"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
@@ -70,7 +69,9 @@ import { CategoryCard, ResourceBreadcrumb } from "./components"
 const EmptyResourceRoom = () => {
   const params = useParams<ResourceRoomRouteParams>()
   const { siteName } = params
-  const { mutateAsync: saveHandler, isError } = useCreateDirectory(siteName)
+  const { mutateAsync: saveHandler, isError, isLoading } = useCreateDirectory(
+    siteName
+  )
   const {
     register,
     handleSubmit,
@@ -148,13 +149,14 @@ const EmptyResourceRoom = () => {
             <Button mr={3} variant="link" onClick={onClose}>
               <Text textStyle="subhead-1">Cancel</Text>
             </Button>
-            <LoadingButton
+            <Button
               isDisabled={!_.isEmpty(errors)}
               type="submit"
               onClick={handleSubmit(onSubmit)}
+              isLoading={isLoading}
             >
               Create
-            </LoadingButton>
+            </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -101,25 +101,24 @@ const EmptyResourceRoom = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
-    <SiteViewLayout
-      divider={undefined} // to remove bottom divider line
-    >
-      <Center as="form" mt="6rem">
-        {/* Resource Room does not exist */}
-        <EmptyArea
-          isItemEmpty
-          actionButton={
-            <Button
-              onClick={onOpen}
-              leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
-            >
-              Create Resource Room
-            </Button>
-          }
-          subText="Create a resource room to get started."
-        />
-      </Center>
-
+    <>
+      <SiteViewLayout>
+        <Center as="form" mt="6rem">
+          {/* Resource Room does not exist */}
+          <EmptyArea
+            isItemEmpty
+            actionButton={
+              <Button
+                onClick={onOpen}
+                leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
+              >
+                Create Resource Room
+              </Button>
+            }
+            subText="Create a resource room to get started."
+          />
+        </Center>
+      </SiteViewLayout>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
@@ -160,7 +159,7 @@ const EmptyResourceRoom = () => {
           </ModalFooter>
         </ModalContent>
       </Modal>
-    </SiteViewLayout>
+    </>
   )
 }
 

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -26,7 +26,6 @@ import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { BiPlus, BiWrench, BiBulb } from "react-icons/bi"
 import {
-  Link,
   Link as RouterLink,
   Redirect,
   Route,

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -150,7 +150,6 @@ const EmptyResourceRoom = () => {
             </Button>
             <Button
               isDisabled={!_.isEmpty(errors)}
-              type="submit"
               onClick={handleSubmit(onSubmit)}
               isLoading={isLoading}
             >

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -326,7 +326,7 @@ const ResourceRoomContent = ({
                   to={`${url}/createDirectory`}
                   leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
                 >
-                  Create Category
+                  Create category
                 </Button>
               }
               subText="Create a resource category to get started."

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -26,6 +26,7 @@ import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { BiPlus, BiWrench, BiBulb } from "react-icons/bi"
 import {
+  Link,
   Link as RouterLink,
   Redirect,
   Route,
@@ -102,27 +103,26 @@ const EmptyResourceRoom = () => {
 
   return (
     <SiteViewLayout>
-      <Box as="form" w="full" mt={100}>
+      <Center as="form" mt="6rem">
         {/* Resource Room does not exist */}
         <VStack spacing={5}>
           <EmptyBoxImage />
-          <VStack spacing={0}>
-            <Center textStyle="subhead-1">
-              There&apos;s nothing here yet.
-            </Center>
-            <Center textStyle="body-2">
-              Create a resource room to get started.
-            </Center>
-          </VStack>
+          <Center>
+            <VStack spacing={0}>
+              <Text textStyle="subhead-1">There&apos;s nothing here yet.</Text>
+              <Text textStyle="body-2">
+                Create a resource room to get started.
+              </Text>
+            </VStack>
+          </Center>
           <Button
-            variant="solid"
             onClick={onOpen}
             leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
           >
             Create Resource Room
           </Button>
         </VStack>
-      </Box>
+      </Center>
 
       <Modal blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
@@ -151,9 +151,7 @@ const EmptyResourceRoom = () => {
           </ModalBody>
           <ModalFooter>
             <Button mr={3} variant="link" onClick={onClose}>
-              <Text textStyle="subhead-1" colorScheme="orange">
-                Cancel
-              </Text>
+              <Text textStyle="subhead-1">Cancel</Text>
             </Button>
             <LoadingButton
               isDisabled={!_.isEmpty(errors)}
@@ -310,7 +308,6 @@ const ResourceRoomContent = ({
             <ResourceBreadcrumb />
           </Box>
         </Section>
-        <Section />
         <Section>
           {directoryData.length !== 0 && (
             <Box w="full">
@@ -329,14 +326,23 @@ const ResourceRoomContent = ({
             {directoryData.length === 0 ? (
               <VStack spacing={5}>
                 <EmptyBoxImage />
-                <VStack spacing={0}>
-                  <Center textStyle="subhead-1">
-                    There&apos;s nothing here yet.
-                  </Center>
-                  <Center textStyle="body-2">
-                    Create a resource category to get started.
-                  </Center>
-                </VStack>
+                <Center>
+                  <VStack spacing={0}>
+                    <Text textStyle="subhead-1">
+                      There&apos;s nothing here yet.
+                    </Text>
+                    <Text textStyle="body-2">
+                      Create a resource category to get started.
+                    </Text>
+                  </VStack>
+                </Center>
+                <Button
+                  as={RouterLink}
+                  to={`${url}/createDirectory`}
+                  leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
+                >
+                  Create Category
+                </Button>
               </VStack>
             ) : (
               directoryData &&

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -146,7 +146,7 @@ const EmptyResourceRoom = () => {
             </FormControl>
           </ModalBody>
           <ModalFooter>
-            <Button mr={3} variant="link" onClick={onClose}>
+            <Button mr={3} variant="clear" onClick={onClose}>
               <Text textStyle="subhead-1">Cancel</Text>
             </Button>
             <Button

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -310,18 +310,21 @@ const ResourceRoomContent = ({
             <ResourceBreadcrumb />
           </Box>
         </Section>
+        <Section />
         <Section>
-          <Box w="full">
-            <SectionHeader label="Resource Categories">
-              <CreateButton as={RouterLink} to={`${url}/createDirectory`}>
-                Create category
-              </CreateButton>
-            </SectionHeader>
-            <SectionCaption icon={BiBulb} label="PRO TIP: ">
-              Categories impact navigation on your site. Organise your resources
-              by creating categories.
-            </SectionCaption>
-          </Box>
+          {directoryData.length !== 0 && (
+            <Box w="full">
+              <SectionHeader label="Resource Categories">
+                <CreateButton as={RouterLink} to={`${url}/createDirectory`}>
+                  Create category
+                </CreateButton>
+              </SectionHeader>
+              <SectionCaption icon={BiBulb} label="PRO TIP: ">
+                Categories impact navigation on your site. Organise your
+                resources by creating categories.
+              </SectionCaption>
+            </Box>
+          )}
           <Skeleton isLoaded={isLoading} w="100%">
             {directoryData.length === 0 ? (
               <VStack spacing={5}>
@@ -334,12 +337,6 @@ const ResourceRoomContent = ({
                     Create a resource category to get started.
                   </Center>
                 </VStack>
-                <Button
-                  variant="solid"
-                  as={RouterLink}
-                  to={`${url}/createDirectory`}
-                  leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
-                />
               </VStack>
             ) : (
               directoryData &&

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -20,6 +20,7 @@ import {
 } from "@chakra-ui/react"
 import { Button, FormLabel, Input } from "@opengovsg/design-system-react"
 import { ContextMenu } from "components/ContextMenu"
+import { EmptyArea } from "components/EmptyArea"
 import { LoadingButton } from "components/LoadingButton"
 import _ from "lodash"
 import { useEffect } from "react"
@@ -106,23 +107,18 @@ const EmptyResourceRoom = () => {
     >
       <Center as="form" mt="6rem">
         {/* Resource Room does not exist */}
-        <VStack spacing={5}>
-          <EmptyBoxImage />
-          <Center>
-            <VStack spacing={0}>
-              <Text textStyle="subhead-1">There&apos;s nothing here yet.</Text>
-              <Text textStyle="body-2">
-                Create a resource room to get started.
-              </Text>
-            </VStack>
-          </Center>
-          <Button
-            onClick={onOpen}
-            leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
-          >
-            Create Resource Room
-          </Button>
-        </VStack>
+        <EmptyArea
+          isItemEmpty
+          actionButton={
+            <Button
+              onClick={onOpen}
+              leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
+            >
+              Create Resource Room
+            </Button>
+          }
+          subText="Create a resource room to get started."
+        />
       </Center>
 
       <Modal isOpen={isOpen} onClose={onClose}>
@@ -324,19 +320,9 @@ const ResourceRoomContent = ({
             </Box>
           )}
           <Skeleton isLoaded={isLoading} w="100%">
-            {directoryData.length === 0 ? (
-              <VStack spacing={5}>
-                <EmptyBoxImage />
-                <Center>
-                  <VStack spacing={0}>
-                    <Text textStyle="subhead-1">
-                      There&apos;s nothing here yet.
-                    </Text>
-                    <Text textStyle="body-2">
-                      Create a resource category to get started.
-                    </Text>
-                  </VStack>
-                </Center>
+            <EmptyArea
+              isItemEmpty={!directoryData?.length}
+              actionButton={
                 <Button
                   as={RouterLink}
                   to={`${url}/createDirectory`}
@@ -344,17 +330,15 @@ const ResourceRoomContent = ({
                 >
                   Create Category
                 </Button>
-              </VStack>
-            ) : (
-              directoryData &&
-              directoryData.length > 0 && (
-                <SimpleGrid columns={3} spacing="1.5rem">
-                  {directoryData.map(({ name }) => (
-                    <CategoryCard title={name} />
-                  ))}
-                </SimpleGrid>
-              )
-            )}
+              }
+              subText="Create a resource category to get started."
+            >
+              <SimpleGrid columns={3} spacing="1.5rem">
+                {directoryData.map(({ name }) => (
+                  <CategoryCard title={name} />
+                ))}
+              </SimpleGrid>
+            </EmptyArea>
           </Skeleton>
         </Section>
       </SiteViewLayout>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -16,7 +16,6 @@ import {
   HStack,
   Text,
   useDisclosure,
-  VStack,
 } from "@chakra-ui/react"
 import { Button, FormLabel, Input } from "@opengovsg/design-system-react"
 import { ContextMenu } from "components/ContextMenu"
@@ -59,7 +58,6 @@ import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 import { useErrorToast, useSuccessToast } from "utils/toasts"
 
-import { EmptyBoxImage } from "assets"
 import { DirectoryData, DirectoryInfoProps } from "types/directory"
 import { ResourceRoomRouteParams } from "types/resources"
 import { DEFAULT_RETRY_MSG, deslugifyDirectory } from "utils"

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -324,7 +324,23 @@ const ResourceRoomContent = ({
           </Box>
           <Skeleton isLoaded={isLoading} w="100%">
             {directoryData.length === 0 ? (
-              <Text>No Categories.</Text>
+              <VStack spacing={5}>
+                <EmptyBoxImage />
+                <VStack spacing={0}>
+                  <Center textStyle="subhead-1">
+                    There&apos;s nothing here yet.
+                  </Center>
+                  <Center textStyle="body-2">
+                    Create a resource category to get started.
+                  </Center>
+                </VStack>
+                <Button
+                  variant="solid"
+                  as={RouterLink}
+                  to={`${url}/createDirectory`}
+                  leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
+                />
+              </VStack>
             ) : (
               directoryData &&
               directoryData.length > 0 && (

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -124,7 +124,7 @@ const EmptyResourceRoom = () => {
         </VStack>
       </Center>
 
-      <Modal blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Create resource room</ModalHeader>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -102,7 +102,9 @@ const EmptyResourceRoom = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
-    <SiteViewLayout>
+    <SiteViewLayout
+      divider={undefined} // to remove bottom divider line
+    >
       <Center as="form" mt="6rem">
         {/* Resource Room does not exist */}
         <VStack spacing={5}>

--- a/src/theme/components/Tabs.ts
+++ b/src/theme/components/Tabs.ts
@@ -3,7 +3,7 @@ import { ComponentMultiStyleConfig } from "@chakra-ui/react"
 export const Tabs: Pick<ComponentMultiStyleConfig, "variants"> = {
   variants: {
     "line-vertical": (props) => {
-      const { colorScheme: c, orientation } = props
+      const { orientation } = props
       const borderProp =
         orientation === "vertical" ? "borderStart" : "borderBottom"
 


### PR DESCRIPTION
## Problem
Currently, our empty state for ResourceRoom is not very pleasant to look at and not intuitive. Isomer should have a more descriptive empty state to guide the user along

Addresses #962

## Solution
As suggested in [figma here](https://www.figma.com/file/7OtNYkc4s9BkFk05ConEbd/V1.5?node-id=1559%3A62055)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] No - this PR is backwards compatible

## Before & After Screenshots

**BEFORE**:


![before](https://user-images.githubusercontent.com/44049504/177727351-b9d43dc4-482c-454d-b458-73090b971257.png)

**AFTER**:

<img width="1267" alt="Screenshot 2022-07-26 at 12 24 38 PM" src="https://user-images.githubusercontent.com/42832651/180922836-77391658-5858-472e-a859-9f3e0a8a9fb3.png">

Other Notes: 
Other changes are linked to outstanding PRs by @seaerchin 

