### PR TITLE
fix(folders): fixed floating context menu for cards in folders

### DIFF
--- a/cypress/e2e/folders.spec.ts
+++ b/cypress/e2e/folders.spec.ts
@@ -174,7 +174,7 @@ describe("Folders flow", () => {
 
     // Rename
     it("Should be able to rename a sub-folder", () => {
-      cy.contains("button", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -199,7 +199,7 @@ describe("Folders flow", () => {
 
     // Delete
     it("Should be able to delete a sub-folder with a page", () => {
-      cy.contains("button", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -214,7 +214,7 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to delete a sub-folder without page", () => {
-      cy.contains("button", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")

--- a/src/layouts/Folders/components/FolderCard.tsx
+++ b/src/layouts/Folders/components/FolderCard.tsx
@@ -33,26 +33,31 @@ export const FolderCard = ({
   }, [encodedName, url])
 
   return (
-    <LinkBox position="relative" w="full">
-      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
-        <Card variant="single">
-          <CardBody alignItems="center">
-            <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
-            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {pageFileNameToTitle(name)}
-            </Text>
-            <Spacer />
-            <Text textStyle="body-2" whiteSpace="nowrap">
-              {`${dirContent.length} item${dirContent.length === 1 ? "" : "s"}`}
-            </Text>
-            {/* 
+    <Box position="relative" w="full">
+      <Card variant="single">
+        <LinkBox>
+          <LinkOverlay as={RouterLink} to={generatedLink}>
+            <CardBody alignItems="center">
+              <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
+              <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+                {pageFileNameToTitle(name)}
+              </Text>
+              <Spacer />
+              <Text textStyle="body-2" whiteSpace="nowrap">
+                {`${dirContent.length} item${
+                  dirContent.length === 1 ? "" : "s"
+                }`}
+              </Text>
+              {/* 
             NOTE: This is a workaround as our card component uses a HStack to orient elements with 1 rem spacing.
             As we require 1.5 rem gap between text and the context menu button, this equates to a box width of 0.5 rem.
             */}
-            <Box w="0.5rem" />
-          </CardBody>
-        </Card>
-      </LinkOverlay>
+              <Box w="0.5rem" />
+            </CardBody>
+          </LinkOverlay>
+        </LinkBox>
+      </Card>
+
       <ContextMenu>
         <ContextMenu.Button />
         <ContextMenu.List>
@@ -80,6 +85,6 @@ export const FolderCard = ({
           </ContextMenu.Item>
         </ContextMenu.List>
       </ContextMenu>
-    </LinkBox>
+    </Box>
   )
 }

--- a/src/layouts/Folders/components/PageCard.tsx
+++ b/src/layouts/Folders/components/PageCard.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   Divider,
   Text,
+  Box,
 } from "@chakra-ui/react"
 import { Card, CardBody } from "components/Card"
 import { ContextMenu } from "components/ContextMenu"
@@ -35,54 +36,56 @@ export const PageCard = ({ name }: PageCardProps): JSX.Element => {
   }, [encodedName, url])
 
   return (
-    <LinkBox position="relative" w="full">
-      <LinkOverlay as={RouterLink} to={generatedLink} w="100%">
-        <Card variant="single">
-          <CardBody alignItems="center">
-            <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
-            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {pageFileNameToTitle(name)}
-            </Text>
-          </CardBody>
-        </Card>
-      </LinkOverlay>
-      <ContextMenu>
-        <ContextMenu.Button />
-        <ContextMenu.List>
-          <ContextMenu.Item
-            icon={<BiEditAlt />}
-            as={RouterLink}
-            to={generatedLink}
-          >
-            <Text>Edit</Text>
-          </ContextMenu.Item>
-          <ContextMenu.Item
-            icon={<BiWrench />}
-            as={RouterLink}
-            to={`${url}/editPageSettings/${encodedName}`}
-          >
-            Settings
-          </ContextMenu.Item>
-          <ContextMenu.Item
-            icon={<BiFolder />}
-            as={RouterLink}
-            to={`${url}/movePage/${encodedName}`}
-          >
-            <HStack spacing="4rem" alignItems="center">
-              <Text>Move to</Text>
-              <Icon as={BiChevronRight} fontSize="1.25rem" />
-            </HStack>
-          </ContextMenu.Item>
-          <Divider />
-          <ContextMenu.Item
-            icon={<BiTrash />}
-            as={RouterLink}
-            to={`${url}/deletePage/${encodedName}`}
-          >
-            Delete
-          </ContextMenu.Item>
-        </ContextMenu.List>
-      </ContextMenu>
-    </LinkBox>
+    <Box position="relative" w="full">
+      <Card variant="single">
+        <LinkBox position="relative">
+          <LinkOverlay as={RouterLink} to={generatedLink}>
+            <CardBody alignItems="center">
+              <Icon as={BiFileBlank} fontSize="1.5rem" fill="icon.alt" />
+              <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+                {pageFileNameToTitle(name)}
+              </Text>
+            </CardBody>
+          </LinkOverlay>
+        </LinkBox>
+        <ContextMenu>
+          <ContextMenu.Button />
+          <ContextMenu.List>
+            <ContextMenu.Item
+              icon={<BiEditAlt />}
+              as={RouterLink}
+              to={generatedLink}
+            >
+              <Text>Edit</Text>
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              icon={<BiWrench />}
+              as={RouterLink}
+              to={`${url}/editPageSettings/${encodedName}`}
+            >
+              Settings
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              icon={<BiFolder />}
+              as={RouterLink}
+              to={`${url}/movePage/${encodedName}`}
+            >
+              <HStack spacing="4rem" alignItems="center">
+                <Text>Move to</Text>
+                <Icon as={BiChevronRight} fontSize="1.25rem" />
+              </HStack>
+            </ContextMenu.Item>
+            <Divider />
+            <ContextMenu.Item
+              icon={<BiTrash />}
+              as={RouterLink}
+              to={`${url}/deletePage/${encodedName}`}
+            >
+              Delete
+            </ContextMenu.Item>
+          </ContextMenu.List>
+        </ContextMenu>
+      </Card>
+    </Box>
   )
 }


### PR DESCRIPTION
**note: updates to e2e tests will come in a subsequent PR**
## Problem
See #998 for the issue - this problem also exists in folders; however, this problem only showed up now because of 2 reasons
1. `Folders` didn't have its card component updated to fit figma at point of merge for the context menu PR. 
2. This problem exists only when using an updated chakra version after merging the cypress update PR

## Solution
Refer to #998 for more deets but the only concrete change is to add a full width `Box` as the parent of `Card` and `ContextMenu`