### PR TITLE
Fix: useUpdateDirectoryHook invalidate query

### DIFF
--- a/src/hooks/directoryHooks/useUpdateDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useUpdateDirectoryHook.jsx
@@ -42,7 +42,10 @@ export function useUpdateDirectoryHook(params, queryParams) {
             _.omit(params, "collectionName"),
           ])
         else if (params.resourceCategoryName)
-          queryClient.invalidateQueries([RESOURCE_ROOM_CONTENT_KEY, params])
+          queryClient.invalidateQueries([
+            RESOURCE_ROOM_CONTENT_KEY,
+            _.omit(params, "resourceCategoryName"),
+          ])
         else if (params.mediaDirectoryName)
           queryClient.invalidateQueries([
             DIR_CONTENT_KEY,


### PR DESCRIPTION
## Problem

This PR fixes an issue where renaming a resource category would not immediately update the name of the displayed folder until refresh, due to the invalidation of the wrong query key.