### PR TITLE
feat(rr): allow update of admins in rr 

### DIFF
--- a/src/hooks/reviewHooks/useUpdateReviewRequest.ts
+++ b/src/hooks/reviewHooks/useUpdateReviewRequest.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from "axios"
 import { useMutation, UseMutationResult, useQueryClient } from "react-query"
+import type { SetOptional } from "type-fest"
 
 import { REVIEW_REQUEST_QUERY_KEY } from "constants/queryKeys"
 
@@ -14,16 +15,22 @@ export const useUpdateReviewRequest = (
 ): UseMutationResult<
   void,
   AxiosError<ErrorDto | MiddlewareErrorDto>,
-  ReviewRequestInfo
+  SetOptional<ReviewRequestInfo, "title">
 > => {
   const queryClient = useQueryClient()
-  return useMutation((data) => updateReviewRequest(siteName, prNumber, data), {
-    onSettled: () => {
-      queryClient.invalidateQueries([
-        REVIEW_REQUEST_QUERY_KEY,
-        siteName,
-        prNumber,
-      ])
-    },
-  })
+  return useMutation(
+    ({ reviewers }) =>
+      updateReviewRequest(siteName, prNumber, {
+        reviewers: reviewers.map(({ value }) => value),
+      }),
+    {
+      onSettled: () => {
+        queryClient.invalidateQueries([
+          REVIEW_REQUEST_QUERY_KEY,
+          siteName,
+          prNumber,
+        ])
+      },
+    }
+  )
 }

