### PR TITLE
chore(collaborators): error messages + parsing

### DIFF
--- a/src/components/CollaboratorModal/components/MainSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/MainSubmodal.tsx
@@ -61,7 +61,7 @@ const CollaboratorListSection = ({ onDelete }: CollaboratorListProps) => {
   const {
     data: collaborators,
     isError,
-  } = CollaboratorHooks.useListCollaboratorsHook(siteName)
+  } = CollaboratorHooks.useListCollaborators(siteName)
   const { isDisabled } = useFormControlContext()
 
   return (

--- a/src/components/Header/ContactModal/ContactVerificationModal.tsx
+++ b/src/components/Header/ContactModal/ContactVerificationModal.tsx
@@ -15,9 +15,10 @@ import { useUpdateContact, useVerifyContact } from "hooks/miscHooks"
 
 import { getAxiosErrorMessage } from "utils/axios"
 
+import { ContactOtpProps } from "types/contact"
 import { useSuccessToast } from "utils"
 
-import { ContactOtpProps, ContactOtpForm } from "./ContactOtpForm"
+import { ContactOtpForm } from "./ContactOtpForm"
 import { ContactProps, ContactSettingsForm } from "./ContactSettingsForm"
 
 interface ContactVerificationModalProps {

--- a/src/hooks/collaboratorHooks/useListCollaboratorsHook.ts
+++ b/src/hooks/collaboratorHooks/useListCollaboratorsHook.ts
@@ -10,7 +10,7 @@ import { Collaborator } from "types/collaborators"
 import { MiddlewareError } from "types/error"
 import { useErrorToast, DEFAULT_RETRY_MSG } from "utils"
 
-export const useListCollaboratorsHook = (
+export const useListCollaborators = (
   siteName: string
 ): UseQueryResult<Collaborator[], AxiosError<MiddlewareError>> => {
   const errorToast = useErrorToast()

--- a/src/hooks/collaboratorHooks/useListCollaboratorsHook.ts
+++ b/src/hooks/collaboratorHooks/useListCollaboratorsHook.ts
@@ -5,10 +5,14 @@ import { LIST_COLLABORATORS_KEY } from "constants/queryKeys"
 
 import useRedirectHook from "hooks/useRedirectHook"
 
+import { getAxiosErrorMessage } from "utils/axios"
+
 import { CollaboratorService } from "services"
 import { Collaborator } from "types/collaborators"
 import { MiddlewareError } from "types/error"
 import { useErrorToast, DEFAULT_RETRY_MSG } from "utils"
+
+const EXCEPTION_ERROR_MESSAGE = `The list of collaborators could not be retrieved. ${DEFAULT_RETRY_MSG}`
 
 export const useListCollaborators = (
   siteName: string
@@ -19,10 +23,7 @@ export const useListCollaborators = (
     [LIST_COLLABORATORS_KEY, siteName],
     () =>
       CollaboratorService.listCollaborators(siteName).then((data) => {
-        return data.collaborators.map(({ SiteMember, ...rest }) => ({
-          ...rest,
-          role: SiteMember.role,
-        }))
+        return data.collaborators
       }),
     {
       onError: (err) => {
@@ -32,7 +33,7 @@ export const useListCollaborators = (
           setRedirectToPage("/sites")
         } else {
           errorToast({
-            description: `The list of collaborators could not be retrieved. ${DEFAULT_RETRY_MSG}`,
+            description: getAxiosErrorMessage(err, EXCEPTION_ERROR_MESSAGE),
           })
         }
       },

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -27,7 +27,7 @@ import { useParams } from "react-router-dom"
 
 import { useReviewRequestRoleContext } from "contexts/ReviewRequestRoleContext"
 
-import { useListCollaboratorsHook } from "hooks/collaboratorHooks"
+import { useListCollaborators } from "hooks/collaboratorHooks"
 import { useUnapproveReviewRequest } from "hooks/reviewHooks"
 import { useApproveReviewRequest } from "hooks/reviewHooks/useApproveReviewRequest"
 import { useGetReviewRequest } from "hooks/reviewHooks/useGetReviewRequest"
@@ -63,7 +63,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
     siteName,
     prNumber
   )
-  const { data: collaborators, isLoading, isError } = useListCollaboratorsHook(
+  const { data: collaborators, isLoading, isError } = useListCollaborators(
     siteName
   )
   const {

--- a/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
@@ -21,7 +21,7 @@ import { useParams } from "react-router-dom"
 
 import { useLoginContext } from "contexts/LoginContext"
 
-import { useListCollaboratorsHook } from "hooks/collaboratorHooks"
+import { useListCollaborators } from "hooks/collaboratorHooks"
 import { useCreateReviewRequest } from "hooks/reviewHooks/useCreateReviewRequest"
 import { useDiff } from "hooks/reviewHooks/useDiff"
 
@@ -43,7 +43,7 @@ export const ReviewRequestModal = (
   const { onClose } = props
   const { siteName } = useParams<{ siteName: string }>()
   const { data: items } = useDiff(siteName)
-  const { data: collaborators } = useListCollaboratorsHook(siteName)
+  const { data: collaborators } = useListCollaborators(siteName)
   const {
     mutateAsync: createReviewRequest,
     isLoading,

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -390,28 +390,25 @@ export const MOCK_COLLABORATORS: Record<string, CollaboratorDto> = {
     id: "1",
     email: "test1@vendor.sg",
     lastLoggedIn: "2022-03-20T07:41:09.661Z",
-    SiteMember: { role: "CONTRIBUTOR" },
+    role: "CONTRIBUTOR",
   },
   CONTRIBUTOR_2: {
     id: "4",
     email: "test4@vendor.sg",
-    githubId: "test4",
     lastLoggedIn: "2022-04-30T07:41:09.661Z",
-    SiteMember: { role: "CONTRIBUTOR" },
+    role: "CONTRIBUTOR",
   },
   ADMIN_1: {
     id: "2",
     email: "test2@test.gov.sg",
-    githubId: "test2",
     lastLoggedIn: "2022-07-30T07:41:09.661Z",
-    SiteMember: { role: "ADMIN" },
+    role: "ADMIN",
   },
   ADMIN_2: {
     id: "3",
     email: "test3@test.gov.sg",
-    githubId: "test3",
     lastLoggedIn: "2022-06-30T07:41:09.661Z",
-    SiteMember: { role: "ADMIN" },
+    role: "ADMIN",
   },
 }
 

--- a/src/types/collaborators.ts
+++ b/src/types/collaborators.ts
@@ -3,12 +3,8 @@ export type SiteMemberRole = "CONTRIBUTOR" | "ADMIN"
 export interface CollaboratorDto {
   id: string
   email: string
-  githubId?: string
   lastLoggedIn: string
-  contactNumber?: number
-  SiteMember: {
-    role: SiteMemberRole
-  }
+  role: SiteMemberRole
 }
 
 // NOTE: Prior to data being given to the UI,

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -14,13 +14,14 @@ const isBackendError = (
 }
 
 export const getAxiosErrorMessage = (
-  error: null | AxiosError<ErrorDto> | AxiosError
+  error: null | AxiosError<ErrorDto> | AxiosError,
+  defaultErrorMessage = DEFAULT_RETRY_MSG
 ): string => {
   if (!error) return ""
 
   if (isBackendError(error)) {
-    return error.response?.data.message || DEFAULT_RETRY_MSG
+    return error.response?.data.message || defaultErrorMessage
   }
 
-  return error.response?.data?.error?.message || DEFAULT_RETRY_MSG
+  return error.response?.data?.error?.message || defaultErrorMessage
 }


### PR DESCRIPTION
to be reviewed alongside BE PR [here](https://github.com/isomerpages/isomercms-backend/pull/568)

## Problem
Previously, list collaborators uses a default error message which is uninformative to the user. this PR changes the error message to be extracted from the error body first, prior to falling back to a default. 

this also removes unused properties from our `CollaboratorsDto` type and shifts the parsing of `SiteMember.role` -> `role` to the backend

## Solution
1. remove unused properties
2. use axios util and update it to allow default msg 
