### PR TITLE
fix: facebook-pixel expected type

### DIFF
--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -27,7 +27,7 @@ describe("Settings page", () => {
     "favicon-isomer.ico",
   ] // [Agency, Favicon, Shareicon]
   const IMAGE_DIR = "/images/"
-  const TEST_FACEBOOK_PIXEL_ID = "12345"
+  const TEST_FACEBOOK_PIXEL_ID = "123456789012345"
   const TEST_GOOGLE_ANALYTICS_GA4_ID = "GA-12345"
   const TEST_LINKEDIN_INSIGHTS_ID = "1234567"
   const TEST_SECONDARY_COLOR = [0, 255, 0] // ([R, G, B])

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -37,15 +37,13 @@ export const AnalyticsSettings = ({
           <FormLabel>Facebook Pixel</FormLabel>
           <Input
             w="100%"
-            type="number"
             {...register("pixel", {
-              valueAsNumber: true,
-              min: {
-                value: 100000000000000,
+              minLength: {
+                value: 15,
                 message: "Your Facebook Pixel id should be a 15 digit number.",
               },
-              max: {
-                value: 999999999999999,
+              maxLength: {
+                value: 15,
                 message: "Your Facebook Pixel id should be a 15 digit number.",
               },
             })}

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -29,7 +29,11 @@ export const AnalyticsSettings = ({
       <VStack spacing="1.5rem" align="flex-start" w="50%">
         <FormControl isDisabled={isError}>
           <FormLabel>Facebook Pixel</FormLabel>
-          <Input w="100%" {...register("pixel")} />
+          <Input
+            w="100%"
+            type="number"
+            {...register("pixel", { valueAsNumber: true })}
+          />
         </FormControl>
 
         <FormControl isDisabled={isError}>

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -1,6 +1,10 @@
 import { VStack, FormControl, Link } from "@chakra-ui/react"
-import { FormLabel, Input } from "@opengovsg/design-system-react"
-import { useFormContext } from "react-hook-form"
+import {
+  FormLabel,
+  FormErrorMessage,
+  Input,
+} from "@opengovsg/design-system-react"
+import { useFormContext, useFormState } from "react-hook-form"
 import { BiInfoCircle } from "react-icons/bi"
 
 import { ANALYTICS_SETUP_LINK, GA_DEPRECATION_LINK } from "constants/config"
@@ -15,6 +19,8 @@ export const AnalyticsSettings = ({
   isError,
 }: AnalyticsSettingsProp): JSX.Element => {
   const { register } = useFormContext()
+  const { errors } = useFormState()
+  const isInvalid = (field: string) => !!errors[field]
   return (
     <Section id="analytics-fields">
       <VStack align="flex-start" spacing="0.5rem">
@@ -27,13 +33,26 @@ export const AnalyticsSettings = ({
         </SectionCaption>
       </VStack>
       <VStack spacing="1.5rem" align="flex-start" w="50%">
-        <FormControl isDisabled={isError}>
+        <FormControl isDisabled={isError} isInvalid={isInvalid("pixel")}>
           <FormLabel>Facebook Pixel</FormLabel>
           <Input
             w="100%"
             type="number"
-            {...register("pixel", { valueAsNumber: true })}
+            {...register("pixel", {
+              valueAsNumber: true,
+              min: {
+                value: 100000000000000,
+                message: "Your Facebook Pixel id should be a 15 digit number.",
+              },
+              max: {
+                value: 999999999999999,
+                message: "Your Facebook Pixel id should be a 15 digit number.",
+              },
+            })}
           />
+          <FormErrorMessage>
+            {errors.pixel && errors.pixel.message}
+          </FormErrorMessage>
         </FormControl>
 
         <FormControl isDisabled={isError}>

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -38,12 +38,8 @@ export const AnalyticsSettings = ({
           <Input
             w="100%"
             {...register("pixel", {
-              minLength: {
-                value: 15,
-                message: "Your Facebook Pixel id should be a 15 digit number.",
-              },
-              maxLength: {
-                value: 15,
+              pattern: {
+                value: /^[0-9]{15}$/,
                 message: "Your Facebook Pixel id should be a 15 digit number.",
               },
             })}


### PR DESCRIPTION
This PR fixes an issue where sites with facebook-pixel were unable to save their settings, due to a mismatch of expected type (number vs string). To be reviewed in conjunction with PR #[776](https://github.com/isomerpages/isomercms-backend/pull/776) on the isomercms backend repo, which has a more detailed writeup on the issue.

The change being introduced in the frontend is the facebook-pixel field enforcing that the length is 15.

### Testing

- [ ] Manually edit a site's facebook-pixel value to be missing
  - [ ] Should be able to save any change in settings
- [ ] Manually edit a site's facebook-pixel value to be an empty string
  - [ ] Should be able to save any change in settings
- [ ] Manually edit a site's facebook-pixel value to be a string (e.g. `facebook-pixel: "12345"`)
  - [ ] Should be able to save any change in settings
- [ ] Should be able to modify facebook-pixel value and have it show up as a number
- [ ] Should be able to delete facebook-pixel and have it show up as null