### PR TITLE
feat(optimise hooks): optimise hooks

### DIFF
--- a/src/hooks/reviewHooks/useDiff.ts
+++ b/src/hooks/reviewHooks/useDiff.ts
@@ -9,7 +9,11 @@ import * as ReviewService from "../../services/ReviewService"
 export const useDiff = (
   siteName: string
 ): UseQueryResult<EditedItemProps[]> => {
-  return useQuery([DIFF_QUERY_KEY, siteName], () =>
-    ReviewService.getDiff(siteName)
+  return useQuery(
+    [DIFF_QUERY_KEY, siteName],
+    () => ReviewService.getDiff(siteName),
+    {
+      refetchOnWindowFocus: false,
+    }
   )
 }

--- a/src/hooks/reviewHooks/useGetReviewRequest.ts
+++ b/src/hooks/reviewHooks/useGetReviewRequest.ts
@@ -16,6 +16,7 @@ export const useGetReviewRequest = (
     () => ReviewService.getReviewRequest(siteName, reviewId),
     {
       retry: false,
+      refetchOnWindowFocus: false,
     }
   )
 }

--- a/src/hooks/settingsHooks/useGetSiteUrl.ts
+++ b/src/hooks/settingsHooks/useGetSiteUrl.ts
@@ -10,6 +10,7 @@ export const useGetSiteUrl = (siteName: string): UseQueryResult<string> => {
     () => getSiteUrl(siteName),
     {
       retry: false,
+      refetchOnWindowFocus: false,
     }
   )
 }

--- a/src/hooks/settingsHooks/useUrlHook.jsx
+++ b/src/hooks/settingsHooks/useUrlHook.jsx
@@ -28,6 +28,7 @@ export function useStagingUrl({ siteName }) {
     [STAGING_URL_KEY, { siteName }],
     () => getStagingUrl(siteName),
     {
+      refetchOnWindowFocus: false,
       initialData: `https://${siteName}.netlify.app`,
     }
   )

--- a/src/hooks/useLastUpdated.ts
+++ b/src/hooks/useLastUpdated.ts
@@ -17,6 +17,7 @@ export const useLastUpdated = (siteName: string): useLastUpdatedReturn => {
     () => getLastUpdated(siteName),
     {
       retry: false,
+      refetchOnWindowFocus: false,
       onError: (err) => {
         console.log(err)
       },


### PR DESCRIPTION
## Problem
We are hitting the API rate limit.

## Solution
It doesnt make sense to call this expensive call site on window refresh. As a low hanging fruit, not doing that.

## Breaking Changes
Introduces [IS164](https://isomeropengov.atlassian.net/jira/software/projects/IS/issues/IS-164). Add PR to this branch before push to dev

## Tests
Open network tab
notice `/collections`, `/stagingUrl`, `/lastUpdated` calls are not called on window focus

## Other testing [to-do]
ensure functionality for collaborators is not broken