### PR TITLE
fix: increase z-index for Menu.List in header items

### DIFF
--- a/src/components/Header/AvatarMenu.tsx
+++ b/src/components/Header/AvatarMenu.tsx
@@ -75,7 +75,7 @@ export const AvatarMenu = ({
           <Menu.List
             role="menu"
             marginTop="0.375rem"
-            zIndex={10}
+            zIndex="sticky"
             {...menuListProps}
           >
             <Box

--- a/src/components/Header/AvatarMenu.tsx
+++ b/src/components/Header/AvatarMenu.tsx
@@ -72,7 +72,12 @@ export const AvatarMenu = ({
               }
             />
           </AvatarMenuButton>
-          <Menu.List role="menu" marginTop="0.375rem" {...menuListProps}>
+          <Menu.List
+            role="menu"
+            marginTop="0.375rem"
+            zIndex={10}
+            {...menuListProps}
+          >
             <Box
               display="flex"
               alignItems="center"

--- a/src/components/Header/NotificationMenu.tsx
+++ b/src/components/Header/NotificationMenu.tsx
@@ -145,7 +145,7 @@ export const NotificationMenu = ({
             w="22.5rem"
             maxHeight="30rem"
             overflowY="scroll"
-            zIndex={10}
+            zIndex="sticky"
             {...menuListProps}
           >
             {displayAll && allNotificationData ? (

--- a/src/components/Header/NotificationMenu.tsx
+++ b/src/components/Header/NotificationMenu.tsx
@@ -145,6 +145,7 @@ export const NotificationMenu = ({
             w="22.5rem"
             maxHeight="30rem"
             overflowY="scroll"
+            zIndex={10}
             {...menuListProps}
           >
             {displayAll && allNotificationData ? (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `z-index` value is unset for the notifications and avatar menu dropdown, which would cause other items that have a `z-index` value defined greater than 0 to block parts of those dropdown menus.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The `z-index` value for the notification and avatar menu has been set to 10, which is a sufficiently high value to not be covered by any other components.

## Before & After Screenshots

**BEFORE**:

<img width="283" alt="Screenshot 2022-11-03 at 15 36 11" src="https://user-images.githubusercontent.com/27919917/199668074-88627b02-adf1-491c-9b20-7ba2ee8a49e6.png">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="283" alt="Screenshot 2022-11-03 at 15 36 11" src="https://user-images.githubusercontent.com/27919917/199668104-917d61ef-014e-42ef-b8c2-e2b520a88b45.png">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

1. Run `npm run dev` on this branch
2. Open any review request page
3. Verify that the review button no longer blocks the notifications menu and the avatar menu

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*