### PR TITLE
fix(rr): add footer to dashboard after rr is approved

### DIFF
--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -55,6 +55,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
     reviewId: string
   }>()
   const { setRedirectToPage } = useRedirectHook()
+  const { onOpen, isOpen, onClose } = useDisclosure()
   // TODO!: redirect to /sites if cannot parse reviewId as string
   const prNumber = parseInt(reviewId, 10)
   // TODO!: Refactor so that loading is not a concern here
@@ -173,17 +174,23 @@ export const ReviewRequestDashboard = (): JSX.Element => {
         <Box pl="9.25rem" pr="2rem">
           <RequestOverview items={data?.changedItems || []} allowEditing />
         </Box>
+        {isApproved && (
+          <Footer>
+            <Button
+              onClick={async () => {
+                await mergeReviewRequest()
+                onOpen()
+              }}
+              isLoading={isMergingReviewRequest}
+            >
+              Publish Now
+            </Button>
+          </Footer>
+        )}
+        {isReviewRequestMerged && (
+          <PublishedModal isOpen={isOpen} onClose={onClose} />
+        )}
       </Box>
-      {isApproved && (
-        <Footer>
-          <Button
-            onClick={mergeReviewRequest}
-            isLoading={isMergingReviewRequest}
-          >
-            Publish Now
-          </Button>
-        </Footer>
-      )}
     </>
   )
 }

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -183,7 +183,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
               }}
               isLoading={isMergingReviewRequest}
             >
-              Publish Now
+              Publish now
             </Button>
           </Footer>
         )}

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -15,6 +15,8 @@ import {
   IconButton,
   useDisclosure,
 } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import { Footer } from "components/Footer"
 import {
   MenuDropdownButton,
   MenuDropdownItem,
@@ -53,10 +55,12 @@ export const ReviewRequestDashboard = (): JSX.Element => {
     reviewId: string
   }>()
   const { setRedirectToPage } = useRedirectHook()
+  // TODO!: redirect to /sites if cannot parse reviewId as string
+  const prNumber = parseInt(reviewId, 10)
   // TODO!: Refactor so that loading is not a concern here
   const { data, isLoading: isGetReviewRequestLoading } = useGetReviewRequest(
     siteName,
-    parseInt(reviewId, 10)
+    prNumber
   )
   const { data: collaborators, isLoading, isError } = useGetCollaborators(
     siteName
@@ -65,6 +69,14 @@ export const ReviewRequestDashboard = (): JSX.Element => {
     mutateAsync: updateReviewRequestViewed,
   } = useUpdateReviewRequestViewed()
   // TODO!: redirect to /sites if cannot parse reviewId as string
+  const {
+    mutateAsync: mergeReviewRequest,
+    isLoading: isMergingReviewRequest,
+    isSuccess: isReviewRequestMerged,
+    // TODO!
+    isError: isMergeError,
+  } = useMergeReviewRequest(siteName, prNumber, false)
+
   const { onCopy, hasCopied } = useClipboard(data?.reviewUrl || "")
 
   const reviewStatus = data?.status
@@ -162,6 +174,16 @@ export const ReviewRequestDashboard = (): JSX.Element => {
           <RequestOverview items={data?.changedItems || []} allowEditing />
         </Box>
       </Box>
+      {isApproved && (
+        <Footer>
+          <Button
+            onClick={mergeReviewRequest}
+            isLoading={isMergingReviewRequest}
+          >
+            Publish Now
+          </Button>
+        </Footer>
+      )}
     </>
   )
 }
@@ -221,7 +243,6 @@ const ApprovalButton = ({
     // TODO!
     isError: isMergeError,
   } = useMergeReviewRequest(siteName, prNumber, false)
-  // TODO! make be change the status to approved
   const {
     mutateAsync: approveReviewRequest,
     isError: isApproveReviewRequestError,
@@ -362,7 +383,6 @@ const SecondaryDetails = ({
           <ManageReviewerModal
             {...props}
             selectedAdmins={selectedAdmins}
-            // TODO!
             admins={allAdmins}
           />
         </Box>


### PR DESCRIPTION
## Problem
The figma has a footer appearing on the review request dashboard after the review request is approved. This footer was initially missing from the rr and this PR adds it back. 

## Solution
1. use our `Footer` component + hook to merge the PR 