### PR TITLE
fix: media name regex check

### DIFF
--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -16,8 +16,7 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
           "Special characters found",
           'Title cannot contain any of the following special characters: ~%^*+#?./`;{}[]"<>',
           (value) => {
-            const prefix = isCreate ? value.split(".")[0] : value
-            return !mediaSpecialCharactersRegexTest.test(prefix)
+            return !mediaSpecialCharactersRegexTest.test(value)
           }
         )
       )


### PR DESCRIPTION
This PR fixes a bug where our regex was not working properly for `.` in media file names. This was due to the change in behaviour where the user can no longer specify the extension of their file when uploading a new file, so the previous check to only run the regex on the portion before the last `.` no longer holds.

### Testing

- [ ] Attempt to create a new image with any name with a `.` (e.g. `blah.picture`), should disable the save button
