### PR TITLE
test(specs assertion): add assertions into spec

### DIFF
--- a/cypress/e2e/editPage.spec.ts
+++ b/cypress/e2e/editPage.spec.ts
@@ -348,7 +348,7 @@ describe("editPage.spec", () => {
       cy.visit(
         `/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM}`
       ).wait(Interceptors.GET)
-      cy.contains("Create category").click()
+      cy.contains("Create category").should("be.visible").click()
       cy.get('input[placeholder="Title"]').type(TEST_CATEGORY)
       cy.contains("Next").click()
 
@@ -358,7 +358,10 @@ describe("editPage.spec", () => {
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM}/resourceCategory/${TEST_CATEGORY_SLUGIFIED}`
       )
-      cy.contains("Create page").click().wait(Interceptors.GET)
+      cy.contains("Create page")
+        .should("be.visible")
+        .click()
+        .wait(Interceptors.GET)
 
       cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE)
       cy.get('input[id="date"]').clear().type(TEST_PAGE_DATE)

--- a/cypress/e2e/resourceCategory.spec.ts
+++ b/cypress/e2e/resourceCategory.spec.ts
@@ -280,7 +280,7 @@ describe("Resource category page", () => {
     cy.clickContextMenuItem("@pageCard", "settings")
 
     cy.get("#layout").select("post")
-    cy.get('input[id="permalink"]').clear().type(TEST_PAGE_PERMALINK)
+    cy.get('input[id="permalink"]').clear().type(TEST_PAGE_PERMALINK).blur()
 
     cy.contains("Save").click().wait(Interceptors.POST)
     cy.contains("Successfully updated page").should("exist")
@@ -309,7 +309,7 @@ describe("Resource category page", () => {
   })
 
   it("Resources category page should allow user to create a new resource page of type link", () => {
-    cy.contains("Create page").click()
+    cy.contains("a", "Create page").should("be.visible").click()
 
     cy.get('input[id="title"]').clear().type(TEST_PAGE_TITLE_LINK)
     cy.get('input[id="date"]').clear().type(TEST_PAGE_DATE)

--- a/cypress/e2e/resources.spec.ts
+++ b/cypress/e2e/resources.spec.ts
@@ -31,7 +31,7 @@ describe("Resources page", () => {
   })
 
   it("Resources page should allow user to create a new resource category", () => {
-    cy.contains("a", "Create category").click()
+    cy.contains("a", "Create category").should("be.visible").click()
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY)
     cy.contains("Next").click()
 
@@ -50,7 +50,7 @@ describe("Resources page", () => {
   })
 
   it("Resources page should not allow user to create a new resource category with invalid name", () => {
-    cy.contains("a", "Create category").click()
+    cy.contains("a", "Create category").should("be.visible").click()
 
     // Disabled button for special characters
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_SPECIAL).blur()
@@ -70,7 +70,7 @@ describe("Resources page", () => {
   })
 
   it("Resources page should allow user to create another new resource category", () => {
-    cy.contains("a", "Create category").click()
+    cy.contains("a", "Create category").should("be.visible").click()
 
     cy.get("input#newDirectoryName").clear().type(TEST_CATEGORY_2)
     cy.contains("Next").click()
@@ -128,7 +128,7 @@ describe("Resources page", () => {
   })
 
   it("Resources page should allow user to navigate into a resource category", () => {
-    cy.contains("a", TEST_CATEGORY).click()
+    cy.contains("a", TEST_CATEGORY).should("be.visible").click()
     cy.url().should(
       "include",
       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}/resourceCategory/${TEST_CATEGORY_SLUGIFIED}`


### PR DESCRIPTION
## Problem
Some specs were flaking due to a lack of assertions (which causes auto retry on the cypress side). This PR adds some assertions to the flakey tests as identified by a run of our e2e tests. 

This PR also adds a `blur` call to the form field to re-trigger FE validation.

## Solution
1. add `should('be.visible')` to force cypress to retry till the dom stabilises
2. add a `blur` call to ensure form validation is retriggered.