### PR TITLE
feat(rr): sorting the modal

### DIFF
--- a/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.stories.tsx
+++ b/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.stories.tsx
@@ -22,7 +22,7 @@ import { MOCK_ITEMS } from "mocks/constants"
 
 import { RequestOverview, RequestOverviewProps } from "./RequestOverview"
 
-const formMeta = {
+const overviewMeta = {
   title: "Components/ReviewRequestModal/Overview",
   component: RequestOverview,
 } as ComponentMeta<typeof RequestOverview>
@@ -99,8 +99,8 @@ const Template: Story<RequestOverviewProps> = ({ items }) => {
   )
 }
 
-export const ManyEditors = Template.bind({})
-ManyEditors.args = {
+export const ManyEdits = Template.bind({})
+ManyEdits.args = {
   items: _.times(100, () => MOCK_ITEMS).flat(),
 }
 
@@ -109,4 +109,4 @@ Playground.args = {
   items: MOCK_ITEMS,
 }
 
-export default formMeta
+export default overviewMeta

--- a/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.tsx
@@ -29,6 +29,7 @@ import {
   Button,
 } from "@opengovsg/design-system-react"
 import {
+  Column,
   ColumnFiltersState,
   createColumnHelper,
   flexRender,
@@ -179,6 +180,15 @@ export const RequestOverview = ({
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
+  const handleFilter = <T, U>(filter: unknown, column: Column<T, U>) => {
+    const curFilterValue = column.getFilterValue()
+    if (_.isEqual(curFilterValue, filter)) {
+      table.resetColumnFilters()
+    } else {
+      column.setFilterValue(filter)
+    }
+  }
+
   const columns = [
     columnHelper.accessor((row) => row.type, {
       id: "type",
@@ -202,7 +212,7 @@ export const RequestOverview = ({
               }
               iconSpacing="0.5rem"
               onClick={() => {
-                column.setFilterValue(["page", "image", "file"])
+                handleFilter(["page", "image", "file"], column)
               }}
             >
               <Flex align="center">
@@ -222,7 +232,7 @@ export const RequestOverview = ({
               iconSpacing="0.5rem"
               icon={<BiCog fontSize="1rem" fill={theme.colors.icon.alt} />}
               onClick={() => {
-                column.setFilterValue(["setting"])
+                handleFilter(["setting"], column)
               }}
             >
               <Flex align="center">
@@ -240,7 +250,7 @@ export const RequestOverview = ({
               icon={<BiCompass fontSize="1rem" fill={theme.colors.icon.alt} />}
               iconSpacing="0.5rem"
               onClick={() => {
-                column.setFilterValue(["nav"])
+                handleFilter(["nav"], column)
               }}
             >
               <Flex align="center">

--- a/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.tsx
@@ -354,7 +354,7 @@ export const RequestOverview = ({
       <Box w="100%" borderWidth="1px" borderRadius="8px" borderColor="gray.100">
         <TableVirtuoso
           style={{
-            height: 400,
+            height: "25rem",
             borderRadius: "8px",
           }}
           // NOTE: Pass in only the list of filtered rows.

--- a/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/Dashboard/components/ReviewRequestModal/RequestOverview/RequestOverview.tsx
@@ -39,6 +39,7 @@ import {
   SortingState,
   useReactTable,
 } from "@tanstack/react-table"
+import _ from "lodash"
 import { useState } from "react"
 import {
   BiGitCompare,
@@ -52,6 +53,7 @@ import {
   BiChevronRight,
   BiChevronDown,
   BiCompass,
+  BiCheck,
 } from "react-icons/bi"
 import { TableVirtuoso } from "react-virtuoso"
 
@@ -191,6 +193,7 @@ export const RequestOverview = ({
           />
           <MenuList>
             <MenuItem
+              minW="10rem"
               icon={
                 // NOTE: Using an Icon component to hook into design system results in a
                 // slightly off center icon, which is why using the base component itself
@@ -202,31 +205,53 @@ export const RequestOverview = ({
                 column.setFilterValue(["page", "image", "file"])
               }}
             >
-              <Text textStyle="subhead-2" textColor="text.body">
-                Pages
-              </Text>
+              <Flex align="center">
+                <Text textStyle="subhead-2" textColor="text.body">
+                  Pages
+                </Text>
+                <Spacer />
+                {_.isEqual(column.getFilterValue(), [
+                  "page",
+                  "image",
+                  "file",
+                ]) && <Icon as={BiCheck} fill="icon.default" fontSize="1rem" />}
+              </Flex>
             </MenuItem>
             <MenuItem
+              minW="10rem"
               iconSpacing="0.5rem"
               icon={<BiCog fontSize="1rem" fill={theme.colors.icon.alt} />}
               onClick={() => {
                 column.setFilterValue(["setting"])
               }}
             >
-              <Text textStyle="subhead-2" textColor="text.body">
-                Settings
-              </Text>
+              <Flex align="center">
+                <Text textStyle="subhead-2" textColor="text.body">
+                  Settings
+                </Text>
+                <Spacer />
+                {_.isEqual(column.getFilterValue(), ["setting"]) && (
+                  <Icon as={BiCheck} fill="icon.default" fontSize="1rem" />
+                )}
+              </Flex>
             </MenuItem>
             <MenuItem
+              minW="10rem"
               icon={<BiCompass fontSize="1rem" fill={theme.colors.icon.alt} />}
               iconSpacing="0.5rem"
               onClick={() => {
                 column.setFilterValue(["nav"])
               }}
             >
-              <Text textStyle="subhead-2" textColor="text.body">
-                Navigation
-              </Text>
+              <Flex align="center">
+                <Text textStyle="subhead-2" textColor="text.body">
+                  Navigation
+                </Text>
+                <Spacer />
+                {_.isEqual(column.getFilterValue(), ["nav"]) && (
+                  <Icon as={BiCheck} fill="icon.default" fontSize="1rem" />
+                )}
+              </Flex>
             </MenuItem>
           </MenuList>
         </Menu>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -203,15 +203,15 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     path: ["some", "thing"],
     url: "www.google.com",
     lastEditedBy: "asdf",
-    lastEditedTime: 129823104823094,
+    lastEditedTime: 129823104094,
   },
   {
     type: ["nav"],
-    name: "some file",
+    name: "another file",
     path: ["some", "thing"],
     url: "www.google.com",
     lastEditedBy: "asdf",
-    lastEditedTime: 129823104823094,
+    lastEditedTime: 823104823094,
   },
   {
     type: ["file"],
@@ -234,7 +234,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     ],
     url: "www.google.com",
     lastEditedBy: "asdf",
-    lastEditedTime: 129823104823094,
+    lastEditedTime: 129823094,
   },
   {
     type: ["image"],
@@ -242,7 +242,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     path: ["some", "thing"],
     url: "www.google.com",
     lastEditedBy: "asdf",
-    lastEditedTime: 129823104823094,
+    lastEditedTime: 129823094,
   },
 ]
 

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -199,7 +199,7 @@ export const MOCK_RESOURCE_CATEGORY_NAME = "mock-resource-category"
 export const MOCK_ITEMS: EditedItemProps[] = [
   {
     type: ["page"],
-    name: "some file",
+    name: "A page",
     path: ["some", "thing"],
     url: "www.google.com",
     lastEditedBy: "asdf",
@@ -207,7 +207,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
   },
   {
     type: ["nav"],
-    name: "another file",
+    name: "A nav",
     path: ["some", "thing"],
     url: "www.google.com",
     lastEditedBy: "asdf",
@@ -215,7 +215,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
   },
   {
     type: ["file"],
-    name: "some file",
+    name: "a file",
     path: ["some", "thing"],
     url: "www.google.com",
     lastEditedBy: "asdf",
@@ -224,7 +224,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
   {
     type: ["setting"],
     name:
-      "some file with an extremely long title that probably can't fit into a single line and we have to truncate this somehow. so we will hopefully display an ellipsis over it",
+      "A setting with an extremely long title that probably can't fit into a single line and we have to truncate this somehow. so we will hopefully display an ellipsis over it",
     // NOTE: We don't have arbitrary nested folders.
     // We only have depth = 2 for our folders.
     path: [
@@ -237,9 +237,26 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 129823094,
   },
   {
+    type: ["setting"],
+    name: "a normal setting",
+    path: ["some", "thing"],
+    url: "www.google.com",
+    lastEditedBy: "asdf",
+    lastEditedTime: 12123498294,
+  },
+  {
     type: ["image"],
     name: "some file",
     path: ["some", "thing"],
+    url: "www.google.com",
+    lastEditedBy: "asdf",
+    lastEditedTime: 129823094,
+  },
+  {
+    // NOTE: This has 2 types - we tiebreak by using the first item in the array.
+    type: ["nav", "setting"],
+    name: "a file with two types",
+    path: ["another", "path"],
     url: "www.google.com",
     lastEditedBy: "asdf",
     lastEditedTime: 129823094,

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -253,7 +253,8 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 129823094,
   },
   {
-    // NOTE: This has 2 types - we tiebreak by using the first item in the array.
+    // NOTE: This has 2 types - we tiebreak by using the first item in the array for the icon.
+    // For the filtering, it should appear in both.
     type: ["nav", "setting"],
     name: "a file with two types",
     path: ["another", "path"],


### PR DESCRIPTION
## Problem
This PR adds sorting and filtering to the modal. This is done through adding `react-table` to the frontend. `react-table` presents a headless view of the data, which allows us to plug it into the respective UI library.  

## Solution
- this uses the inbuilt functionality of `react-table` of `filter` + `sort` to achieve this. 
- the docs are abit unclear on how to accomplish this so i'll try to note this down below.

`react-table` uses its `columnHelper` to define its data model. through using the `columnHelper`, we are able to define the following forms of columns: 
1. accessor - these read data from our data model 
2. display - these do **not** read any data but instead, display arbitrary content 
3. grouping - no data model, only used to group other columns together.

accessor columns access our data model through the use of an `accessor` key. **This affects filtering/sorting!** when we sort and filter the column, we pass the **whole** row to the column and let the column decide what it's interested in (through the `accessor` key). 

this allows `react-table` to decouple the data model from the view layer.  