### PR TITLE
fix(rr): disable adding admins if user isn't the requestor

### DIFF
--- a/src/contexts/ReviewRequestRoleContext.tsx
+++ b/src/contexts/ReviewRequestRoleContext.tsx
@@ -40,7 +40,7 @@ const getReviewRequestRole = (
 
 export const ReviewRequestRoleProvider = ({
   children,
-}: PropsWithChildren<Record<string, never>>): JSX.Element => {
+}: PropsWithChildren<Record<string, unknown>>): JSX.Element => {
   const { siteName, reviewId } = useParams<{
     siteName: string
     reviewId: string

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -336,6 +336,7 @@ const SecondaryDetails = ({
 }: SecondaryDetailsProps) => {
   const { date, time } = getDateTimeFromUnixTime(reviewRequestedTime.getTime())
   const props = useDisclosure()
+  const { role } = useReviewRequestRoleContext()
   const selectedAdmins = reviewers.map((reviewer) => {
     return {
       value: reviewer,
@@ -384,6 +385,7 @@ const SecondaryDetails = ({
             size="sm"
             ml="-0.25rem"
             bg="blue.50"
+            isDisabled={role !== "requestor"}
             onClick={props.onOpen}
           />
           <ManageReviewerModal

--- a/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.stories.tsx
+++ b/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.stories.tsx
@@ -1,8 +1,12 @@
 import { useDisclosure } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { ComponentMeta, Story } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
 
-import { MOCK_ADMINS } from "mocks/constants"
+import { ReviewRequestRoleProvider } from "contexts/ReviewRequestRoleContext"
+
+import { MOCK_ADMINS, MOCK_REVIEW_REQUEST } from "mocks/constants"
+import { buildReviewRequestData } from "mocks/utils"
 
 import {
   ManageReviewerModal,
@@ -12,6 +16,28 @@ import {
 const modalMeta = {
   title: "Components/ReviewRequest/Manage Reviewer Modal",
   component: ManageReviewerModal,
+  decorators: [
+    (StoryFn) => {
+      return (
+        <MemoryRouter initialEntries={["/sites/storybook/review/1"]}>
+          <Route path="/sites/:siteName/review/:reviewId">
+            <ReviewRequestRoleProvider>
+              <StoryFn />
+            </ReviewRequestRoleProvider>
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+  parameters: {
+    msw: {
+      handlers: {
+        reviewRequests: buildReviewRequestData({
+          reviewRequest: MOCK_REVIEW_REQUEST,
+        }),
+      },
+    },
+  },
 } as ComponentMeta<typeof ManageReviewerModal>
 
 type TemplateProps = Pick<ManageReviewerModalProps, "selectedAdmins" | "admins">

--- a/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
+++ b/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
@@ -16,6 +16,8 @@ import { Controller, FormProvider, useForm } from "react-hook-form"
 import { useParams } from "react-router-dom"
 import Select from "react-select"
 
+import { useReviewRequestRoleContext } from "contexts/ReviewRequestRoleContext"
+
 import { useUpdateReviewRequest } from "hooks/reviewHooks/useUpdateReviewRequest"
 
 import { getAxiosErrorMessage } from "utils/axios"
@@ -41,6 +43,7 @@ export const ManageReviewerModal = ({
   const prNumber = parseInt(reviewId, 10)
   const successToast = useSuccessToast()
   const errorToast = useErrorToast()
+  const { role } = useReviewRequestRoleContext()
 
   const {
     mutateAsync: updateReviewRequest,
@@ -104,6 +107,7 @@ export const ManageReviewerModal = ({
           </Button>
           <Button
             isLoading={isUpdateReviewRequestLoading}
+            isDisabled={role !== "requestor"}
             type="submit"
             onClick={onSubmit}
           >

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -6,7 +6,11 @@ import {
   ResourcePageData,
 } from "types/directory"
 import { NotificationData } from "types/notifications"
-import { EditedItemProps, ReviewRequestStatus } from "types/reviewRequest"
+import {
+  EditedItemProps,
+  ReviewRequestStatus,
+  ReviewRequest,
+} from "types/reviewRequest"
 import { BackendSiteSettings } from "types/settings"
 import {
   CollaboratorsStats,
@@ -437,3 +441,22 @@ export const MOCK_COMMENTS_DATA = [
     isNew: true,
   },
 ]
+
+const MOCK_EDITED_ITEM: EditedItemProps = {
+  type: ["file"],
+  name: "mock item",
+  path: ["some", "path"],
+  url: "isomer.sg",
+  lastEditedBy: "a user",
+  lastEditedTime: Date.now(),
+}
+
+export const MOCK_REVIEW_REQUEST: ReviewRequest = {
+  reviewUrl: "www.google.com",
+  title: "Mock Review Request",
+  status: ReviewRequestStatus.OPEN,
+  requestor: MOCK_USER.email,
+  reviewers: Array(20).fill("mock reviewer"),
+  reviewRequestedTime: Date.now(),
+  changedItems: Array(20).fill(MOCK_EDITED_ITEM),
+}

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -9,6 +9,7 @@ import {
   ResourcePageData,
 } from "types/directory"
 import { NotificationData } from "types/notifications"
+import { ReviewRequest } from "types/reviewRequest"
 import { BackendSiteSettings } from "types/settings"
 import {
   CollaboratorsStats,
@@ -163,3 +164,7 @@ export const buildMarkCommentsAsReadData = apiDataBuilder<CommentData[]>(
   "*/sites/:siteName/review/:requestId/comments/viewedComments",
   "post"
 )
+
+export const buildReviewRequestData = apiDataBuilder<{
+  reviewRequest: ReviewRequest
+}>("*/sites/:siteName/review/:reviewId")


### PR DESCRIPTION
## Problem
currently, users who are not the requestor are able to perform crud operations on the reviewers. This is too permissive and leads to issues wrt stale state.

This PR **disables** this functionality if the user is not the requestor

## Solution
1. get `role` and disable the button(s) accordingly