### PR TITLE
ref(e2e): test structure

### DIFF
--- a/cypress/api/collaborators.api.ts
+++ b/cypress/api/collaborators.api.ts
@@ -1,0 +1,11 @@
+import { E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
+import { USER_TYPES } from "../fixtures/users"
+
+export const addAdmin = (admin: string): void => {
+  cy.createEmailUser(
+    admin,
+    USER_TYPES.Email.Admin,
+    USER_TYPES.Email.Admin,
+    E2E_EMAIL_TEST_SITE.name
+  )
+}

--- a/cypress/api/constants.ts
+++ b/cypress/api/constants.ts
@@ -1,0 +1,3 @@
+import { BACKEND_URL, E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
+
+export const E2E_EMAIL_SITE_API_URL = `${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}`

--- a/cypress/api/index.ts
+++ b/cypress/api/index.ts
@@ -1,1 +1,3 @@
 export * from "./reviewRequest.api"
+export * from "./pages.api"
+export * from "./collaborators.api"

--- a/cypress/api/index.ts
+++ b/cypress/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./reviewRequest.api"

--- a/cypress/api/pages.api.ts
+++ b/cypress/api/pages.api.ts
@@ -1,0 +1,31 @@
+import { UnlinkedPageDto } from "../../src/types/pages"
+import { BACKEND_URL } from "../fixtures/constants"
+
+export const editUnlinkedPage = (
+  pageName: string,
+  pageContent: string,
+  site: string
+): void => {
+  readUnlinkedPage(pageName, site).then(({ sha, content }) => {
+    return cy.request(
+      "POST",
+      `${BACKEND_URL}/sites/${site}/pages/pages/${pageName}`,
+      {
+        content: {
+          frontMatter: content.frontMatter,
+          pageBody: pageContent,
+        },
+        sha,
+      }
+    )
+  })
+}
+
+export const readUnlinkedPage = (
+  pageName: string,
+  site: string
+): Cypress.Chainable<UnlinkedPageDto> => {
+  return cy
+    .request("GET", `${BACKEND_URL}/sites/${site}/pages/pages/${pageName}`)
+    .then(({ body }) => body)
+}

--- a/cypress/api/reviewRequest.api.ts
+++ b/cypress/api/reviewRequest.api.ts
@@ -1,8 +1,6 @@
-import {
-  BACKEND_URL,
-  E2E_EMAIL_TEST_SITE,
-  Interceptors,
-} from "../fixtures/constants"
+import { Interceptors } from "../fixtures/constants"
+
+import { E2E_EMAIL_SITE_API_URL } from "./constants"
 
 /**
  * @precondition Assumes that the default interceptors are set up.
@@ -15,13 +13,9 @@ export const createReviewRequest = async (
   reviewers: string[],
   description?: string
 ): Promise<void> => {
-  cy.request(
-    "POST",
-    `${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/request`,
-    {
-      reviewers,
-      title,
-      description,
-    }
-  ).wait(Interceptors.POST)
+  cy.request("POST", `${E2E_EMAIL_SITE_API_URL}/review/request`, {
+    reviewers,
+    title,
+    description,
+  }).wait(Interceptors.POST)
 }

--- a/cypress/api/reviewRequest.api.ts
+++ b/cypress/api/reviewRequest.api.ts
@@ -1,0 +1,27 @@
+import {
+  BACKEND_URL,
+  E2E_EMAIL_TEST_SITE,
+  Interceptors,
+} from "../fixtures/constants"
+
+/**
+ * @precondition Assumes that the default interceptors are set up.
+ * This creates a review request and waits for it using the default interceptors
+ * Note that this creates a review request for the test site using the
+ * session of the currently active user.
+ */
+export const createReviewRequest = async (
+  title: string,
+  reviewers: string[],
+  description?: string
+): Promise<void> => {
+  cy.request(
+    "POST",
+    `${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/request`,
+    {
+      reviewers,
+      title,
+      description,
+    }
+  ).wait(Interceptors.POST)
+}

--- a/cypress/api/reviewRequest.api.ts
+++ b/cypress/api/reviewRequest.api.ts
@@ -1,21 +1,40 @@
-import { Interceptors } from "../fixtures/constants"
-
 import { E2E_EMAIL_SITE_API_URL } from "./constants"
 
+const BASE_URL = `${E2E_EMAIL_SITE_API_URL}/review`
+
 /**
- * @precondition Assumes that the default interceptors are set up.
  * This creates a review request and waits for it using the default interceptors
  * Note that this creates a review request for the test site using the
  * session of the currently active user.
  */
-export const createReviewRequest = async (
+export const createReviewRequest = (
   title: string,
   reviewers: string[],
   description?: string
-): Promise<void> => {
-  cy.request("POST", `${E2E_EMAIL_SITE_API_URL}/review/request`, {
-    reviewers,
-    title,
-    description,
-  }).wait(Interceptors.POST)
+): Cypress.Chainable<number> => {
+  return cy
+    .request("POST", `${BASE_URL}/request`, {
+      reviewers,
+      title,
+      description,
+    })
+    .then(({ body }) => body.pullRequestNumber)
+}
+
+export const listReviewRequests = (): Cypress.Chainable<{ id: number }[]> => {
+  return cy
+    .request("GET", `${BASE_URL}/summary`)
+    .then(({ body }) => body.reviews)
+}
+
+export const closeReviewRequests = (): void => {
+  listReviewRequests().then((reviewRequests) => {
+    reviewRequests.forEach(({ id }) => {
+      cy.request("DELETE", `${BASE_URL}/${id}`)
+    })
+  })
+}
+
+export const approveReviewRequest = (id: number): void => {
+  cy.request("POST", `${BASE_URL}/${id}/approve`)
 }

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -5,6 +5,10 @@ import {
   Interceptors,
   TEST_REPO_NAME,
 } from "../fixtures/constants"
+import {
+  ADD_COLLABORATOR_INPUT_SELECTOR,
+  DELETE_BUTTON_SELECTOR,
+} from "../fixtures/selectors"
 import { USER_TYPES } from "../fixtures/users"
 import { visitE2eEmailTestRepo } from "../utils"
 
@@ -33,10 +37,6 @@ const DUPLICATE_COLLABORATOR_ERROR_MESSAGE =
 const NON_EXISTING_USER_ERROR_MESSAGE =
   "This user does not have an Isomer account. Ask them to log in to Isomer and try adding them again."
 
-const ADD_COLLABORATOR_INPUT_SELECTOR = "input[name='newCollaboratorEmail']"
-
-const DELETE_COLLABORATOR_BUTTON_SELECTOR = 'button[id^="delete-"]'
-
 const getCollaboratorsModal = () => {
   cy.contains("Site collaborators")
     .parent()
@@ -60,7 +60,7 @@ const removeCollaborator = (email: string) => {
     .parent()
     .parent()
     .within(() => {
-      cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).click()
+      cy.get(DELETE_BUTTON_SELECTOR).click()
     })
 
   cy.contains("button", "Remove collaborator").click().wait(Interceptors.DELETE)
@@ -156,7 +156,7 @@ describe("collaborators flow", () => {
       // Act
       // NOTE: Remove all collaborators except the initial admin
       getCollaboratorsModal()
-        .get(DELETE_COLLABORATOR_BUTTON_SELECTOR)
+        .get(DELETE_BUTTON_SELECTOR)
         .then((buttons) => {
           if (buttons.length > 1) {
             buttons.slice(1).each((idx, button) => {
@@ -166,7 +166,7 @@ describe("collaborators flow", () => {
         })
 
       // Assert
-      cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).should("be.disabled")
+      cy.get(DELETE_BUTTON_SELECTOR).should("be.disabled")
     })
 
     it("should prevent admins of a site from removing collaborators of another site", () => {

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -60,6 +60,8 @@ describe("collaborators flow", () => {
   })
 
   describe("Admin adding a collaborator", () => {
+    after(() => removeOtherCollaborators())
+
     it("should not be able to click the add collaborator button when the input is empty", () => {
       // Act
       // Assert
@@ -113,9 +115,6 @@ describe("collaborators flow", () => {
       // Assert
       cy.get("form").contains(collaborator).should("be.visible")
       cy.get("form").contains("Contributor").should("be.visible")
-
-      // Cleanup
-      removeCollaborator(collaborator)
     })
   })
 
@@ -126,6 +125,7 @@ describe("collaborators flow", () => {
 
       // Act
       removeCollaborator(collaborator)
+      closeModal()
 
       // Assert
       cy.contains("Collaborator removed successfully").should("be.visible")

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -11,6 +11,10 @@ import {
 } from "../fixtures/selectors"
 import { USER_TYPES } from "../fixtures/users"
 import { visitE2eEmailTestRepo } from "../utils"
+import {
+  getCollaboratorsModal,
+  removeOtherCollaborators,
+} from "../utils/collaborators"
 
 const collaborator = E2E_EMAIL_COLLAB.email
 
@@ -36,17 +40,6 @@ const DUPLICATE_COLLABORATOR_ERROR_MESSAGE =
 
 const NON_EXISTING_USER_ERROR_MESSAGE =
   "This user does not have an Isomer account. Ask them to log in to Isomer and try adding them again."
-
-const getCollaboratorsModal = () => {
-  cy.contains("Site collaborators")
-    .parent()
-    .parent()
-    .parent()
-    .within(() => cy.get("button").click())
-
-  // NOTE: the form encloses the displayed modal component
-  return cy.get("form").should("be.visible")
-}
 
 const inputCollaborators = (user: string) => {
   getCollaboratorsModal().get(ADD_COLLABORATOR_INPUT_SELECTOR).type(user).blur()
@@ -155,15 +148,7 @@ describe("collaborators flow", () => {
     it("should not be able to remove the last site member", () => {
       // Act
       // NOTE: Remove all collaborators except the initial admin
-      getCollaboratorsModal()
-        .get(DELETE_BUTTON_SELECTOR)
-        .then((buttons) => {
-          if (buttons.length > 1) {
-            buttons.slice(1).each((idx, button) => {
-              button.click()
-            })
-          }
-        })
+      removeOtherCollaborators()
 
       // Assert
       cy.get(DELETE_BUTTON_SELECTOR).should("be.disabled")

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -5,7 +5,7 @@ import {
   Interceptors,
   TEST_REPO_NAME,
 } from "../fixtures/constants"
-import { DELETE_BUTTON_SELECTOR } from "../fixtures/selectors"
+import { DELETE_BUTTON_SELECTOR as DELETE_COLLABORATOR_BUTTON_SELECTOR } from "../fixtures/selectors"
 import { USER_TYPES } from "../fixtures/users"
 import { closeModal, visitE2eEmailTestRepo } from "../utils"
 import {
@@ -46,7 +46,7 @@ const removeCollaborator = (email: string) => {
     .parent()
     .parent()
     .within(() => {
-      cy.get(DELETE_BUTTON_SELECTOR).click()
+      cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).click()
     })
 
   cy.contains("button", "Remove collaborator").click().wait(Interceptors.DELETE)
@@ -137,7 +137,7 @@ describe("collaborators flow", () => {
       removeOtherCollaborators()
 
       // Assert
-      cy.get(DELETE_BUTTON_SELECTOR).should("be.disabled")
+      cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).should("be.disabled")
     })
 
     it("should prevent admins of a site from removing collaborators of another site", () => {

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -2,11 +2,11 @@ import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
   E2E_EMAIL_COLLAB,
-  E2E_EMAIL_TEST_SITE,
   Interceptors,
   TEST_REPO_NAME,
 } from "../fixtures/constants"
 import { USER_TYPES } from "../fixtures/users"
+import { visitE2eEmailTestRepo } from "../utils"
 
 const collaborator = E2E_EMAIL_COLLAB.email
 
@@ -36,11 +36,6 @@ const NON_EXISTING_USER_ERROR_MESSAGE =
 const ADD_COLLABORATOR_INPUT_SELECTOR = "input[name='newCollaboratorEmail']"
 
 const DELETE_COLLABORATOR_BUTTON_SELECTOR = 'button[id^="delete-"]'
-
-const visitE2eEmailTestRepo = () => {
-  cy.visit(`${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
-  cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
-}
 
 const getCollaboratorsModal = () => {
   cy.contains("Site collaborators")

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../fixtures/constants"
 import { DELETE_BUTTON_SELECTOR } from "../fixtures/selectors"
 import { USER_TYPES } from "../fixtures/users"
-import { visitE2eEmailTestRepo } from "../utils"
+import { closeModal, visitE2eEmailTestRepo } from "../utils"
 import {
   addCollaborator,
   getCollaboratorsModal,
@@ -108,6 +108,7 @@ describe("collaborators flow", () => {
       cy.get("input[name='isAcknowledged']").next().click()
       cy.contains("Continue").click().wait(Interceptors.POST)
       ignoreAcknowledgementError()
+      closeModal()
 
       // Assert
       cy.get("form").contains(collaborator).should("be.visible")

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -31,6 +31,9 @@ const ignoreDuplicateError = () =>
 const ignoreNotFoundError = () =>
   cy.on("uncaught:exception", (err) => !err.message.includes("404"))
 
+const ignoreForbiddenError = () =>
+  cy.on("uncaught:exception", (err) => !err.message.includes("403"))
+
 const ADD_COLLABORATOR_ERROR_MESSAGE =
   "This collaborator couldn't be added. Visit our guide for more assistance"
 
@@ -70,6 +73,7 @@ describe("collaborators flow", () => {
     it("should not be able to add a non-whitelisted collaborator", () => {
       // Act
       inputCollaborators("some_gibberish@gmail.com")
+      ignoreForbiddenError()
 
       // Assert
       cy.contains(ADD_COLLABORATOR_ERROR_MESSAGE).should("be.visible")

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -50,3 +50,6 @@ export const BACKEND_URL = Cypress.env("BACKEND_URL")
 
 export const E2E_EMAIL_REPO_STAGING_LINK =
   "https://staging.d2qim5mov3pptm.amplifyapp.com"
+
+export const MOCK_REVIEW_TITLE = "Some interesting title"
+export const MOCK_REVIEW_DESCRIPTION = "Some interesting description"

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -47,3 +47,6 @@ export const CMS_BASEURL: string | undefined = Cypress.env("BASEURL")
 export const BASE_SEO_LINK = "www.open.gov.sg"
 
 export const BACKEND_URL = Cypress.env("BACKEND_URL")
+
+export const E2E_EMAIL_REPO_STAGING_LINK =
+  "https://staging.d2qim5mov3pptm.amplifyapp.com"

--- a/cypress/fixtures/selectors/collaborators.ts
+++ b/cypress/fixtures/selectors/collaborators.ts
@@ -1,0 +1,2 @@
+export const ADD_COLLABORATOR_INPUT_SELECTOR =
+  "input[name='newCollaboratorEmail']"

--- a/cypress/fixtures/selectors/common.ts
+++ b/cypress/fixtures/selectors/common.ts
@@ -1,1 +1,5 @@
 export const DELETE_BUTTON_SELECTOR = 'button[id^="delete-"]'
+
+export const GET_HELP_LINK_SELECTOR = "a[href='https://guide.isomer.gov.sg/']"
+
+export const DROPDOWN_BUTTON_SELECTOR = "button[aria-label='Select options']"

--- a/cypress/fixtures/selectors/common.ts
+++ b/cypress/fixtures/selectors/common.ts
@@ -1,0 +1,1 @@
+export const DELETE_BUTTON_SELECTOR = 'button[id^="delete-"]'

--- a/cypress/fixtures/selectors/index.ts
+++ b/cypress/fixtures/selectors/index.ts
@@ -1,0 +1,2 @@
+export * from "./collaborators"
+export * from "./common"

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -60,7 +60,8 @@ declare namespace Cypress {
       // NOTE: have to (re)declare the type here
       // otherwise the import leads to a type error
       userType: "Email admin" | "Email collaborator",
-      InitialUserType: "Email admin" | "Email collaborator"
+      InitialUserType: "Email admin" | "Email collaborator",
+      site?: string
     ): Chainable<void>
   }
 }

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -44,7 +44,7 @@ Cypress.Commands.add(
     cy.setCookie(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
     cy.setCookie(E2E_COOKIE.EmailUserType.key, userType)
     cy.setCookie(E2E_COOKIE.Email.key, email)
-    cy.request("GET", `${BACKEND_URL}/auth/whoami`).wait(Interceptors.GET)
+    cy.request("GET", `${BACKEND_URL}/auth/whoami`)
 
     cy.setEmailSessionDefaults(initialUserType)
     cy.visit(`${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -35,10 +35,11 @@ Cypress.Commands.add(
   (
     email: string,
     userType: EmailUserTypes,
-    initialUserType: EmailUserTypes
+    initialUserType: EmailUserTypes,
+    site = ""
   ) => {
     cy.clearCookies()
-    cy.setCookie(E2E_COOKIE.Site.key, "")
+    cy.setCookie(E2E_COOKIE.Site.key, site)
     cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
     cy.setCookie(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
     cy.setCookie(E2E_COOKIE.EmailUserType.key, userType)

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -11,6 +11,7 @@ import {
   E2E_EMAIL_ADMIN,
   Interceptors,
   CMS_BASEURL,
+  BACKEND_URL,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 
@@ -42,9 +43,7 @@ Cypress.Commands.add(
     cy.setCookie(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
     cy.setCookie(E2E_COOKIE.EmailUserType.key, userType)
     cy.setCookie(E2E_COOKIE.Email.key, email)
-    cy.request("GET", `${Cypress.env("BACKEND_URL")}/auth/whoami`).wait(
-      Interceptors.GET
-    )
+    cy.request("GET", `${BACKEND_URL}/auth/whoami`).wait(Interceptors.GET)
 
     cy.setEmailSessionDefaults(initialUserType)
     cy.visit(`${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -9,9 +9,9 @@ import {
   E2E_SITE_KEY,
   E2E_COOKIE,
   E2E_EMAIL_ADMIN,
-  Interceptors,
   CMS_BASEURL,
   BACKEND_URL,
+  E2E_EMAIL_COLLAB,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 
@@ -26,7 +26,10 @@ Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
   cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
   cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, userType)
   cy.setCookie(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
-  cy.setCookie(E2E_COOKIE.Email.key, E2E_EMAIL_ADMIN.email)
+  cy.setCookie(
+    E2E_COOKIE.Email.key,
+    userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_COLLAB.email
+  )
   cy.setCookie(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
 })
 

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -26,6 +26,7 @@ Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
   cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, userType)
   cy.setCookie(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
   cy.setCookie(E2E_COOKIE.Email.key, E2E_EMAIL_ADMIN.email)
+  cy.setCookie(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
 })
 
 Cypress.Commands.add(

--- a/cypress/utils/collaborators.ts
+++ b/cypress/utils/collaborators.ts
@@ -1,4 +1,9 @@
-import { DELETE_BUTTON_SELECTOR } from "../fixtures/selectors"
+import { Interceptors } from "../fixtures/constants"
+import {
+  ADD_COLLABORATOR_INPUT_SELECTOR,
+  DELETE_BUTTON_SELECTOR,
+} from "../fixtures/selectors"
+import { USER_TYPES } from "../fixtures/users"
 
 import { closeModal } from "./modal"
 
@@ -22,9 +27,33 @@ export const removeOtherCollaborators = (): void => {
       if (buttons.length > 1) {
         buttons.slice(1).each((_, button) => {
           button.click()
+          cy.contains("button", "Remove collaborator").click()
+          cy.contains("Collaborator removed successfully").should("be.visible")
         })
       }
     })
+
+  closeModal()
+}
+
+export const inputCollaborators = (user: string): void => {
+  getCollaboratorsModal().get(ADD_COLLABORATOR_INPUT_SELECTOR).type(user).blur()
+  // NOTE: need to ignore the 422 w/ specific error message because we haven't ack yet
+  cy.contains("Add collaborator").click().wait(Interceptors.POST)
+}
+
+export const addCollaborator = (collaborator: string): void => {
+  cy.createEmailUser(
+    collaborator,
+    USER_TYPES.Email.Collaborator,
+    USER_TYPES.Email.Admin
+  )
+
+  inputCollaborators(collaborator)
+
+  cy.get("input[name='isAcknowledged']").next().click()
+  cy.contains("Continue").click().wait(Interceptors.POST)
+  cy.on("uncaught:exception", (err) => !err.message.includes("422"))
 
   closeModal()
 }

--- a/cypress/utils/collaborators.ts
+++ b/cypress/utils/collaborators.ts
@@ -1,0 +1,30 @@
+import { DELETE_BUTTON_SELECTOR } from "../fixtures/selectors"
+
+import { closeModal } from "./modal"
+
+export const getCollaboratorsModal = (): Cypress.Chainable<
+  JQuery<HTMLFormElement>
+> => {
+  cy.contains("Site collaborators")
+    .parent()
+    .parent()
+    .parent()
+    .within(() => cy.get("button").click())
+
+  // NOTE: the form encloses the displayed modal component
+  return cy.get("form").should("be.visible")
+}
+
+export const removeOtherCollaborators = (): void => {
+  getCollaboratorsModal()
+    .get(DELETE_BUTTON_SELECTOR)
+    .then((buttons) => {
+      if (buttons.length > 1) {
+        buttons.slice(1).each((_, button) => {
+          button.click()
+        })
+      }
+    })
+
+  closeModal()
+}

--- a/cypress/utils/header.ts
+++ b/cypress/utils/header.ts
@@ -1,0 +1,12 @@
+import { GET_HELP_LINK_SELECTOR } from "../fixtures/selectors"
+
+// NOTE: This is a `div` tag styled like a `button`
+export const getOpenStagingButton = (): Cypress.Chainable<
+  JQuery<HTMLElement>
+> => cy.contains("a", "Open staging")
+export const getNotificationsButton = (): Cypress.Chainable<
+  JQuery<HTMLElement>
+> => cy.get(GET_HELP_LINK_SELECTOR).parent().next()
+
+export const getAvatarButton = (): Cypress.Chainable<JQuery<HTMLElement>> =>
+  getNotificationsButton().next().next()

--- a/cypress/utils/index.ts
+++ b/cypress/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./navigation"

--- a/cypress/utils/index.ts
+++ b/cypress/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./navigation"
 export * from "./modal"
 export * from "./collaborators"
+export * from "./header"

--- a/cypress/utils/index.ts
+++ b/cypress/utils/index.ts
@@ -1,1 +1,3 @@
 export * from "./navigation"
+export * from "./modal"
+export * from "./collaborators"

--- a/cypress/utils/modal.ts
+++ b/cypress/utils/modal.ts
@@ -1,0 +1,3 @@
+export const closeModal = (): void => {
+  cy.get('button[aria-label="Close"]').click()
+}

--- a/cypress/utils/modal.ts
+++ b/cypress/utils/modal.ts
@@ -1,3 +1,3 @@
 export const closeModal = (): void => {
-  cy.get('button[aria-label="Close"]').click()
+  cy.get('button[aria-label="Close"][class^="chakra-modal"]').click()
 }

--- a/cypress/utils/navigation.ts
+++ b/cypress/utils/navigation.ts
@@ -1,6 +1,6 @@
 import { BACKEND_URL, E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
 
-export const visitE2eEmailTestRepo = () => {
+export const visitE2eEmailTestRepo = (): void => {
   cy.visit(`${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
   cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
 }

--- a/cypress/utils/navigation.ts
+++ b/cypress/utils/navigation.ts
@@ -1,6 +1,6 @@
-import { BACKEND_URL, E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
+import { CMS_BASEURL, E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
 
 export const visitE2eEmailTestRepo = (): void => {
-  cy.visit(`${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
+  cy.visit(`${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
   cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
 }

--- a/cypress/utils/navigation.ts
+++ b/cypress/utils/navigation.ts
@@ -1,0 +1,6 @@
+import { BACKEND_URL, E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
+
+export const visitE2eEmailTestRepo = () => {
+  cy.visit(`${BACKEND_URL}/sites/${E2E_EMAIL_TEST_SITE.repo}/dashboard`)
+  cy.contains(E2E_EMAIL_TEST_SITE.repo).should("be.visible")
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,22 +34,34 @@ if (!E2E_COMMIT_HASH) {
   )
 }
 const GITHUB_ORG_NAME = "isomerpages"
-const REPO_NAME = "e2e-test-repo"
+const E2E_GITHUB_REPO_NAME = "e2e-test-repo"
+const E2E_EMAIL_REPO_NAME = "e2e-email-test-repo"
+const E2E_EMAIL_COMMIT_HASH = "93593ceb8ee8af690267e49ea787701fc73baed8"
 
-const resetE2eTestRepo = async () => {
-  const baseRefEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO_NAME}/git/refs`
-  const refEndpoint = `${baseRefEndpoint}/heads/staging`
+const resetRepo = async (repo, hash) => {
+  const endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/refs/heads/staging`
   await axios.patch(
-    refEndpoint,
+    endpoint,
     {
-      sha: E2E_COMMIT_HASH,
+      sha: hash,
       force: true,
     },
     {
       headers,
     }
   )
-  console.log(`Successfully reset e2e-test-repo to ${E2E_COMMIT_HASH}`)
+  console.log(`Successfully reset ${repo} to ${hash}`)
+}
+
+const resetGithubE2eTestRepo = () =>
+  resetRepo(E2E_GITHUB_REPO_NAME, E2E_COMMIT_HASH)
+
+const resetEmailE2eTestRepo = () =>
+  resetRepo(E2E_EMAIL_REPO_NAME, E2E_EMAIL_COMMIT_HASH)
+
+const resetE2eTestRepo = async () => {
+  await resetGithubE2eTestRepo()
+  await resetEmailE2eTestRepo()
 }
 
 // resets the e2e repo then runs the corresponding cypress command

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const { spawn } = require("child_process")
 
 const axios = require("axios")

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -1,0 +1,8 @@
+export interface UnlinkedPageDto {
+  pageName: string
+  sha: string
+  content: {
+    frontMatter: string
+    pageBody: string
+  }
+}


### PR DESCRIPTION
## Problem
While writing the scaffold for dashboard tests, i realised that alot of our code could be reused across test specs. in order to facilitate this code sharing, utility code/constants in `collaborators.spec` have been sharded out into a utils + constants file, which will be used later on.

Similarly, whilst working on `dashboard.spec`, some selectors + util functions were also sharded out as they could be reused later on (notably comments/notifs)

## Solution
- Shard out constants, utils and selectors 
    - constants and selectors differ in that `constants` are a value, whereas `selectors` are meant to extract some HTML element 
    - prefer util functions over commands to prevent pollution of `cy` namespace (see [here](https://github.com/isomerpages/isomercms-frontend/pull/1295#issuecomment-1582156373)) 
- This PR also adds a reset for our email test repo, similar to what is being done at present for github. 
- API requests added to cypress; see [here](https://github.com/isomerpages/isomercms-frontend/pull/1295#issuecomment-1582156373) for an overview of why we prefer this over a DOM driven action 