### PR TITLE
fix(edit page): avoid using textContent to display XSS modal

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -162,12 +162,9 @@ const EditPage = ({ match }) => {
                   <br />
                   <Code>{i + 1}</Code>:
                   <Code>
-                    {elem.attribute?.textContent || elem.element?.textContent
-                      ? (
-                          elem.attribute?.textContent ||
-                          elem.element?.textContent
-                        ).replace("<", "&lt;")
-                      : elem}
+                    {elem.attribute?.nodeName ||
+                      elem.element?.outerHTML ||
+                      elem}
                   </Code>
                 </>
               ))}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Isomer CMS will throw an error if the `textContent` value is an empty string, which is possible in the following few examples:
1. `<script></script>` - empty content for a whole tag that will be removed
2. `<p evil>Text</p>` - empty attribute content for the `evil` attribute that will be removed

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The use of `textContent` has been replaced with either `outerHTML` for removed elements, or `nodeName` for removed attributes.

## Before & After Screenshots

**AFTER**:

![Screenshot 2022-09-19 at 18 05 35](https://user-images.githubusercontent.com/27919917/190994804-6b3fda76-a853-456c-b31b-ebef195f75ad.png)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

1. Go to any site and edit a page
2. Try to save content matching any of the above cases
3. Verify that the XSS warning modal appears (instead of throwing an error)

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*