### PR TITLE
chore(request overivew): don't show diff for files/images

### DIFF
--- a/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
@@ -435,6 +435,9 @@ const RequestOverviewTable = ({
             icon={<BiShow />}
             aria-label="view file changes"
             variant="link"
+            isDisabled={
+              row.original.type === "file" || row.original.type === "image"
+            }
             onClick={() =>
               onClick(
                 row.original.title,


### PR DESCRIPTION
## Problem
files/images don't have a meaningful diff so we should disable the button

## Solution
- disable button (forgot to push prior to merge) 

## Tests
- [ ] add a new file 
- [ ] add a new image
- [ ] request review request
- [ ] both shud not be clickable