### PR TITLE
chore(datadog): update rum session replay % to 100

### DIFF
--- a/src/constants/datadog.ts
+++ b/src/constants/datadog.ts
@@ -1,6 +1,6 @@
 export const DATADOG_RUM_SETTINGS = {
   sessionSampleRate: 100,
-  sessionReplaySampleRate: 20,
+  sessionReplaySampleRate: 100,
   trackUserInteractions: true,
   trackResources: true,
   trackLongTasks: true,


### PR DESCRIPTION
## Problem
Last time we had monitoring % at 20, this meant that some (actually most) of the sessions weren't recorded (events still logged, but session replay not there). because our cms isn't very stable right now, we want more info on user actions

## Solution
set monitoring % to 100