### PR TITLE
build(netlify): add plugin for netlify to inject app version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,5 @@
   [build.environment]
     CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
     TERM = "xterm"
+[[plugins]]
+package = "/plugins/netlify/env"

--- a/plugins/netlify/env/index.js
+++ b/plugins/netlify/env/index.js
@@ -1,0 +1,5 @@
+// NOTE: Taken from https://answers.netlify.com/t/unable-to-set-npm-package-version-in-the-environment-variables/77584
+/* eslint-disable no-param-reassign */
+export const onPreBuild = function ({ netlifyConfig, packageJson }) {
+  netlifyConfig.build.environment.REACT_APP_VERSION = packageJson.version
+}

--- a/plugins/netlify/env/index.js
+++ b/plugins/netlify/env/index.js
@@ -1,5 +1,5 @@
 // NOTE: Taken from https://answers.netlify.com/t/unable-to-set-npm-package-version-in-the-environment-variables/77584
 /* eslint-disable no-param-reassign */
-export const onPreBuild = function ({ netlifyConfig, packageJson }) {
+export const onPreBuild = ({ netlifyConfig, packageJson }) => {
   netlifyConfig.build.environment.REACT_APP_VERSION = packageJson.version
 }

--- a/plugins/netlify/env/manifest.yml
+++ b/plugins/netlify/env/manifest.yml
@@ -1,0 +1,1 @@
+name: netlify-env

--- a/plugins/netlify/env/package.json
+++ b/plugins/netlify/env/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "netlify-env",
+  "version": "1.0.0",
+  "type": "module"
+}


### PR DESCRIPTION
## Problem
Currently, engineers have to manually swap out the `REACT_APP_VERSION` on every release, which is annoying and prone to errors. 

Closes [IS-117]

## Solution
Use a local netlify build plugin to inject the react app version prior to build as documented [here](https://answers.netlify.com/t/unable-to-set-npm-package-version-in-the-environment-variables/77584). 


[IS-117]: https://isomeropengov.atlassian.net/browse/IS-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Tests
Prior to testing, the deploy notes section below **must be done**
1. update the package version 
2. push the branch to `staging`

this was done with a fake package version of `0.0.0`, see below ss
![Screenshot 2023-05-19 at 2 36 24 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/cb66b0c9-a2d6-4c9a-b0b0-04b1ed14f6cd)


## Deploy notes
1. remove the `REACT_APP_VERSION` env var from netlify (done for `staging`) since that is extra.

