### PR TITLE
fix(navBar): API change

### DIFF
--- a/src/components/navbar/NavSection.jsx
+++ b/src/components/navbar/NavSection.jsx
@@ -179,7 +179,7 @@ const NavSection = ({
   const [newSectionType, setNewSectionType] = useState()
   const selectInputRef = useRef()
   const sectionCreationHandler = () => {
-    selectInputRef.current.select.clearValue()
+    selectInputRef.current.clearValue()
     const event = {
       target: {
         id: `link-create`,


### PR DESCRIPTION
## Problem

Nav Bar wasnt allowing for adding folders/submenus etc.

Closes IS-61

## Solution

`selectInputRef.current.select` was undefined. Not too sure when the API changed, but looking at the [docs](https://react-select.com/props), suggest that `clearValue` should be used, rather than `select.clearValue`

## Tests 
Should be able to create Folders , submenus and single pages properly now. 
