### PR TITLE
fix: allow trailing slash for site URL but remove on save

### DIFF
--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -146,6 +146,20 @@ describe("Settings page", () => {
     cy.get("@seoInput").should("have.value", expected)
   })
 
+  it("should be able to update the SEO to a valid value with trailing slash", () => {
+    // Arrange
+    const expected = "www.space.open.gov.sg"
+    const input = `${expected}/`
+    cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
+
+    // Act
+    cy.get("@seoInput").clear().type(input)
+
+    // Assert
+    cy.saveSettings()
+    cy.get("@seoInput").should("have.value", expected)
+  })
+
   it("should not be able to input the protocol at the beginning of the url", () => {
     // Arrange
     const INVALID_SEO_INPUTS = [
@@ -181,7 +195,7 @@ describe("Settings page", () => {
 
   it("should not allow malformed URLs for the SEO URL", () => {
     // Arrange
-    const MALFORMED_URLS = ["www.open.", "open"]
+    const MALFORMED_URLS = ["www.open.", "open", "open.gov.sg//"]
     cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
 
     MALFORMED_URLS.forEach((malformedUrl) => {

--- a/src/hooks/settingsHooks/useUpdateSettings.ts
+++ b/src/hooks/settingsHooks/useUpdateSettings.ts
@@ -49,10 +49,12 @@ const convertfromFe = ({
 
   // Remove trailing slash in site URL if present
   if (
-    "url" in renamedBasicSettings &&
-    (<string>renamedBasicSettings.url).endsWith("/")
+    !!renamedBasicSettings.url &&
+    // This is a safe cast as the `url` key gets mapped into a string
+    // if it is present and the property is also a string
+    (renamedBasicSettings.url as string).endsWith("/")
   ) {
-    renamedBasicSettings.url = (<string>renamedBasicSettings.url).slice(0, -1)
+    renamedBasicSettings.url = (renamedBasicSettings.url as string).slice(0, -1)
   }
 
   return {

--- a/src/hooks/settingsHooks/useUpdateSettings.ts
+++ b/src/hooks/settingsHooks/useUpdateSettings.ts
@@ -47,6 +47,14 @@ const convertfromFe = ({
     (_value, key) => FE_TO_BE[key]
   )
 
+  // Remove trailing slash in site URL if present
+  if (
+    "url" in renamedBasicSettings &&
+    (<string>renamedBasicSettings.url).endsWith("/")
+  ) {
+    renamedBasicSettings.url = (<string>renamedBasicSettings.url).slice(0, -1)
+  }
+
   return {
     ...renamedBasicSettings,
     social_media: socialMediaContent,

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -27,7 +27,7 @@ export const TIKTOK_REGEX = ".com/@)([a-zA-Z0-9_-]+([/.])?)+$"
 // 3. The last section after "+" is to match the TLD segment of the domain
 // 4. The "^" and "$" ensures that we are matching the whole string (to prevent the user from adding "https://")
 export const DOMAIN_NAME_REGEX =
-  "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/?$"
+  "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]\\/?$"
 const PHONE_REGEX = "^\\+65(6|8|9)[0-9]{7}$"
 const EMAIL_REGEX =
   '^(([^<>()\\[\\]\\.,;:\\s@\\"]+(\\.[^<>()\\[\\]\\.,;:\\s@\\"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z-0-9]+\\.)+[a-zA-Z]{2,}))$'

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -27,7 +27,7 @@ export const TIKTOK_REGEX = ".com/@)([a-zA-Z0-9_-]+([/.])?)+$"
 // 3. The last section after "+" is to match the TLD segment of the domain
 // 4. The "^" and "$" ensures that we are matching the whole string (to prevent the user from adding "https://")
 export const DOMAIN_NAME_REGEX =
-  "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+  "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/?$"
 const PHONE_REGEX = "^\\+65(6|8|9)[0-9]{7}$"
 const EMAIL_REGEX =
   '^(([^<>()\\[\\]\\.,;:\\s@\\"]+(\\.[^<>()\\[\\]\\.,;:\\s@\\"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z-0-9]+\\.)+[a-zA-Z]{2,}))$'


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The site URL field in the site settings page does not allow for trailing slashes.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The domain name regex has been updated to allow for a single trailing slash in the site URL input field.
- Any trailing slash will be removed before sending the domain name to the backend.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**:
- Run `npm run tests`

**Smoke tests**:
- Run `npm run dev`.
- Use any site and navigate to the site settings page.
- Add a valid domain to the SEO field (site URL) and add a single trailing slash.
- Click anywhere outside the field, no error message will be shown.
- Click on "Save", the updated settings can be saved and the trailing slash will disappear.

## Deploy Notes

*None*