### PR TITLE
Feat/add external permalink to resource

### DIFF
--- a/src/components/PageSettingsModal/PageSettingsModal.jsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.jsx
@@ -147,6 +147,13 @@ export const PageSettingsModal = ({
                   >
                     <Box mb="0.75rem">
                       <FormLabel mb={0}>Page URL</FormLabel>
+                      {resourceRoomName && (
+                        <FormLabel.Description color="text.description">
+                          Enter what you want to link to (e.g. /page-url for
+                          pages on your site, or https://www.url.com for
+                          external websites).
+                        </FormLabel.Description>
+                      )}
                       <FormLabel.Description color="text.description">
                         {siteUrl}
                       </FormLabel.Description>

--- a/src/components/PageSettingsModal/PageSettingsSchema.jsx
+++ b/src/components/PageSettingsModal/PageSettingsSchema.jsx
@@ -4,6 +4,7 @@ import * as Yup from "yup"
 import {
   permalinkRegexTest,
   specialCharactersRegexTest,
+  resourcePermalinkRegexText,
   PAGE_SETTINGS_PERMALINK_MIN_LENGTH,
   PAGE_SETTINGS_PERMALINK_MAX_LENGTH,
   PAGE_SETTINGS_TITLE_MIN_LENGTH,
@@ -32,9 +33,27 @@ export const PageSettingsSchema = (existingTitlesArray = []) =>
         "Title is already in use. Please choose a different title.",
         (value) => !_.includes(existingTitlesArray, value)
       ),
-    permalink: Yup.string().when("layout", (layout, schema) =>
-      layout !== "file"
-        ? schema
+    permalink: Yup.string().when("layout", (layout, schema) => {
+      switch (layout) {
+        case "file":
+          return schema
+        case "post":
+          return schema
+            .required("Permalink is required")
+            .min(
+              PAGE_SETTINGS_PERMALINK_MIN_LENGTH,
+              `Permalink must be longer than ${PAGE_SETTINGS_PERMALINK_MIN_LENGTH} characters`
+            )
+            .max(
+              PAGE_SETTINGS_PERMALINK_MAX_LENGTH,
+              `Permalink must be shorter than ${PAGE_SETTINGS_PERMALINK_MAX_LENGTH} characters`
+            )
+            .matches(
+              resourcePermalinkRegexText,
+              "Permalink should contain alphanumeric characters separated by hyphens and slashes only"
+            )
+        default:
+          return schema
             .required("Permalink is required")
             .min(
               PAGE_SETTINGS_PERMALINK_MIN_LENGTH,
@@ -48,8 +67,8 @@ export const PageSettingsSchema = (existingTitlesArray = []) =>
               permalinkRegexTest,
               "Permalink should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only"
             )
-        : schema
-    ),
+      }
+    }),
     layout: Yup.string().when("$type", (type, schema) =>
       type === "resourcePage"
         ? schema

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -12,7 +12,8 @@ import {
 
 // Common regexes and constants
 // ==============
-const PERMALINK_REGEX = "^((/([a-zA-Z0-9]+-)*[a-zA-Z0-9]+)+)/?$"
+const INTERNAL_PERMALINK_REGEX = "^((/([a-zA-Z0-9]+-)*[a-zA-Z0-9]+)+)/?$"
+const EXTERNAL_PERMALINK_REGEX = "^https://"
 export const URL_REGEX_PREFIX = "^(https://)?(www.)?("
 export const URL_REGEX_SUFFIX = ".com/)([a-zA-Z0-9_-]+([/.])?)+$"
 export const TELEGRAM_REGEX = "telegram|t).me/([a-zA-Z0-9_-]+([/.])?)+$"
@@ -35,7 +36,10 @@ const DATE_REGEX = "^([0-9]{4}-[0-9]{2}-[0-9]{2})$"
 const ALPHABETS_ONLY_REGEX = '^[a-zA-Z" "\\._-]+$'
 const ALPHANUMERICS_ONLY_REGEX = '^[a-zA-Z0-9" "\\._-]+$'
 
-export const permalinkRegexTest = RegExp(PERMALINK_REGEX)
+export const permalinkRegexTest = RegExp(INTERNAL_PERMALINK_REGEX)
+export const resourcePermalinkRegexText = RegExp(
+  `(${INTERNAL_PERMALINK_REGEX})|(${EXTERNAL_PERMALINK_REGEX})`
+)
 export const phoneRegexTest = RegExp(PHONE_REGEX)
 export const emailRegexTest = RegExp(EMAIL_REGEX)
 export const dateRegexTest = RegExp(DATE_REGEX)


### PR DESCRIPTION
ON HOLD: Updating resource pages to allow for external permalinks as a third type of resource

## Problem

This PR introduces the ability to use external permalinks for resource pages, to allow users to use resource cards to link to external pages. Resolves #1046.

This PR also separates the validation for resource page permalinks and other pages permalinks, as external permalinks for unlinked/collection pages do not work in the same way. While resource pages can be used to link out to external pages, the other types of pages will continue to interpret it as an internal link - we should therefore be using a separate set of validation specifically for resource page permalinks. 

TODO:
Nat raised the issue that being able to have both internal and external permalinks is confusing - we're looking into making this a third type of resource page instead 