### PR TITLE
fix(e2e-tests): update e2e tests 

### DIFF
--- a/cypress/e2e/editPage.spec.ts
+++ b/cypress/e2e/editPage.spec.ts
@@ -43,7 +43,7 @@ describe("editPage.spec", () => {
     const LINK_URL = "https://www.google.com"
 
     before(() => {
-      cy.setDefaultPrimaryColour()
+      cy.setDefaultSettings()
 
       // NOTE: We need to repeat the interceptor here as
       // cypress resolves by type before nesting level.
@@ -335,7 +335,7 @@ describe("editPage.spec", () => {
     const TEST_PAGE_DATE = "2021-05-17"
 
     before(() => {
-      cy.setDefaultPrimaryColour()
+      cy.setDefaultSettings()
 
       // NOTE: We need to repeat the interceptor here as
       // cypress resolves by type before nesting level.

--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -1,4 +1,8 @@
-import { TEST_PRIMARY_COLOR, TEST_REPO_NAME } from "../fixtures/constants"
+import {
+  TEST_PRIMARY_COLOR,
+  TEST_REPO_NAME,
+  BASE_SEO_LINK,
+} from "../fixtures/constants"
 
 describe("Settings page", () => {
   const BASE_TITLE = "TEST"
@@ -58,6 +62,11 @@ describe("Settings page", () => {
       .parent()
       .find("input")
       .each((elem) => cy.wrap(elem).clear())
+    cy.contains("label", "SEO")
+      .parent()
+      .parent()
+      .find("input")
+      .type(BASE_SEO_LINK)
     cy.contains("label", "Primary")
       .parent()
       .find('button[aria-label="Select colour"]')
@@ -122,6 +131,40 @@ describe("Settings page", () => {
     cy.saveSettings()
 
     cy.get("#title").should("have.value", TEST_TITLE)
+  })
+
+  it("should be able to update the SEO to a valid value", () => {
+    // Arrange
+    const expected = "www.space.open.gov.sg"
+    cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
+
+    // Act
+    cy.get("@seoInput").clear().type(expected)
+
+    // Assert
+    cy.saveSettings()
+    cy.get("@seoInput").should("have.value", expected)
+  })
+
+  it("should not be able to input the protocol at the beginning of the url", () => {
+    // Arrange
+    const INVALID_SEO_INPUTS = [
+      `https://${BASE_SEO_LINK}`,
+      `http://${BASE_SEO_LINK}`,
+    ]
+    cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
+
+    INVALID_SEO_INPUTS.forEach((invalidInput) => {
+      // Act
+      // NOTE: We need to blur for the error message to show
+      // as the validation mode is after the first unfocus
+      cy.get("@seoInput").clear().type(invalidInput).blur()
+
+      // Assert
+      cy.contains("The web domain you have entered is not valid").should(
+        "exist"
+      )
+    })
   })
 
   it("Should toggle Masthead and Show Reach buttons and have change reflect correctly on save", () => {

--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -167,6 +167,34 @@ describe("Settings page", () => {
     })
   })
 
+  it("should not allow URLs with subdomains for the SEO URL", () => {
+    // Arrange
+    const urlWithSubdomain = "www.open.gov.sg/sub"
+    cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
+
+    // Act
+    cy.get("@seoInput").clear().type(urlWithSubdomain).blur()
+
+    // Assert
+    cy.contains("The web domain you have entered is not valid").should("exist")
+  })
+
+  it("should not allow malformed URLs for the SEO URL", () => {
+    // Arrange
+    const MALFORMED_URLS = ["www.open.", "open"]
+    cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
+
+    MALFORMED_URLS.forEach((malformedUrl) => {
+      // Act
+      cy.get("@seoInput").clear().type(malformedUrl).blur()
+
+      // Assert
+      cy.contains("The web domain you have entered is not valid").should(
+        "exist"
+      )
+    })
+  })
+
   it("Should toggle Masthead and Show Reach buttons and have change reflect correctly on save", () => {
     // Arrange
     // NOTE: Initial state is display govt masthead off and show reach on

--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -167,7 +167,7 @@ describe("Settings page", () => {
     })
   })
 
-  it("should not allow URLs with subdomains for the SEO URL", () => {
+  it("should not allow URLs with sub-directories for the SEO URL", () => {
     // Arrange
     const urlWithSubdomain = "www.open.gov.sg/sub"
     cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -17,3 +17,5 @@ export enum Interceptors {
 }
 
 export const CMS_BASEURL: string | undefined = Cypress.env("BASEURL")
+
+export const BASE_SEO_LINK = "www.open.gov.sg"

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -20,7 +20,12 @@ declare namespace Cypress {
      * @param {string} as The alias that should be given to the first sibling
      */
     getFirstSiblingAs(as: string): Chainable<JQuery<HTMLElement>>
-    setDefaultPrimaryColour(): Chainable<void>
+    /**
+     * Sets default primary colour as well as the SEO field.
+     * The SEO field has to be set as there is no default given.
+     * This is to avoid adversely impacting the SEO of the site.
+     */
+    setDefaultSettings(): Chainable<void>
     setSessionDefaults(): Chainable<void>
     /**
      * Setup the default interceptors for post/get/delete requests.

--- a/cypress/support/settings.ts
+++ b/cypress/support/settings.ts
@@ -1,4 +1,5 @@
 import {
+  BASE_SEO_LINK,
   COOKIE_NAME,
   COOKIE_VALUE,
   E2E_USER,
@@ -21,7 +22,8 @@ Cypress.Commands.add("visitLoadSettings", (siteName, sitePath) => {
   cy.wait("@awaitSettings")
 })
 
-Cypress.Commands.add("setDefaultPrimaryColour", () => {
+// TODO: need to add default values for SEO
+Cypress.Commands.add("setDefaultSettings", () => {
   cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
 
   window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(E2E_USER))
@@ -34,7 +36,15 @@ Cypress.Commands.add("setDefaultPrimaryColour", () => {
   cy.contains(/^g/).siblings().clear().type(TEST_PRIMARY_COLOR[1].toString())
 
   cy.contains(/^b/).siblings().clear().type(TEST_PRIMARY_COLOR[2].toString())
+
   cy.contains("button", "Select").click()
+
+  cy.contains("label", "SEO")
+    .parent()
+    .parent()
+    .find("input")
+    .clear()
+    .type(BASE_SEO_LINK)
 
   cy.saveSettings()
 })

--- a/cypress/support/settings.ts
+++ b/cypress/support/settings.ts
@@ -22,7 +22,6 @@ Cypress.Commands.add("visitLoadSettings", (siteName, sitePath) => {
   cy.wait("@awaitSettings")
 })
 
-// TODO: need to add default values for SEO
 Cypress.Commands.add("setDefaultSettings", () => {
   cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
 

--- a/src/hooks/moveHooks/useMoveHook.jsx
+++ b/src/hooks/moveHooks/useMoveHook.jsx
@@ -1,7 +1,10 @@
 import { useContext } from "react"
 import { useMutation, useQueryClient } from "react-query"
 
-import { DIR_CONTENT_KEY } from "constants/queryKeys"
+import {
+  DIR_CONTENT_KEY,
+  RESOURCE_CATEGORY_CONTENT_KEY,
+} from "constants/queryKeys"
 
 import { ServicesContext } from "contexts/ServicesContext"
 
@@ -29,6 +32,7 @@ export function useMoveHook(params, queryParams) {
       if (queryParams && queryParams.onError) queryParams.onError()
     },
     onSuccess: (resp) => {
+      console.log(params)
       if (!resp)
         successToast({
           description: `File is already in this folder`,
@@ -37,13 +41,15 @@ export function useMoveHook(params, queryParams) {
         successToast({
           description: `Successfully moved file`,
         })
-      if (params.mediaRoom || params.collectionName || params.resourceRoomName)
+      if (params.mediaRoom || params.collectionName)
         queryClient.invalidateQueries([
           // invalidates collection pages or resource pages
           DIR_CONTENT_KEY,
           { ...params },
         ])
-      else
+      else if (params.resourceCategoryName) {
+        queryClient.invalidateQueries([RESOURCE_CATEGORY_CONTENT_KEY, params])
+      } else
         queryClient.invalidateQueries([
           DIR_CONTENT_KEY,
           { ...params, isUnlinked: true },

--- a/src/hooks/moveHooks/useMoveHook.jsx
+++ b/src/hooks/moveHooks/useMoveHook.jsx
@@ -32,7 +32,6 @@ export function useMoveHook(params, queryParams) {
       if (queryParams && queryParams.onError) queryParams.onError()
     },
     onSuccess: (resp) => {
-      console.log(params)
       if (!resp)
         successToast({
           description: `File is already in this folder`,

--- a/src/hooks/pageHooks/useCreatePageHook.jsx
+++ b/src/hooks/pageHooks/useCreatePageHook.jsx
@@ -2,7 +2,10 @@ import _ from "lodash"
 import { useContext } from "react"
 import { useMutation, useQueryClient } from "react-query"
 
-import { DIR_CONTENT_KEY } from "constants/queryKeys"
+import {
+  DIR_CONTENT_KEY,
+  RESOURCE_CATEGORY_CONTENT_KEY,
+} from "constants/queryKeys"
 
 import { ServicesContext } from "contexts/ServicesContext"
 
@@ -28,13 +31,19 @@ export function useCreatePageHook(params, queryParams) {
     {
       ...queryParams,
       onSuccess: (resp) => {
-        if (params.collectionName || params.resourceRoomName)
+        if (params.collectionName)
           queryClient.invalidateQueries([
             // invalidates collection pages or resource pages
             DIR_CONTENT_KEY,
             _.omit(params, "fileName"),
           ])
-        else
+        else if (params.resourceCategoryName) {
+          queryClient.invalidateQueries([
+            // invalidates collection pages or resource pages
+            RESOURCE_CATEGORY_CONTENT_KEY,
+            _.omit(params, "fileName"),
+          ])
+        } else
           queryClient.invalidateQueries([
             DIR_CONTENT_KEY,
             { siteName: params.siteName, isUnlinked: true },


### PR DESCRIPTION
## Problem
see #1033 for an overview of the bugs uncovered during release ;--; 

Partially resolves #1033

## Solution
1. add query key invalidation for `move`/`createPage` hooks
2. update cypress test command to fill in the SEO by default
3. add success/failure e2e test for SEO Field
