### PR TITLE
style: remove fixed widths in sites dashboard

### DIFF
--- a/src/styles/isomer-cms/pages/Sites.module.scss
+++ b/src/styles/isomer-cms/pages/Sites.module.scss
@@ -1,8 +1,6 @@
 @import "../elements/variable";
 
 @mixin single-site {
-  margin-left: $site-margin-horizontal;
-  margin-right: $site-margin-horizontal;
   margin-top: $site-margin-vertical;
   margin-bottom: $site-margin-vertical;
   height: $site-height;
@@ -12,16 +10,20 @@
 
 .sitesContainer {
   width: 100%;
+  max-width: $sites-container-width;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   margin-top: 30px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
 
   .sectionHeader {
-    width: $sites-container-width;
-    margin-left: $site-margin-horizontal * 2;
+
 
     .sectionTitle {
       font-size: 28px;
@@ -32,22 +34,21 @@
 
   .sites {
     display: flex;
-    flex-direction: rows;
+    flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;
     flex-wrap: wrap;
-    width: $sites-container-width;
+    column-gap: 32px;
 
     .infoText {
       margin-top: $site-margin-vertical;
-      margin-left: $site-margin-horizontal;
     }
 
     .siteContainer {
       // width: 33.33%;
       box-sizing: border-box;
       display: flex;
-      flex-direction: rows;
+      flex-direction: row;
       justify-content: center;
       align-items: center;
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Content in sites dashboard gets hidden when window resizes:

https://user-images.githubusercontent.com/29480346/219262891-ebfe6312-61dc-4e15-afd1-d59e846cae7a.mov

This is because the page containers (`.sectionHeader` and `.sites`) have a fixed width.

## Solution

1. Change invalid CSS `flex-direction: rows` to `flex-direction: row`; this is the CSS default so this doesn't change any behaviour
2. Instead of using `margin-left` and `margin-right` on individual `site` cards, use the [widely supported](https://caniuse.com/mdn-css_properties_column-gap_flex_context) `column-gap` to fix spacing between cards
3. Centre `.sitesContainer` using `auto` margins and give it a `max-width` so it doesn't grow too wide on bigger screens
4. Add some padding to `.sitesContainer` so it doesn't bump against the edge of the screen when window is resized

Screen recording below is already approved by @NatMaeTan:

https://user-images.githubusercontent.com/29480346/219264672-c00f4b34-614e-4efb-973f-aa1a69099ea9.mov
