### PR TITLE
fix: touch up site dashboard

### DIFF
--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -6,8 +6,10 @@ import {
   MOCK_SITE_DASHBOARD_COLLABORATORS_STATISTICS,
   MOCK_SITE_DASHBOARD_INFO,
   MOCK_SITE_DASHBOARD_REVIEW_REQUESTS,
+  MOCK_USER,
 } from "mocks/constants"
 import {
+  buildLoginData,
   buildSiteDashboardCollaboratorsStatistics,
   buildSiteDashboardInfo,
   buildSiteDashboardReviewRequests,
@@ -41,6 +43,7 @@ const SiteDashboardMeta = {
         collaboratorsStatistics: buildSiteDashboardCollaboratorsStatistics(
           MOCK_SITE_DASHBOARD_COLLABORATORS_STATISTICS
         ),
+        loginData: buildLoginData(_.set(MOCK_USER, "userId", "")),
       },
     },
   },

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -60,7 +60,8 @@ export const SiteDashboard = (): JSX.Element => {
     isLoading: isCollaboratorsStatisticsLoading,
   } = useGetCollaboratorsStatistics(siteName)
 
-  const { savedAt, savedBy, publishedAt, publishedBy } = siteInfo || {}
+  const savedAt = getDateTimeFromUnixTime(siteInfo?.savedAt || 0)
+  const publishedAt = getDateTimeFromUnixTime(siteInfo?.publishedAt || 0)
 
   return (
     <SiteViewLayout overflow="hidden">
@@ -160,9 +161,7 @@ export const SiteDashboard = (): JSX.Element => {
                           <b>Last saved</b>{" "}
                           {isSiteInfoError
                             ? "Unable to retrieve data"
-                            : `${
-                                getDateTimeFromUnixTime(savedAt).date
-                              }, ${savedBy}`}
+                            : `${savedAt.date}, ${siteInfo?.savedBy}`}
                         </Text>
                       </Skeleton>
 
@@ -171,9 +170,7 @@ export const SiteDashboard = (): JSX.Element => {
                           <b>Last published</b>{" "}
                           {isSiteInfoError
                             ? "Unable to retrieve data"
-                            : `${
-                                getDateTimeFromUnixTime(publishedAt).date
-                              }, ${publishedBy}`}
+                            : `${publishedAt.date}, ${siteInfo?.publishedBy}`}
                         </Text>
                       </Skeleton>
                     </VStack>

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -23,14 +23,18 @@ import {
   MenuDropdownButton,
   MenuDropdownItem,
 } from "components/MenuDropdownButton"
+import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
+
+import { useLoginContext } from "contexts/LoginContext"
 
 import {
   useGetSiteInfo,
   useGetReviewRequests,
   useGetCollaboratorsStatistics,
 } from "hooks/siteDashboardHooks"
+import useRedirectHook from "hooks/useRedirectHook"
 
 import { getDateTimeFromUnixTime } from "utils/date"
 
@@ -44,6 +48,9 @@ import { ReviewRequestCard } from "./components/ReviewRequestCard"
 
 export const SiteDashboard = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
+  const { setRedirectToPage } = useRedirectHook()
+  const { userId } = useLoginContext()
+
   const {
     data: siteInfo,
     isError: isSiteInfoError,
@@ -62,6 +69,13 @@ export const SiteDashboard = (): JSX.Element => {
 
   const savedAt = getDateTimeFromUnixTime(siteInfo?.savedAt || 0)
   const publishedAt = getDateTimeFromUnixTime(siteInfo?.publishedAt || 0)
+
+  useEffect(() => {
+    // GitHub users should not be able to access this page
+    if (userId !== "Unknown user" && !!userId) {
+      setRedirectToPage(`/sites/${siteName}/workspace`)
+    }
+  })
 
   return (
     <SiteViewLayout overflow="hidden">

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -32,6 +32,8 @@ import {
   useGetCollaboratorsStatistics,
 } from "hooks/siteDashboardHooks"
 
+import { getDateTimeFromUnixTime } from "utils/date"
+
 import { SiteDashboardHumanImage } from "assets"
 
 import { SiteViewLayout } from "../layouts"
@@ -57,6 +59,8 @@ export const SiteDashboard = (): JSX.Element => {
     isError: isCollaboratorsStatisticsError,
     isLoading: isCollaboratorsStatisticsLoading,
   } = useGetCollaboratorsStatistics(siteName)
+
+  const { savedAt, savedBy, publishedAt, publishedBy } = siteInfo || {}
 
   return (
     <SiteViewLayout overflow="hidden">
@@ -156,7 +160,9 @@ export const SiteDashboard = (): JSX.Element => {
                           <b>Last saved</b>{" "}
                           {isSiteInfoError
                             ? "Unable to retrieve data"
-                            : `${siteInfo?.savedAt}, ${siteInfo?.savedBy}`}
+                            : `${
+                                getDateTimeFromUnixTime(savedAt).date
+                              }, ${savedBy}`}
                         </Text>
                       </Skeleton>
 
@@ -165,7 +171,9 @@ export const SiteDashboard = (): JSX.Element => {
                           <b>Last published</b>{" "}
                           {isSiteInfoError
                             ? "Unable to retrieve data"
-                            : `${siteInfo?.publishedAt}, ${siteInfo?.publishedBy}`}
+                            : `${
+                                getDateTimeFromUnixTime(publishedAt).date
+                              }, ${publishedBy}`}
                         </Text>
                       </Skeleton>
                     </VStack>

--- a/src/layouts/SiteDashboard/components/ReviewRequestCard.tsx
+++ b/src/layouts/SiteDashboard/components/ReviewRequestCard.tsx
@@ -13,6 +13,8 @@ import { Link, useParams } from "react-router-dom"
 
 import { useLoginContext } from "contexts/LoginContext"
 
+import { getDateTimeFromUnixTime } from "utils/date"
+
 import {
   ReviewRequestStatus,
   SiteDashboardReviewRequest,
@@ -33,6 +35,7 @@ export const ReviewRequestCard = ({
 }): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
   const { email } = useLoginContext()
+  const { date, time } = getDateTimeFromUnixTime(reviewRequest.createdAt)
 
   return (
     <DisplayCard
@@ -75,8 +78,8 @@ export const ReviewRequestCard = ({
           {reviewRequest.title}
         </DisplayCardTitle>
         <DisplayCardCaption>
-          #{reviewRequest.id} created by {reviewRequest.author} on{" "}
-          {reviewRequest.createdAt}
+          #{reviewRequest.id} created by {reviewRequest.author} on {date},{" "}
+          {time}
         </DisplayCardCaption>
       </DisplayCardHeader>
       <DisplayCardContent>

--- a/src/layouts/Sites.jsx
+++ b/src/layouts/Sites.jsx
@@ -6,17 +6,23 @@ import { Link } from "react-router-dom"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
+import { useLoginContext } from "contexts/LoginContext"
+
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import siteStyles from "styles/isomer-cms/pages/Sites.module.scss"
 
 import { convertUtcToTimeDiff } from "utils/dateUtils"
 
 const Sites = ({ siteNames }) => {
+  const { userId } = useLoginContext()
+  const isEmailLoginUser = !userId
+  const urlLink = isEmailLoginUser ? "dashboard" : "workspace"
+
   if (siteNames && siteNames.length > 0)
     return siteNames.map((siteName) => (
       <div className={siteStyles.siteContainer} key={siteName.repoName}>
         <div className={siteStyles.site}>
-          <Link to={`/sites/${siteName.repoName}/workspace`}>
+          <Link to={`/sites/${siteName.repoName}/${urlLink}`}>
             <div className={siteStyles.siteImage} />
             <div className={siteStyles.siteDescription}>
               <div className={siteStyles.siteName}>{siteName.repoName}</div>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -224,9 +224,9 @@ export const MOCK_SITE_DASHBOARD_COLLABORATORS_STATISTICS: CollaboratorsStats = 
 }
 
 export const MOCK_SITE_DASHBOARD_INFO: SiteDashboardInfo = {
-  savedAt: 1642559061,
+  savedAt: 1642559061000,
   savedBy: "Siti_Julaiha_ASMURI@hdb.gov.sg",
-  publishedAt: 1642559061,
+  publishedAt: 1642559061000,
   publishedBy: "Siti_Julaiha_ASMURI@hdb.gov.sg",
   stagingUrl: "https://opengovsg-test-staging.netlify.app",
   siteUrl: "https://www.open.gov.sg",

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -53,15 +53,17 @@ export const buildSettingsData = apiDataBuilder<BackendSiteSettings>(
 
 export const buildSiteDashboardReviewRequests = apiDataBuilder<
   SiteDashboardReviewRequest[]
->("*/sites/:siteName/review/summary")
+>("*/sites/:siteName/review/summary", "get")
 
 // TODO: To be replaced with collaborators PR
 export const buildSiteDashboardCollaboratorsStatistics = apiDataBuilder<CollaboratorsStats>(
-  "*/sites/:siteName/collaborators/statistics"
+  "*/sites/:siteName/collaborators/statistics",
+  "get"
 )
 
 export const buildSiteDashboardInfo = apiDataBuilder<SiteDashboardInfo>(
-  "*/sites/:siteName/info"
+  "*/sites/:siteName/info",
+  "get"
 )
 
 export const buildFolderData = apiDataBuilder<(PageData | DirectoryData)[]>(

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,7 +13,7 @@ export const getDateTimeFromUnixTime = (
       year: "numeric",
       day: "numeric",
     }),
-    time: date.toLocaleTimeString("en-GB", {
+    time: date.toLocaleTimeString("en-US", {
       timeStyle: "short",
     }),
   }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The site dashboard displays the Unix timestamp directly instead of a human-readable date format, which is hard to interpret for users. Also, the site dashboard is designed for email login users, but both GitHub login users and email login users are able to access it.

Fixes #1115.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The dates on the site dashboard is now displayed in a human-readable format.
- The site dashboard has been restricted to only email login users, GitHub login users will be redirected to the workspace.
- Time format has been changed to use 12-hour time instead of 24-hour time.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

1. Run with `npm run dev`.
2. Navigate to the site dashboard of any site (as an email login user)
3. Verify that the dates shown are in the human-readable format
4. Log out and log in through GitHub
5. Navigate to the site dashboard of any site (by changing the URL)
6. Verify that the user will be redirected to the workspace.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*