### PR TITLE
[IS-71] chore(sites.spec): fix e2e

### DIFF
--- a/cypress/e2e/sites.spec.ts
+++ b/cypress/e2e/sites.spec.ts
@@ -1,19 +1,27 @@
-import { CMS_BASEURL, TEST_REPO_NAME } from "../fixtures/constants"
+import {
+  CMS_BASEURL,
+  Interceptors,
+  TEST_REPO_NAME,
+} from "../fixtures/constants"
 
 describe("Sites page", () => {
   beforeEach(() => {
     cy.setSessionDefaults()
-    // NOTE: This is to v1 so we are redefining it here
-    cy.intercept("GET", "/v1/**").as("getRequest")
+    cy.setupDefaultInterceptors()
   })
 
   it("Sites page should have sites header", () => {
-    cy.visit(`${CMS_BASEURL}/sites`).wait("@getRequest")
-    cy.contains("Sites")
+    cy.visit(`${CMS_BASEURL}/sites`).wait(Interceptors.GET)
+    cy.contains("Get help").should("exist")
   })
 
   it("Sites page should allow user to click into a test site repo", () => {
-    cy.visit(`${CMS_BASEURL}/sites`).wait("@getRequest")
+    cy.visit(`${CMS_BASEURL}/sites`)
+      // NOTE: `/whoami` and `/sites`
+      .wait(Interceptors.GET)
+      .wait(Interceptors.GET)
+
+    cy.contains("Loading sites").should("not.exist")
 
     cy.contains(TEST_REPO_NAME).click()
     cy.url().should(


### PR DESCRIPTION
## Problem
e2e were failing cos we were issuing requests to `v2` instead of `v1` now. 

Closes IS-71

## Solution
- Change to use `setupDefaultInterceptors`, which listens on `v2` endpoints. 
- add an assertion that the `Loading sites` text should not be visible prior to attempting to click 
