### PR TITLE
fix(workspace): update feature tour hierarchy

### DIFF
--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -72,82 +72,86 @@ const WorkspacePage = (): JSX.Element => {
       .length > 0
 
   return (
-    <SiteEditLayout overflow="hidden">
+    <>
       <FeatureTourHandler
         localStorageKey={LOCAL_STORAGE_KEYS.WorkspaceFeatureTour}
         steps={WORKSPACE_FEATURE_STEPS}
       />
-      <VStack spacing="2rem" w="100%" alignItems="start">
-        {hasOpenReviewRequests && (
-          <ReviewRequestAlert
-            reviewRequestUrl={`/sites/${siteName}/dashboard`}
-          />
-        )}
-        <MainPages siteName={siteName} isLoading={!!pagesData} />
-      </VStack>
-      <Skeleton isLoaded={!isDirLoading} w="100%">
-        <EmptyArea
-          isItemEmpty={isFoldersEmpty && isPagesEmpty}
-          actionButton={
-            <MenuDropdownButton
-              variant="outline"
-              mainButtonText="Create page"
-              as={Link}
-              to={`${url}/createPage`}
-            >
-              <MenuDropdownItem
+      <SiteEditLayout overflow="hidden">
+        <VStack spacing="2rem" w="100%" alignItems="start">
+          {hasOpenReviewRequests && (
+            <ReviewRequestAlert
+              reviewRequestUrl={`/sites/${siteName}/dashboard`}
+            />
+          )}
+          <MainPages siteName={siteName} isLoading={!!pagesData} />
+        </VStack>
+        <Skeleton isLoaded={!isDirLoading} w="100%">
+          <EmptyArea
+            isItemEmpty={isFoldersEmpty && isPagesEmpty}
+            actionButton={
+              <MenuDropdownButton
+                variant="outline"
+                mainButtonText="Create page"
                 as={Link}
                 to={`${url}/createPage`}
-                icon={
-                  <Icon as={BiFileBlank} fontSize="1.25rem" fill="icon.alt" />
+              >
+                <MenuDropdownItem
+                  as={Link}
+                  to={`${url}/createPage`}
+                  icon={
+                    <Icon as={BiFileBlank} fontSize="1.25rem" fill="icon.alt" />
+                  }
+                >
+                  <Text textStyle="body-1" fill="text.body">
+                    Create page
+                  </Text>
+                </MenuDropdownItem>
+                <MenuDropdownItem
+                  as={Link}
+                  to={`${url}/createDirectory`}
+                  icon={
+                    <Icon as={BiFolder} fontSize="1.25rem" fill="icon.alt" />
+                  }
+                >
+                  <Text textStyle="body-1" fill="text.body">
+                    Create folder
+                  </Text>
+                </MenuDropdownItem>
+              </MenuDropdownButton>
+            }
+          >
+            <SiteViewContent>
+              <EmptyArea
+                isItemEmpty={isFoldersEmpty}
+                actionButton={
+                  <CreateButton as={Link} to={`${url}/createDirectory`}>
+                    Create folder
+                  </CreateButton>
                 }
               >
-                <Text textStyle="body-1" fill="text.body">
-                  Create page
-                </Text>
-              </MenuDropdownItem>
-              <MenuDropdownItem
-                as={Link}
-                to={`${url}/createDirectory`}
-                icon={<Icon as={BiFolder} fontSize="1.25rem" fill="icon.alt" />}
+                <WorkspaceFolders
+                  siteName={siteName}
+                  pagesData={pagesData}
+                  url={url}
+                  dirsData={dirsData}
+                />
+              </EmptyArea>
+              <EmptyArea
+                isItemEmpty={isPagesEmpty}
+                actionButton={
+                  <CreateButton as={Link} to={`${url}/createPage`}>
+                    Create page
+                  </CreateButton>
+                }
               >
-                <Text textStyle="body-1" fill="text.body">
-                  Create folder
-                </Text>
-              </MenuDropdownItem>
-            </MenuDropdownButton>
-          }
-        >
-          <SiteViewContent>
-            <EmptyArea
-              isItemEmpty={isFoldersEmpty}
-              actionButton={
-                <CreateButton as={Link} to={`${url}/createDirectory`}>
-                  Create folder
-                </CreateButton>
-              }
-            >
-              <WorkspaceFolders
-                siteName={siteName}
-                pagesData={pagesData}
-                url={url}
-                dirsData={dirsData}
-              />
-            </EmptyArea>
-            <EmptyArea
-              isItemEmpty={isPagesEmpty}
-              actionButton={
-                <CreateButton as={Link} to={`${url}/createPage`}>
-                  Create page
-                </CreateButton>
-              }
-            >
-              <UngroupedPages pagesData={pagesData} url={url} />
-            </EmptyArea>
-          </SiteViewContent>
-        </EmptyArea>
-      </Skeleton>
-    </SiteEditLayout>
+                <UngroupedPages pagesData={pagesData} url={url} />
+              </EmptyArea>
+            </SiteViewContent>
+          </EmptyArea>
+        </Skeleton>
+      </SiteEditLayout>
+    </>
   )
 }
 


### PR DESCRIPTION
## Problem
Previously `FeatureTour` was nested under `SiteEditLayout` despite not being a visual component. This resulted in a visual mismatch (see below)

## Solution
shift `FeatureTour` to be outside `SiteEditLayout` (functionality works fine on local)

**before**
![Screenshot 2023-05-19 at 3 49 34 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/57247cc1-1c7b-409d-a63a-33d51544fd46)

**after**
![Screenshot 2023-05-19 at 3 52 10 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/58d53347-e39b-4848-bcae-e3deb993148b)


## Tests
1. clear the `localStorage` of the feature tour key
2. go to a site w/ a review request pending on **email login**
3. navigate to the dashboard
4. ensure that the feature tour still works
5. go to the workspace
6. check that the components are visually consistent