### PR TITLE
Fix: remove permalink for file type resources

### DIFF
--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -51,7 +51,7 @@ interface ResourceModalParams {
 interface ResourcePageFrontMatter {
   layout: string
   title: string
-  permalink: string
+  permalink?: string
   date: string
   // eslint-disable-next-line camelcase
   file_url?: string
@@ -172,7 +172,10 @@ export const ResourcePageSettingsModal = ({
         })
         setValue("permalink", "")
       }
-      if (pageData.content.frontMatter.layout === "link") {
+      if (
+        pageData.content.frontMatter.layout === "link" &&
+        pageData.content.frontMatter.permalink
+      ) {
         // remove https:// from resource pages with external permalinks
         setValue(
           "permalink",
@@ -191,7 +194,9 @@ export const ResourcePageSettingsModal = ({
     const processedData = {
       ...data,
     }
-    if (data.layout === "link") {
+    if (data.layout === "file") {
+      delete processedData.permalink
+    } else if (data.layout === "link") {
       processedData.permalink = `https://${processedData.permalink}`
     }
     return onProceed({


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/isomerpages/isomercms-frontend/pull/1064 - a permalink was being generated for all resource pages, even for file type resources, which caused the file specified to not show up. This PR fixes the behaviour by removing this param for file type resources.