### PR TITLE
fix(hooks): update query keys for page and directory deletion hooks

### DIFF
--- a/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
@@ -2,7 +2,11 @@ import _ from "lodash"
 import { useContext } from "react"
 import { useMutation, useQueryClient } from "react-query"
 
-import { DIR_CONTENT_KEY } from "constants/queryKeys"
+import {
+  DIR_CONTENT_KEY,
+  RESOURCE_ROOM_CONTENT_KEY,
+  RESOURCE_CATEGORY_CONTENT_KEY,
+} from "constants/queryKeys"
 
 import { ServicesContext } from "contexts/ServicesContext"
 
@@ -49,11 +53,16 @@ export function useDeleteDirectoryHook(params, queryParams) {
           DIR_CONTENT_KEY,
           _.omit(params, "collectionName"),
         ])
-      else if (params.resourceCategoryName)
+      else if (params.resourceCategoryName) {
         queryClient.invalidateQueries([
-          DIR_CONTENT_KEY,
+          RESOURCE_CATEGORY_CONTENT_KEY,
+          _.omit(params, "resourceRoomName"),
+        ])
+        queryClient.invalidateQueries([
+          RESOURCE_ROOM_CONTENT_KEY,
           _.omit(params, "resourceCategoryName"),
         ])
+      }
       if (queryParams && queryParams.onSuccess) queryParams.onSuccess()
     },
   })

--- a/src/hooks/pageHooks/useDeletePageHook.jsx
+++ b/src/hooks/pageHooks/useDeletePageHook.jsx
@@ -2,7 +2,10 @@ import _ from "lodash"
 import { useContext } from "react"
 import { useMutation, useQueryClient } from "react-query"
 
-import { DIR_CONTENT_KEY } from "constants/queryKeys"
+import {
+  DIR_CONTENT_KEY,
+  RESOURCE_CATEGORY_CONTENT_KEY,
+} from "constants/queryKeys"
 
 import { ServicesContext } from "contexts/ServicesContext"
 
@@ -28,13 +31,18 @@ export function useDeletePageHook(params, queryParams) {
       successToast({
         description: `Successfully deleted page!`,
       })
-      if (params.collectionName || params.resourceRoomName)
+      if (params.collectionName)
         queryClient.invalidateQueries([
           // invalidates collection pages or resource pages
           DIR_CONTENT_KEY,
           _.omit(params, "fileName"),
         ])
-      else
+      else if (params.resourceRoomName) {
+        queryClient.invalidateQueries([
+          RESOURCE_CATEGORY_CONTENT_KEY,
+          _.omit(params, "fileName"),
+        ])
+      } else
         queryClient.invalidateQueries([
           DIR_CONTENT_KEY,
           { siteName: params.siteName, isUnlinked: true },


### PR DESCRIPTION
## Problem
in #973, some deletion hooks did not have their keys updated and this resulted in pages and folders in `resources` not automatically updating even when the pages/folders within were deleted.  

## Solution
1. update query keys
2. pass `params` and omit extra keys

**note**: this is a bandaid solution and a more permanent fix would be to refactor these deletion hooks akin to what has been done in #973 instead