### PR TITLE
fix(reorderingmodal): removed chakra.button from folderItem

### DIFF
--- a/src/components/folders/FolderItem.jsx
+++ b/src/components/folders/FolderItem.jsx
@@ -6,7 +6,7 @@ import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 import { pageFileNameToTitle } from "utils"
 
 const FolderItem = ({ item }) => {
-  const { name } = item
+  const { name, type } = item
 
   return (
     <Box
@@ -16,7 +16,13 @@ const FolderItem = ({ item }) => {
     >
       <Box className={`${elementStyles.card} ${elementStyles.folderItem}`}>
         <div className={contentStyles.contentContainerFolderRow}>
-          <i className={`bx bxs-file-blank ${elementStyles.folderItemIcon}`} />
+          {type === "file" ? (
+            <i
+              className={`bx bxs-file-blank ${elementStyles.folderItemIcon}`}
+            />
+          ) : (
+            <i className={`bx bxs-folder ${elementStyles.folderItemIcon}`} />
+          )}
           <span className={`${elementStyles.folderItemText} mr-auto`}>
             {pageFileNameToTitle(name)}
           </span>

--- a/src/components/folders/FolderItem.jsx
+++ b/src/components/folders/FolderItem.jsx
@@ -1,40 +1,12 @@
-import {
-  chakra,
-  LinkOverlay,
-  LinkBox,
-  Divider,
-  HStack,
-  Icon,
-  Text,
-  Box,
-} from "@chakra-ui/react"
-import { ContextMenu } from "components/ContextMenu"
-import { useMemo } from "react"
-import {
-  BiChevronRight,
-  BiEditAlt,
-  BiFolder,
-  BiTrash,
-  BiWrench,
-} from "react-icons/bi"
-import { Link as RouterLink, useRouteMatch } from "react-router-dom"
+import { Box } from "@chakra-ui/react"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 
 import { pageFileNameToTitle } from "utils"
 
-const FolderItem = ({ item, isDisabled }) => {
-  const { url } = useRouteMatch()
-
-  const { name, type, children } = item
-  const encodedName = encodeURIComponent(name)
-
-  const generatedLink = useMemo(() => {
-    return type === "dir"
-      ? `${url}/subfolders/${encodedName}`
-      : `${url}/editPage/${encodedName}`
-  }, [encodedName, type, url])
+const FolderItem = ({ item }) => {
+  const { name } = item
 
   return (
     <Box
@@ -42,84 +14,14 @@ const FolderItem = ({ item, isDisabled }) => {
       className={`${contentStyles.component} ${contentStyles.card}`}
       position="relative"
     >
-      <LinkBox w="100%">
-        <LinkOverlay as={RouterLink} to={!isDisabled && generatedLink}>
-          <chakra.button
-            className={`${elementStyles.card} ${contentStyles.card} ${elementStyles.folderItem}`}
-          >
-            <div className={contentStyles.contentContainerFolderRow}>
-              {type === "file" ? (
-                <i
-                  className={`bx bxs-file-blank ${elementStyles.folderItemIcon}`}
-                />
-              ) : (
-                <i
-                  className={`bx bxs-folder ${elementStyles.folderItemIcon}`}
-                />
-              )}
-              <span className={`${elementStyles.folderItemText} mr-auto`}>
-                {pageFileNameToTitle(name)}
-              </span>
-              {children ? (
-                <span className={`${elementStyles.folderItemText} mr-5`}>
-                  {children.length} item{children.length === 1 ? "" : "s"}
-                </span>
-              ) : null}
-            </div>
-          </chakra.button>
-        </LinkOverlay>
-      </LinkBox>
-      {!isDisabled && (
-        <ContextMenu>
-          <ContextMenu.Button right="1.875rem" bottom="1.875rem" />
-          <ContextMenu.List>
-            <ContextMenu.Item
-              icon={<BiEditAlt />}
-              as={RouterLink}
-              to={generatedLink}
-            >
-              <Text>Edit</Text>
-            </ContextMenu.Item>
-            <ContextMenu.Item
-              icon={<BiWrench />}
-              as={RouterLink}
-              to={
-                type === "dir"
-                  ? `${url}/editDirectorySettings/${encodedName}`
-                  : `${url}/editPageSettings/${encodedName}`
-              }
-            >
-              Settings
-            </ContextMenu.Item>
-            {type !== "dir" && (
-              <ContextMenu.Item
-                icon={<BiFolder />}
-                as={RouterLink}
-                to={`${url}/movePage/${encodedName}`}
-              >
-                <HStack spacing="4rem" alignItems="center">
-                  <Text>Move to</Text>
-                  <Icon as={BiChevronRight} fontSize="1.25rem" />
-                </HStack>
-              </ContextMenu.Item>
-            )}
-            <>
-              <Divider />
-              <ContextMenu.Item
-                icon={<BiTrash />}
-                as={RouterLink}
-                to={
-                  type === "dir"
-                    ? `${url}/deleteDirectory/${encodedName}`
-                    : `${url}/deletePage/${encodedName}`
-                }
-              >
-                Delete
-              </ContextMenu.Item>
-            </>
-          </ContextMenu.List>
-        </ContextMenu>
-      )}
+      <Box className={`${elementStyles.card} ${elementStyles.folderItem}`}>
+        <div className={contentStyles.contentContainerFolderRow}>
+          <i className={`bx bxs-file-blank ${elementStyles.folderItemIcon}`} />
+          <span className={`${elementStyles.folderItemText} mr-auto`}>
+            {pageFileNameToTitle(name)}
+          </span>
+        </div>
+      </Box>
     </Box>
   )
 }

--- a/src/components/folders/ReorderingModal.jsx
+++ b/src/components/folders/ReorderingModal.jsx
@@ -112,7 +112,6 @@ const ReorderingModal = ({ params, dirData, onProceed, onClose }) => {
                               key={folderContentItem.name}
                               item={folderContentItem}
                               itemIndex={folderContentIndex}
-                              isDisabled
                             />
                           </div>
                         )}

--- a/src/components/folders/ReorderingModal.jsx
+++ b/src/components/folders/ReorderingModal.jsx
@@ -4,7 +4,7 @@ import { Footer } from "components/Footer"
 import { LoadingButton } from "components/LoadingButton"
 import update from "immutability-helper"
 import PropTypes from "prop-types"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { Droppable, Draggable, DragDropContext } from "react-beautiful-dnd"
 
 // Import styles
@@ -17,15 +17,7 @@ import { deslugifyDirectory } from "utils"
 
 const ReorderingModal = ({ params, dirData, onProceed, onClose }) => {
   const { collectionName, subCollectionName } = params
-  const [dirOrder, setDirOrder] = useState([])
-
-  /** ******************************** */
-  /*     useEffects to load data     */
-  /** ******************************** */
-
-  useEffect(() => {
-    if (dirData) setDirOrder(dirData)
-  }, [dirData])
+  const [dirOrder, setDirOrder] = useState(dirData)
 
   /** ******************************** */
   /*     handler functions    */

--- a/src/components/folders/ReorderingModal.jsx
+++ b/src/components/folders/ReorderingModal.jsx
@@ -4,7 +4,7 @@ import { Footer } from "components/Footer"
 import { LoadingButton } from "components/LoadingButton"
 import update from "immutability-helper"
 import PropTypes from "prop-types"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Droppable, Draggable, DragDropContext } from "react-beautiful-dnd"
 
 // Import styles
@@ -17,7 +17,11 @@ import { deslugifyDirectory } from "utils"
 
 const ReorderingModal = ({ params, dirData, onProceed, onClose }) => {
   const { collectionName, subCollectionName } = params
-  const [dirOrder, setDirOrder] = useState(dirData)
+  const [dirOrder, setDirOrder] = useState([])
+
+  useEffect(() => {
+    if (dirData) setDirOrder(dirData)
+  }, [dirData])
 
   /** ******************************** */
   /*     handler functions    */

--- a/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
@@ -2,7 +2,11 @@ import _ from "lodash"
 import { useContext } from "react"
 import { useMutation, useQueryClient } from "react-query"
 
-import { DIR_CONTENT_KEY } from "constants/queryKeys"
+import {
+  DIR_CONTENT_KEY,
+  RESOURCE_ROOM_CONTENT_KEY,
+  RESOURCE_CATEGORY_CONTENT_KEY,
+} from "constants/queryKeys"
 
 import { ServicesContext } from "contexts/ServicesContext"
 
@@ -49,11 +53,16 @@ export function useDeleteDirectoryHook(params, queryParams) {
           DIR_CONTENT_KEY,
           _.omit(params, "collectionName"),
         ])
-      else if (params.resourceCategoryName)
+      else if (params.resourceCategoryName) {
         queryClient.invalidateQueries([
-          DIR_CONTENT_KEY,
+          RESOURCE_CATEGORY_CONTENT_KEY,
+          _.omit(params, "resourceRoomName"),
+        ])
+        queryClient.invalidateQueries([
+          RESOURCE_ROOM_CONTENT_KEY,
           _.omit(params, "resourceCategoryName"),
         ])
+      }
       if (queryParams && queryParams.onSuccess) queryParams.onSuccess()
     },
   })

--- a/src/hooks/pageHooks/useDeletePageHook.jsx
+++ b/src/hooks/pageHooks/useDeletePageHook.jsx
@@ -2,7 +2,10 @@ import _ from "lodash"
 import { useContext } from "react"
 import { useMutation, useQueryClient } from "react-query"
 
-import { DIR_CONTENT_KEY } from "constants/queryKeys"
+import {
+  DIR_CONTENT_KEY,
+  RESOURCE_CATEGORY_CONTENT_KEY,
+} from "constants/queryKeys"
 
 import { ServicesContext } from "contexts/ServicesContext"
 
@@ -28,13 +31,18 @@ export function useDeletePageHook(params, queryParams) {
       successToast({
         description: `Successfully deleted page!`,
       })
-      if (params.collectionName || params.resourceRoomName)
+      if (params.collectionName)
         queryClient.invalidateQueries([
           // invalidates collection pages or resource pages
           DIR_CONTENT_KEY,
           _.omit(params, "fileName"),
         ])
-      else
+      else if (params.resourceRoomName) {
+        queryClient.invalidateQueries([
+          RESOURCE_CATEGORY_CONTENT_KEY,
+          _.omit(params, "fileName"),
+        ])
+      } else
         queryClient.invalidateQueries([
           DIR_CONTENT_KEY,
           { siteName: params.siteName, isUnlinked: true },

--- a/src/hooks/pageHooks/useUpdatePageHook.jsx
+++ b/src/hooks/pageHooks/useUpdatePageHook.jsx
@@ -44,7 +44,10 @@ export function useUpdatePageHook(params, queryParams) {
             _.omit(params, "fileName"),
           ])
         else if (params.resourceRoomName) {
-          queryClient.invalidateQueries([RESOURCE_CATEGORY_CONTENT_KEY, params])
+          queryClient.invalidateQueries([
+            RESOURCE_CATEGORY_CONTENT_KEY,
+            _.omit(params, "fileName"),
+          ])
         } else
           queryClient.invalidateQueries([
             DIR_CONTENT_KEY,


### PR DESCRIPTION
## Problem
Previously, drag and drop did not work on `develop`. this is because having the`chakra.button` interfered with the draggable as they both respond to `onClick` events. 

Related to #1033 

## Solution
1. remove extra stuff from `FolderItem` as it's only used in re-ordering modal now.