### PR TITLE
fix: open external links in a new tab

### DIFF
--- a/src/components/CollaboratorModal/components/AcknowledgementSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/AcknowledgementSubmodal.tsx
@@ -72,7 +72,11 @@ export const AcknowledgementSubmodalContent = ({
       <Checkbox {...register("isAcknowledged")}>
         <Text color="text.body" fontSize="16px">
           <Text as="span">I agree to Isomer&lsquo;s</Text>{" "}
-          <Link href={TERMS_OF_USE_LINK} target="_blank">
+          <Link
+            href={TERMS_OF_USE_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Terms of Use
           </Link>
         </Text>

--- a/src/layouts/ReviewRequest/components/PublishedModal/PublishedModal.tsx
+++ b/src/layouts/ReviewRequest/components/PublishedModal/PublishedModal.tsx
@@ -74,6 +74,8 @@ export const PublishedModal = (
             colorScheme="primary"
             textColor="text.title.brandSecondary"
             as={Link}
+            rel="noopener noreferrer"
+            target="_blank"
             href={siteUrl}
             isLoading={isLoading}
           >


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently, the "Go to live site" link in the modal that appears when the user publishes a review request will open in the same tab. This behaviour can be rather annoying to the user as it navigates the user away from the CMS.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Changed the link for the "Go to live site" link in the published modal of review requests to open in a new tab.
- Also added `rel="noopener noreferrer"` for security purposes in this modal and in the collaborators modal.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

1. Run `npm run dev` on this branch
2. Navigate to any approved review request and click on "Publish now"
3. Once the review request is published, the modal will appear. Click on "Go to live site"
4. Verify that the site opens in a new tab.
5. Navigate to the site dashboard of any site
6. Click on "Manage" for site collaborators
7. Add a new collaborator that is whitelisted with an expiry date.
8. Click on the "Terms of Use" link in the acknowledgement modal, verify that the terms of use page opens in a new tab.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*