### PR TITLE
fix(constants): update diff values to be constant

### DIFF
--- a/src/layouts/ReviewRequest/components/DiffView/DiffView.stories.tsx
+++ b/src/layouts/ReviewRequest/components/DiffView/DiffView.stories.tsx
@@ -23,20 +23,20 @@ Default.args = {
 
 export const UpperCodeFold = Template.bind({})
 UpperCodeFold.args = {
-  newValue: NEW_DIFF_VALUE + NEW_DIFF_VALUE,
-  oldValue: NEW_DIFF_VALUE + OLD_DIFF_VALUE,
+  newValue: [NEW_DIFF_VALUE, NEW_DIFF_VALUE].join("\n"),
+  oldValue: [NEW_DIFF_VALUE, OLD_DIFF_VALUE].join("\n"),
 }
 
 export const LowerCodeFold = Template.bind({})
 LowerCodeFold.args = {
-  newValue: NEW_DIFF_VALUE + NEW_DIFF_VALUE,
-  oldValue: OLD_DIFF_VALUE + NEW_DIFF_VALUE,
+  newValue: [NEW_DIFF_VALUE, NEW_DIFF_VALUE].join("\n"),
+  oldValue: [OLD_DIFF_VALUE, NEW_DIFF_VALUE].join("\n"),
 }
 
 export const DualCodeFold = Template.bind({})
 DualCodeFold.args = {
-  newValue: NEW_DIFF_VALUE + NEW_DIFF_VALUE + NEW_DIFF_VALUE,
-  oldValue: NEW_DIFF_VALUE + OLD_DIFF_VALUE + NEW_DIFF_VALUE,
+  newValue: [NEW_DIFF_VALUE, NEW_DIFF_VALUE, NEW_DIFF_VALUE].join("\n"),
+  oldValue: [NEW_DIFF_VALUE, OLD_DIFF_VALUE, NEW_DIFF_VALUE].join("\n"),
 }
 
 export const UpperCodeFoldWithInitialChanges = Template.bind({})

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -489,12 +489,7 @@ export const MOCK_SITES_DATA: SiteDataRequest = {
 }
 
 const generateDiffValues = () =>
-  Array(10)
-    .fill([])
-    .map(() => {
-      return "the quick brown fox jumps over the lazy dog"
-    })
-    .join("\n")
+  Array(10).join("the quick brown fox jumps over the lazy dog\n")
 
 export const OLD_DIFF_VALUE = generateDiffValues()
 export const NEW_DIFF_VALUE = generateDiffValues().toUpperCase()

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -243,6 +243,7 @@ export const MOCK_SITE_DASHBOARD_INFO: SiteDashboardInfo = {
 
 export const MOCK_ITEMS: EditedItemProps[] = [
   {
+    title: "A page",
     type: "page",
     name: "A page",
     path: ["some", "thing"],
@@ -252,6 +253,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 129823104094,
   },
   {
+    title: "A nav",
     type: "nav",
     name: "A nav",
     path: ["some", "thing"],
@@ -259,6 +261,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 823104823094,
   },
   {
+    title: "a file",
     type: "file",
     name: "a file",
     path: ["some", "thing"],
@@ -266,6 +269,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 129823104823094,
   },
   {
+    title: "setting",
     type: "setting",
     name:
       "A setting with an extremely long title that probably can't fit into a single line and we have to truncate this somehow. so we will hopefully display an ellipsis over it",
@@ -280,6 +284,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 129823094,
   },
   {
+    title: "a normal setting",
     type: "setting",
     name: "a normal setting",
     path: ["some", "thing"],
@@ -287,6 +292,7 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedTime: 12123498294,
   },
   {
+    title: "some file",
     type: "image",
     name: "some file",
     path: ["some", "thing"],
@@ -431,6 +437,7 @@ export const MOCK_COMMENTS_DATA: CommentData[] = [
 ]
 
 const MOCK_EDITED_ITEM: EditedItemProps = {
+  title: "Mock item",
   type: "page",
   name: "mock item",
   path: ["some", "path"],
@@ -480,22 +487,14 @@ export const MOCK_SITES_DATA: SiteDataRequest = {
     },
   ],
 }
-// 100 lines of random characters, where each line is [0, 100] characters long
-// ASCII 48 - 122 is [a-zA-Z0-9] and some punctuation
+
 const generateDiffValues = () =>
-  Array(100)
+  Array(10)
     .fill([])
     .map(() => {
-      const length = _.random(0, 100)
-      return Array(length)
-        .fill("")
-        .map(() => {
-          const char = _.random(48, 122)
-          return String.fromCharCode(char)
-        })
-        .join("")
+      return "the quick brown fox jumps over the lazy dog"
     })
     .join("\n")
 
 export const OLD_DIFF_VALUE = generateDiffValues()
-export const NEW_DIFF_VALUE = generateDiffValues()
+export const NEW_DIFF_VALUE = generateDiffValues().toUpperCase()


### PR DESCRIPTION
## Problem
chromatic cannot render our diff view cos too big ._. also, because the diff view is randomly generated atm, this means that misc changes also incur a deploy to chromatic (cos the diff view value changed)

## Solution
1. hard code `const` values for display
2. change # lines to 10 instead of 100 ._.

## Tests
- [ ] check if chromatic deploy works