### PR TITLE
feat(review-request): send review request modal 

### DIFF
--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -1,0 +1,24 @@
+import {
+  Button,
+  ButtonProps,
+  LinkProps,
+  Link,
+} from "@opengovsg/design-system-react"
+
+// NOTE: This button exists just to ensure that the text won't have an underline displayed
+// TODO: We should make a separate variant for button rather than a new component
+export const ButtonLink = (props: ButtonProps & LinkProps): JSX.Element => {
+  return (
+    <Button
+      as={Link}
+      rel="noopener noreferrer"
+      target="_blank"
+      textDecoration="none"
+      _hover={{
+        textDecoration: "none",
+        bgColor: "primary.600",
+      }}
+      {...props}
+    />
+  )
+}

--- a/src/components/ButtonLink/index.ts
+++ b/src/components/ButtonLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./ButtonLink"

--- a/src/layouts/ReviewRequest/components/ReviewRequestForm/ReviewRequestForm.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestForm/ReviewRequestForm.tsx
@@ -2,11 +2,10 @@ import { VStack, FormControl } from "@chakra-ui/react"
 import { FormLabel, Input, Textarea } from "@opengovsg/design-system-react"
 import Select from "react-select"
 
+import { User } from "types/reviewRequest"
+
 export interface ReviewRequestFormProps {
-  admins: {
-    value: string
-    label: string
-  }[]
+  admins: User[]
 }
 
 export const ReviewRequestForm = ({

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.stories.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.stories.tsx
@@ -1,0 +1,49 @@
+import { Button, useDisclosure } from "@chakra-ui/react"
+import { Story, ComponentMeta } from "@storybook/react"
+
+import { MOCK_ADMINS } from "mocks/constants"
+
+import { SendRequestModal, SendRequestModalProps } from "./SendRequestModal"
+
+const modalMeta = {
+  title: "Components/ReviewRequest/Send Request Modal",
+  component: SendRequestModal,
+} as ComponentMeta<typeof SendRequestModal>
+type TemplateProps = Pick<
+  SendRequestModalProps,
+  "admins" | "reviewUrl" | "reviewTitle" | "siteName"
+>
+
+const Template: Story<TemplateProps> = ({
+  admins,
+  reviewUrl,
+  reviewTitle,
+  siteName,
+}: TemplateProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure({ defaultIsOpen: true })
+  return (
+    <>
+      <Button onClick={onOpen}>Open Modal</Button>
+      <SendRequestModal
+        admins={admins}
+        isOpen={isOpen}
+        onClose={onClose}
+        reviewUrl={reviewUrl}
+        reviewTitle={reviewTitle}
+        siteName={siteName}
+      >
+        <Button colorScheme="danger">Click me</Button>
+      </SendRequestModal>
+    </>
+  )
+}
+
+export const Playground = Template.bind({})
+Playground.args = {
+  admins: MOCK_ADMINS,
+  reviewUrl: "isomer.gov.sg/8201826dnsa0r",
+  reviewTitle: "please review my pr here",
+  siteName: "a testing site for isomer",
+}
+
+export default modalMeta

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
@@ -1,0 +1,175 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  Text,
+  VStack,
+  HStack,
+  ModalProps,
+  Box,
+  useClipboard,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+import { ButtonLink } from "components/ButtonLink"
+import _ from "lodash"
+import { BiCopy, BiMailSend } from "react-icons/bi"
+import Select from "react-select"
+
+import { User } from "types/reviewRequest"
+
+const generateEmailToAdmins = (
+  admins: User[],
+  siteName: string,
+  reviewUrl: string,
+  reviewTitle: string
+): string => {
+  // NOTE: We are guaranteed the existence of at least 1 admin
+  // as the invariant for them to get to this step is to select
+  // their reviewers.
+  const to = admins[0].value
+  const cc = admins.slice(1).map(({ value }) => value)
+  const subject = `New review request for ${siteName}`
+  const body = `I’ve asked you to review changes to my site!%0D%0D
+
+Request title: ${reviewTitle}%0D
+View it on IsomerCMS: ${reviewUrl}`
+
+  console.log(to, cc)
+
+  return `mailto:${to}${cc.length > 0 ? `?cc=${cc}` : ""}&subject=${encodeURI(
+    subject
+  )}&body=${body}`
+}
+
+export interface SendRequestModalProps extends ModalProps {
+  admins: User[]
+  reviewUrl: string
+  reviewTitle: string
+  siteName: string
+}
+
+export const SendRequestModal = ({
+  admins,
+  reviewUrl,
+  reviewTitle,
+  siteName,
+  ...props
+}: SendRequestModalProps): JSX.Element => {
+  const { onCopy, hasCopied } = useClipboard(reviewUrl)
+  const sortedAdmins = _.sortBy(admins, (user) => user.label)
+  const displayedAdmins = sortedAdmins.slice(0, 2)
+  const remainingAdmins = sortedAdmins.slice(2)
+
+  return (
+    <Modal {...props}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Text textStyle="h4">Send Review Request</Text>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {/* NOTE: Setting pb because using the ModalFooter results in an overly large bottom margin */}
+          <VStack spacing="2rem" w="100%" pb="2rem">
+            <VStack spacing="0.75rem" align="flex-start" w="100%">
+              <Text textStyle="subhead-1" color="text.label">
+                Email reviewers a link to your request
+              </Text>
+              <HStack spacing="0.5rem" w="100%">
+                <Select
+                  value={displayedAdmins}
+                  options={remainingAdmins}
+                  isMulti
+                  isClearable={false}
+                  components={{
+                    Input: () =>
+                      remainingAdmins.length > 0 ? (
+                        <Text
+                          ml="0.25rem"
+                          textDecoration="underline"
+                          color="text.link.default"
+                          textStyle="body-2"
+                        >{`+${remainingAdmins.length} more`}</Text>
+                      ) : null,
+                  }}
+                  styles={{
+                    // NOTE: Setting fixed height so that it is same size as button
+                    container: (base) => ({
+                      ...base,
+                      width: "100%",
+                      height: "2.75rem",
+                    }),
+                    control: (base) => ({ ...base, height: "100%" }),
+                    multiValueRemove: (base) => ({ ...base, display: "none" }),
+                  }}
+                />
+                <ButtonLink
+                  leftIcon={<BiMailSend fontSize="1.25rem" fill="white" />}
+                  href={generateEmailToAdmins(
+                    admins,
+                    siteName,
+                    reviewUrl,
+                    reviewTitle
+                  )}
+                >
+                  <Text textColor="white">Open mail app</Text>
+                </ButtonLink>
+              </HStack>
+            </VStack>
+            <VStack w="100%" align="flex-start" spacing="0.75rem">
+              <Text textStyle="subhead-1" color="text.label">
+                Or copy and share this request link with reviewers
+              </Text>
+              <HStack spacing="0.5rem" w="100%">
+                <Box
+                  py="0.625rem"
+                  pl="1rem"
+                  w="100%"
+                  border="1px solid"
+                  borderColor="border.input.default"
+                  borderRadius="4px"
+                >
+                  <Text textStyle="body-1">{reviewUrl}</Text>
+                </Box>
+                {/* Closes after 1.5s and does not refocus on the button to avoid the outline */}
+                <Popover returnFocusOnClose={false} isOpen={hasCopied}>
+                  <PopoverTrigger>
+                    <Button
+                      onClick={onCopy}
+                      variant="outline"
+                      leftIcon={<BiCopy fontSize="1.25rem" />}
+                    >
+                      Copy
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    bg="background.action.alt"
+                    _focus={{
+                      boxShadow: "none",
+                    }}
+                    w="fit-content"
+                    border="none"
+                  >
+                    <PopoverArrow bg="background.action.alt" />
+                    <PopoverBody>
+                      <Text textStyle="body-2" color="text.inverse">
+                        Link copied!
+                      </Text>
+                    </PopoverBody>
+                  </PopoverContent>
+                </Popover>
+              </HStack>
+            </VStack>
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
@@ -36,11 +36,11 @@ const generateEmailToAdmins = (
   const to = admins[0].value
   const cc = admins.slice(1).map(({ value }) => value)
   const subject = `New review request for ${siteName}`
-  // NOTE: %0D is a newline. Using \n does not work, possibly because
+  // NOTE: %0D%0A is a newline. Using \n does not work, possibly because
   // the body portion is interpreted as text/plain
-  const body = `I’ve asked you to review changes to my site!%0D%0D
+  const body = `I’ve asked you to review changes to my site!%0D%0A%0D%0A
 
-Request title: ${reviewTitle}%0D
+Request title: ${reviewTitle}%0D%0A
 View it on IsomerCMS: ${reviewUrl}`
 
   return `mailto:${to}${cc.length > 0 ? `?cc=${cc}` : ""}&subject=${encodeURI(

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
@@ -24,6 +24,10 @@ import Select from "react-select"
 
 import { User } from "types/reviewRequest"
 
+// NOTE: %0D%0A is a newline. Using \n does not work, possibly because
+// the body portion is interpreted as text/plain
+const EMAIL_NEWLINE = "%0D%0A"
+
 const generateEmailToAdmins = (
   admins: User[],
   siteName: string,
@@ -36,11 +40,9 @@ const generateEmailToAdmins = (
   const to = admins[0].value
   const cc = admins.slice(1).map(({ value }) => value)
   const subject = `New review request for ${siteName}`
-  // NOTE: %0D%0A is a newline. Using \n does not work, possibly because
-  // the body portion is interpreted as text/plain
-  const body = `I’ve asked you to review changes to my site!%0D%0A%0D%0A
+  const body = `I’ve asked you to review changes to my site!${EMAIL_NEWLINE}${EMAIL_NEWLINE}
 
-Request title: ${reviewTitle}%0D%0A
+Request title: ${reviewTitle}${EMAIL_NEWLINE}
 View it on IsomerCMS: ${reviewUrl}`
 
   return `mailto:${to}${cc.length > 0 ? `?cc=${cc}` : ""}&subject=${encodeURI(

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
@@ -36,12 +36,12 @@ const generateEmailToAdmins = (
   const to = admins[0].value
   const cc = admins.slice(1).map(({ value }) => value)
   const subject = `New review request for ${siteName}`
+  // NOTE: %0D is a newline. Using \n does not work, possibly because
+  // the body portion is interpreted as text/plain
   const body = `I’ve asked you to review changes to my site!%0D%0D
 
 Request title: ${reviewTitle}%0D
 View it on IsomerCMS: ${reviewUrl}`
-
-  console.log(to, cc)
 
   return `mailto:${to}${cc.length > 0 ? `?cc=${cc}` : ""}&subject=${encodeURI(
     subject

--- a/src/layouts/ReviewRequest/components/SendRequestModal/index.ts
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./SendRequestModal"

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -9,16 +9,15 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
-  Link,
   ModalHeader,
   ModalOverlay,
   useDisclosure,
   Skeleton,
-  LinkProps,
   Center,
   VStack,
 } from "@chakra-ui/react"
-import { Button, ButtonProps, IconButton } from "@opengovsg/design-system-react"
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import { ButtonLink } from "components/ButtonLink"
 import { BiArrowBack } from "react-icons/bi"
 import { Link as RouterLink, useParams } from "react-router-dom"
 
@@ -102,22 +101,5 @@ export const SiteViewHeader = (): JSX.Element => {
         </ModalContent>
       </Modal>
     </>
-  )
-}
-
-// NOTE: This button exists just to ensure that the text won't have an underline displayed
-const ButtonLink = (props: ButtonProps & LinkProps) => {
-  return (
-    <Button
-      as={Link}
-      rel="noopener noreferrer"
-      target="_blank"
-      textDecoration="none"
-      _hover={{
-        textDecoration: "none",
-        bgColor: "primary.600",
-      }}
-      {...props}
-    />
   )
 }

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -266,15 +266,15 @@ export const MOCK_ITEMS: EditedItemProps[] = [
 
 export const MOCK_ADMINS = [
   {
-    value: "a cat",
+    value: "cat@cat.sg",
     label: "Cat",
   },
   {
-    value: "Someone",
+    value: "Someone@anonymous.sg",
     label: "Unknown",
   },
   {
-    value: "a long label",
+    value: "aLongLabel@tooLongFor.me",
     label:
       "an extremely long label, so long that it should overflow. so let us see if it truly does. if it is so long, should it be called a paralabel? as it is a paragraph label.",
   },

--- a/src/theme/foundations/colours.ts
+++ b/src/theme/foundations/colours.ts
@@ -73,6 +73,9 @@ export const colours: { [k in IsomerColorScheme]: NestedRecord } = {
     },
   },
   border: {
+    input: {
+      default: "#BFBFBF",
+    },
     action: {
       default: "#276EF1",
       light: "#E9E9E9",

--- a/src/types/reviewRequest.ts
+++ b/src/types/reviewRequest.ts
@@ -1,0 +1,4 @@
+export interface User {
+  value: string
+  label: string
+}


### PR DESCRIPTION
## Problem
This PR adds the send request modal, which the requestor sees after submitting a review request. 

Part of #1070 

## Solution
1. Add modal 
2. Add a utility function to generate the `mailTo` content. This was done with reference from [here](https://css-tricks.com/snippets/html/mailto-links/) as well as [here](https://www.rfc-editor.org/rfc/rfc2368#page-3) (for line breaks.)