### PR TITLE
Fix: publish button delay

### DIFF
--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -260,7 +260,6 @@ const CancelRequestButton = ({
   )
 }
 
-// NOTE: Utility component exists to soothe over state management
 const ApprovalButton = ({
   isApproved,
   setIsApproved,


### PR DESCRIPTION
This PR fixes an issue with the publish button not immediately reflecting the state of the reviewer's action. See video for current behaviour:

https://user-images.githubusercontent.com/22111124/236171845-5196365d-850a-4ea8-881c-e930184bbca4.mov

The issue is that the publish now button is determined by our backend review request state instead of the user's direct action - the behaviour of the button state has been replicated to the publish now button as well.

As a safeguard, to prevent users from being able to publish even if the approval state has failed, an additional guard has been added to the backend in PR #[752](https://github.com/isomerpages/isomercms-backend/pull/752), to be reviewed in conjunction with this PR.