### PR TITLE
chore(routeselector): add ability to use markdown

### DIFF
--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -29,7 +29,9 @@ const { REACT_APP_BANNER_MESSAGE: BANNER_MESSAGE } = process.env
 export const RouteSelector = () => (
   <>
     {!!BANNER_MESSAGE && (
-      <Banner variant={BANNER_VARIANT}>{BANNER_MESSAGE}</Banner>
+      <Banner useMarkdown variant={BANNER_VARIANT}>
+        {BANNER_MESSAGE}
+      </Banner>
     )}
     <Switch>
       <RedirectIfLoggedInRoute exact path="/" component={Home} />


### PR DESCRIPTION
## Problem
previously, the banner did not have the ability to use markdown. this is a problem when we want to have external link

## Solution
1. specify `useMarkdown` option