### PR TITLE
fix(folders.spec): change selector to account for altered dom structure

### DIFF
--- a/cypress/e2e/folders.spec.ts
+++ b/cypress/e2e/folders.spec.ts
@@ -174,7 +174,7 @@ describe("Folders flow", () => {
 
     // Rename
     it("Should be able to rename a sub-folder", () => {
-      cy.contains("button", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_SUBFOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -199,7 +199,7 @@ describe("Folders flow", () => {
 
     // Delete
     it("Should be able to delete a sub-folder with a page", () => {
-      cy.contains("button", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_EDITED_SUBFOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -214,7 +214,7 @@ describe("Folders flow", () => {
     })
 
     it("Should be able to delete a sub-folder without page", () => {
-      cy.contains("button", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE)
+      cy.contains("a", PRETTIFIED_SUBFOLDER_NO_PAGES_TITLE)
         .parent()
         .parent()
         .as("folderItem")
@@ -353,7 +353,7 @@ describe("Folders flow", () => {
     })
   })
 
-  describe("Create page, delete page, edit page settings in subfolder", () => {
+  describe.only("Create page, delete page, edit page settings in subfolder", () => {
     before(() => {
       cy.setupDefaultInterceptors()
       cy.setSessionDefaults()

--- a/cypress/e2e/folders.spec.ts
+++ b/cypress/e2e/folders.spec.ts
@@ -353,7 +353,7 @@ describe("Folders flow", () => {
     })
   })
 
-  describe.only("Create page, delete page, edit page settings in subfolder", () => {
+  describe("Create page, delete page, edit page settings in subfolder", () => {
     before(() => {
       cy.setupDefaultInterceptors()
       cy.setSessionDefaults()


### PR DESCRIPTION
## Problem
Altered dom structure in the prior PR #1016 meant that the existing tests that relied on clicking the context menu might fail here. 

## Solution
1. change selector so that context menu clicking works