### PR TITLE
feat: adding gitguardian precommit hook

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -14,3 +14,6 @@ export CYPRESS_TEST_REPO_NAME=''
 export E2E_COMMIT_HASH=bcfe46da1288b3302c5bb5f72c5c58b50574f26c
 export PERSONAL_ACCESS_TOKEN=''
 export USERNAME=''
+
+# GitGuardian
+export GITGUARDIAN_API_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .env.production.local
 .vscode
 .idea
+.cache_ggshield
 
 npm-debug.log*
 yarn-debug.log*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+source .env && ggshield secret scan pre-commit

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ npm install
 npm run start
 ```
 
+### Setting up GitGuardian
+
+To setup, follow these instructions:
+
+1. Install GitGuardian
+
+```
+brew install gitguardian/tap/ggshield
+```
+
+2. Add the API Key to your `.env` file
+
+```
+# Service API key from GitGuardian account
+export GITGUARDIAN_API_KEY=abc123
+```
+
+Notes:
+
+Only if necessary,
+
+- To skip all pre-commit hooks, use `$ git commit -m "commit message" -n`
+- To skip only GitGuardian’s hook, use `$ SKIP=ggshield git commit -m "commit message"`
+
 ### Running end-to-end tests using Cypress
 
 Add the following Cypress environment variables:
@@ -43,8 +67,11 @@ npm run cypress:open
 ```
 
 ### Release
+
 Run the following on the release branch to tag and push changes automatically:
+
 ```
 npm run release --isomer_update=<versionType>
 ```
+
 where versionType corresponds to npm version types. This only works on non-Windows platforms, for Windows, modify the release script to use %npm_config_update% instead of $npm_config_update.


### PR DESCRIPTION
## Problem

While we do have checks post-commit to identify any secrets are committed, we should also attempt to prevent this even before a commit can occur.

After considering some solutions - https://github.com/awslabs/git-secrets and Git Guardian, we decided to go with GitGuardian since we are already using it.

## Solution

We add Git Guardian as a pre-commit hook which scans commits for any leaked secrets before actually performing the commit.

**Breaking Changes**

There is a breaking change for local development since this commit makes Git Guardian setup somewhat mandatory.

- [x] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**New dev dependencies**:

No new dependencies are added to our package. Git Guardian will be installed on the OS-level instead as a brew package.