### PR TITLE
test(e2e): scaffold dashboard tests 

### DIFF
--- a/cypress/e2e/dashboard.spec.ts
+++ b/cypress/e2e/dashboard.spec.ts
@@ -1,0 +1,270 @@
+import {
+  addAdmin,
+  approveReviewRequest,
+  closeReviewRequests,
+  createReviewRequest,
+  listReviewRequests,
+} from "../api"
+import { editUnlinkedPage } from "../api/pages.api"
+import {
+  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_REPO_STAGING_LINK,
+  E2E_EMAIL_TEST_SITE,
+  MOCK_REVIEW_DESCRIPTION,
+  MOCK_REVIEW_TITLE,
+} from "../fixtures/constants"
+import { USER_TYPES } from "../fixtures/users"
+import {
+  addCollaborator,
+  getOpenStagingButton,
+  removeOtherCollaborators,
+  visitE2eEmailTestRepo,
+} from "../utils"
+
+const getReviewRequestButton = () => cy.contains("button", "Request a Review")
+const getSubmitReviewButton = () => cy.contains("button", "Submit Review")
+
+const selectReviewer = (email: string) => {
+  cy.get("div[id^='react-select']").contains(E2E_EMAIL_COLLAB.email).click()
+}
+const removeReviewers = () => cy.get('div[aria-label^="Remove"]').click()
+
+const TITLE_INPUT_SELECTOR =
+  "input[placeholder='Title your request'][name='title']"
+const DESCRIPTION_TEXTAREA_SELECTOR =
+  "textarea[name='description'][placeholder='Briefly describe the changes you’ve made, and add a review deadline (if applicable)']"
+
+const getAddReviewerDropdown = () =>
+  cy.contains("Select Admins to add as reviewers").parent()
+
+const goToWorkspace = () => cy.contains("a", "Edit site").click()
+
+const REVIEW_MODAL_SUBTITLE =
+  "An Admin needs to review and approve your changes before they can be published"
+
+describe("dashboard flow", () => {
+  beforeEach(() => {
+    cy.setupDefaultInterceptors()
+    cy.setEmailSessionDefaults("Email admin")
+    visitE2eEmailTestRepo()
+  })
+  describe("no review requests", () => {
+    beforeEach(() => {
+      closeReviewRequests()
+    })
+    it('should open the staging site on click of the "Open staging" button', () => {
+      // Act
+      getOpenStagingButton()
+        .should("have.attr", "href", E2E_EMAIL_REPO_STAGING_LINK)
+        .should("have.attr", "target", "_blank")
+    })
+    it('should open the "Request a Review" modal on click of the "Request a Review" button', () => {
+      // Act
+      getReviewRequestButton().click()
+
+      // Assert
+      cy.contains(REVIEW_MODAL_SUBTITLE).should("be.visible")
+    })
+    it.skip("should be able to navigate to the staging site using the dropdown button", () => {
+      throw new Error("Not implemented")
+    })
+    it.skip("should be able to navigate to the production site using the dropdown button", () => {
+      throw new Error("Not implemented")
+    })
+    it.skip('should navigate to the isomer guide on click of the "Get help" button', () => {
+      throw new Error("Not implemented")
+    })
+    it.skip("should navigate to the settings page when manage site settings is clicked", () => {
+      throw new Error("Not implemented")
+    })
+    it.skip("should navigate to the workspace when edit site is clicked", () => {
+      // Arrange
+      // NOTE: There shouldn't be an alert
+      // Act
+      // Assert
+      throw new Error("Not implemented")
+    })
+  })
+  describe("create review request", () => {
+    beforeEach(() => {
+      // NOTE: We want to start this test suite on a clean slate
+      // and prevent other tests from interfering
+      removeOtherCollaborators()
+    })
+
+    it("should not be able to create a review request when the site has 1 collaborator", () => {
+      // Arrange
+      getReviewRequestButton().click()
+      cy.contains(REVIEW_MODAL_SUBTITLE).should("be.visible")
+
+      // Act
+      getAddReviewerDropdown().click()
+
+      // Assert
+      cy.contains("No options").should("be.visible")
+    })
+    it("should not be able to create a review request without a reviewer", () => {
+      // Arrange
+      cy.createEmailUser(
+        E2E_EMAIL_COLLAB.email,
+        USER_TYPES.Email.Collaborator,
+        USER_TYPES.Email.Admin
+      )
+      addCollaborator(E2E_EMAIL_COLLAB.email)
+
+      // Act
+      // NOTE: There should be at least 1 other admin to be able to create a review request
+      getReviewRequestButton().click()
+      cy.contains(REVIEW_MODAL_SUBTITLE).should("be.visible")
+
+      // Assert
+      getAddReviewerDropdown().click()
+      cy.contains("No options").should("be.visible")
+    })
+    it.skip("should not be able to create a review request when there are no changes", () => {
+      // Arrange
+      // Act
+      // Assert
+      throw new Error("Not implemented")
+    })
+    it("should be able to create a review request successfully", () => {
+      // Arrange
+      addAdmin(E2E_EMAIL_COLLAB.email)
+      editUnlinkedPage(
+        "faq.md",
+        "some asdfasdfasdf content",
+        E2E_EMAIL_TEST_SITE.repo
+      )
+
+      // Act
+      getReviewRequestButton().click()
+      cy.contains(REVIEW_MODAL_SUBTITLE).should("be.visible")
+      cy.get(TITLE_INPUT_SELECTOR).type(MOCK_REVIEW_TITLE)
+      // NOTE: should not allow submitting of review prior to selecting reviewer
+      getSubmitReviewButton().should("be.disabled")
+      getAddReviewerDropdown().click()
+      // select reviewer and click
+      selectReviewer(E2E_EMAIL_COLLAB.email)
+      removeReviewers()
+      getSubmitReviewButton().should("be.disabled")
+      // add back reviewer
+      getAddReviewerDropdown().click()
+      selectReviewer(E2E_EMAIL_COLLAB.email)
+      cy.get(DESCRIPTION_TEXTAREA_SELECTOR).type(MOCK_REVIEW_DESCRIPTION)
+
+      // Assert
+      getSubmitReviewButton().click()
+      cy.contains("Review request submitted").should("be.visible")
+    })
+  })
+  describe.skip("has pending review requests", () => {
+    before(() => {
+      addAdmin(E2E_EMAIL_COLLAB.email)
+      // NOTE: Create a review request if none exists
+      listReviewRequests().then((requests) => {
+        if (!requests || !requests.length) {
+          createReviewRequest(
+            MOCK_REVIEW_TITLE,
+            [E2E_EMAIL_COLLAB.email],
+            MOCK_REVIEW_DESCRIPTION
+          )
+        }
+      })
+    })
+    it("should have the pending review alert on the workspace", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should prevent the requestor from approving their own review request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it('should show the review request on the workspace with the tag "Pending review"', () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should have changes reflected in the currently open review request", () => {
+      // Arrange
+      // TODO: If this is hard, maybe we can just do delete + add content + have new page
+      // NOTE: We define changes as being
+      // 1. Adding a new page
+      // 2. Editing an existing page
+      // 3. Deleting an existing page
+      // 4. Rename an existing page
+      // 5. Moving an existing page
+      // Act
+      // Assert
+    })
+    it("should be able to have the request approved as a collaborator", () => {
+      // Arrange
+      cy.setEmailSessionDefaults("Email collaborator")
+      // Act
+      // Assert
+    })
+  })
+  describe.skip("has approved review requests", () => {
+    before(() => {
+      addAdmin(E2E_EMAIL_COLLAB.email)
+      // NOTE: Create a review request if none exists
+      listReviewRequests().then((requests) => {
+        if (!requests || !requests.length) {
+          createReviewRequest(
+            MOCK_REVIEW_TITLE,
+            [E2E_EMAIL_COLLAB.email],
+            MOCK_REVIEW_DESCRIPTION
+          ).then((id) => approveReviewRequest(id))
+        }
+      })
+    })
+    it("should have the alert on the workspace", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should show the review request as being approved on the dashboard", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should prevent edits while the request is not merged", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should allow the requestor to merge the review request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should allow the reviewer to merge the review request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+  })
+  describe.skip("changing review request states", () => {
+    it("should allow the reviewer to unapprove the request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should allow the requestor to close the review request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should disallow users from viewing a closed review request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+    it("should disallow users from viewing a merged review request", () => {
+      // Arrange
+      // Act
+      // Assert
+    })
+  })
+})

