### PR TITLE
fix: add GITHUB_TOKEN environment variable for ci-e2e

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -90,6 +90,7 @@ jobs:
       USERNAME: ${{secrets.USERNAME}}
       PERSONAL_ACCESS_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN}}
       E2E_COMMIT_HASH: ${{secrets.E2E_COMMIT_HASH}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add missing `GITHUB_TOKEN` environment variable for the updated ci-e2e workflow. This is required to authenticate the request to the GitHub API ([see the failed run for more details](https://github.com/isomerpages/isomercms-frontend/actions/runs/3134900623/jobs/5090121951)).