### PR TITLE
fix(usegetpagehook): calls `useErrorToast`

### DIFF
--- a/src/hooks/pageHooks/useGetPageHook.jsx
+++ b/src/hooks/pageHooks/useGetPageHook.jsx
@@ -11,7 +11,7 @@ import { DEFAULT_RETRY_MSG } from "utils"
 
 export function useGetPageHook(params, queryParams) {
   const { pageService } = useContext(ServicesContext)
-  const errorToast = useErrorToast
+  const errorToast = useErrorToast()
   return useQuery(
     [PAGE_CONTENT_KEY, { ...params }],
     () => pageService.get(params),


### PR DESCRIPTION
## Problem
we weren't calling the `useErrorToast` function previously, leading to a runtime error. (sidenote, this would've been caught by ts)

## Solution
call the function