### PR TITLE
feat(monitoring): adds RUM and heatmaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7162,6 +7162,28 @@
         }
       }
     },
+    "@datadog/browser-core": {
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.38.0.tgz",
+      "integrity": "sha512-KNX9ShWtA1A1xAesE11ydyIBtlgNT6hsQ0xeYIxqDnCYPClLuXDnZefggxcDpppvYS+ymqWjpwSRBf0Oqh7T4w=="
+    },
+    "@datadog/browser-rum": {
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.38.0.tgz",
+      "integrity": "sha512-fPxdPXCHbDUBztdKHbOLyJsdqVcRzEFGE5fWefKjgn3dsYcnypkR+y4k/tVi9KeFcOM3fa7EV5/1hZTj7T3oUQ==",
+      "requires": {
+        "@datadog/browser-core": "4.38.0",
+        "@datadog/browser-rum-core": "4.38.0"
+      }
+    },
+    "@datadog/browser-rum-core": {
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.38.0.tgz",
+      "integrity": "sha512-rp1FxQuGb6g06/a0OT6gTCNEUcjmXC4yXFdd6OnsEbf+h1PAMHiMDGmt5Y2THDpN0x2xzLXG1NBpk291E4eZRw==",
+      "requires": {
+        "@datadog/browser-core": "4.38.0"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -19804,7 +19826,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "copy-concurrently": {
@@ -21746,7 +21768,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "ejs": {
@@ -21825,7 +21847,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "end-of-stream": {
@@ -30463,7 +30485,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "memfs": {
@@ -30540,7 +30562,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "merge-stream": {
@@ -30558,7 +30580,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "microevent.ts": {
@@ -39912,7 +39934,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
     "unquote": {
@@ -40170,7 +40192,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@chakra-ui/theme-tools": "^2.0.1",
     "@chakra-ui/utils": "^2.0.1",
     "@craco/craco": "^6.4.3",
+    "@datadog/browser-rum": "^4.38.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^2.8.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,20 +32,20 @@ const apiClient = axios.create({
 
 // datadog env var
 const {
-  DATADOG_APP_ID,
-  DATADOG_CLIENT_TOKEN,
-  APP_VERSION,
+  REACT_APP_DATADOG_APP_ID,
+  REACT_APP_DATADOG_CLIENT_TOKEN,
+  REACT_APP_VERSION,
   REACT_APP_ENV,
 } = process.env
 
 datadogRum.init({
-  applicationId: DATADOG_APP_ID,
-  clientToken: DATADOG_CLIENT_TOKEN,
+  applicationId: REACT_APP_DATADOG_APP_ID,
+  clientToken: REACT_APP_DATADOG_CLIENT_TOKEN,
   site: "datadoghq.com",
   service: "isomercms-frontend",
   env: REACT_APP_ENV,
   // Specify a version number to identify the deployed version of your application in Datadog
-  version: APP_VERSION,
+  version: REACT_APP_VERSION,
   sessionSampleRate: 100,
   sessionReplaySampleRate: 20,
   trackUserInteractions: true,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { datadogRum } from "@datadog/browser-rum"
 import { ThemeProvider } from "@opengovsg/design-system-react"
 import axios from "axios"
 import { useEffect } from "react"
@@ -28,6 +29,33 @@ const apiClient = axios.create({
   baseURL: API_BASE_URL_V2,
   timeout: 100000, // 100 secs
 })
+
+// datadog env var
+const {
+  DATADOG_APP_ID,
+  DATADOG_CLIENT_TOKEN,
+  APP_VERSION,
+  REACT_APP_ENV,
+} = process.env
+
+datadogRum.init({
+  applicationId: DATADOG_APP_ID,
+  clientToken: DATADOG_CLIENT_TOKEN,
+  site: "datadoghq.com",
+  service: "isomercms-frontend",
+  env: REACT_APP_ENV,
+  // Specify a version number to identify the deployed version of your application in Datadog
+  version: APP_VERSION,
+  sessionSampleRate: 100,
+  sessionReplaySampleRate: 20,
+  trackUserInteractions: true,
+  trackResources: true,
+  trackLongTasks: true,
+  defaultPrivacyLevel: "mask-user-input",
+  enableExperimentalFeatures: ["clickmap"],
+})
+
+datadogRum.startSessionReplayRecording()
 
 const App = () => {
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import { RouteSelector } from "routing/RouteSelector"
 
 import theme from "theme"
 
+import { DATADOG_RUM_SETTINGS } from "./constants/datadog"
+
 // axios settings
 axios.defaults.withCredentials = true
 
@@ -46,13 +48,7 @@ datadogRum.init({
   env: REACT_APP_ENV,
   // Specify a version number to identify the deployed version of your application in Datadog
   version: REACT_APP_VERSION,
-  sessionSampleRate: 100,
-  sessionReplaySampleRate: 20,
-  trackUserInteractions: true,
-  trackResources: true,
-  trackLongTasks: true,
-  defaultPrivacyLevel: "mask-user-input",
-  enableExperimentalFeatures: ["clickmap"],
+  ...DATADOG_RUM_SETTINGS,
 })
 
 datadogRum.startSessionReplayRecording()

--- a/src/constants/datadog.ts
+++ b/src/constants/datadog.ts
@@ -1,0 +1,9 @@
+export const DATADOG_RUM_SETTINGS = {
+  sessionSampleRate: 100,
+  sessionReplaySampleRate: 20,
+  trackUserInteractions: true,
+  trackResources: true,
+  trackLongTasks: true,
+  defaultPrivacyLevel: "mask-user-input",
+  enableExperimentalFeatures: ["clickmap"],
+} as const


### PR DESCRIPTION
**NOTE: HAVEN'T ADD ENV VARS TO 1PW YET!!! will add when PR approved**

## Problem
Isomer had no monitoring last time, which made it difficult to understand user behaviour. In order to solve this, one possible way is to add datadog monitoring. This adds datadog RUM (realtime user monitoring) into the codebase, together with heatmaps 

Closes IS-4

## Solution
1. install datadog sdk
2. initialise datadog sdk with new env vars

## Deploy Notes
we require the below env vars to be updated in order for data tracking for dd

**New environment variables**:
```
# Datadog
export REACT_APP_DATADOG_APP_ID=xxx
export REACT_APP_DATADOG_CLIENT_TOKEN=xxxx

# version
export REACT_APP_VERSION=0.21.2
```

**New dependencies**:
- `dependency` : `@datadog/browser-rum`

**notes**
- app blockers will block data reporting :(