### PR TITLE
feat(getAllSites): optimise get all sites, dont reload on window focus

### DIFF
--- a/src/hooks/allSitesHooks/useGetAllSites.ts
+++ b/src/hooks/allSitesHooks/useGetAllSites.ts
@@ -15,6 +15,7 @@ export const useGetAllSites = (
     () => AllSitesService.getAllSites(),
     {
       retry: false,
+      refetchOnWindowFocus: false,
     }
   )
 }


### PR DESCRIPTION
## Problem

We are hitting the API rate limit. 

Closes [insert issue #]

## Solution

It doesnt make sense to call this expensive call site on window refresh. As a low hanging fruit, not doing that. 

**Breaking Changes**

User needs to refresh the page in order to get the updated list of sites. This inaccuracy hit seems reasonable to improve perf. 

## Tests 
1. Open network tab
2. Notice you dont call `/sites` on window refresh 