### PR TITLE
fix(siteviewheader): conditional url for back button

### DIFF
--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -11,12 +11,14 @@ import { IconButton } from "@opengovsg/design-system-react"
 import { AvatarMenu } from "components/Header/AvatarMenu"
 import { NotificationMenu } from "components/Header/NotificationMenu"
 import { BiArrowBack } from "react-icons/bi"
-import { Link as RouterLink, useParams } from "react-router-dom"
+import { Link as RouterLink, useLocation, useParams } from "react-router-dom"
 
 import { useLoginContext } from "contexts/LoginContext"
 
 export const SiteViewHeader = (): JSX.Element => {
   const { displayedName } = useLoginContext()
+  const { pathname } = useLocation()
+  const isAtSiteDashboard = pathname.endsWith("dashboard")
   const { siteName } = useParams<{ siteName: string }>()
   return (
     <Flex
@@ -29,16 +31,16 @@ export const SiteViewHeader = (): JSX.Element => {
     >
       <HStack spacing="1.25rem">
         <IconButton
-          aria-label="Back to My sites"
+          aria-label="Back to site dashboard"
           variant="clear"
           icon={
             <Icon as={BiArrowBack} fontSize="1.25rem" fill="icon.secondary" />
           }
           as={RouterLink}
-          to="/sites"
+          to={isAtSiteDashboard ? "/sites" : `/sites/${siteName}/dashboard`}
         />
         <Text color="text.label" textStyle="body-1">
-          Back to My sites
+          {isAtSiteDashboard ? "My sites" : "Site dashboard"}
         </Text>
       </HStack>
       <Spacer />

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -31,7 +31,9 @@ export const SiteViewHeader = (): JSX.Element => {
     >
       <HStack spacing="1.25rem">
         <IconButton
-          aria-label="Back to site dashboard"
+          aria-label={`Back to ${
+            isAtSiteDashboard ? "my sites" : "site dashboard"
+          }`}
           variant="clear"
           icon={
             <Icon as={BiArrowBack} fontSize="1.25rem" fill="icon.secondary" />


### PR DESCRIPTION
## Problem
Part of #1113 - this PR makes the `SiteViewHeader` conditionally go back to either the dashboard or sites, depending on whether they are at the dashboard itself.

As `SiteViewHeader` is **only** used at review request related stuff, this header should only be seen by **email** users.

Closes #1113 

## Solution
add conditional for href on back button
