### PR TITLE
feat: add webp to allowed images

### DIFF
--- a/src/components/MediaCreationModal/MediaCreationModal.jsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.jsx
@@ -60,7 +60,7 @@ export const MediaCreationModal = ({
           id="file-upload"
           accept={
             mediaRoom === "images"
-              ? "image/jpeg, image/png, image/gif, image/svg+xml, image/tiff, image/bmp, image/x-icon"
+              ? "image/jpeg, image/png, image/gif, image/svg+xml, image/tiff, image/bmp, image/x-icon, image/webp"
               : "application/pdf"
           }
           hidden

--- a/src/components/MediaCreationModal/MediaCreationModal.jsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.jsx
@@ -7,6 +7,8 @@ import {
 import { useEffect, useRef } from "react"
 import { useForm, FormProvider } from "react-hook-form"
 
+import { ALLOWED_FILE_TYPES, ALLOWED_IMAGE_TYPES } from "constants/media"
+
 import { useErrorToast } from "utils/toasts"
 import { MEDIA_FILE_MAX_SIZE } from "utils/validators"
 
@@ -60,8 +62,12 @@ export const MediaCreationModal = ({
           id="file-upload"
           accept={
             mediaRoom === "images"
-              ? "image/jpeg, image/png, image/gif, image/svg+xml, image/tiff, image/bmp, image/x-icon, image/webp"
-              : "application/pdf"
+              ? ALLOWED_IMAGE_TYPES.map((imgType) => `image/${imgType}`).join(
+                  ", "
+                )
+              : ALLOWED_FILE_TYPES.map(
+                  (fileType) => `application/${fileType}`
+                ).join(", ")
           }
           hidden
         />

--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -12,6 +12,8 @@ import { useEffect } from "react"
 import { useForm, useFormContext } from "react-hook-form"
 import { Link } from "react-router-dom"
 
+import { ALLOWED_FILE_TYPES, ALLOWED_IMAGE_TYPES } from "constants/media"
+
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 import mediaStyles from "styles/isomer-cms/pages/Media.module.scss"
@@ -95,8 +97,12 @@ export const MediaSettingsModal = ({
             <p>
               For {mediaRoom} other than
               {mediaRoom === "images"
-                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'`
-                : ` 'pdf'`}
+                ? ` ${ALLOWED_IMAGE_TYPES.map((imgType) => `'${imgType}'`).join(
+                    ", "
+                  )}`
+                : ` ${ALLOWED_FILE_TYPES.map(
+                    (fileType) => `'${fileType}'`
+                  ).join(", ")}`}
               , please use{" "}
               <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">
                 {" "}

--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -95,7 +95,7 @@ export const MediaSettingsModal = ({
             <p>
               For {mediaRoom} other than
               {mediaRoom === "images"
-                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'`
+                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'`
                 : ` 'pdf'`}
               , please use{" "}
               <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">

--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -38,7 +38,7 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
         if (mediaRoom === "images") {
           return schema.test(
             "Special characters found",
-            "Title must end with one of the following extensions: 'png', 'jpeg', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'",
+            "Title must end with one of the following extensions: 'png', 'jpeg', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'",
             (value) => imagesSuffixRegexTest.test(value)
           )
         }

--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -1,5 +1,7 @@
 import * as Yup from "yup"
 
+import { ALLOWED_FILE_TYPES, ALLOWED_IMAGE_TYPES } from "constants/media"
+
 import {
   imagesSuffixRegexTest,
   filesSuffixRegexTest,
@@ -38,14 +40,18 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
         if (mediaRoom === "images") {
           return schema.test(
             "Special characters found",
-            "Title must end with one of the following extensions: 'png', 'jpeg', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'",
+            `Title must end with one of the following extensions: ${ALLOWED_IMAGE_TYPES.map(
+              (imgType) => `'${imgType}'`
+            ).join(", ")}`,
             (value) => imagesSuffixRegexTest.test(value)
           )
         }
         if (mediaRoom === "files") {
           return schema.test(
             "Special characters found",
-            "Title must end with the following extensions: 'pdf'",
+            `Title must end with the following extensions: ${ALLOWED_FILE_TYPES.map(
+              (fileType) => `'${fileType}'`
+            ).join(", ")}`,
             (value) => filesSuffixRegexTest.test(value)
           )
         }

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -9,6 +9,8 @@ import { useState, useEffect } from "react"
 import { useFormContext } from "react-hook-form"
 import { Link, useRouteMatch } from "react-router-dom"
 
+import { ALLOWED_FILE_TYPES, ALLOWED_IMAGE_TYPES } from "constants/media"
+
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 import mediaStyles from "styles/isomer-cms/pages/Media.module.scss"
@@ -89,8 +91,12 @@ const MediasSelectModal = ({
           <p>
             For {mediaRoom} other than
             {mediaRoom === "images"
-              ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'`
-              : ` 'pdf'`}
+              ? ` ${ALLOWED_IMAGE_TYPES.map((imgType) => `'${imgType}'`).join(
+                  ", "
+                )}`
+              : ` ${ALLOWED_FILE_TYPES.map((fileType) => `'${fileType}'`).join(
+                  ", "
+                )}`}
             , please use
             <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">
               https://go.gov.sg

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -89,7 +89,7 @@ const MediasSelectModal = ({
           <p>
             For {mediaRoom} other than
             {mediaRoom === "images"
-              ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'`
+              ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'`
               : ` 'pdf'`}
             , please use
             <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">

--- a/src/constants/media.ts
+++ b/src/constants/media.ts
@@ -1,0 +1,11 @@
+export const ALLOWED_IMAGE_TYPES = [
+  "png",
+  "jpg",
+  "gif",
+  "tif",
+  "bmp",
+  "ico",
+  "svg",
+  "webp",
+]
+export const ALLOWED_FILE_TYPES = ["pdf"]

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -4,6 +4,8 @@ import _ from "lodash"
 import { BiBulb, BiUpload } from "react-icons/bi"
 import { Link, Switch, useRouteMatch, useHistory } from "react-router-dom"
 
+import { ALLOWED_FILE_TYPES, ALLOWED_IMAGE_TYPES } from "constants/media"
+
 import { useGetMediaFolders } from "hooks/directoryHooks"
 
 import { DeleteWarningScreen } from "layouts/screens/DeleteWarningScreen"
@@ -122,8 +124,12 @@ export const Media = (): JSX.Element => {
               <br />
               For {pluralMediaLabel} other than
               {mediaType === "images"
-                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'`
-                : ` 'pdf'`}
+                ? ` ${ALLOWED_IMAGE_TYPES.map((imgType) => `'${imgType}'`).join(
+                    ", "
+                  )}`
+                : ` ${ALLOWED_FILE_TYPES.map(
+                    (fileType) => `'${fileType}'`
+                  ).join(", ")}`}
               , please use
               <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">
                 {" "}

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -122,7 +122,7 @@ export const Media = (): JSX.Element => {
               <br />
               For {pluralMediaLabel} other than
               {mediaType === "images"
-                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'`
+                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg', 'webp'`
                 : ` 'pdf'`}
               , please use
               <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -48,7 +48,7 @@ export const slugifyLowerFalseRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 export const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX)
 export const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 export const mediaSpecialCharactersRegexTest = /[~%^?*+#./\\`;~{}[\]"<>]/
-export const imagesSuffixRegexTest = /^.+\.(svg|jpg|jpeg|png|gif|tif|bmp|ico)$/
+export const imagesSuffixRegexTest = /^.+\.(svg|jpg|jpeg|png|gif|tif|bmp|ico|webp)$/
 export const filesSuffixRegexTest = /^.+\.(pdf)$/
 
 const ISOMER_TEMPLATE_PROTECTED_DIRS = [


### PR DESCRIPTION
This PR adds webp to the list of allowable image types in Isomer. To be reviewed in conjunction with PR[#623](https://github.com/isomerpages/isomercms-backend/pull/623) on the isomercms-backend repo.