### PR TITLE
fix: update stagingUrl endpoint from v1 to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .env.test.local
 .env.production.local
 .vscode
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/hooks/settingsHooks/useUrlHook.jsx
+++ b/src/hooks/settingsHooks/useUrlHook.jsx
@@ -5,7 +5,7 @@ import { SITE_URL_KEY, STAGING_URL_KEY } from "constants/queryKeys"
 
 const getStagingUrl = async (siteName) => {
   const resp = await axios.get(
-    `${process.env.REACT_APP_BACKEND_URL}/sites/${siteName}/stagingUrl`
+    `${process.env.REACT_APP_BACKEND_URL_V2}/sites/${siteName}/stagingUrl`
   )
   return resp.data.stagingUrl
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The "View Staging" button in the header does not work as expected for sites without the staging URLs in the description. This was due to the button calling the `/v1/sites/:siteName/stagingUrl` endpoint, which extracts the staging URL from the repository description.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The "View Staging" button has been updated to call the `/v2/sites/:siteName/stagingUrl` endpoint instead, which extracts the staging URL from the `_config.yml` file.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**:
- Run `npm run tests`

**Smoke tests**:
- Run `npm run dev`
- Log in and access any site without a staging URL in the description, such as `moe-princesselizabeth`, `moe-dunearnsec` and `moe-temasekpri`.
- Verify that the "View Staging" button now works.

## Deploy Notes

*None*
