### PR TITLE
fix(media): remove ?sanitize=true for svg and adjust heading

### DIFF
--- a/cypress/e2e/files.spec.ts
+++ b/cypress/e2e/files.spec.ts
@@ -28,8 +28,8 @@ describe("Files", () => {
     it("Files should contain Directories and Ungrouped Files", () => {
       cy.contains("Directories")
       cy.contains("Ungrouped files")
-      cy.contains("Upload new file")
-      cy.contains("Create new directory")
+      cy.contains("Upload file")
+      cy.contains("Create directory")
     })
 
     it("Should be able to create new file with valid title", () => {
@@ -112,8 +112,8 @@ describe("Files", () => {
     })
 
     it("Should be able to delete file", () => {
-      cy.contains("button", OTHER_FILE_TITLE).as("filePreview")
-      cy.clickContextMenuItem("@filePreview", "Delete")
+      cy.contains("div", OTHER_FILE_TITLE).as("filePreview")
+      cy.clickContextMenuItem("@filePreview", "Delete file")
       cy.contains("button", "delete").click().wait(Interceptors.DELETE)
 
       // ASSERTS
@@ -133,7 +133,7 @@ describe("Files", () => {
     })
 
     it("Should be able to create new file directory", () => {
-      cy.contains("Create new directory").click()
+      cy.contains("Create directory").click()
       cy.get("#newDirectoryName").clear().type(DIRECTORY_TITLE)
 
       cy.get("button")

--- a/cypress/e2e/files.spec.ts
+++ b/cypress/e2e/files.spec.ts
@@ -184,7 +184,7 @@ describe("Files", () => {
       cy.setSessionDefaults()
 
       cy.visit(`/sites/${TEST_REPO_NAME}/media/files/mediaDirectory/files`)
-      cy.contains("Create new directory").click()
+      cy.contains("Create directory").click()
       cy.get("#newDirectoryName").clear().type(DIRECTORY_TITLE)
       cy.get("button")
         .contains(/^Next$/)

--- a/cypress/e2e/files.spec.ts
+++ b/cypress/e2e/files.spec.ts
@@ -112,7 +112,7 @@ describe("Files", () => {
     })
 
     it("Should be able to delete file", () => {
-      cy.contains("div", OTHER_FILE_TITLE).as("filePreview")
+      cy.contains("button", OTHER_FILE_TITLE).as("filePreview")
       cy.clickContextMenuItem("@filePreview", "Delete file")
       cy.contains("button", "delete").click().wait(Interceptors.DELETE)
 

--- a/cypress/e2e/files.spec.ts
+++ b/cypress/e2e/files.spec.ts
@@ -112,7 +112,11 @@ describe("Files", () => {
     })
 
     it("Should be able to delete file", () => {
-      cy.contains("button", OTHER_FILE_TITLE).as("filePreview")
+      cy.contains("button", OTHER_FILE_TITLE)
+        .parent()
+        .parent()
+        .parent()
+        .as("filePreview")
       cy.clickContextMenuItem("@filePreview", "Delete file")
       cy.contains("button", "delete").click().wait(Interceptors.DELETE)
 
@@ -154,6 +158,7 @@ describe("Files", () => {
       cy.contains("div", DIRECTORY_TITLE)
         .parent()
         .parent()
+        .parent()
         .should("exist")
         .as("folderItem")
       cy.clickContextMenuItem("@folderItem", "settings").wait(Interceptors.GET)
@@ -167,6 +172,7 @@ describe("Files", () => {
     it("Should be able to delete file directory", () => {
       // User should be able delete directory
       cy.contains("div", OTHER_DIRECTORY_TITLE)
+        .parent()
         .parent()
         .parent()
         .should("exist")
@@ -226,7 +232,7 @@ describe("Files", () => {
     })
 
     it("Should be able to delete file from file directory", () => {
-      cy.contains(OTHER_FILE_TITLE).as("fileItem")
+      cy.contains(OTHER_FILE_TITLE).parent().parent().parent().as("fileItem")
       cy.clickContextMenuItem("@fileItem", "Delete")
       cy.contains("button", "delete").click().should("not.exist")
 

--- a/cypress/e2e/images.spec.ts
+++ b/cypress/e2e/images.spec.ts
@@ -15,7 +15,7 @@ describe("Images", () => {
       cy.setupDefaultInterceptors()
 
       cy.visit(`/sites/${TEST_REPO_NAME}/media/images/mediaDirectory/images`)
-      cy.contains("Create new album").click()
+      cy.contains("Create album").click()
       cy.get("#newDirectoryName").clear().type(ALBUM_TITLE)
       cy.get("button")
         .contains(/^Next$/)
@@ -59,7 +59,7 @@ describe("Images", () => {
       cy.contains("button", OTHER_IMAGE_TITLE)
         .as("imagePreview")
         .should("exist")
-      cy.clickContextMenuItem("@imagePreview", "Delete")
+      cy.clickContextMenuItem("@imagePreview", "Delete image")
       cy.contains("button", "delete").click().wait(Interceptors.DELETE)
 
       // ASSERTS

--- a/cypress/support/medias.ts
+++ b/cypress/support/medias.ts
@@ -2,7 +2,7 @@ import "cypress-pipe"
 import { Interceptors } from "../fixtures/constants"
 
 Cypress.Commands.add("uploadMedia", (mediaTitle, mediaPath, disableAction) => {
-  cy.contains(`Upload new`).click().get("#file-upload").attachFile(mediaPath)
+  cy.contains(`Upload`).click().get("#file-upload").attachFile(mediaPath)
 
   cy.get("#name").clear().type(mediaTitle).blur()
   if (!disableAction)

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -35,7 +35,8 @@ import {
 interface MediaLabels {
   singularMediaLabel: "file" | "image"
   pluralMediaLabel: "files" | "images"
-  directoryLabel: "directory" | "album"
+  singularDirectoryLabel: "directory" | "album"
+  pluralDirectoryLabel: "directories" | "albums"
 }
 
 // Utility method to help ease over the various labels associated
@@ -45,14 +46,16 @@ const getMediaLabels = (mediaType: "files" | "images"): MediaLabels => {
     return {
       singularMediaLabel: "file",
       pluralMediaLabel: "files",
-      directoryLabel: "directory",
+      singularDirectoryLabel: "directory",
+      pluralDirectoryLabel: "directories",
     }
   }
 
   return {
     singularMediaLabel: "image",
     pluralMediaLabel: "images",
-    directoryLabel: "album",
+    singularDirectoryLabel: "album",
+    pluralDirectoryLabel: "albums",
   }
 }
 
@@ -68,7 +71,8 @@ export const Media = (): JSX.Element => {
   const {
     singularMediaLabel,
     pluralMediaLabel,
-    directoryLabel,
+    singularDirectoryLabel,
+    pluralDirectoryLabel,
   } = getMediaLabels(mediaType)
 
   return (
@@ -83,9 +87,9 @@ export const Media = (): JSX.Element => {
           </Box>
         </Section>
         <Section>
-          <SectionHeader label="Albums">
+          <SectionHeader label={_.upperFirst(pluralDirectoryLabel)}>
             <CreateButton as={Link} to={`${url}/createDirectory`}>
-              {`Create ${directoryLabel}`}
+              {`Create ${singularDirectoryLabel}`}
             </CreateButton>
           </SectionHeader>
           <Skeleton
@@ -102,9 +106,7 @@ export const Media = (): JSX.Element => {
         </Section>
         <Section>
           <Box w="100%">
-            <SectionHeader
-              label={`Ungrouped ${_.upperFirst(pluralMediaLabel)}`}
-            >
+            <SectionHeader label={`Ungrouped ${pluralMediaLabel}`}>
               <Button
                 as={Link}
                 to={`${url}/createMedia`}

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -102,7 +102,9 @@ export const Media = (): JSX.Element => {
         </Section>
         <Section>
           <Box w="100%">
-            <SectionHeader label="Ungrouped Images">
+            <SectionHeader
+              label={`Ungrouped ${_.upperFirst(pluralMediaLabel)}`}
+            >
               <Button
                 as={Link}
                 to={`${url}/createMedia`}

--- a/src/layouts/Media/components/FilePreviewCard.tsx
+++ b/src/layouts/Media/components/FilePreviewCard.tsx
@@ -27,7 +27,10 @@ export const FilePreviewCard = ({
   return (
     <Box position="relative" h="100%">
       <LinkBox position="relative" h="100%">
-        <LinkOverlay as={RouterLink} to={`${url}/editPage/${encodedName}`}>
+        <LinkOverlay
+          as={RouterLink}
+          to={`${url}/editMediaSettings/${encodedName}`}
+        >
           <Card variant="multi">
             <CardBody>
               <Icon as={BxFileArchiveSolid} fontSize="1.5rem" fill="icon.alt" />
@@ -65,7 +68,7 @@ export const FilePreviewCard = ({
               as={RouterLink}
               to={`${url}/deleteMedia/${encodedName}`}
             >
-              Delete page
+              Delete file
             </ContextMenu.Item>
           </>
         </ContextMenu.List>

--- a/src/layouts/Media/components/ImagePreviewCard.tsx
+++ b/src/layouts/Media/components/ImagePreviewCard.tsx
@@ -36,7 +36,7 @@ export const ImagePreviewCard = ({
   const styles = useMultiStyleConfig(CARD_THEME_KEY, {})
   const encodedName = encodeURIComponent(name)
   const { setRedirectToPage } = useRedirectHook()
-  const fileExt = mediaUrl.split(".").pop()
+  const fileExt = mediaUrl.split(".").pop()?.split("?").shift()
 
   return (
     <Box position="relative">

--- a/src/layouts/Media/components/ImagePreviewCard.tsx
+++ b/src/layouts/Media/components/ImagePreviewCard.tsx
@@ -13,12 +13,27 @@ import {
   HStack,
 } from "@chakra-ui/react"
 import { ContextMenu } from "components/ContextMenu"
+import _ from "lodash"
 import { BiChevronRight, BiEditAlt, BiFolder, BiTrash } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
 
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { CARD_THEME_KEY } from "theme/components/Card"
+
+const getFileExt = (mediaUrl: string): string => {
+  // NOTE: If it starts with data, the image is within a private repo.
+  // Hence, we will extract the portion after the specifier
+  // till the terminating semi-colon for use as the extension
+  if (mediaUrl.startsWith("data:image/")) {
+    return _.takeWhile(mediaUrl.slice(11), (char) => char !== ";").join("")
+  }
+
+  // Otherwise, this will point to a publicly accessible github url
+  return (
+    mediaUrl.split(".").pop()?.split("?").shift() || "Unknown file extension"
+  )
+}
 
 interface ImagePreviewCardProps {
   name: string
@@ -36,7 +51,7 @@ export const ImagePreviewCard = ({
   const styles = useMultiStyleConfig(CARD_THEME_KEY, {})
   const encodedName = encodeURIComponent(name)
   const { setRedirectToPage } = useRedirectHook()
-  const fileExt = mediaUrl.split(".").pop()?.split("?").shift()
+  const fileExt = getFileExt(mediaUrl)
 
   return (
     <Box position="relative">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There are some minor issues with the images and files pages:
1. SVG files will have an additional "?sanitize=true" string that appears together with the file extension, which can be confusing to users.
2. The "Ungrouped Images" heading appears for both images and files pages.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The way to obtain the file extension has been adjusted to strip away any additional characters after a single "?" character, which is only present for svg files.

## Before & After Screenshots

**BEFORE**:

<img width="497" alt="Screenshot 2022-09-09 at 17 20 01" src="https://user-images.githubusercontent.com/27919917/189316994-c3df3abd-8d2c-46e2-a2dc-646561b5db28.png">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="498" alt="Screenshot 2022-09-09 at 17 20 30" src="https://user-images.githubusercontent.com/27919917/189317083-25366974-e810-46b7-b4a2-0a915274ec42.png">

## Tests

<!-- What tests should be run to confirm functionality? -->

**Smoke tests**:
- Run `npm run dev`.
- Log in and navigate to any site's images page that has an SVG file
- Verify that the "?sanitize=true" portion does not appear
- Navigate to the Files page
- Verify that the text are adjusted to suit the Files page instead of the Images page

**e2e tests**:
- Run `npm run test-e2e`