### PR TITLE
Fix/hitting character limit when adding <iframe/>

### DIFF
--- a/src/utils/allowedHTML.ts
+++ b/src/utils/allowedHTML.ts
@@ -1,12 +1,8 @@
 /**
- * Defines the list of allowed HTML tags that do not count towards the total
+ * HTML tag that do not count towards the total
  * character limit.
- *
  */
-const regrexTests = [
-  new RegExp("(<iframe.*/iframe>)", "gm"),
-  new RegExp("(<div.*/div>)", "gm"),
-]
+const IFRAME_TAG_REGEX = new RegExp("(<iframe.*/iframe>)", "gm")
 
 /**
  * @param text raw text input by user
@@ -14,8 +10,8 @@ const regrexTests = [
  */
 export const getLengthWithoutTags = (text: string): number => {
   let finalText = text
-  for (const regrexTest of regrexTests) {
-    finalText = finalText.replace(regrexTest, "")
-  }
+
+  finalText = finalText.replace(IFRAME_TAG_REGEX, "")
+
   return finalText.length
 }

--- a/src/utils/allowedHTML.ts
+++ b/src/utils/allowedHTML.ts
@@ -9,5 +9,5 @@ const IFRAME_TAG_REGEX = new RegExp("(<iframe.*/iframe>)", "gm")
  * @returns the character length after removing specifc HTML tags
  */
 export const getLengthWithoutTags = (text: string): number => {
- return text.replace(IFRAME_TAG_REGEX, "").length
+  return text.replace(IFRAME_TAG_REGEX, "").length
 }

--- a/src/utils/allowedHTML.ts
+++ b/src/utils/allowedHTML.ts
@@ -3,14 +3,19 @@
  * character limit.
  *
  */
-
-const iFrameRegrexTest = new RegExp("(<iframe.*/iframe>)", "gm")
+const regrexTests = [
+  new RegExp("(<iframe.*/iframe>)", "gm"),
+  new RegExp("(<div.*/div>)", "gm"),
+]
 
 /**
  * @param text raw text input by user
  * @returns the character length after removing specifc HTML tags
  */
 export const getLengthWithoutTags = (text: string): number => {
-  const removeIFrameTags = text.replace(iFrameRegrexTest, "")
-  return removeIFrameTags.length
+  let finalText = text
+  for (const regrexTest of regrexTests) {
+    finalText = finalText.replace(regrexTest, "")
+  }
+  return finalText.length
 }

--- a/src/utils/allowedHTML.ts
+++ b/src/utils/allowedHTML.ts
@@ -9,9 +9,5 @@ const IFRAME_TAG_REGEX = new RegExp("(<iframe.*/iframe>)", "gm")
  * @returns the character length after removing specifc HTML tags
  */
 export const getLengthWithoutTags = (text: string): number => {
-  let finalText = text
-
-  finalText = finalText.replace(IFRAME_TAG_REGEX, "")
-
-  return finalText.length
+ return text.replace(IFRAME_TAG_REGEX, "").length
 }

--- a/src/utils/allowedHTML.ts
+++ b/src/utils/allowedHTML.ts
@@ -1,0 +1,16 @@
+/**
+ * Defines the list of allowed HTML tags that do not count towards the total
+ * character limit.
+ *
+ */
+
+const iFrameRegrexTest = new RegExp("(<iframe.*/iframe>)", "gm")
+
+/**
+ * @param text raw text input by user
+ * @returns the character length after removing specifc HTML tags
+ */
+export const getLengthWithoutTags = (text: string): number => {
+  const removeIFrameTags = text.replace(iFrameRegrexTest, "")
+  return removeIFrameTags.length
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -9,6 +9,8 @@ import {
   generatePageFileName,
 } from "utils"
 
+import { getLengthWithoutTags } from "./allowedHTML"
+
 // Common regexes and constants
 // ==============
 const PERMALINK_REGEX = "^((/([a-zA-Z0-9]+-)*[a-zA-Z0-9]+)+)/?$"
@@ -560,7 +562,7 @@ const validateContactType = (contactType, value) => {
       break
     }
     case "other": {
-      if (value.length > CONTACT_DESCRIPTION_MAX_LENGTH) {
+      if (getLengthWithoutTags(value) > CONTACT_DESCRIPTION_MAX_LENGTH) {
         errorMessage = `Description should be shorter than ${CONTACT_DESCRIPTION_MAX_LENGTH} characters.`
       }
       break
@@ -640,7 +642,9 @@ const validateLocationType = (locationType, value) => {
       break
     }
     case "description": {
-      if (value.length > LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH) {
+      if (
+        getLengthWithoutTags(value) > LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH
+      ) {
         errorMessage = `Description should be shorter than ${LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH} characters.`
       }
       break

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -562,7 +562,7 @@ const validateContactType = (contactType, value) => {
       break
     }
     case "other": {
-      if (getLengthWithoutTags(value) > CONTACT_DESCRIPTION_MAX_LENGTH) {
+      if (value.length > CONTACT_DESCRIPTION_MAX_LENGTH) {
         errorMessage = `Description should be shorter than ${CONTACT_DESCRIPTION_MAX_LENGTH} characters.`
       }
       break
@@ -642,9 +642,7 @@ const validateLocationType = (locationType, value) => {
       break
     }
     case "description": {
-      if (
-        getLengthWithoutTags(value) > LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH
-      ) {
+      if (value.length > LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH) {
         errorMessage = `Description should be shorter than ${LOCATION_OPERATING_DESCRIPTION_MAX_LENGTH} characters.`
       }
       break

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -380,7 +380,7 @@ const validateInfobarSection = (sectionError, sectionType, field, value) => {
         errorMessage = `The description should be longer than ${INFOBAR_DESCRIPTION_MIN_LENGTH} characters.`
       }
       // Description is too long
-      if (value.length > INFOBAR_DESCRIPTION_MAX_LENGTH) {
+      if (getLengthWithoutTags(value) > INFOBAR_DESCRIPTION_MAX_LENGTH) {
         errorMessage = `The description should be shorter than ${INFOBAR_DESCRIPTION_MAX_LENGTH} characters.`
       }
       break


### PR DESCRIPTION
## Problem 

Since HTML code regarding iframe is part of the 400 character limit (see image below), this does not allow certain agencies to add in iframe. Currently, the workaround is to manually adding the code directly to the back end.

Closes #994

## Solution

Using a regex pattern to get instances of `<iframe></iframe>` and `<div></div>` (what our current users are using), and then not including this subset of the sting as part of the total character count allowed.

Note: This is meant to be a temporary workaround, once we move to block editing, this should not be an issue 
