### PR TITLE
Fix/remove sensitive data from local storage

### DIFF
--- a/src/components/Header/ContactModal/ContactVerificationModal.tsx
+++ b/src/components/Header/ContactModal/ContactVerificationModal.tsx
@@ -38,7 +38,7 @@ export const ContactVerificationModal = ({
     error: verifyError,
   } = useVerifyContact()
 
-  const { verifyLoginAndSetLocalStorage } = useLoginContext()
+  const { verifyLoginAndGetUserDetails } = useLoginContext()
 
   const [mobile, setMobile] = useState<string>("")
 
@@ -56,7 +56,7 @@ export const ContactVerificationModal = ({
     successToast({
       description: `Successfully changed contact number to ${mobile}!`,
     })
-    verifyLoginAndSetLocalStorage()
+    verifyLoginAndGetUserDetails()
   }
 
   return (

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -25,7 +25,7 @@ const VerifyUserDetailsModal = () => {
   const {
     email: loggedInEmail,
     contactNumber: loggedInContactNumber,
-    verifyLoginAndSetLocalStorage,
+    verifyLoginAndGetUserDetails,
     displayedName,
   } = useContext(LoginContext)
   const { setRedirectToLogout } = useRedirectHook()
@@ -104,7 +104,7 @@ const VerifyUserDetailsModal = () => {
       setMobileNumber("")
       setOtp("")
 
-      await verifyLoginAndSetLocalStorage()
+      await verifyLoginAndGetUserDetails()
     } catch (err) {
       setError("Invalid OTP. Failed to verify OTP.")
     } finally {

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,6 +1,3 @@
 export enum LOCAL_STORAGE_KEYS {
-  GithubId = "userId",
-  User = "user",
   SitesIsPrivate = "sites-is-private",
-  Email = "email",
 }

--- a/src/contexts/LoginContext.tsx
+++ b/src/contexts/LoginContext.tsx
@@ -18,7 +18,7 @@ const { REACT_APP_BACKEND_URL_V2: BACKEND_URL } = process.env
 
 interface LoginContextProps extends LoggedInUser {
   logout: () => Promise<void>
-  verifyLoginAndSetLocalStorage: () => Promise<void>
+  verifyLoginAndGetUserDetails: () => Promise<void>
 }
 
 const LoginContext = createContext<null | LoginContextProps>(null)
@@ -41,7 +41,7 @@ const LoginProvider = ({
   const [storedUserId, setStoredUserId] = useState("")
   const [storedUserContact, setStoredUserContact] = useState("")
   const [storedUserEmail, setStoredUserEmail] = useState("")
-  const verifyLoginAndSetLocalStorage = useCallback(async () => {
+  const verifyLoginAndGetUserDetails = useCallback(async () => {
     const { data: loggedInUser } = await axios.get<LoggedInUser>(
       `${BACKEND_URL}/auth/whoami`
     )
@@ -73,7 +73,7 @@ const LoginProvider = ({
   )
 
   useEffect(() => {
-    verifyLoginAndSetLocalStorage()
+    verifyLoginAndGetUserDetails()
     // Dependency array must be empty here - the pointer to the verify callback method doesn't seem to be stable so this useEffect would be called repeatedly
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // Run only once
@@ -83,7 +83,7 @@ const LoginProvider = ({
     email: storedUserEmail,
     contactNumber: storedUserContact,
     logout,
-    verifyLoginAndSetLocalStorage,
+    verifyLoginAndGetUserDetails,
     displayedName: `${storedUserId ? "@" : ""}${
       storedUserId || storedUserEmail
     }`,

--- a/src/hooks/loginHooks/useVerifyOtp.ts
+++ b/src/hooks/loginHooks/useVerifyOtp.ts
@@ -12,11 +12,11 @@ export const useVerifyOtp = (): UseMutationResult<
   AxiosError,
   VerifyOtpParams
 > => {
-  const { verifyLoginAndSetLocalStorage } = useLoginContext()
+  const { verifyLoginAndGetUserDetails } = useLoginContext()
   return useMutation<void, AxiosError, VerifyOtpParams>(
     (body) => LoginService.verifyLoginOtp(body),
     {
-      onSuccess: verifyLoginAndSetLocalStorage,
+      onSuccess: verifyLoginAndGetUserDetails,
     }
   )
 }


### PR DESCRIPTION
## Problem

This PR removes the sensitive data (email and phone number) stored in our local storage on the frontend. Instead of retrieving this information from local storage, we now query our backend directly, as this is not an expensive operation.