### PR TITLE
test(editpage.spec): fix for editpage.spec

### DIFF
--- a/cypress/e2e/editPage.spec.ts
+++ b/cypress/e2e/editPage.spec.ts
@@ -38,10 +38,10 @@ describe("editPage.spec", () => {
     )
 
     const DEFAULT_IMAGE_TITLE = "isomer-logo.svg"
-    const ADDED_IMAGE_TITLE = "balloon.png"
+    const ADDED_IMAGE_TITLE = "balloon"
     const ADDED_IMAGE_PATH = "images/balloon.png"
 
-    const ADDED_FILE_TITLE = "singapore-pages.pdf"
+    const ADDED_FILE_TITLE = "singapore-pages"
     const ADDED_FILE_PATH = "files/singapore.pdf"
 
     const LINK_TITLE = "link"
@@ -82,7 +82,7 @@ describe("editPage.spec", () => {
 
     it("Edit page (unlinked) should provide a warning to users when navigating away", () => {
       cy.get(".CodeMirror-scroll").type(TEST_PAGE_CONTENT)
-      cy.contains(":button", "Back to Workspace").click()
+      cy.get('button[aria-label="Back to sites"]').click()
 
       cy.contains("Warning")
       cy.contains(":button", "No").click()
@@ -94,7 +94,7 @@ describe("editPage.spec", () => {
       )
       cy.contains(TEST_PAGE_CONTENT)
 
-      cy.contains(":button", "Back to Workspace").click()
+      cy.get('button[aria-label="Back to sites"]').click()
 
       cy.contains("Warning")
       cy.contains(":button", "Yes").click()
@@ -303,12 +303,18 @@ describe("editPage.spec", () => {
     })
 
     it("Edit page (collection) should have third nav menu", () => {
-      cy.get("#sidenav").contains(TEST_PAGE_TITLE).should("exist")
+      cy.wait(Interceptors.GET)
+      // NOTE: Wait for the markdown editor + preview to load
+      cy.get(".spinner-border").should("not.exist")
+      cy.get("#sidenav")
+        .should("be.visible")
+        .contains(TEST_PAGE_TITLE)
+        .should("exist")
     })
 
     it("Edit page (collection) should provide a warning to users when navigating away", () => {
       cy.get(".CodeMirror-scroll").type(TEST_PAGE_CONTENT)
-      cy.contains(":button", TEST_FOLDER_TITLE).click()
+      cy.get('button[aria-label="Back to sites"]').click()
 
       cy.contains("Warning")
       cy.contains(":button", "No").click()
@@ -320,7 +326,7 @@ describe("editPage.spec", () => {
       )
       cy.contains(TEST_PAGE_CONTENT)
 
-      cy.contains(":button", TEST_FOLDER_TITLE).click()
+      cy.get('button[aria-label="Back to sites"]').click()
 
       cy.contains("Warning")
       cy.contains(":button", "Yes").click()

--- a/cypress/e2e/editPage.spec.ts
+++ b/cypress/e2e/editPage.spec.ts
@@ -25,6 +25,8 @@ describe("editPage.spec", () => {
     const TEST_PAGE_CONTENT = "lorem ipsum"
     const TEST_INSTAGRAM_EMBED_SCRIPT =
       '<script async src="//www.instagram.com/embed.js"></script>'
+    const TEST_SANITIZED_INSTAGRAM_EMBED_SCRIPT =
+      '<script async="" src="//www.instagram.com/embed.js"></script>'
     const TEST_UNTRUSTED_SCRIPT =
       '<script src="https://www.example.com/evil.js"></script>'
     const TEST_INLINE_SCRIPT = '<script>alert("hello")</script>'
@@ -200,7 +202,7 @@ describe("editPage.spec", () => {
 
       // 2. Content is there even after refreshing
       cy.reload()
-      cy.contains(TEST_INSTAGRAM_EMBED_SCRIPT).should("exist")
+      cy.contains(TEST_SANITIZED_INSTAGRAM_EMBED_SCRIPT).should("exist")
     })
 
     it("Edit page (unlinked) should not allow users to add untrusted external scripts", () => {


### PR DESCRIPTION
## Problem
Previously, `editPage.spec.ts` was failing due to our new CMS frontend. This was due to components changing, which made the selectors not function as intended. Also, vapt fixes caused us to omit file extensions, which led to tests failing.

Closes IS-63

## Solution
1. change selectors 
2. add assertion to only proceed when loading is complete
3. omit extension for file names

**Notes**
there are some backend changes required in order for this PR to function properly. because our FE uses `!!userId` to determine if a user should be directed to the github login flow (which is what our tests work with), this requires a backend change to also return `userId` when it is the `E2E_USER`. separately, we should probably maintain 2 types of users for e2e (github + email) or, if we decide that we want to deprecate github in the future, make our existing tests compat w/ email flow.

instagram embed snippet has been changed to fit the backend's sanitization values. see the corresponding [BE PR](https://github.com/isomerpages/isomercms-backend/pull/703) for more detailas