### PR TITLE
feat: make updated at field optional on sites page

### DIFF
--- a/src/layouts/Sites.tsx
+++ b/src/layouts/Sites.tsx
@@ -88,9 +88,11 @@ const SitesContent = ({ siteNames }: { siteNames?: SiteData[] }) => {
                 borderRadius="0px 0px 4px 4px"
               >
                 <Text fontSize="0.9em">{siteName.repoName}</Text>
-                <Text fontSize="0.6em" color="base.content.light">
-                  {convertUtcToTimeDiff(siteName.lastUpdated)}
-                </Text>
+                {siteName.lastUpdated && (
+                  <Text fontSize="0.6em" color="base.content.light">
+                    {convertUtcToTimeDiff(siteName.lastUpdated)}
+                  </Text>
+                )}
               </VStack>
             </Link>
           </div>


### PR DESCRIPTION
## Problem

See https://github.com/isomerpages/isomercms-backend/pull/754 for context

Closes IS-165

## Solution

Conditionally render the "Updated at" field on '/sites' route

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

