### PR TITLE
Is 157 view request link does not bring user to the view request page

### DIFF
--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -49,13 +49,9 @@ export const SiteEditHeader = (): JSX.Element => {
     isLoading: isReviewRequestsLoading,
   } = useGetReviewRequests(siteName)
 
-  console.log(reviewRequests)
-
   const openReviewRequests = reviewRequests
     ? reviewRequests.filter((request) => request.status === "OPEN")
     : []
-
-  console.log(openReviewRequests)
 
   const shouldDisableReviewRequestButton =
     isReviewRequestsLoading || openReviewRequests.length > 0

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -25,6 +25,7 @@ import { Link as RouterLink, useParams } from "react-router-dom"
 import { useLoginContext } from "contexts/LoginContext"
 
 import { useStagingUrl } from "hooks/settingsHooks"
+import { useGetReviewRequests } from "hooks/siteDashboardHooks"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
 
@@ -43,6 +44,21 @@ export const SiteEditHeader = (): JSX.Element => {
   // NOTE: Even if we have an unknown user, we assume that it is github
   // and avoid showing new features.
   const isGithubUser = !!userId
+  const {
+    data: reviewRequests,
+    isLoading: isReviewRequestsLoading,
+  } = useGetReviewRequests(siteName)
+
+  console.log(reviewRequests)
+
+  const openReviewRequests = reviewRequests
+    ? reviewRequests.filter((request) => request.status === "OPEN")
+    : []
+
+  console.log(openReviewRequests)
+
+  const shouldDisableReviewRequestButton =
+    isReviewRequestsLoading || openReviewRequests.length > 0
 
   return (
     <>
@@ -93,6 +109,7 @@ export const SiteEditHeader = (): JSX.Element => {
               id="isomer-workspace-feature-tour-step-1"
               leftIcon={<Icon as={BiCheckCircle} fontSize="1.25rem" />}
               onClick={onReviewRequestModalOpen}
+              isDisabled={shouldDisableReviewRequestButton}
             >
               Request a Review
             </Button>


### PR DESCRIPTION
## Problem

The "Request Review" button should be disabled if there is an already existing PR in "Open" status

Closes IS-157

## Solution

Fetch and filter the current list of PRs and if there exists a PR in Open state, we disable the button

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Test Plan

You should be able to click on Review Request iff there are no open PRs. Else, the button should be disabled
