### PR TITLE
fix(gh-actions): handle failures from bots and refine PR comments

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -90,8 +90,6 @@ jobs:
       USERNAME: ${{secrets.USERNAME}}
       PERSONAL_ACCESS_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN}}
       E2E_COMMIT_HASH: ${{secrets.E2E_COMMIT_HASH}}
-      COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
-      COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      issueNumber:
+        description: "The pull request number to build e2e tests on"
+        required: true
+        default: 1
+        type: number
 
 # Required for allowing PRs to master branch to be of highest priority
 concurrency:
@@ -84,9 +90,7 @@ jobs:
       USERNAME: ${{secrets.USERNAME}}
       PERSONAL_ACCESS_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN}}
       E2E_COMMIT_HASH: ${{secrets.E2E_COMMIT_HASH}}
-      # overwrite commit message sent to Dashboard
       COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
-      # re-enable PR comment bot
       COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
 
     steps:
@@ -101,5 +105,25 @@ jobs:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - name: Get pull request information (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: octokit/request-action@v2.x
+        id: get_pull_request
+        with:
+          route: GET /repos/{repository}/pulls/{pull_number}
+          repository: ${{ github.repository }} # isomerpages/isomercms-frontend
+          pull_number: ${{ inputs.issueNumber }}
+      - name: Save new environment variables (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        # COMMIT_INFO_MESSAGE: To overwrite commit message sent to Dashboard
+        # COMMIT_INFO_SHA: To re-enable PR comment bot for Cypress
+        run: |
+          echo "COMMIT_INFO_MESSAGE=${{ fromJSON(steps.get_pull_request.outputs.data).title }}" >> $GITHUB_ENV
+          echo "COMMIT_INFO_SHA=${{ fromJSON(steps.get_pull_request.outputs.data).head.sha }}" >> $GITHUB_ENV
+      - name: Save new environment variables (pull_request)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "COMMIT_INFO_MESSAGE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+          echo "COMMIT_INFO_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       - run: npm ci
       - run: npm run test:ci

--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Check if user is part of Isomer core team
         uses: tspascoal/get-user-teams-membership@v1
         id: checkUserMember
+        continue-on-error: true
         with:
           username: ${{ github.actor }}
           team: ${{ env.ISOMER_CORE_TEAM_SLUG }}
@@ -137,7 +138,7 @@ jobs:
 
       - name: Dispatch e2e test suite workflow run
         if: ${{ env.ISOMER_CAN_RUN_E2E == 'true' }}
-        run: gh workflow run ${{ env.ISOMER_E2E_WORKFLOW_NAME }}
+        run: gh workflow run ${{ env.ISOMER_E2E_WORKFLOW_NAME }} -f issueNumber=${{ env.ISOMER_PULL_NUMBER }}
         env:
           # The original GITHUB_TOKEN cannot perform workflow dispatch
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The e2e tests GitHub Actions workflow does not handle `workflow_dispatch` events well, causing the PR comments to be given to incorrect pull requests. Also, the step to check for user's team membership does not work well for bot accounts.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The original e2e test workflow has been updated to allow specifying the pull request number. This number will be used to determine the name of the original branch, the SHA of the HEAD commit for that branch and the title of the pull request. This fix was performed on [advice from the Cypress documentation](https://docs.cypress.io/guides/continuous-integration/github-actions#Pull-requests-commit-message-is-merge-SHA-into-SHA).
- The step to check the user's team membership has been updated to continue on errors, so that the workflow does not fail unexpectedly.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

No tests were prepared as they are refinements to an earlier PR #1055.