### PR TITLE
Fix: convert email to lower case

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -566,12 +566,12 @@ const deleteMediaSubfolder = async ({ siteName, mediaType, customPath }) => {
 // Login
 const getEmailOtp = (email) => {
   const endpoint = `${BACKEND_URL_V2}/user/email/otp`
-  return axios.post(endpoint, { email })
+  return axios.post(endpoint, { email: email.toLowerCase() })
 }
 
 const verifyEmailOtp = async (email, otp) => {
   const endpoint = `${BACKEND_URL_V2}/user/email/verifyOtp`
-  const res = await axios.post(endpoint, { email, otp })
+  const res = await axios.post(endpoint, { email: email.toLowerCase(), otp })
   return res.data
 }
 

--- a/src/services/CollaboratorService.ts
+++ b/src/services/CollaboratorService.ts
@@ -29,7 +29,7 @@ export const addCollaborator = async (
 ): Promise<void> => {
   const endpoint = getCollaboratorEndpoint(siteName)
   return apiService
-    .post(endpoint, { email, acknowledge: isAcknowledged })
+    .post(endpoint, { email: email.toLowerCase(), acknowledge: isAcknowledged })
     .then((res) => res.data)
 }
 

--- a/src/services/LoginService.ts
+++ b/src/services/LoginService.ts
@@ -4,7 +4,7 @@ import { apiService } from "./ApiService"
 
 export const sendLoginOtp = async ({ email }: LoginParams): Promise<void> => {
   const endpoint = `/auth/login`
-  return apiService.post(endpoint, { email })
+  return apiService.post(endpoint, { email: email.toLowerCase() })
 }
 
 export const verifyLoginOtp = async ({
@@ -12,5 +12,5 @@ export const verifyLoginOtp = async ({
   otp,
 }: VerifyOtpParams): Promise<void> => {
   const endpoint = `/auth/verify`
-  return apiService.post(endpoint, { email, otp })
+  return apiService.post(endpoint, { email: email.toLowerCase(), otp })
 }


### PR DESCRIPTION
This PR enforces that our email params are converted to lowercase before being sent to the backend. See https://github.com/isomerpages/isomercms-backend/pull/785 for why this is necessary.