### PR TITLE
fix: add checks to Header component

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -28,6 +28,7 @@ import { useParams } from "react-router-dom"
 import { useLoginContext } from "contexts/LoginContext"
 
 import { useStagingUrl } from "hooks/settingsHooks"
+import { useGetReviewRequests } from "hooks/siteDashboardHooks"
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
@@ -62,6 +63,21 @@ const Header = ({
     onClose: onReviewRequestModalClose,
   } = useDisclosure()
   const { userId } = useLoginContext()
+  const {
+    data: reviewRequests,
+    isLoading: isReviewRequestsLoading,
+  } = useGetReviewRequests(siteName)
+
+  // Note: if PR is in APPROVED status, it will auto-redirect to dashboard as no edits should happen
+  // But have added here to be explicit of the status checks
+  const openReviewRequests = reviewRequests
+    ? reviewRequests.filter(
+        (request) => request.status === "OPEN" || request.status === "APPROVED"
+      )
+    : []
+
+  const shouldDisableReviewRequestButton =
+    isReviewRequestsLoading || openReviewRequests.length > 0
 
   const {
     backButtonLabel: backButtonTextFromParams,
@@ -143,6 +159,7 @@ const Header = ({
             <Button
               leftIcon={<Icon as={BiCheckCircle} fontSize="1.25rem" />}
               onClick={onReviewRequestModalOpen}
+              isDisabled={shouldDisableReviewRequestButton}
             >
               Request a Review
             </Button>

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -49,8 +49,12 @@ export const SiteEditHeader = (): JSX.Element => {
     isLoading: isReviewRequestsLoading,
   } = useGetReviewRequests(siteName)
 
+  // Note: if PR is in APPROVED status, it will auto-redirect to dashboard as no edits should happen
+  // But have added here to be explicit of the status checks
   const openReviewRequests = reviewRequests
-    ? reviewRequests.filter((request) => request.status === "OPEN")
+    ? reviewRequests.filter(
+        (request) => request.status === "OPEN" || request.status === "APPROVED"
+      )
     : []
 
   const shouldDisableReviewRequestButton =


### PR DESCRIPTION
## Problem

On the edit pages, request review button is still enabled when there is >= 1 PR in Open/Approved status

Closes IS-222

## Solution

Add the same check we did for SiteEditHeader to Header component as well

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Test

Ensure that the review request button is disabled on all pages when there are >=1 PR in Open/Approved states