### PR TITLE
fix(file not uploaded when having 2 dots): Improve user experience by throwing an error

### DIFF
--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -20,7 +20,7 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
       )
       .test(
         "File not supported",
-        "Title cannot contain any '.' apart from file extension",
+        "File names cannot contain dots, except the extension at the end (e.g. '.png' or '.pdf')",
         (value) => {
           return (value.match(/\./g) || []).length <= 1
         }

--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -18,6 +18,13 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
         'Title cannot contain any of the following special characters: ~%^*+#?./`;{}[]"<>',
         (value) => !mediaSpecialCharactersRegexTest.test(value.split(".")[0])
       )
+      .test(
+        "File not supported",
+        "Title cannot contain any '.' apart from file extension",
+        (value) => {
+          return (value.match(/\./g) || []).length <= 1
+        }
+      )
       .min(
         MEDIA_SETTINGS_TITLE_MIN_LENGTH,
         `Title must be longer than ${MEDIA_SETTINGS_TITLE_MIN_LENGTH} characters`


### PR DESCRIPTION


## Problem

Currently, when uploading files with dots, IsomerCMS fails with an ambigous message stating "A new media file could not be created. Please try again or check your internet connection" This is a bandage on the front end rather than a permanent fix

Closes #1021. 

## Solution

Throw an error when the user attempts to upload a file with dots within the file name, excluding the extension. 

**Breaking Changes**



- [] Yes - this PR contains breaking changes
- [X] No - this PR is backwards compatible