--- a/src/hooks/reviewHooks/useUpdateReviewRequest.ts
+++ b/src/hooks/reviewHooks/useUpdateReviewRequest.ts
@@ -1,0 +1,29 @@
+import { AxiosError } from "axios"
+import { useMutation, UseMutationResult, useQueryClient } from "react-query"
+
+import { REVIEW_REQUEST_QUERY_KEY } from "constants/queryKeys"
+
+import { updateReviewRequest } from "services/ReviewService"
+
+import { MiddlewareErrorDto, ErrorDto } from "types/error"
+import { ReviewRequestInfo } from "types/reviewRequest"
+
+export const useUpdateReviewRequest = (
+  siteName: string,
+  prNumber: number
+): UseMutationResult<
+  void,
+  AxiosError<ErrorDto | MiddlewareErrorDto>,
+  ReviewRequestInfo
+> => {
+  const queryClient = useQueryClient()
+  return useMutation((data) => updateReviewRequest(siteName, prNumber, data), {
+    onSettled: () => {
+      queryClient.invalidateQueries([
+        REVIEW_REQUEST_QUERY_KEY,
+        siteName,
+        prNumber,
+      ])
+    },
+  })
+}

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -218,10 +218,9 @@ const ApprovalButton = ({
     mutateAsync: mergeReviewRequest,
     isLoading: isMergingReviewRequest,
     isSuccess: isReviewRequestMerged,
-    // TODO!
+    // TODO! - display error toast on merge failure
     isError: isMergeError,
   } = useMergeReviewRequest(siteName, prNumber, false)
-  // TODO! make be change the status to approved
   const {
     mutateAsync: approveReviewRequest,
     isError: isApproveReviewRequestError,
@@ -362,7 +361,6 @@ const SecondaryDetails = ({
           <ManageReviewerModal
             {...props}
             selectedAdmins={selectedAdmins}
-            // TODO!
             admins={allAdmins}
           />
         </Box>

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -52,11 +52,12 @@ export const ReviewRequestDashboard = (): JSX.Element => {
     siteName: string
     reviewId: string
   }>()
+  const prNumber = parseInt(reviewId, 10)
   const { setRedirectToPage } = useRedirectHook()
   // TODO!: Refactor so that loading is not a concern here
   const { data, isLoading: isGetReviewRequestLoading } = useGetReviewRequest(
     siteName,
-    parseInt(reviewId, 10)
+    prNumber
   )
   const { data: collaborators, isLoading, isError } = useGetCollaborators(
     siteName
@@ -69,7 +70,6 @@ export const ReviewRequestDashboard = (): JSX.Element => {
 
   const reviewStatus = data?.status
   const isApproved = reviewStatus === ReviewRequestStatus.APPROVED
-
   useEffect(() => {
     if (
       reviewStatus === ReviewRequestStatus.CLOSED ||

--- a/src/services/ReviewService.ts
+++ b/src/services/ReviewService.ts
@@ -2,6 +2,7 @@ import {
   EditedItemProps,
   ReviewRequest,
   ReviewRequestDto,
+  ReviewRequestInfo,
   UserDto,
 } from "types/reviewRequest"
 
@@ -87,4 +88,13 @@ export const getSiteUrl = async (siteName: string): Promise<string> => {
   return apiService
     .get<{ siteUrl: string }>(endpoint)
     .then(({ data }) => data.siteUrl)
+}
+
+export const updateReviewRequest = async (
+  siteName: string,
+  prNumber: number,
+  updatedReviewRequestInfo: ReviewRequestInfo
+): Promise<void> => {
+  const endpoint = `/sites/${siteName}/review/${prNumber}`
+  return apiService.post(endpoint, updatedReviewRequestInfo)
 }

--- a/src/services/ReviewService.ts
+++ b/src/services/ReviewService.ts
@@ -1,9 +1,9 @@
 import {
   EditedItemProps,
   ReviewRequest,
-  ReviewRequestDto,
-  ReviewRequestInfo,
+  CreateReviewRequestDto,
   UserDto,
+  UpdateReviewRequestDto,
 } from "types/reviewRequest"
 
 import { apiService } from "./ApiService"
@@ -35,7 +35,7 @@ export const getCollaborators = async (
 
 export const createReviewRequest = async (
   siteName: string,
-  reviewData: ReviewRequestDto
+  reviewData: CreateReviewRequestDto
 ): Promise<number> => {
   const endpoint = `/sites/${siteName}/review/request`
   return apiService.post<number>(endpoint, reviewData).then(({ data }) => data)
@@ -93,7 +93,7 @@ export const getSiteUrl = async (siteName: string): Promise<string> => {
 export const updateReviewRequest = async (
   siteName: string,
   prNumber: number,
-  updatedReviewRequestInfo: ReviewRequestInfo
+  updatedReviewRequestInfo: UpdateReviewRequestDto
 ): Promise<void> => {
   const endpoint = `/sites/${siteName}/review/${prNumber}`
   return apiService.post(endpoint, updatedReviewRequestInfo)

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -7,3 +7,11 @@ export interface MiddlewareError {
 export interface ErrorDto {
   message: string
 }
+
+export interface MiddlewareErrorDto {
+  error: {
+    code: number
+    message: string
+    name?: string
+  }
+}

--- a/src/types/reviewRequest.ts
+++ b/src/types/reviewRequest.ts
@@ -40,7 +40,7 @@ export interface CreateReviewRequestDto
 }
 
 export type UpdateReviewRequestDto = SetOptional<
-  Partial<CreateReviewRequestDto>,
+  CreateReviewRequestDto,
   "title"
 >
 

--- a/src/types/reviewRequest.ts
+++ b/src/types/reviewRequest.ts
@@ -1,3 +1,5 @@
+import type { SetOptional } from "type-fest"
+
 export enum ReviewRequestStatus {
   OPEN = "OPEN",
   APPROVED = "APPROVED",
@@ -32,9 +34,15 @@ export interface ReviewRequestInfo {
   reviewers: User[]
 }
 
-export interface ReviewRequestDto extends Omit<ReviewRequestInfo, "reviewers"> {
+export interface CreateReviewRequestDto
+  extends Omit<ReviewRequestInfo, "reviewers"> {
   reviewers: string[]
 }
+
+export type UpdateReviewRequestDto = SetOptional<
+  Partial<CreateReviewRequestDto>,
+  "title"
+>
 
 export interface ReviewRequest {
   reviewUrl: string


### PR DESCRIPTION
## Problem
See #1108 for an overview of the problem

Closes #1108 

## Solution
1. remove `stateManager` functionality and use `react-hook-forms` to manage state instead.
2. create new hooks + service api to ping the backend on update admin change.

**Breaking Changes**
- Requires the corresponding backend PR to be merged to work. 