### PR TITLE
Fix/frontmatter for link resources

### DIFF
--- a/src/components/PageSettingsModal/PageSettingsSchema.jsx
+++ b/src/components/PageSettingsModal/PageSettingsSchema.jsx
@@ -36,9 +36,8 @@ export const PageSettingsSchema = (existingTitlesArray = []) =>
     permalink: Yup.string().when("layout", (layout, schema) => {
       switch (layout) {
         case "file":
-          return schema
         case "link":
-          return schema.required("Permalink is required")
+          return schema
         default:
           return schema
             .required("Permalink is required")
@@ -73,5 +72,8 @@ export const PageSettingsSchema = (existingTitlesArray = []) =>
       ),
     file_url: Yup.string().when("layout", (layout, schema) =>
       layout === "file" ? schema.required("File url is required") : schema
+    ),
+    external: Yup.string().when("layout", (layout, schema) =>
+      layout === "link" ? schema.required("Link is required") : schema
     ),
   })

--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -55,6 +55,7 @@ interface ResourcePageFrontMatter {
   date: string
   // eslint-disable-next-line camelcase
   file_url?: string
+  external?: string
   description?: string
   image?: string
 }
@@ -172,16 +173,21 @@ export const ResourcePageSettingsModal = ({
         })
         setValue("permalink", "")
       }
-      if (
-        pageData.content.frontMatter.layout === "link" &&
-        pageData.content.frontMatter.permalink
-      ) {
-        // remove https:// from resource pages with external permalinks
-        setValue(
-          "permalink",
-          pageData.content.frontMatter.permalink.replace("https://", "")
-        )
+      if (pageData.content.frontMatter.layout === "link") {
+        if (pageData.content.frontMatter.permalink) {
+          // backwards compatible with previous link files
+          setValue(
+            "external",
+            pageData.content.frontMatter.permalink.replace("https://", "")
+          )
+        } else if (pageData.content.frontMatter.external) {
+          setValue(
+            "external",
+            pageData.content.frontMatter.external.replace("https://", "")
+          )
+        }
         trigger("permalink")
+        trigger("external")
       }
     }
   }, [fileName, pageData, setValue, trigger])
@@ -197,7 +203,8 @@ export const ResourcePageSettingsModal = ({
     if (data.layout === "file") {
       delete processedData.permalink
     } else if (data.layout === "link") {
-      processedData.permalink = `https://${processedData.permalink}`
+      delete processedData.permalink
+      processedData.external = `https://${processedData.external}`
     }
     return onProceed({
       pageData,
@@ -234,6 +241,7 @@ export const ResourcePageSettingsModal = ({
                 isInvalid={!!errors.layout?.message}
                 onChange={() => {
                   trigger("permalink")
+                  trigger("external")
                 }}
               >
                 <Box mb="0.75rem">
@@ -386,7 +394,7 @@ export const ResourcePageSettingsModal = ({
                 </>
               )}
               {watch("layout") === "link" && (
-                <FormControl isRequired isInvalid={!!errors.permalink}>
+                <FormControl isRequired isInvalid={!!errors.external}>
                   <Box mb="0.75rem">
                     <FormLabel mb={0}>Link</FormLabel>
                     <FormLabel.Description color="text.description">
@@ -400,7 +408,7 @@ export const ResourcePageSettingsModal = ({
                       w="100%"
                       id="link"
                       placeholder="www.open.gov.sg"
-                      {...register("permalink", {
+                      {...register("external", {
                         required: true,
                       })}
                     />


### PR DESCRIPTION
This PR adds the external param to the front matter of link resources. Previously, as permalink is used by jekyll to determine the files to build, any permalinks with # or ? would cause a build error with jekyll, which disallows those files. As such, this PR modifies the external link url to use a different unrelated param. To be reviewed in conjunction with 
https://github.com/isomerpages/isomercms-backend/pull/598 on the backend and https://github.com/isomerpages/isomerpages-template/pull/285 on the isomerpages-template repos.