### PR TITLE
fix: file name in test

### DIFF
--- a/cypress/e2e/files.spec.ts
+++ b/cypress/e2e/files.spec.ts
@@ -2,7 +2,7 @@ import "cypress-file-upload"
 import { Interceptors, TEST_REPO_NAME } from "../fixtures/constants"
 
 describe("Files", () => {
-  const FILE_TITLE = "singapore"
+  const FILE_TITLE = "singapore-file"
   const OTHER_FILE_TITLE = "america"
   const EXISTING_FILE_TITLE = "New Uber BrandSystem QuickGuide"
   const TEST_FILE_PATH = "files/singapore.pdf"


### PR DESCRIPTION
## Problem

This PR fixes our files test spec - it currently works on its own but not after being run sequentially with edit page, due to the partial match of the file being uploaded in the `editpage` spec (`singapore-pages` in `editpage`, `singapore` in `files`). The file being searched for in `files` has been changed to `singapore-file` in order to avoid this overlap.