### PR TITLE
Is 59/fix/disallow files and subfolders starting with restricted characters

### DIFF
--- a/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
@@ -7,6 +7,7 @@ import {
   DIRECTORY_SETTINGS_TITLE_MIN_LENGTH,
   DIRECTORY_SETTINGS_TITLE_MAX_LENGTH,
   resourceCategoryRegexTest,
+  jekyllFirstCharacterRegexTest,
 } from "utils/validators"
 
 import { deslugifyDirectory } from "utils"
@@ -46,6 +47,11 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
               "Special characters found",
               'Title cannot contain any of the following special characters: ~%^*_+-./`;{}[]"<>',
               (value) => !specialCharactersRegexTest.test(value)
+            )
+            .test(
+              "Restricted first character found",
+              "Title cannot start with any of the following special characters: ._#~",
+              (value) => !jekyllFirstCharacterRegexTest.test(value)
             )
         }
         if (type === "resourceRoomName") {

--- a/src/components/PageSettingsModal/PageSettingsSchema.jsx
+++ b/src/components/PageSettingsModal/PageSettingsSchema.jsx
@@ -4,6 +4,7 @@ import * as Yup from "yup"
 import {
   permalinkRegexTest,
   specialCharactersRegexTest,
+  jekyllFirstCharacterRegexTest,
   dateRegexTest,
   PAGE_SETTINGS_PERMALINK_MIN_LENGTH,
   PAGE_SETTINGS_PERMALINK_MAX_LENGTH,
@@ -19,6 +20,11 @@ export const PageSettingsSchema = (existingTitlesArray = []) =>
         "Special characters found",
         'Title cannot contain any of the following special characters: ~%^*_+-./`;{}[]"<>',
         (value) => !specialCharactersRegexTest.test(value)
+      )
+      .test(
+        "File starts with restricted character",
+        "Title cannot start with any of the following special characters: ._#~",
+        (value) => !jekyllFirstCharacterRegexTest.test(value)
       )
       .min(
         PAGE_SETTINGS_TITLE_MIN_LENGTH,

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -48,6 +48,7 @@ export const RESOURCE_CATEGORY_REGEX = "^([a-zA-Z0-9]*[- ]?)+$"
 export const slugifyLowerFalseRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 export const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX)
 export const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
+export const jekyllFirstCharacterRegexTest = /^[._#~]/
 export const mediaSpecialCharactersRegexTest = /[~%^?*+#./\\`;~{}[\]"<>]/
 export const imagesSuffixRegexTest = /^.+\.(svg|jpg|jpeg|png|gif|tif|bmp|ico)$/
 export const filesSuffixRegexTest = /^.+\.(pdf)$/


### PR DESCRIPTION
## Problem

This PR fixes an issue with missing pages, which were showing up on the CMS but not on the actual site. On further investigation, we found that [jekyll has a list of restricted first characters for files/folders which will not be built](https://jekyllrb.com/docs/structure/) unless explicitly specified via the config file in the include directive. The special characters are (`.`, `~`, `#`, and `_`), all of which are already restricted for various reasons except for `#`. We have opted to restrict the use of `#` as the first character for subcollections and page titles, as this is the quickest way of resolving this issue - other methods we could require significant testing/engineering effort (either writing to the config file if we detect this special character, or decoupling file name and file front matter title).

To be reviewed in conjunction with PR [#699](https://github.com/isomerpages/isomercms-backend/pull/699) on the isomercms backend repo.