### PR TITLE
Feat/ga4

### DIFF
--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -28,6 +28,7 @@ describe("Settings page", () => {
   const IMAGE_DIR = "/images/"
   const TEST_FACEBOOK_PIXEL_ID = "12345"
   const TEST_GOOGLE_ANALYTICS_ID = "UA-39345131-3"
+  const TEST_GOOGLE_ANALYTICS_GA4_ID = "GA-12345"
   const TEST_LINKEDIN_INSIGHTS_ID = "1234567"
   const TEST_SECONDARY_COLOR = [0, 255, 0] // ([R, G, B])
   const TEST_FACEBOOK_LINK = "https://www.facebook.com/testfb"
@@ -278,6 +279,10 @@ describe("Settings page", () => {
       .next()
       .as("ga")
       .type(TEST_GOOGLE_ANALYTICS_ID)
+    cy.contains("label", "Google Analytics")
+      .next()
+      .as("ga4")
+      .type(TEST_GOOGLE_ANALYTICS_GA4_ID)
     cy.contains("label", "LinkedIn Insights")
       .next()
       .as("insights")
@@ -289,6 +294,7 @@ describe("Settings page", () => {
     // Assert
     cy.get("@pixel").should("have.value", TEST_FACEBOOK_PIXEL_ID)
     cy.get("@ga").should("have.value", TEST_GOOGLE_ANALYTICS_ID)
+    cy.get("@ga4").should("have.value", TEST_GOOGLE_ANALYTICS_GA4_ID)
     cy.get("@insights").should("have.value", TEST_LINKEDIN_INSIGHTS_ID)
   })
 

--- a/src/components/Header/AllSitesHeader.tsx
+++ b/src/components/Header/AllSitesHeader.tsx
@@ -9,6 +9,8 @@ import {
 } from "@chakra-ui/react"
 import { AvatarMenu } from "components/Header/AvatarMenu"
 
+import { ISOMER_GUIDE_LINK } from "constants/config"
+
 import { useLoginContext } from "contexts/LoginContext"
 
 export const AllSitesHeader = (): JSX.Element => {
@@ -31,7 +33,7 @@ export const AllSitesHeader = (): JSX.Element => {
       <Spacer />
       <HStack spacing="2rem">
         <LinkBox position="relative">
-          <LinkOverlay href="https://guide.isomer.gov.sg/" isExternal>
+          <LinkOverlay href={ISOMER_GUIDE_LINK} isExternal>
             <Text
               color="text.link.dark"
               noOfLines={1}

--- a/src/components/VerifyUserDetailsModal.jsx
+++ b/src/components/VerifyUserDetailsModal.jsx
@@ -2,6 +2,8 @@ import { Link } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { useContext, useEffect, useState } from "react"
 
+import { IDENTITY_GUIDE_LINK } from "constants/config"
+
 import {
   getEmailOtp,
   verifyEmailOtp,
@@ -190,7 +192,7 @@ const VerifyUserDetailsModal = () => {
               all users of Isomer CMS. Only <b>.gov.sg</b> or{" "}
               <b>whitelisted email addresses</b> will be accepted. You must
               verify your email before proceeding.{" "}
-              <Link isExternal href="https://go.gov.sg/isomer-identity">
+              <Link isExternal href={IDENTITY_GUIDE_LINK}>
                 Read more.
               </Link>
             </div>

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,10 @@
+export const ANALYTICS_SETUP_LINK =
+  "https://guide.isomer.gov.sg/analytics-and-tracking/google-analytics"
+export const GA_DEPRECATION_LINK =
+  "https://support.google.com/analytics/answer/11583528?hl=en"
+export const TERMS_OF_USE_LINK =
+  "https://guide.isomer.gov.sg/terms-and-privacy/terms-of-use"
+export const PRIVACY_POLICY_LINK =
+  "https://guide.isomer.gov.sg/terms-and-privacy/privacy-statement"
+export const ISOMER_GUIDE_LINK = "https://guide.isomer.gov.sg/"
+export const IDENTITY_GUIDE_LINK = "https://go.gov.sg/isomer-identity"

--- a/src/hooks/settingsHooks/constants.ts
+++ b/src/hooks/settingsHooks/constants.ts
@@ -12,6 +12,7 @@ export const BE_TO_FE: {
   favicon: "favicon",
   facebook_pixel: "pixel",
   google_analytics: "ga",
+  google_analytics_ga4: "ga4",
   linkedin_insights: "insights",
   is_government: "displayGovMasthead",
   colors: "colours",

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -22,6 +22,7 @@ const DEFAULT_BE_STATE = {
   shareicon: "/images/isomer-logo.svg",
   facebook_pixel: "",
   google_analytics: "",
+  google_analytics_ga4: "",
   linkedin_insights: "",
   is_government: false,
   contact_us: "",

--- a/src/layouts/Login/LoginPage.tsx
+++ b/src/layouts/Login/LoginPage.tsx
@@ -23,6 +23,8 @@ import {
 import { useState, PropsWithChildren } from "react"
 import { useHistory } from "react-router-dom"
 
+import { PRIVACY_POLICY_LINK, TERMS_OF_USE_LINK } from "constants/config"
+
 import { useLogin, useVerifyOtp } from "hooks/loginHooks"
 
 import { getAxiosErrorMessage } from "utils/axios"
@@ -150,17 +152,11 @@ const LoginContent = (): JSX.Element => {
           </TabPanel>
           <Text color="text.helper" fontSize="0.625rem" pt="2rem">
             By clicking ‘Log in’, you are acknowledging and agreeing to Isomer’s{" "}
-            <Link
-              href="https://guide.isomer.gov.sg/terms-and-privacy/terms-of-use"
-              isExternal
-            >
+            <Link href={TERMS_OF_USE_LINK} isExternal>
               Terms of Use
             </Link>
             {" and our "}
-            <Link
-              href="https://guide.isomer.gov.sg/terms-and-privacy/privacy-statement"
-              isExternal
-            >
+            <Link href={PRIVACY_POLICY_LINK} isExternal>
               Privacy policy
             </Link>
           </Text>

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -19,7 +19,7 @@ export const AnalyticsSettings = ({
     <Section id="analytics-fields">
       <VStack align="flex-start" spacing="0.5rem">
         <SectionHeader label="Analytics" />
-        <SectionCaption label="" icon={BiInfoCircle}>
+        <SectionCaption icon={BiInfoCircle}>
           For Analytics set up, refer to our guide{" "}
           <Link href={ANALYTICS_SETUP_LINK} isExternal>
             here
@@ -34,7 +34,7 @@ export const AnalyticsSettings = ({
 
         <FormControl isDisabled={isError}>
           <FormLabel>Google Analytics (UA)</FormLabel>
-          <SectionCaption label="" icon={BiInfoCircle}>
+          <SectionCaption icon={BiInfoCircle}>
             This field will be removed following the deprecation of Universal
             Analytics on 1 July 2023.{" "}
             <Link href={GA_DEPRECATION_LINK} isExternal>

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -34,8 +34,23 @@ export const AnalyticsSettings = ({
         </FormControl>
 
         <FormControl isDisabled={isError}>
-          <FormLabel>Google Analytics</FormLabel>
-          <Input w="100%" {...register("ga")} />
+          <FormLabel>Google Analytics (UA)</FormLabel>
+          <SectionCaption label="" icon={BiInfoCircle}>
+            This field will be removed following the deprecation of Universal
+            Analytics on 1 July 2023.{" "}
+            <Link
+              href="https://support.google.com/analytics/answer/11583528?hl=en"
+              isExternal
+            >
+              Read more
+            </Link>
+          </SectionCaption>
+          <Input isDisabled w="100%" {...register("ga")} />
+        </FormControl>
+
+        <FormControl isDisabled={isError}>
+          <FormLabel>Google Analytics (GA4)</FormLabel>
+          <Input w="100%" {...register("ga4")} />
         </FormControl>
 
         <FormControl isDisabled={isError}>

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -3,6 +3,8 @@ import { FormLabel, Input } from "@opengovsg/design-system-react"
 import { useFormContext } from "react-hook-form"
 import { BiInfoCircle } from "react-icons/bi"
 
+import { ANALYTICS_SETUP_LINK, GA_DEPRECATION_LINK } from "constants/config"
+
 import { Section, SectionHeader, SectionCaption } from "layouts/components"
 
 interface AnalyticsSettingsProp {
@@ -19,10 +21,7 @@ export const AnalyticsSettings = ({
         <SectionHeader label="Analytics" />
         <SectionCaption label="" icon={BiInfoCircle}>
           For Analytics set up, refer to our guide{" "}
-          <Link
-            href="https://guide.isomer.gov.sg/analytics-and-tracking/google-analytics"
-            isExternal
-          >
+          <Link href={ANALYTICS_SETUP_LINK} isExternal>
             here
           </Link>
         </SectionCaption>
@@ -38,10 +37,7 @@ export const AnalyticsSettings = ({
           <SectionCaption label="" icon={BiInfoCircle}>
             This field will be removed following the deprecation of Universal
             Analytics on 1 July 2023.{" "}
-            <Link
-              href="https://support.google.com/analytics/answer/11583528?hl=en"
-              isExternal
-            >
+            <Link href={GA_DEPRECATION_LINK} isExternal>
               Read more
             </Link>
           </SectionCaption>

--- a/src/layouts/components/Section/SectionCaption.tsx
+++ b/src/layouts/components/Section/SectionCaption.tsx
@@ -2,7 +2,7 @@ import { TextProps, Text, Icon, HStack } from "@chakra-ui/react"
 
 interface SectionCaptionProps extends TextProps {
   icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element
-  label: string
+  label?: string
 }
 // eslint-disable-next-line import/prefer-default-export
 export const SectionCaption = ({

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -13,6 +13,8 @@ import { NotificationMenu } from "components/Header/NotificationMenu"
 import { BiArrowBack } from "react-icons/bi"
 import { Link as RouterLink, useLocation, useParams } from "react-router-dom"
 
+import { ISOMER_GUIDE_LINK } from "constants/config"
+
 import { useLoginContext } from "contexts/LoginContext"
 
 export const SiteViewHeader = (): JSX.Element => {
@@ -48,7 +50,7 @@ export const SiteViewHeader = (): JSX.Element => {
       <Spacer />
       <HStack>
         <LinkBox position="relative">
-          <LinkOverlay href="https://guide.isomer.gov.sg/" isExternal>
+          <LinkOverlay href={ISOMER_GUIDE_LINK} isExternal>
             <Text
               color="text.link.dark"
               noOfLines={1}

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -158,6 +158,7 @@ export const MOCK_BE_SETTINGS: BackendSiteSettings = {
   // NOTE: No shareicon/logo/favicon as no uploaded img within the story
   facebook_pixel: "many pixel",
   google_analytics: "some analytics",
+  google_analytics_ga4: "some ga4 analytics",
   linkedin_insights: "some insightful comment",
   is_government: true,
   colors: {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -40,6 +40,7 @@ export interface SiteAnalyticsSettings {
   pixel: string
   ga: string
   insights: string
+  ga4: string
 }
 
 export type SiteSettings = SiteInfo &
@@ -58,6 +59,8 @@ export interface BackendSiteSettings {
   facebook_pixel?: string
   // eslint-disable-next-line camelcase
   google_analytics?: string
+  // eslint-disable-next-line camelcase
+  google_analytics_ga4?: string
   // eslint-disable-next-line camelcase
   linkedin_insights?: string
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
## Problem

This PR adds the GA4 field to our settings page, and converts the previous UA field to be uneditable, in order to push users towards using the new GA4, in light of the deprecation of UA in July. To be reviewed in conjunction with PR [#689](https://github.com/isomerpages/isomercms-backend/pull/689) on the isomercms-backend repo.