--- a/cypress/e2e/dashboard.spec.ts
+++ b/cypress/e2e/dashboard.spec.ts
@@ -79,7 +79,7 @@ describe("dashboard flow", () => {
     })
     it.skip("should navigate to the workspace when edit site is clicked", () => {
       // Arrange
-      // NOTE: There shouldn't be an alert
+      // NOTE: There shouldn't be a review request alert
       // Act
       // Assert
       throw new Error("Not implemented")
@@ -219,7 +219,7 @@ describe("dashboard flow", () => {
         }
       })
     })
-    it("should have the alert on the workspace", () => {
+    it("should have the review request approved alert stating that editing is disabled when on the workspace", () => {
       // Arrange
       // Act
       // Assert

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -55,12 +55,26 @@ declare namespace Cypress {
     deleteMedia(mediaTitle: string, disableAction?: boolean): Chainable<void>
     saveSettings(): Chainable<void>
     visitLoadSettings(siteName: string, sitePath: string): Chainable<void>
+    /**
+     * Creates a email user with the given email and user type.
+     * This requires the `initialUserType`, which sets the current active session
+     * back to said user type.
+     *
+     * We require this due to Cypress sessions being async,
+     * and running in `beforeEach` leads to test bodies being ran without
+     * the required setup.
+     * @param email Email of the user to create
+     * @param userType The user type to create
+     * @param initialUserType The user type to set the session to once creation is done
+     * @param site The site the user belongs to. Leaving this blank means that
+     * the user does not belong to any site.
+     */
     createEmailUser(
       email: string,
       // NOTE: have to (re)declare the type here
       // otherwise the import leads to a type error
       userType: "Email admin" | "Email collaborator",
-      InitialUserType: "Email admin" | "Email collaborator",
+      initialUserType: "Email admin" | "Email collaborator",
       site?: string
     ): Chainable<void>
   }


### PR DESCRIPTION
## Problem
Isomer doesn't have e2e tests at present. as part of the effort to add more e2e tests, this PR scaffolds dashboard tests. 

Closes IS-251

## Solution
1. Add test cases for a few obvious cases
2. Add remaining test description + skip

**Notes**
1. for existing test cases - just see if there are additional conditions that we should be checking for. using `cypress:open` should allow the tests to be ran successfully
2. for test descriptions - check to see if there's any i've missed out. 