### PR TITLE
Feat/restrict identity routes

### DIFF
--- a/src/__tests__/RouteSelector.spec.jsx
+++ b/src/__tests__/RouteSelector.spec.jsx
@@ -1,5 +1,6 @@
 import "../tests/TestDecoder.mock"
 import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "react-query"
 import { MemoryRouter } from "react-router-dom"
 import "@testing-library/jest-dom/extend-expect"
 
@@ -142,19 +143,23 @@ jest.mock("layouts/NotFoundPage", () => {
   }
 })
 
+const queryClient = new QueryClient()
+
 // Context mocks
 const LoggedInContextProvider = ({ children }) => {
   const loggedInContextData = {
-    userId: "test-user",
+    userId: "",
     email: "test-email",
     displayedName: "test-user",
     logout: jest.fn(),
   }
 
   return (
-    <LoginContext.Provider value={loggedInContextData}>
-      {children}
-    </LoginContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      <LoginContext.Provider value={loggedInContextData}>
+        {children}
+      </LoginContext.Provider>
+    </QueryClientProvider>
   )
 }
 
@@ -167,9 +172,11 @@ const NotLoggedInContextProvider = ({ children }) => {
   }
 
   return (
-    <LoginContext.Provider value={notLoggedInContextData}>
-      {children}
-    </LoginContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      <LoginContext.Provider value={notLoggedInContextData}>
+        {children}
+      </LoginContext.Provider>
+    </QueryClientProvider>
   )
 }
 

--- a/src/components/Header/NotificationMenu.tsx
+++ b/src/components/Header/NotificationMenu.tsx
@@ -12,6 +12,8 @@ import { PropsWithChildren, useEffect, useState } from "react"
 import { BiBell, BiDownArrowAlt } from "react-icons/bi"
 import { useParams } from "react-router-dom"
 
+import { useLoginContext } from "contexts/LoginContext"
+
 import {
   useGetAllNotifications,
   useGetNotifications,
@@ -84,6 +86,7 @@ export const NotificationMenuItem = ({
 }
 
 export const NotificationMenu = (props: MenuListProps): JSX.Element => {
+  const { userId } = useLoginContext()
   const { siteName } = useParams<{ siteName: string }>()
   const [displayAll, setDisplayAll] = useState(false)
   const [hasNotification, setHasNotification] = useState(false)
@@ -111,7 +114,9 @@ export const NotificationMenu = (props: MenuListProps): JSX.Element => {
         recentNotificationData.some((notification) => !notification.isRead)
       )
   }, [recentNotificationData])
-  return (
+  return userId ? (
+    <></>
+  ) : (
     <Menu autoSelect={false}>
       {({ isOpen }) => (
         <>


### PR DESCRIPTION
## Problem

Currently, github login users are still able to access email login features due to the lack of restrictions on the backend. This PR introduces the relevant restrictions to prevent github login users from receiving notifications, as well as handling the new behaviour of review request status to prevent github users from being locked out from editing their repo. To be reviewed in conjunction with PR #[573](https://github.com/isomerpages/isomercms-backend/pull/573) on the isomercms-backend repo.