### PR TITLE
Fix: refetch diff info when modal is opened

### DIFF
--- a/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
@@ -40,9 +40,9 @@ export const ReviewRequestModal = (
   const errorToast = useErrorToast()
   const successToast = useSuccessToast()
 
-  const { onClose } = props
+  const { onClose, isOpen } = props
   const { siteName } = useParams<{ siteName: string }>()
-  const { data: items } = useDiff(siteName)
+  const { data: items, refetch } = useDiff(siteName)
   const { data: collaborators } = useListCollaborators(siteName)
   const {
     mutateAsync: createReviewRequest,
@@ -60,6 +60,9 @@ export const ReviewRequestModal = (
     onClose()
   })
 
+  useEffect(() => {
+    if (isOpen) refetch()
+  }, [refetch, isOpen])
   // Trigger an error toast informing the user
   // if review request not created
   useEffect(() => {


### PR DESCRIPTION
This PR fixes an issue that occurs when attempting to make a pull request via the button in the header. The diff info is determined when the modal component is mounted, which happens on page load, even when the modal has not yet been opened. This means that users will not be able to see the changes directly after making an edit, which affects single changes the most since the pull request cannot be opened:

https://user-images.githubusercontent.com/22111124/236365515-4a6b3c10-47bc-4646-ae36-0a2d6b294918.mov

This behaviour would be made worse by our switch to not refetching on window focus - this would mean that users have to refresh their page to see any changes made. To fix this issue, we have 2 main options:

1. Invalidate the query key of the diff endpoint after every update to the repo
2. Force a refetch on the modal opening

I have opted for the second option as the header is present in almost all pages - invalidating the query would mean that we would be back to the original behaviour of every page having to make this call to github. In addition, this information is only useful for users when they want to create a review request, which can only be done from the review request modal - refetching only on the modal opening helps to reduce the number of api calls we need to make.