### PR TITLE
feat(featureFlag): Site launch implementation

### DIFF
--- a/src/services/SiteLaunchService.ts
+++ b/src/services/SiteLaunchService.ts
@@ -1,0 +1,7 @@
+export const isUserUsingSiteLaunchFeature = (siteName: string): boolean => {
+  // whitelisting sites that we want to trial this feature with
+  const whiteListedRepos = process.env.SITE_LAUNCH_FEATURE_WHITELISTED_REPOS?.split(
+    ","
+  )
+  return whiteListedRepos ? whiteListedRepos.includes(siteName) : false
+}


### PR DESCRIPTION
## Problem

We want to trial out the site launch features with a subset of users. 

This PR aims to get early feedback on a hacky approach that the upcoming site launch PRs aims to implement this. 

## Solution

We store the repos that we intend to trial this on as an env var in the FE separated by commas, and this state is held only in the FE.  

Benefits: 
+ easy to implement and subsequently remove
+ don't have to redeploy to add agencies that want to trial this out, just need change the env var

Limitations: 
- super hacky 
- technically backend APIs exposed to all users (but not really a concern since its an authenticated route anyways)

Ideally, we would leverage on a platform like Darkly to implement feature flags like this. While that is still a possible in the future, am opting for a more brute-force quicker solution to gather feedback from our users early.

## Reviewer notes
Specifically seeking feedback on
- Cleaner, easy to implement solutions 
- Strong concerns against using this approach in the short term 


**New environment variables**:

- `env var` : SITE_LAUNCH_FEATURE_WHITELISTED_REPOS 