### PR TITLE
chore(permalinks): change permalink to lowercase

### DIFF
--- a/src/__tests__/utils.jsx
+++ b/src/__tests__/utils.jsx
@@ -63,7 +63,7 @@ describe("Utils test", () => {
         resourceRoomName,
         resourceCategoryName,
       }
-      const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`
+      const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`.toLowerCase()
 
       expect(getDefaultFrontMatter(params, [])).toMatchObject({
         title: exampleTitle,
@@ -79,7 +79,7 @@ describe("Utils test", () => {
         resourceCategoryName,
       }
       const exampleResourceTitle = `${exampleDate}-${exampleLayout}-${exampleTitle}`
-      const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`
+      const examplePermalink = `/${resourceRoomName}/${resourceCategoryName}/permalink`.toLowerCase()
 
       expect(
         getDefaultFrontMatter(params, [

--- a/src/components/PageSettingsModal/PageSettingsSchema.jsx
+++ b/src/components/PageSettingsModal/PageSettingsSchema.jsx
@@ -53,6 +53,9 @@ export const PageSettingsSchema = (existingTitlesArray = []) =>
               permalinkRegexTest,
               "Permalink should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only"
             )
+            .test("is-lowercase", "Permalink must be lowercase", (value) => {
+              return value === value.toLowerCase()
+            })
       }
     }),
     layout: Yup.string().oneOf(["file", "post", "link"]),

--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -107,7 +107,7 @@ const generateDefaultFrontMatter = (
   const resourceCategoryPermalink = slugify(resourceCategoryName)
     ? `${slugify(resourceCategoryName)}`
     : "unrecognised/"
-  const examplePermalink = `/${resourceRoomPermalink}/${resourceCategoryPermalink}/permalink`
+  const examplePermalink = `/${resourceRoomPermalink}/${resourceCategoryPermalink}/permalink`.toLowerCase()
   return {
     title: exampleTitle,
     permalink: examplePermalink,

--- a/src/utils/legacy.js
+++ b/src/utils/legacy.js
@@ -436,6 +436,7 @@ export const getDefaultFrontMatter = (params, existingTitles) => {
     }`
   }
   examplePermalink += `permalink`
+  examplePermalink = examplePermalink.toLowerCase()
   if (!resourceRoomName)
     return {
       title: exampleTitle,


### PR DESCRIPTION
## Problem

Currently, netlify links are lower casing. [To move towards Amplify infra](https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9baff55ef4aebbe9f472fadf5a096?pvs=4), and ensure backward compatibility, all permalinks are going to be lower cased. 

Closes #1188 

## Solution

Change permalink to lower casing. 

**Breaking Changes**


- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ X ] No - this PR is backwards compatible

## Tests

<!-- What tests should be run to confirm functionality? -->

Permalinks for pages are now only lower casing. Typing capital casing throws an error.
Previously, creating new pages within folders with CAPS has a default link in CAPS. This is no longer the case. 
Similar behaviour is observed when creating resource pages of type POST Content. 

