### PR TITLE
Fix: remove . when no file extension

### DIFF
--- a/src/components/MediaCreationModal/MediaCreationModal.jsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.jsx
@@ -23,7 +23,7 @@ export const MediaCreationModal = ({
   const inputFile = useRef(null)
   const errorToast = useErrorToast()
 
-  const existingTitlesArray = mediasData.map((item) => item.name)
+  const existingTitlesArray = mediasData.map((item) => getFileName(item.name))
   const [fileExt, setFileExt] = useState("")
 
   const methods = useForm({

--- a/src/components/MediaCreationModal/MediaCreationModal.jsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.jsx
@@ -4,11 +4,13 @@ import {
   MediaSettingsSchema,
   MediaSettingsModal,
 } from "components/MediaSettingsModal"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useForm, FormProvider } from "react-hook-form"
 
 import { useErrorToast } from "utils/toasts"
 import { MEDIA_FILE_MAX_SIZE } from "utils/validators"
+
+import { getFileExt, getFileName } from "utils"
 
 // eslint-disable-next-line import/prefer-default-export
 export const MediaCreationModal = ({
@@ -22,6 +24,7 @@ export const MediaCreationModal = ({
   const errorToast = useErrorToast()
 
   const existingTitlesArray = mediasData.map((item) => item.name)
+  const [fileExt, setFileExt] = useState("")
 
   const methods = useForm({
     mode: "onTouched",
@@ -38,7 +41,9 @@ export const MediaCreationModal = ({
       })
     } else {
       mediaReader.onload = () => {
-        methods.setValue("name", media.name)
+        const fileName = getFileName(media.name)
+        setFileExt(getFileExt(media.name))
+        methods.setValue("name", fileName)
         methods.setValue("content", mediaReader.result)
       }
       mediaReader.readAsDataURL(media)
@@ -68,7 +73,14 @@ export const MediaCreationModal = ({
         <MediaSettingsModal
           params={params}
           mediasData={mediasData}
-          onProceed={onProceed}
+          onProceed={(submissionData) => {
+            return onProceed({
+              data: {
+                ...submissionData.data,
+                name: `${submissionData.data.name}.${fileExt}`,
+              },
+            })
+          }}
           mediaRoom={mediaRoom}
           onClose={onClose}
           toggleUploadInput={() => inputFile.current.click()}

--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -64,6 +64,7 @@ export const MediaSettingsModal = ({
       context: { mediaRoom, isCreate },
     })
 
+  // fileExt is blank for newly created files - mediaData is undefined for the create flow
   const fileExt = getFileExt(mediaData?.name || "")
 
   /** ******************************** */
@@ -86,6 +87,7 @@ export const MediaSettingsModal = ({
     return onProceed({
       data: {
         ...rest,
+        // Period is appended only if fileExt exists, otherwise MediaCreationModal handles the period and extension appending
         name: `${name}${fileExt ? `.${fileExt}` : ""}`,
       },
     })

--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -86,7 +86,7 @@ export const MediaSettingsModal = ({
     return onProceed({
       data: {
         ...rest,
-        name: `${name}.${fileExt}`,
+        name: `${name}${fileExt ? `.${fileExt}` : ""}`,
       },
     })
   }

--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -1,8 +1,6 @@
 import * as Yup from "yup"
 
 import {
-  imagesSuffixRegexTest,
-  filesSuffixRegexTest,
   mediaSpecialCharactersRegexTest,
   MEDIA_SETTINGS_TITLE_MIN_LENGTH,
   MEDIA_SETTINGS_TITLE_MAX_LENGTH,
@@ -40,29 +38,15 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
       )
       // When this is called, mediaRoom is one of either images or files
       .when(["$mediaRoom", "$isCreate"], (mediaRoom, isCreate, schema) => {
-        if (isCreate && mediaRoom === "images") {
-          return schema.test(
-            "Special characters found",
-            "Title must end with one of the following extensions: 'png', 'jpeg', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'",
-            (value) => imagesSuffixRegexTest.test(value)
-          )
-        }
-        if (isCreate && mediaRoom === "files") {
-          return schema.test(
-            "Special characters found",
-            "Title must end with the following extensions: 'pdf'",
-            (value) => filesSuffixRegexTest.test(value)
-          )
-        }
-
         return schema.test(
           "Invalid case",
           "This is an invalid value for the mediaRoom type!",
           () => mediaRoom === "files" || mediaRoom === "images"
         )
       })
+      .lowercase()
       .notOneOf(
-        existingTitlesArray,
+        existingTitlesArray.map((title) => title.toLowerCase()),
         "Title is already in use. Please choose a different title."
       ),
   })

--- a/src/layouts/screens/MediaSettingsScreen.jsx
+++ b/src/layouts/screens/MediaSettingsScreen.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types"
 import { useGetMediaFolders } from "hooks/directoryHooks"
 import { useGetMediaHook, useUpdateMediaHook } from "hooks/mediaHooks"
 
+import { getFileName } from "utils"
+
 export const MediaSettingsScreen = ({ match, onClose }) => {
   const { params, decodedParams } = match
   const { data: mediaData } = useGetMediaHook(params)
@@ -17,7 +19,10 @@ export const MediaSettingsScreen = ({ match, onClose }) => {
       params={decodedParams}
       onClose={onClose}
       mediaData={mediaData}
-      mediasData={mediasData}
+      mediasData={mediasData.map(({ name, ...rest }) => ({
+        name: getFileName(name),
+        ...rest,
+      }))}
       onProceed={updateHandler}
     />
   )


### PR DESCRIPTION
This PR fixes an issue where newly created files were unable to be uploaded. This issue was due to the shared create/update media modal - we recently disallowed the changing of extension on renaming of existing images, by automatically appending  the extension to the filename of the existing file. However, for newly added items, they had no such extension, and this caused the uploaded file to have `.` appended to it. This PR fixes this behaviour for the creation flow.

This PR also restricts the renaming of newly uploaded images to prevent users from modifying their extension, and changes our duplicate filename check to be case insensitive.