### PR TITLE
fix(comments): remove hardcoded value

### DIFF
--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -167,7 +167,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
           </VStack>
           <Flex h="100%" w="7.25rem" pt="2rem" justifyContent="end">
             {/* TODO: swap this to a slide out component and not a drawer */}
-            <CommentsDrawer siteName="siteName" requestId={1} />
+            <CommentsDrawer siteName={siteName} requestId={prNumber} />
           </Flex>
         </HStack>
         <Box pl="9.25rem" pr="2rem">

--- a/src/layouts/ReviewRequest/components/Comments/SendCommentForm.tsx
+++ b/src/layouts/ReviewRequest/components/Comments/SendCommentForm.tsx
@@ -81,7 +81,7 @@ export const SendCommentForm = ({
             aria-label="link to send comment"
             type="submit"
             isLoading={formState.isSubmitting}
-            disabled={!formState.isValid}
+            isDisabled={!formState.isValid}
           />
         </HStack>
         <FormErrorMessage>{formState.errors.comment?.message}</FormErrorMessage>


### PR DESCRIPTION
## Problem
This PR removes hardcoded values in comments and there's a corresponding backend commit which swaps router order.

This allows comments to work
## Solution

swap hardcoded values for dynamic values
