### PR TITLE
feat(dashboard): Dont reload on window focus

### DIFF
--- a/src/hooks/siteDashboardHooks/useGetCollaboratorsStatistics.ts
+++ b/src/hooks/siteDashboardHooks/useGetCollaboratorsStatistics.ts
@@ -15,6 +15,7 @@ export const useGetCollaboratorsStatistics = (
     () => SiteDashboardService.getCollaboratorsStatistics(siteName),
     {
       retry: false,
+      refetchOnWindowFocus: false,
     }
   )
 }

--- a/src/hooks/siteDashboardHooks/useGetReviewRequests.ts
+++ b/src/hooks/siteDashboardHooks/useGetReviewRequests.ts
@@ -17,6 +17,7 @@ export const useGetReviewRequests = (
     () => SiteDashboardService.getReviewRequests(siteName),
     {
       retry: false,
+      refetchOnWindowFocus: false,
     }
   )
 }

--- a/src/hooks/siteDashboardHooks/useGetSiteInfo.ts
+++ b/src/hooks/siteDashboardHooks/useGetSiteInfo.ts
@@ -15,6 +15,7 @@ export const useGetSiteInfo = (
     () => SiteDashboardService.getSiteInfo(siteName),
     {
       retry: false,
+      refetchOnWindowFocus: false,
     }
   )
 }


### PR DESCRIPTION
Problem
We are hitting the API rate limit.

Closes [insert issue #]

Solution
It doesnt make sense to call this expensive call site on window refresh. As a low hanging fruit, not doing that.

Breaking Changes

User needs to refresh the page in order to get the updated site deets. This inaccuracy hit seems reasonable to improve perf.

Tests
Open network tab
Notice you dont call /dashboard on window refresh