### PR TITLE
fix: add support for site url config parameter

### DIFF
--- a/src/hooks/settingsHooks/constants.ts
+++ b/src/hooks/settingsHooks/constants.ts
@@ -21,6 +21,7 @@ export const BE_TO_FE: {
   show_reach: "showReach",
   logo: "agencyLogo",
   social_media: "socialMediaContent",
+  url: "url",
 }
 
 export const FE_TO_BE = invert(BE_TO_FE)

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -29,6 +29,7 @@ const DEFAULT_BE_STATE = {
   faq: "",
   show_reach: false,
   logo: "/images/isomer-logo.svg",
+  url: "",
 }
 
 const DEFAULT_SOCIAL_MEDIA_SETTINGS: SiteSocialMediaSettings = {
@@ -89,14 +90,7 @@ const convertfromBe = (backendSettings: BackendSiteSettings): SiteSettings => {
   }
 
   const rest = _(backendSettings)
-    .omit([
-      ...TOGGLED_VALUES,
-      "socialMediaContent",
-      "colors",
-      // These properties are extra and will lead to errors in validation
-      "resources_name",
-      "url",
-    ])
+    .omit([...TOGGLED_VALUES, "socialMediaContent", "colors"])
     .pickBy()
     .value()
 

--- a/src/layouts/Settings/GeneralSettings.tsx
+++ b/src/layouts/Settings/GeneralSettings.tsx
@@ -53,6 +53,20 @@ export const GeneralSettings = ({
             {...register("description")}
           />
         </FormControl>
+        <FormControl isDisabled={isError} isRequired>
+          <Box mb="0.75rem">
+            <FormLabel mb={0}>Site URL</FormLabel>
+            <FormLabel.Description color="text.description">
+              This is the URL that the Isomer site will be published to.
+            </FormLabel.Description>
+          </Box>
+          <Input
+            w="100%"
+            id="url"
+            placeholder="https://"
+            {...register("url", { required: true })}
+          />
+        </FormControl>
         <FormControl isDisabled={isError}>
           <Flex justifyContent="space-between" w="100%">
             <FormLabel>Display government masthead</FormLabel>

--- a/src/layouts/Settings/GeneralSettings.tsx
+++ b/src/layouts/Settings/GeneralSettings.tsx
@@ -1,9 +1,23 @@
-import { VStack, FormControl, Flex, Box } from "@chakra-ui/react"
-import { FormLabel, Input, Textarea } from "@opengovsg/design-system-react"
+import {
+  VStack,
+  FormControl,
+  Flex,
+  Box,
+  InputLeftAddon,
+  InputGroup,
+} from "@chakra-ui/react"
+import {
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Textarea,
+} from "@opengovsg/design-system-react"
 import { FormTitle } from "components/Form"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, useFormState } from "react-hook-form"
 
 import { Section, SectionHeader } from "layouts/components"
+
+import { DOMAIN_NAME_REGEX } from "utils/validators"
 
 import { FormToggle } from "./components/FormToggle"
 import { SettingsFormFieldMedia } from "./components/SettingsFormFieldMedia"
@@ -16,6 +30,7 @@ export const GeneralSettings = ({
   isError,
 }: GeneralSettingsProp): JSX.Element => {
   const { register } = useFormContext()
+  const { errors } = useFormState()
 
   return (
     <Section id="general-fields">
@@ -53,19 +68,29 @@ export const GeneralSettings = ({
             {...register("description")}
           />
         </FormControl>
-        <FormControl isDisabled={isError} isRequired>
+        <FormControl isDisabled={isError} isRequired isInvalid={errors.url}>
           <Box mb="0.75rem">
-            <FormLabel mb={0}>Site URL</FormLabel>
+            <FormLabel mb={0}>Search Engine Optimisation (SEO)</FormLabel>
             <FormLabel.Description color="text.description">
-              This is the URL that the Isomer site will be published to.
+              Enter the web domain of your live site, to improve its position on
+              search result pages.
             </FormLabel.Description>
           </Box>
-          <Input
-            w="100%"
-            id="url"
-            placeholder="https://"
-            {...register("url", { required: true })}
-          />
+          <InputGroup>
+            <InputLeftAddon>https://</InputLeftAddon>
+            <Input
+              w="100%"
+              id="url"
+              placeholder="www.open.gov.sg"
+              {...register("url", {
+                required: true,
+                pattern: RegExp(DOMAIN_NAME_REGEX),
+              })}
+            />
+          </InputGroup>
+          <FormErrorMessage>
+            The web domain you have entered is not valid.
+          </FormErrorMessage>
         </FormControl>
         <FormControl isDisabled={isError}>
           <Flex justifyContent="space-between" w="100%">

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -3,6 +3,7 @@ export interface SiteInfo {
   description: string
   displayGovMasthead: boolean
   shareicon: string
+  url: string
 }
 
 export interface SiteLogoSettings {
@@ -74,6 +75,7 @@ export interface BackendSiteSettings {
   favicon?: string
   // eslint-disable-next-line camelcase
   social_media?: BackendSiteSocialMedia
+  url?: string
 }
 
 interface BackendSiteColours {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -16,6 +16,8 @@ export const URL_REGEX_PREFIX = "^(https://)?(www.)?("
 export const URL_REGEX_SUFFIX = ".com/)([a-zA-Z0-9_-]+([/.])?)+$"
 export const TELEGRAM_REGEX = "telegram|t).me/([a-zA-Z0-9_-]+([/.])?)+$"
 export const TIKTOK_REGEX = ".com/@)([a-zA-Z0-9_-]+([/.])?)+$"
+export const DOMAIN_NAME_REGEX =
+  "(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]"
 const PHONE_REGEX = "^\\+65(6|8|9)[0-9]{7}$"
 const EMAIL_REGEX =
   '^(([^<>()\\[\\]\\.,;:\\s@\\"]+(\\.[^<>()\\[\\]\\.,;:\\s@\\"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z-0-9]+\\.)+[a-zA-Z]{2,}))$'

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,6 +1,7 @@
 import _ from "lodash"
 import moment from "moment-timezone"
 
+import { getLengthWithoutTags } from "./allowedHTML"
 import { deslugifyDirectory } from "./deslugify"
 import {
   generatePageFileName,
@@ -9,8 +10,6 @@ import {
   titleToPageFileName,
 } from "./legacy"
 
-import { getLengthWithoutTags } from "./allowedHTML"
-
 // Common regexes and constants
 // ==============
 const PERMALINK_REGEX = "^((/([a-zA-Z0-9]+-)*[a-zA-Z0-9]+)+)/?$"
@@ -18,8 +17,17 @@ export const URL_REGEX_PREFIX = "^(https://)?(www.)?("
 export const URL_REGEX_SUFFIX = ".com/)([a-zA-Z0-9_-]+([/.])?)+$"
 export const TELEGRAM_REGEX = "telegram|t).me/([a-zA-Z0-9_-]+([/.])?)+$"
 export const TIKTOK_REGEX = ".com/@)([a-zA-Z0-9_-]+([/.])?)+$"
+// Domain name regex (source: https://regexr.com/3au3g and https://stackoverflow.com/a/30007882)
+// 1. The first group (up till the "+") matches each segment of the domain (split by ".")
+//    a. Each segment of the domain must start and end with an alphanumeric character
+//    b. Each segment of the domain can contain at most 63 characters (hence the upper bound of 61 characters)
+//    c. Each segment of the domain can contain dashes within it
+//    d. Each segment of the domain must contain at least 1 character (the first "[a-z0-9]")
+// 2. The "+" ensures that we match a second-level domain and above
+// 3. The last section after "+" is to match the TLD segment of the domain
+// 4. The "^" and "$" ensures that we are matching the whole string (to prevent the user from adding "https://")
 export const DOMAIN_NAME_REGEX =
-  "(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]"
+  "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
 const PHONE_REGEX = "^\\+65(6|8|9)[0-9]{7}$"
 const EMAIL_REGEX =
   '^(([^<>()\\[\\]\\.,;:\\s@\\"]+(\\.[^<>()\\[\\]\\.,;:\\s@\\"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z-0-9]+\\.)+[a-zA-Z]{2,}))$'


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://github.com/isomerpages/isomercms-backend/issues/454.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The `url` configuration parameter in `_config.yml` can now be configured on the frontend with a validation of the domain name if given.

## Before & After Screenshots

**BEFORE**:
<img width="509" alt="Screenshot 2022-08-16 at 16 25 49" src="https://user-images.githubusercontent.com/27919917/184833728-51bf77e8-106f-428d-b6ca-e4fafd03a0d6.png">

**AFTER**:
<img width="503" alt="Screenshot 2022-08-16 at 16 25 04" src="https://user-images.githubusercontent.com/27919917/184833574-fe754b7f-6852-4542-8bcd-e7f9fed47a99.png">

## Tests

<!-- What tests should be run to confirm functionality? -->

Frontend PR for https://github.com/isomerpages/isomercms-backend/pull/490.

## Deploy Notes

*None*