### PR TITLE
fix: open the Isomer guide in a new tab

### DIFF
--- a/src/components/Header/AllSitesHeader.tsx
+++ b/src/components/Header/AllSitesHeader.tsx
@@ -32,7 +32,7 @@ export const AllSitesHeader = (): JSX.Element => {
       <Spacer />
       <HStack spacing="2rem">
         <LinkBox position="relative">
-          <LinkOverlay as={RouterLink} to="https://guide.isomer.gov.sg/">
+          <LinkOverlay href="https://guide.isomer.gov.sg/" isExternal>
             <Text color="text.link.dark" noOfLines={1}>
               Get help
             </Text>

--- a/src/components/Header/AllSitesHeader.tsx
+++ b/src/components/Header/AllSitesHeader.tsx
@@ -8,7 +8,6 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { AvatarMenu } from "components/Header/AvatarMenu"
-import { Link as RouterLink } from "react-router-dom"
 
 import { useLoginContext } from "contexts/LoginContext"
 

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -48,7 +48,7 @@ export const SiteViewHeader = (): JSX.Element => {
       <Spacer />
       <HStack>
         <LinkBox position="relative">
-          <LinkOverlay as={RouterLink} to="https://guide.isomer.gov.sg/">
+          <LinkOverlay href="https://guide.isomer.gov.sg/" isExternal>
             <Text color="text.link.dark" noOfLines={1}>
               Get help
             </Text>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The current "Get help" link is an external link, but the link is incorrect and does not open in a new tab.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The RouterLink component has been removed as it is an external link and not an internal application link
- The `isExternal` attribute has been applied to open the link in a new tab

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

1. Run `npm run dev` on this branch
2. Navigate to the all sites page, verify that the "Get help" link opens in a new tab
3. Navigate to the site dashboard of any site, verify that the "Get help" link opens in a new tab

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*