### PR TITLE
fix: improve copy of SEO settings field per design

### DIFF
--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -209,6 +209,17 @@ describe("Settings page", () => {
     })
   })
 
+  it("should not allow SEO URL field to be empty", () => {
+    // Arrange
+    cy.contains("label", "SEO").parent().parent().find("input").as("seoInput")
+
+    // Act
+    cy.get("@seoInput").clear().blur()
+
+    // Assert
+    cy.contains("This field cannot be left blank").should("exist")
+  })
+
   it("Should toggle Masthead and Show Reach buttons and have change reflect correctly on save", () => {
     // Arrange
     // NOTE: Initial state is display govt masthead off and show reach on

--- a/src/layouts/Settings/GeneralSettings.tsx
+++ b/src/layouts/Settings/GeneralSettings.tsx
@@ -72,7 +72,7 @@ export const GeneralSettings = ({
           <Box mb="0.75rem">
             <FormLabel mb={0}>Search Engine Optimisation (SEO)</FormLabel>
             <FormLabel.Description color="text.description">
-              Enter the web domain of your live site, to improve its position on
+              Enter the web domain of your site, to improve its position on
               search result pages.
             </FormLabel.Description>
           </Box>
@@ -89,13 +89,16 @@ export const GeneralSettings = ({
             />
           </InputGroup>
           <FormErrorMessage>
-            The web domain you have entered is not valid.
+            {errors.url?.type === "required" &&
+              "This field cannot be left blank"}
+            {errors.url?.type === "pattern" &&
+              "The web domain you have entered is not valid"}
           </FormErrorMessage>
         </FormControl>
         <FormControl isDisabled={isError}>
           <Flex justifyContent="space-between" w="100%">
             <FormLabel>Display government masthead</FormLabel>
-            {/* NOTE: This should be toggle from design system 
+            {/* NOTE: This should be toggle from design system
                 but the component is broken and doesn't display a slider */}
             <FormToggle name="displayGovMasthead" />
           </Flex>

--- a/src/layouts/Settings/GeneralSettings.tsx
+++ b/src/layouts/Settings/GeneralSettings.tsx
@@ -19,6 +19,8 @@ import { Section, SectionHeader } from "layouts/components"
 
 import { DOMAIN_NAME_REGEX } from "utils/validators"
 
+import type { SiteInfo } from "types/settings"
+
 import { FormToggle } from "./components/FormToggle"
 import { SettingsFormFieldMedia } from "./components/SettingsFormFieldMedia"
 
@@ -30,7 +32,7 @@ export const GeneralSettings = ({
   isError,
 }: GeneralSettingsProp): JSX.Element => {
   const { register } = useFormContext()
-  const { errors } = useFormState()
+  const { errors } = useFormState<SiteInfo>()
 
   return (
     <Section id="general-fields">
@@ -68,7 +70,7 @@ export const GeneralSettings = ({
             {...register("description")}
           />
         </FormControl>
-        <FormControl isDisabled={isError} isRequired isInvalid={errors.url}>
+        <FormControl isDisabled={isError} isRequired isInvalid={!!errors.url}>
           <Box mb="0.75rem">
             <FormLabel mb={0}>Search Engine Optimisation (SEO)</FormLabel>
             <FormLabel.Description color="text.description">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The copy used for the SEO settings field can be confusing for users.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The copy used for the SEO settings field has been improved as provided by design.
- The error message when the field is empty has also been improved.

## Tests

**Smoke tests**:

- Run `npm run dev`.
- Use any site and navigate to the site settings page.
- The updated description will be shown.
- Add any text to the SEO field (site URL) and then remove it.
- Click anywhere outside the field, the updated error message will be shown.

## Deploy Notes

*None*