### PR TITLE
test(e2e): add initial collaborators e2e tests

### DIFF
--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -10,6 +10,11 @@ import { USER_TYPES } from "../fixtures/users"
 
 const collaborator = E2E_EMAIL_COLLAB.email
 
+// NOTE: The below functions are required because
+// the collaborators modal uses the backend's error message
+// in order to display the error message to the user.
+// This means that we need to ignore the network error
+// because it's expected (as the FE queries the BE)
 const ignoreAcknowledgementError = () =>
   cy.on("uncaught:exception", (err) => !err.message.includes("422"))
 

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -1,5 +1,5 @@
 import {
-  BACKEND_URL,
+  CMS_BASEURL,
   E2E_EMAIL_ADMIN,
   E2E_EMAIL_COLLAB,
   E2E_EMAIL_TEST_SITE,
@@ -38,7 +38,7 @@ const ADD_COLLABORATOR_INPUT_SELECTOR = "input[name='newCollaboratorEmail']"
 const DELETE_COLLABORATOR_BUTTON_SELECTOR = 'button[id^="delete-"]'
 
 const visitE2eEmailTestRepo = () => {
-  cy.visit(`${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
+  cy.visit(`${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
   cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
 }
 
@@ -176,7 +176,7 @@ describe("collaborators flow", () => {
 
     it("should prevent admins of a site from removing collaborators of another site", () => {
       // Arrange
-      cy.visit(`${BACKEND_URL}/sites/${TEST_REPO_NAME}/dashboard`)
+      cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/dashboard`)
       cy.contains(TEST_REPO_NAME).should("be.visible")
       ignoreNotFoundError()
 

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -1,0 +1,129 @@
+import {
+  E2E_EMAIL_ADMIN,
+  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_TEST_SITE,
+  Interceptors,
+} from "../fixtures/constants"
+import { USER_TYPES } from "../fixtures/users"
+
+const collaborator = E2E_EMAIL_COLLAB.email
+
+const ignoreAcknowledgementError = () =>
+  cy.on("uncaught:exception", (err) => !err.message.includes("422"))
+
+const ignoreDuplicateError = () =>
+  cy.on("uncaught:exception", (err) => !err.message.includes("409"))
+
+const ignoreNotFoundError = () =>
+  cy.on("uncaught:exception", (err) => !err.message.includes("404"))
+
+const ADD_COLLABORATOR_ERROR_MESSAGE =
+  "This collaborator couldn't be added. Visit our guide for more assistance"
+
+const DUPLICATE_COLLABORATOR_ERROR_MESSAGE =
+  "User is already a member of the site"
+
+const NON_EXISTING_USER_ERROR_MESSAGE =
+  "This user does not have an Isomer account. Ask them to log in to Isomer and try adding them again."
+
+const ADD_COLLABORATOR_INPUT_SELECTOR = "input[name='newCollaboratorEmail']"
+
+const visitE2eEmailTestRepo = () => {
+  cy.visit(`http://localhost:3000/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
+  cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
+}
+
+const getCollaboratorsModal = () => {
+  cy.contains("Site collaborators")
+    .parent()
+    .parent()
+    .parent()
+    .within(() => cy.get("button").click())
+
+  // NOTE: the form encloses the displayed modal component
+  return cy.get("form").should("be.visible")
+}
+
+const addCollaboratorsFor = (user: string) => {
+  getCollaboratorsModal().get(ADD_COLLABORATOR_INPUT_SELECTOR).type(user).blur()
+  // NOTE: need to ignore the 422 w/ specific error message because we haven't ack yet
+  cy.contains("Add collaborator").click().wait(Interceptors.POST)
+}
+
+const removeCollaborator = (email: string) => {
+  cy.get("form")
+    .contains("div", email)
+    .parent()
+    .parent()
+    .within(() => {
+      cy.get('button[id^="delete-"]').click()
+    })
+
+  cy.contains("button", "Remove collaborator").click().wait(Interceptors.DELETE)
+}
+
+describe("collaborators flow", () => {
+  beforeEach(() => {
+    cy.setEmailSessionDefaults("Email admin")
+    cy.setupDefaultInterceptors()
+    visitE2eEmailTestRepo()
+  })
+
+  describe("Admin adding a collaborator", () => {
+    it("should not be able to click the add collaborator button when the input is empty", () => {
+      // Act
+      // Assert
+      getCollaboratorsModal().contains("Add collaborator").should("be.disabled")
+    })
+    it("should not be able to add a non-whitelisted collaborator", () => {
+      // Act
+      addCollaboratorsFor("some_gibberish@gmail.com")
+
+      // Assert
+      cy.contains(ADD_COLLABORATOR_ERROR_MESSAGE).should("be.visible")
+    })
+    it("should not be able to add an existing user", () => {
+      // Act
+      addCollaboratorsFor(E2E_EMAIL_ADMIN.email)
+      ignoreDuplicateError()
+
+      // Assert
+      cy.contains(DUPLICATE_COLLABORATOR_ERROR_MESSAGE).should("be.visible")
+    })
+    it("should not be able to add a collaborator without an isomer account", () => {
+      // Act
+      // NOTE: Initial admin will always be added manually
+      addCollaboratorsFor("gibberish@nonsense.gov.sg")
+      ignoreNotFoundError()
+
+      // Assert
+      cy.contains(NON_EXISTING_USER_ERROR_MESSAGE).should("be.visible")
+    })
+    it("should be able to add a collaborator", () => {
+      // Arrange
+      // NOTE: Mock a login with a collaborator account;
+      // This creates the user account in our backend.
+      cy.createEmailUser(
+        collaborator,
+        USER_TYPES.Email.Collaborator,
+        USER_TYPES.Email.Admin
+      )
+
+      // Act
+      // NOTE: Initial admin will always be added manually
+      addCollaboratorsFor(collaborator)
+      // NOTE: Cannot proceed without acknowledgement
+      cy.contains("Continue").should("be.disabled")
+      cy.get("input[name='isAcknowledged']").next().click()
+      cy.contains("Continue").click().wait(Interceptors.POST)
+      ignoreAcknowledgementError()
+
+      // Assert
+      cy.get("form").contains(collaborator).should("be.visible")
+      cy.get("form").contains("Contributor").should("be.visible")
+
+      // Cleanup
+      removeCollaborator(collaborator)
+    })
+  })
+})

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -1,4 +1,5 @@
 import {
+  BACKEND_URL,
   E2E_EMAIL_ADMIN,
   E2E_EMAIL_COLLAB,
   E2E_EMAIL_TEST_SITE,
@@ -29,8 +30,10 @@ const NON_EXISTING_USER_ERROR_MESSAGE =
 
 const ADD_COLLABORATOR_INPUT_SELECTOR = "input[name='newCollaboratorEmail']"
 
+const DELETE_COLLABORATOR_BUTTON_SELECTOR = 'button[id^="delete-"]'
+
 const visitE2eEmailTestRepo = () => {
-  cy.visit(`http://localhost:3000/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
+  cy.visit(`${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
   cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
 }
 
@@ -57,7 +60,7 @@ const removeCollaborator = (email: string) => {
     .parent()
     .parent()
     .within(() => {
-      cy.get('button[id^="delete-"]').click()
+      cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).click()
     })
 
   cy.contains("button", "Remove collaborator").click().wait(Interceptors.DELETE)
@@ -153,7 +156,7 @@ describe("collaborators flow", () => {
       // Act
       // NOTE: Remove all collaborators except the initial admin
       getCollaboratorsModal()
-        .get('button[id^="delete-"]')
+        .get(DELETE_COLLABORATOR_BUTTON_SELECTOR)
         .then((buttons) => {
           if (buttons.length > 1) {
             buttons.slice(1).each((idx, button) => {
@@ -163,12 +166,12 @@ describe("collaborators flow", () => {
         })
 
       // Assert
-      cy.get('button[id^="delete-"]').should("be.disabled")
+      cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).should("be.disabled")
     })
 
     it("should prevent admins of a site from removing collaborators of another site", () => {
       // Arrange
-      cy.visit(`http://localhost:3000/sites/${TEST_REPO_NAME}/dashboard`)
+      cy.visit(`${BACKEND_URL}/sites/${TEST_REPO_NAME}/dashboard`)
       cy.contains(TEST_REPO_NAME).should("be.visible")
       ignoreNotFoundError()
 

--- a/cypress/e2e/editPage.spec.ts
+++ b/cypress/e2e/editPage.spec.ts
@@ -18,7 +18,7 @@ const SECONDARY_COLOUR = "rgb(0, 255, 0)"
 describe("editPage.spec", () => {
   beforeEach(() => {
     cy.setupDefaultInterceptors()
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
   })
 
   describe("Edit unlinked page", () => {
@@ -257,7 +257,7 @@ describe("editPage.spec", () => {
     const LINK_URL = "https://www.google.com"
 
     before(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
 
       // Set up test resource categories
       // NOTE: We need to repeat the interceptor here as

--- a/cypress/e2e/files.spec.ts
+++ b/cypress/e2e/files.spec.ts
@@ -15,7 +15,7 @@ describe("Files", () => {
 
   describe("Create file, delete file, edit file settings in Files", () => {
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
 
       cy.visit(
@@ -105,7 +105,7 @@ describe("Files", () => {
 
   describe("Create file directory, delete file directory, edit file directory settings in Files", () => {
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
 
       cy.visit(
@@ -165,7 +165,7 @@ describe("Files", () => {
 
   describe("Create file, delete file, edit file settings, and move files in file directories", () => {
     before(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
 
       cy.visit(`/sites/${TEST_REPO_NAME}/media/files/mediaDirectory/files`)
       cy.contains("Create directory").click()
@@ -184,7 +184,7 @@ describe("Files", () => {
     })
 
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
       cy.visit(
         `/sites/${TEST_REPO_NAME}/media/files/mediaDirectory/files%2F${DIRECTORY_TITLE}`

--- a/cypress/e2e/folders.spec.ts
+++ b/cypress/e2e/folders.spec.ts
@@ -90,7 +90,7 @@ describe("Folders flow", () => {
 
   describe("Create subfolder, rename subfolder, delete subfolder from Folders", () => {
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
@@ -226,7 +226,7 @@ describe("Folders flow", () => {
 
   describe("Create page, delete page, edit page settings in folder", () => {
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
@@ -353,7 +353,7 @@ describe("Folders flow", () => {
   describe("Create page, delete page, edit page settings in subfolder", () => {
     before(() => {
       cy.setupDefaultInterceptors()
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}`
       )
@@ -375,7 +375,7 @@ describe("Folders flow", () => {
     })
 
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
       cy.visit(
         `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/folders/${DEFAULT_REPO_FOLDER_NAME}/subfolders/${PARSED_TEST_SUBFOLDER_NO_PAGES_TITLE}`

--- a/cypress/e2e/images.spec.ts
+++ b/cypress/e2e/images.spec.ts
@@ -12,7 +12,7 @@ describe("Images", () => {
   const ANOTHER_ALBUM_TITLE = "Green"
 
   before(() => {
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     cy.setupDefaultInterceptors()
 
     cy.visit(
@@ -35,7 +35,7 @@ describe("Images", () => {
 
   describe("Create album, delete album, edit album settings in Images", () => {
     beforeEach(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
 
       cy.visit(
@@ -111,7 +111,7 @@ describe("Images", () => {
   })
   describe("Create image, delete image, edit image settings, and move images in image albums", () => {
     before(() => {
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
       cy.setupDefaultInterceptors()
       cy.visit(
         `/sites/${TEST_REPO_NAME}/media/images/mediaDirectory/images%2F${ALBUM_TITLE}`
@@ -133,7 +133,7 @@ describe("Images", () => {
 
     beforeEach(() => {
       cy.setupDefaultInterceptors()
-      cy.setSessionDefaults()
+      cy.setGithubSessionDefaults()
 
       cy.visit(
         `/sites/${TEST_REPO_NAME}/media/images/mediaDirectory/images%2F${ALBUM_TITLE}`

--- a/cypress/e2e/move.spec.ts
+++ b/cypress/e2e/move.spec.ts
@@ -30,7 +30,7 @@ describe("Move flow", () => {
 
   beforeEach(() => {
     cy.setupDefaultInterceptors()
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
   })
 
   describe("Move pages out of Workspace", () => {

--- a/cypress/e2e/resourceCategory.spec.ts
+++ b/cypress/e2e/resourceCategory.spec.ts
@@ -36,7 +36,7 @@ describe("Resource category page", () => {
 
   before(() => {
     cy.setupDefaultInterceptors()
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
 
     // Set up test resource categories
     cy.visit(`/sites/${TEST_REPO_NAME}/resourceRoom/resources`).wait(
@@ -49,7 +49,7 @@ describe("Resource category page", () => {
 
   beforeEach(() => {
     cy.setupDefaultInterceptors()
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     cy.visit(
       `/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}/resourceCategory/${TEST_CATEGORY_SLUGIFIED}`
     )

--- a/cypress/e2e/resources.spec.ts
+++ b/cypress/e2e/resources.spec.ts
@@ -19,7 +19,7 @@ describe("Resources page", () => {
 
   beforeEach(() => {
     cy.setupDefaultInterceptors()
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     cy.visit(
       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/resourceRoom/${TEST_RESOURCE_ROOM_NAME}`
     ).wait(Interceptors.GET)

--- a/cypress/e2e/settings.spec.ts
+++ b/cypress/e2e/settings.spec.ts
@@ -50,7 +50,7 @@ describe("Settings page", () => {
     cy.visitLoadSettings(TEST_REPO_NAME, sitePath)
 
   before(() => {
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     cy.setupDefaultInterceptors()
 
     visitLoadSettings(`/sites/${TEST_REPO_NAME}/settings`).wait(
@@ -116,7 +116,7 @@ describe("Settings page", () => {
   })
 
   beforeEach(() => {
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     visitLoadSettings(`/sites/${TEST_REPO_NAME}/settings`)
     // Double check that settings are loaded before running tests cos sometimes the tests run too quickly
     cy.get("#title").should((elem) => {

--- a/cypress/e2e/sites.spec.ts
+++ b/cypress/e2e/sites.spec.ts
@@ -6,7 +6,7 @@ import {
 
 describe("Sites page", () => {
   beforeEach(() => {
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     cy.setupDefaultInterceptors()
   })
 

--- a/cypress/e2e/workspace.spec.ts
+++ b/cypress/e2e/workspace.spec.ts
@@ -8,7 +8,7 @@ import {
 
 describe("Workspace Pages flow", () => {
   beforeEach(() => {
-    cy.setSessionDefaults()
+    cy.setGithubSessionDefaults()
     cy.setupDefaultInterceptors()
 
     cy.visit(`${CMS_BASEURL}/sites/${TEST_REPO_NAME}/workspace`).wait(

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -45,3 +45,5 @@ export enum Interceptors {
 export const CMS_BASEURL: string | undefined = Cypress.env("BASEURL")
 
 export const BASE_SEO_LINK = "www.open.gov.sg"
+
+export const BACKEND_URL = Cypress.env("BACKEND_URL")

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -5,6 +5,8 @@ export const E2E_USER = {
   email: "test@open.gov.sg",
   contactNumber: "99999999",
 }
+export const E2E_USER_TYPE_COOKIE_KEY = "e2eUserType"
+
 export const LOCAL_STORAGE_USERID_KEY = "userId"
 export const LOCAL_STORAGE_USER_KEY = "user"
 export const TEST_REPO_NAME: string | undefined = Cypress.env("TEST_REPO_NAME")

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -5,8 +5,32 @@ export const E2E_USER = {
   email: "test@open.gov.sg",
   contactNumber: "99999999",
 }
-export const E2E_USER_TYPE_COOKIE_KEY = "e2eUserType"
 
+export const E2E_EMAIL_ADMIN = {
+  email: "admin@e2e.gov.sg",
+} as const
+
+export const E2E_EMAIL_COLLAB = {
+  email: "collab@e2e.gov.sg",
+} as const
+
+export const E2E_EMAIL_TEST_SITE = {
+  name: "e2e email test site",
+  repo: "e2e-email-test-repo",
+}
+
+export const E2E_COOKIE = {
+  Auth: {
+    key: Cypress.env("COOKIE_NAME"),
+    value: Cypress.env("COOKIE_VALUE"),
+  },
+  Site: { key: "site", value: E2E_EMAIL_TEST_SITE.name },
+  EmailUserType: { key: "e2eUserType" },
+  Email: { key: "email" },
+}
+
+export const E2E_USER_TYPE_COOKIE_KEY = "e2eUserType"
+export const E2E_SITE_KEY = "site"
 export const LOCAL_STORAGE_USERID_KEY = "userId"
 export const LOCAL_STORAGE_USER_KEY = "user"
 export const TEST_REPO_NAME: string | undefined = Cypress.env("TEST_REPO_NAME")

--- a/cypress/fixtures/users.ts
+++ b/cypress/fixtures/users.ts
@@ -1,0 +1,9 @@
+export const USER_TYPES = {
+  Email: {
+    Admin: "Email admin",
+    Collaborator: "Email collaborator",
+  },
+  Github: "Github user",
+} as const
+
+export type EmailUserTypes = typeof USER_TYPES["Email"][keyof typeof USER_TYPES["Email"]]

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -55,5 +55,12 @@ declare namespace Cypress {
     deleteMedia(mediaTitle: string, disableAction?: boolean): Chainable<void>
     saveSettings(): Chainable<void>
     visitLoadSettings(siteName: string, sitePath: string): Chainable<void>
+    createEmailUser(
+      email: string,
+      // NOTE: have to (re)declare the type here
+      // otherwise the import leads to a type error
+      userType: "Email admin" | "Email collaborator",
+      InitialUserType: "Email admin" | "Email collaborator"
+    ): Chainable<void>
   }
 }

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -27,6 +27,10 @@ declare namespace Cypress {
      */
     setDefaultSettings(): Chainable<void>
     setGithubSessionDefaults(): Chainable<void>
+
+    setEmailSessionDefaults(
+      userType: "Email admin" | "Email collaborator"
+    ): Chainable<void>
     /**
      * Setup the default interceptors for post/get/delete requests.
      * These interceptors are aliased to the `Interceptors` enum.

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -26,7 +26,7 @@ declare namespace Cypress {
      * This is to avoid adversely impacting the SEO of the site.
      */
     setDefaultSettings(): Chainable<void>
-    setSessionDefaults(): Chainable<void>
+    setGithubSessionDefaults(): Chainable<void>
     /**
      * Setup the default interceptors for post/get/delete requests.
      * These interceptors are aliased to the `Interceptors` enum.

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -4,10 +4,25 @@ import {
   LOCAL_STORAGE_USER_KEY,
   E2E_USER,
   LOCAL_STORAGE_USERID_KEY,
+  E2E_USER_TYPE_COOKIE_KEY,
 } from "../fixtures/constants"
 
 Cypress.Commands.add("setGithubSessionDefaults", () => {
   cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+  cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, "Github user")
   window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(E2E_USER))
   window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
 })
+
+Cypress.Commands.add(
+  "setEmailSessionDefaults",
+  (userType: "Email admin" | "Email collaborator") => {
+    cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+    cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, userType)
+    window.localStorage.setItem(
+      LOCAL_STORAGE_USER_KEY,
+      JSON.stringify(E2E_USER)
+    )
+    window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
+  }
+)

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -5,24 +5,45 @@ import {
   E2E_USER,
   LOCAL_STORAGE_USERID_KEY,
   E2E_USER_TYPE_COOKIE_KEY,
+  E2E_EMAIL_TEST_SITE,
+  E2E_SITE_KEY,
+  E2E_COOKIE,
+  E2E_EMAIL_ADMIN,
 } from "../fixtures/constants"
+import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 
 Cypress.Commands.add("setGithubSessionDefaults", () => {
   cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-  cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, "Github user")
+  cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, USER_TYPES.Github)
   window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(E2E_USER))
   window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
 })
 
+Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
+  cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
+  cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, userType)
+  cy.setCookie(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
+  cy.setCookie(E2E_COOKIE.Email.key, E2E_EMAIL_ADMIN.email)
+})
+
 Cypress.Commands.add(
-  "setEmailSessionDefaults",
-  (userType: "Email admin" | "Email collaborator") => {
+  "createEmailUser",
+  (
+    email: string,
+    userType: EmailUserTypes,
+    initialUserType: EmailUserTypes
+  ) => {
+    cy.clearCookies()
+    cy.setCookie(E2E_COOKIE.Site.key, "")
     cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-    cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, userType)
-    window.localStorage.setItem(
-      LOCAL_STORAGE_USER_KEY,
-      JSON.stringify(E2E_USER)
+    cy.setCookie(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
+    cy.setCookie(E2E_COOKIE.EmailUserType.key, userType)
+    cy.setCookie(E2E_COOKIE.Email.key, email)
+    cy.request("GET", `${Cypress.env("BACKEND_URL")}/auth/whoami`)
+
+    cy.setEmailSessionDefaults(initialUserType)
+    cy.visit(
+      `http://localhost:3000/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`
     )
-    window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
   }
 )

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -10,6 +10,7 @@ import {
   E2E_COOKIE,
   E2E_EMAIL_ADMIN,
   Interceptors,
+  BACKEND_URL,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 
@@ -46,7 +47,7 @@ Cypress.Commands.add(
 
     cy.setEmailSessionDefaults(initialUserType)
     cy.visit(
-      `http://localhost:3000/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`
+      `http://${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`
     )
   }
 )

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -10,7 +10,7 @@ import {
   E2E_COOKIE,
   E2E_EMAIL_ADMIN,
   Interceptors,
-  BACKEND_URL,
+  CMS_BASEURL,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 
@@ -46,8 +46,6 @@ Cypress.Commands.add(
     )
 
     cy.setEmailSessionDefaults(initialUserType)
-    cy.visit(
-      `http://${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`
-    )
+    cy.visit(`${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
   }
 )

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -6,7 +6,7 @@ import {
   LOCAL_STORAGE_USERID_KEY,
 } from "../fixtures/constants"
 
-Cypress.Commands.add("setSessionDefaults", () => {
+Cypress.Commands.add("setGithubSessionDefaults", () => {
   cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
   window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(E2E_USER))
   window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -9,6 +9,7 @@ import {
   E2E_SITE_KEY,
   E2E_COOKIE,
   E2E_EMAIL_ADMIN,
+  Interceptors,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 
@@ -39,7 +40,9 @@ Cypress.Commands.add(
     cy.setCookie(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
     cy.setCookie(E2E_COOKIE.EmailUserType.key, userType)
     cy.setCookie(E2E_COOKIE.Email.key, email)
-    cy.request("GET", `${Cypress.env("BACKEND_URL")}/auth/whoami`)
+    cy.request("GET", `${Cypress.env("BACKEND_URL")}/auth/whoami`).wait(
+      Interceptors.GET
+    )
 
     cy.setEmailSessionDefaults(initialUserType)
     cy.visit(

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,18 +46,20 @@ const {
   REACT_APP_ENV,
 } = process.env
 
-datadogRum.init({
-  applicationId: REACT_APP_DATADOG_APP_ID,
-  clientToken: REACT_APP_DATADOG_CLIENT_TOKEN,
-  site: "datadoghq.com",
-  service: "isomercms-frontend",
-  env: REACT_APP_ENV,
-  // Specify a version number to identify the deployed version of your application in Datadog
-  version: REACT_APP_VERSION,
-  ...DATADOG_RUM_SETTINGS,
-})
+if (REACT_APP_ENV === "staging" || REACT_APP_ENV === "production") {
+  datadogRum.init({
+    applicationId: REACT_APP_DATADOG_APP_ID,
+    clientToken: REACT_APP_DATADOG_CLIENT_TOKEN,
+    site: "datadoghq.com",
+    service: "isomercms-frontend",
+    env: REACT_APP_ENV,
+    // Specify a version number to identify the deployed version of your application in Datadog
+    version: REACT_APP_VERSION,
+    ...DATADOG_RUM_SETTINGS,
+  })
 
-datadogRum.startSessionReplayRecording()
+  datadogRum.startSessionReplayRecording()
+}
 
 const App = () => {
   useEffect(() => {


### PR DESCRIPTION
**note: this requires the corresponding [be](https://github.com/isomerpages/isomercms-backend/pull/782) PR**

## Problem
current e2e tests only cover the github flow. this PR adds in collaborator tests that cover the email login flow.


## Solution
1. add in spec for collab tests

**New environment variables**:
- `CYPRESS_BACKEND_URL` : backend url of our website, required to make the request to create a user

## Tests
- [ ] **first, add the e2e email repo to your db** (required b/c e2e email users only have access to this/gh repo)
- [ ] run `npm run cypress:open` 
- [ ] click on the collaborators spec