### PR TITLE
Is 150 fix feature tour zindex

### DIFF
--- a/src/features/FeatureTour/FeatureTour.tsx
+++ b/src/features/FeatureTour/FeatureTour.tsx
@@ -105,7 +105,7 @@ export const FeatureTour = ({
         styles={{
           options: {
             arrowColor,
-            zIndex: 2000, // need this for it to be on top of the navbar
+            zIndex: 1100, // need this for it to be on top of the navbar
           },
         }}
         spotlightPadding={3}

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -26,7 +26,7 @@ import {
   MenuDropdownItem,
 } from "components/MenuDropdownButton"
 import _ from "lodash"
-import { useState, useEffect } from "react"
+import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
 
@@ -63,9 +63,6 @@ export const SiteDashboard = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
   const { setRedirectToPage } = useRedirectHook()
   const { userId } = useLoginContext()
-  const [isReviewRequestModelOpen, setIsReviewRequestModelOpen] = useState(
-    false
-  )
 
   const {
     data: siteInfo,
@@ -159,12 +156,10 @@ export const SiteDashboard = (): JSX.Element => {
 
         {/* Content */}
         <Flex px="4rem" pt="1.25rem" gap="0.5rem">
-          {!isReviewRequestModelOpen && (
-            <FeatureTourHandler
-              localStorageKey={LOCAL_STORAGE_KEYS.DashboardFeatureTour}
-              steps={DASHBOARD_FEATURE_STEPS}
-            />
-          )}
+          <FeatureTourHandler
+            localStorageKey={LOCAL_STORAGE_KEYS.DashboardFeatureTour}
+            steps={DASHBOARD_FEATURE_STEPS}
+          />
           {/* Left column */}
           <Box w="60%" id="isomer-dashboard-feature-tour-step-2">
             <DisplayCard variant="full">
@@ -183,15 +178,10 @@ export const SiteDashboard = (): JSX.Element => {
                   <Skeleton w="100%" height="16rem" />
                 )}
                 {isReviewRequestsError || validReviewRequests?.length === 0 ? (
-                  <EmptyReviewRequest
-                    setIsReviewRequestModelOpen={setIsReviewRequestModelOpen}
-                  />
+                  <EmptyReviewRequest />
                 ) : (
                   validReviewRequests?.map((reviewRequest) => (
-                    <ReviewRequestCard
-                      reviewRequest={reviewRequest}
-                      setIsReviewRequestModelOpen={setIsReviewRequestModelOpen}
-                    />
+                    <ReviewRequestCard reviewRequest={reviewRequest} />
                   ))
                 )}
               </DisplayCardContent>

--- a/src/layouts/SiteDashboard/components/EmptyReviewRequest.tsx
+++ b/src/layouts/SiteDashboard/components/EmptyReviewRequest.tsx
@@ -7,11 +7,8 @@ import { ReviewRequestModal } from "layouts/ReviewRequest"
 
 import { EmptyWhiteBoxImage } from "assets"
 
-export const EmptyReviewRequest = ({
-  setIsReviewRequestModelOpen,
-}): JSX.Element => {
+export const EmptyReviewRequest = (): JSX.Element => {
   const { isOpen, onClose, onOpen } = useDisclosure()
-  setIsReviewRequestModelOpen(isOpen)
   return (
     <>
       <DisplayCard variant="content" w="100%">


### PR DESCRIPTION
## Problem

This fix replaces the temporary hotfix for the feature tour conflict with the CMS FE modals (see https://github.com/isomerpages/isomercms-frontend/pull/1250)

Closes IS-150

## Solution

Each component has a different zIndex. The feature tour elements should have a zIndex between that of the elements on CMS dashboard and workspace and the modals. This will prevent users from interacting with the feature tour components when modals are open

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Testing
Run this locally and ensure you are able to use both the feature tour and modals without conflicts
