### PR TITLE
fix(notificationmenu): update button to get sitename using hook

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -112,7 +112,7 @@ const Header = ({
           </Flex>
         ) : null}
         <HStack flex={1} justifyContent="flex-end">
-          <NotificationMenu siteName={siteName} />
+          <NotificationMenu />
           <Button
             onClick={onOpen}
             variant="outline"

--- a/src/components/Header/NotificationMenu.tsx
+++ b/src/components/Header/NotificationMenu.tsx
@@ -10,6 +10,7 @@ import { Menu, Spinner } from "@opengovsg/design-system-react"
 import { ContextMenuItem } from "components/ContextMenu/ContextMenuItem"
 import { PropsWithChildren, useEffect, useState } from "react"
 import { BiBell, BiDownArrowAlt } from "react-icons/bi"
+import { useParams } from "react-router-dom"
 
 import {
   useGetAllNotifications,
@@ -82,15 +83,8 @@ export const NotificationMenuItem = ({
   )
 }
 
-interface NotificationMenuProps {
-  siteName: string
-  menuListProps?: MenuListProps
-}
-
-export const NotificationMenu = ({
-  siteName,
-  menuListProps,
-}: NotificationMenuProps): JSX.Element => {
+export const NotificationMenu = (props: MenuListProps): JSX.Element => {
+  const { siteName } = useParams<{ siteName: string }>()
   const [displayAll, setDisplayAll] = useState(false)
   const [hasNotification, setHasNotification] = useState(false)
   const {
@@ -146,7 +140,7 @@ export const NotificationMenu = ({
             maxHeight="30rem"
             overflowY="scroll"
             zIndex="sticky"
-            {...menuListProps}
+            {...props}
           >
             {displayAll && allNotificationData ? (
               <>

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -65,7 +65,7 @@ export const SiteEditHeader = (): JSX.Element => {
         </HStack>
         <Spacer />
         <HStack>
-          <NotificationMenu siteName={siteName} />
+          <NotificationMenu />
           <Button
             onClick={onOpen}
             variant="outline"

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -54,7 +54,7 @@ export const SiteViewHeader = (): JSX.Element => {
             </Text>
           </LinkOverlay>
         </LinkBox>
-        <NotificationMenu siteName={siteName} />
+        <NotificationMenu />
         <AvatarMenu name={displayedName} />
       </HStack>
     </Flex>


### PR DESCRIPTION
## Problem
The notification button uses `siteName`, which it obtains as props. this is passed down at present but because we use the notification button in our **legacy** `header` component, the `params` prop is **entirely optional** and there's no guarantee that it exists.

This causes a bug in pages which uses the legacy header, as `siteName` is `undefined`, leading to an erroneous query on the backend. 

## Solution
1. remove `siteName` as a prop of the notification button and use the `useParam` hook to retrieve `siteName`.
    - an alternate solution would be to use the `SiteEditHeader` rather than the legacy `Header` but it's not been tested with legacy pages yet and might have stylistic changes so the above solution was adopted  