### PR TITLE
Feat(siteLaunchPad): Disclaimer pages Storybook

### DIFF
--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom"
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 
 import {
+  SiteLaunchDto,
   SiteLaunchFrontEndStatus,
   SiteLaunchStatusProps,
   SITE_LAUNCH_TASKS_LENGTH,
@@ -29,6 +30,38 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
   if (!SiteLaunchContextData)
     throw new Error("useSiteLaunchContext must be used within an RoleProvider")
   return SiteLaunchContextData
+}
+
+function updateSiteLaunchStatusOnApiCall(
+  siteLaunchDto: SiteLaunchDto | undefined,
+  siteLaunchStatusProps: SiteLaunchStatusProps,
+  setSiteLaunchStatusProps: (
+    siteLaunchStatusProps: SiteLaunchStatusProps
+  ) => void
+): void {
+  if (
+    siteLaunchDto?.siteStatus === "NOT_LAUNCHED" &&
+    siteLaunchStatusProps.siteLaunchStatus === "LOADING"
+  ) {
+    setSiteLaunchStatusProps({
+      siteLaunchStatus: "NOT_LAUNCHED",
+      stepNumber: 0,
+    })
+  }
+  // this condition is added to prevent redundant re-renders
+  const isSiteLaunchFEAndBESynced =
+    siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
+  if (
+    (siteLaunchDto?.siteStatus === "LAUNCHED" ||
+      siteLaunchDto?.siteStatus === "LAUNCHING") &&
+    !isSiteLaunchFEAndBESynced
+  ) {
+    setSiteLaunchStatusProps({
+      siteLaunchStatus: siteLaunchDto.siteStatus,
+      stepNumber: SITE_LAUNCH_TASKS_LENGTH,
+      dnsRecords: siteLaunchDto.dnsRecords,
+    })
+  }
 }
 
 export const SiteLaunchProvider = ({

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useState } from "react"
 import { useParams } from "react-router-dom"
 
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
@@ -6,6 +6,8 @@ import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 import {
   SiteLaunchFrontEndStatus,
   SiteLaunchStatusProps,
+  SiteLaunchTaskTypeIndex,
+  SITE_LAUNCH_TASKS,
   SITE_LAUNCH_TASKS_LENGTH,
 } from "types/siteLaunch"
 
@@ -19,7 +21,7 @@ interface SiteLaunchContextProps {
 interface SiteLaunchProviderProps {
   children: React.ReactNode
   initialSiteLaunchStatus?: SiteLaunchFrontEndStatus
-  initialStepNumber?: number
+  initialStepNumber?: SiteLaunchTaskTypeIndex
 }
 
 const SiteLaunchContext = createContext<SiteLaunchContextProps | null>(null)
@@ -43,7 +45,7 @@ export const SiteLaunchProvider = ({
     setSiteLaunchStatusProps,
   ] = useState<SiteLaunchStatusProps>({
     siteLaunchStatus: initialSiteLaunchStatus || "LOADING",
-    stepNumber: initialStepNumber || 0,
+    stepNumber: initialStepNumber || SITE_LAUNCH_TASKS.NOT_STARTED,
   })
 
   const { data: siteLaunchDto } = useGetSiteLaunchStatus(siteName)

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -4,7 +4,6 @@ import { useParams } from "react-router-dom"
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 
 import {
-  SiteLaunchDto,
   SiteLaunchFrontEndStatus,
   SiteLaunchStatusProps,
   SITE_LAUNCH_TASKS_LENGTH,
@@ -30,38 +29,6 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
   if (!SiteLaunchContextData)
     throw new Error("useSiteLaunchContext must be used within an RoleProvider")
   return SiteLaunchContextData
-}
-
-function updateSiteLaunchStatusOnApiCall(
-  siteLaunchDto: SiteLaunchDto,
-  siteLaunchStatusProps: SiteLaunchStatusProps,
-  setSiteLaunchStatusProps: (
-    siteLaunchStatusProps: SiteLaunchStatusProps
-  ) => void
-): void {
-  if (
-    siteLaunchDto.siteStatus === "NOT_LAUNCHED" &&
-    siteLaunchStatusProps.siteLaunchStatus === "LOADING"
-  ) {
-    setSiteLaunchStatusProps({
-      siteLaunchStatus: "NOT_LAUNCHED",
-      stepNumber: 0,
-    })
-  }
-  // this condition is added to prevent redundant re-renders
-  const isSiteLaunchFEAndBESynced =
-    siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
-  if (
-    (siteLaunchDto.siteStatus === "LAUNCHED" ||
-      siteLaunchDto.siteStatus === "LAUNCHING") &&
-    !isSiteLaunchFEAndBESynced
-  ) {
-    setSiteLaunchStatusProps({
-      siteLaunchStatus: siteLaunchDto.siteStatus,
-      stepNumber: SITE_LAUNCH_TASKS_LENGTH,
-      dnsRecords: siteLaunchDto.dnsRecords,
-    })
-  }
 }
 
 export const SiteLaunchProvider = ({

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react"
+import { createContext, useContext, useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -33,14 +33,14 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
 }
 
 function updateSiteLaunchStatusOnApiCall(
-  siteLaunchDto: SiteLaunchDto | undefined,
+  siteLaunchDto: SiteLaunchDto,
   siteLaunchStatusProps: SiteLaunchStatusProps,
   setSiteLaunchStatusProps: (
     siteLaunchStatusProps: SiteLaunchStatusProps
   ) => void
 ): void {
   if (
-    siteLaunchDto?.siteStatus === "NOT_LAUNCHED" &&
+    siteLaunchDto.siteStatus === "NOT_LAUNCHED" &&
     siteLaunchStatusProps.siteLaunchStatus === "LOADING"
   ) {
     setSiteLaunchStatusProps({
@@ -52,8 +52,8 @@ function updateSiteLaunchStatusOnApiCall(
   const isSiteLaunchFEAndBESynced =
     siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
   if (
-    (siteLaunchDto?.siteStatus === "LAUNCHED" ||
-      siteLaunchDto?.siteStatus === "LAUNCHING") &&
+    (siteLaunchDto.siteStatus === "LAUNCHED" ||
+      siteLaunchDto.siteStatus === "LAUNCHING") &&
     !isSiteLaunchFEAndBESynced
   ) {
     setSiteLaunchStatusProps({

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -66,9 +66,7 @@ const SiteDashboardMeta = {
       return (
         <MemoryRouter initialEntries={["/sites/storybook/dashboard"]}>
           <Route path="/sites/:siteName/dashboard">
-            <SiteLaunchProvider>
-              <Story />
-            </SiteLaunchProvider>
+            <Story />
           </Route>
         </MemoryRouter>
       )

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -23,6 +23,7 @@ import {
   buildSiteDashboardReviewRequests,
   buildSiteLaunchDto,
 } from "mocks/utils"
+import { SITE_LAUNCH_TASKS_LENGTH } from "types/siteLaunch"
 
 import { SiteDashboard } from "./SiteDashboard"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -23,7 +23,6 @@ import {
   buildSiteDashboardReviewRequests,
   buildSiteLaunchDto,
 } from "mocks/utils"
-import { SITE_LAUNCH_TASKS_LENGTH } from "types/siteLaunch"
 
 import { SiteDashboard } from "./SiteDashboard"
 
@@ -66,7 +65,9 @@ const SiteDashboardMeta = {
       return (
         <MemoryRouter initialEntries={["/sites/storybook/dashboard"]}>
           <Route path="/sites/:siteName/dashboard">
-            <Story />
+            <SiteLaunchProvider>
+              <Story />
+            </SiteLaunchProvider>
           </Route>
         </MemoryRouter>
       )

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -29,7 +29,6 @@ import _ from "lodash"
 import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
-import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -29,6 +29,7 @@ import _ from "lodash"
 import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
+import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -61,6 +61,13 @@ import { CollaboratorsStatistics } from "./components/CollaboratorsStatistics"
 import { EmptyReviewRequest } from "./components/EmptyReviewRequest"
 import { ReviewRequestCard } from "./components/ReviewRequestCard"
 
+interface SiteLaunchDisplayCardProps {
+  siteName: string
+  siteLaunchStatus?: SiteLaunchFrontEndStatus
+  isSiteLaunchLoading: boolean
+  siteLaunchChecklistStepNumber?: number
+}
+
 export const SiteDashboard = (): JSX.Element => {
   const {
     isOpen: isCollaboratorsModalOpen,

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentMeta, Story } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { SiteLaunchProvider } from "contexts/SiteLaunchContext"
+
+import { buildSiteLaunchDto } from "mocks/utils"
+
+import { SiteLaunchPad } from "./SiteLaunchPad"
+
+const SiteLaunchPadMeta = {
+  title: "Pages/SiteLaunchPad",
+  component: SiteLaunchPad,
+  parameters: {
+    msw: {
+      handlers: {
+        siteLaunchStatusProps: buildSiteLaunchDto({
+          siteStatus: "NOT_LAUNCHED",
+        }),
+      },
+    },
+  },
+  decorators: [
+    (StoryFn) => {
+      return (
+        <MemoryRouter initialEntries={["/sites/storybook/siteLaunchPad"]}>
+          <Route path="/sites/:siteName/siteLaunchPad">
+            <SiteLaunchProvider>
+              <StoryFn />
+            </SiteLaunchProvider>
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as ComponentMeta<typeof SiteLaunchPad>
+
+const Template = SiteLaunchPad
+export const Default: Story = Template.bind({})
+export default SiteLaunchPadMeta

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -1,0 +1,159 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalBody,
+  Text,
+} from "@chakra-ui/react"
+import {
+  Button,
+  Checkbox,
+  Link,
+  ModalCloseButton,
+} from "@opengovsg/design-system-react"
+import { useState } from "react"
+
+import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
+
+import { SiteViewLayout } from "layouts/layouts"
+
+import { SiteLaunchStatusProps, SITE_LAUNCH_PAGES } from "types/siteLaunch"
+
+import {
+  SiteLaunchDisclaimerBody,
+  SiteLaunchDisclaimerTitle,
+} from "./components/SiteLaunchDisclaimer"
+import {
+  SiteLaunchInfoGatheringTitle,
+  SiteLaunchInfoGatheringBody,
+} from "./components/SiteLaunchInfoGathering"
+
+const RiskAcceptanceModal = ({
+  isOpen,
+  setPageNumber,
+}: {
+  isOpen: boolean
+  setPageNumber: (number: number) => void
+}): JSX.Element => {
+  const [isDisabled, setIsDisabled] = useState(true)
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Text textStyle="h4">
+            Check if you have full control over your DNS
+          </Text>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <br />
+          <Text textStyle="body-2" fontWeight="bold">
+            The biggest reason for site launch failure is because of unknown
+            cloudfront records.
+          </Text>
+          <br />
+
+          <Text textStyle="body-2">
+            <Text as="b">Please do your best to find this out. </Text>
+            If you are unsure, consult your ITD team on this. If your domain is
+            a .gov.sg domain, You can go to{" "}
+            <Link href="https://dnschecker.org/">DNS checker</Link> and check if
+            your A record starts with 35.
+          </Text>
+          <br />
+          <Text textStyle="body-2">
+            Isomer will not be held liable for any extended period of downtime
+            due to unknown cloudfront records. Downtime could happen even if
+            your site is not currently using cloudfront, but has used it
+            previously.
+          </Text>
+          <br />
+          <br />
+          <Checkbox
+            onChange={(e) => {
+              e.preventDefault()
+              setIsDisabled(!e.target.checked)
+            }}
+          >
+            <Text textStyle="body-1" color="black">
+              I understand the risks
+            </Text>
+          </Checkbox>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            mr={3}
+            onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)}
+            variant="link"
+          >
+            Cancel
+          </Button>
+          <Button
+            isDisabled={isDisabled}
+            type="submit"
+            onClick={() => setPageNumber(SITE_LAUNCH_PAGES.CHECKLIST)}
+          >
+            Continue
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+const pageInitialNumber = (
+  siteLaunchStatusProps: SiteLaunchStatusProps | undefined
+) => {
+  const hasUserAlreadyStartedChecklistTasks =
+    siteLaunchStatusProps?.siteLaunchStatus === "CHECKLIST_TASKS_PENDING"
+  if (hasUserAlreadyStartedChecklistTasks) return SITE_LAUNCH_PAGES.CHECKLIST
+  const isSiteLaunchInProgress =
+    siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHING"
+  if (isSiteLaunchInProgress) return SITE_LAUNCH_PAGES.CHECKLIST
+  return SITE_LAUNCH_PAGES.DISCLAIMER
+}
+export const SiteLaunchPad = (): JSX.Element => {
+  const {
+    siteLaunchStatusProps,
+    setSiteLaunchStatusProps,
+  } = useSiteLaunchContext()
+
+  const [pageNumber, setPageNumber] = useState(
+    pageInitialNumber(siteLaunchStatusProps)
+  )
+
+  let title = <SiteLaunchDisclaimerTitle />
+  let body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+  switch (pageNumber) {
+    case SITE_LAUNCH_PAGES.DISCLAIMER:
+      title = <SiteLaunchDisclaimerTitle />
+      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+      break
+    case SITE_LAUNCH_PAGES.INFO_GATHERING:
+    case SITE_LAUNCH_PAGES.RISK_ACCEPTANCE: // Risk acceptance modal overlay
+      title = <SiteLaunchInfoGatheringTitle />
+      body = <SiteLaunchInfoGatheringBody setPageNumber={setPageNumber} />
+      break
+
+    // todo case for site launch pages checklist
+    default:
+      title = <SiteLaunchDisclaimerTitle />
+      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+  }
+  return (
+    <SiteViewLayout overflow="hidden">
+      {title}
+      {body}
+      <RiskAcceptanceModal
+        isOpen={pageNumber === SITE_LAUNCH_PAGES.RISK_ACCEPTANCE}
+        setPageNumber={setPageNumber}
+      />
+    </SiteViewLayout>
+  )
+}

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -30,13 +30,15 @@ import {
   SiteLaunchInfoGatheringBody,
 } from "./components/SiteLaunchInfoGathering"
 
+interface RiskAcceptanceModalProps {
+  isOpen: boolean
+  setPageNumber: (number: number) => void
+}
+
 const RiskAcceptanceModal = ({
   isOpen,
   setPageNumber,
-}: {
-  isOpen: boolean
-  setPageNumber: (number: number) => void
-}): JSX.Element => {
+}: RiskAcceptanceModalProps): JSX.Element => {
   const [isDisabled, setIsDisabled] = useState(true)
   return (
     <Modal
@@ -46,35 +48,32 @@ const RiskAcceptanceModal = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
-          <Text textStyle="h4">
+          <Text as="h4" textStyle="h4">
             Check if you have full control over your DNS
           </Text>
         </ModalHeader>
         <ModalCloseButton />
-        <ModalBody>
-          <br />
-          <Text textStyle="body-2" fontWeight="bold">
+        <ModalBody mt="2rem">
+          <Text textStyle="body-2" fontWeight="bold" mb="2rem">
             The biggest reason for site launch failure is because of unknown
             cloudfront records.
           </Text>
-          <br />
 
-          <Text textStyle="body-2">
+          <Text textStyle="body-2" mb="2rem">
             <Text as="b">Please do your best to find this out. </Text>
             If you are unsure, consult your ITD team on this. If your domain is
             a .gov.sg domain, You can go to{" "}
             <Link href="https://dnschecker.org/">DNS checker</Link> and check if
             your A record starts with 35.
           </Text>
-          <br />
-          <Text textStyle="body-2">
+
+          <Text textStyle="body-2" mb="4rem">
             Isomer will not be held liable for any extended period of downtime
             due to unknown cloudfront records. Downtime could happen even if
             your site is not currently using cloudfront, but has used it
             previously.
           </Text>
-          <br />
-          <br />
+
           <Checkbox
             onChange={(e) => {
               e.preventDefault()
@@ -107,7 +106,7 @@ const RiskAcceptanceModal = ({
     </Modal>
   )
 }
-const pageInitialNumber = (
+const getInitialPageNumber = (
   siteLaunchStatusProps: SiteLaunchStatusProps | undefined
 ) => {
   const hasUserAlreadyStartedChecklistTasks =
@@ -125,11 +124,11 @@ export const SiteLaunchPad = (): JSX.Element => {
   } = useSiteLaunchContext()
 
   const [pageNumber, setPageNumber] = useState(
-    pageInitialNumber(siteLaunchStatusProps)
+    getInitialPageNumber(siteLaunchStatusProps)
   )
 
-  let title = <SiteLaunchDisclaimerTitle />
-  let body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+  let title: JSX.Element
+  let body: JSX.Element
   switch (pageNumber) {
     case SITE_LAUNCH_PAGES.DISCLAIMER:
       title = <SiteLaunchDisclaimerTitle />

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import {
   Modal,
   ModalOverlay,
@@ -14,6 +15,7 @@ import {
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
 import { useState } from "react"
+import { useForm } from "react-hook-form"
 
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
@@ -39,7 +41,9 @@ const RiskAcceptanceModal = ({
   isOpen,
   setPageNumber,
 }: RiskAcceptanceModalProps): JSX.Element => {
-  const [isDisabled, setIsDisabled] = useState(true)
+  const { register, handleSubmit, watch } = useForm({})
+  const isRiskAccepted = watch("isRiskAccepted")
+
   return (
     <Modal
       isOpen={isOpen}
@@ -74,15 +78,8 @@ const RiskAcceptanceModal = ({
             previously.
           </Text>
 
-          <Checkbox
-            onChange={(e) => {
-              e.preventDefault()
-              setIsDisabled(!e.target.checked)
-            }}
-          >
-            <Text textStyle="body-1" color="black">
-              I understand the risks
-            </Text>
+          <Checkbox {...register("isRiskAccepted")}>
+            <Text textStyle="body-1">I understand the risks</Text>
           </Checkbox>
         </ModalBody>
 
@@ -95,9 +92,11 @@ const RiskAcceptanceModal = ({
             Cancel
           </Button>
           <Button
-            isDisabled={isDisabled}
+            isDisabled={!isRiskAccepted}
             type="submit"
-            onClick={() => setPageNumber(SITE_LAUNCH_PAGES.CHECKLIST)}
+            onClick={handleSubmit(() => {
+              setPageNumber(SITE_LAUNCH_PAGES.CHECKLIST)
+            })}
           >
             Continue
           </Button>
@@ -118,10 +117,7 @@ const getInitialPageNumber = (
   return SITE_LAUNCH_PAGES.DISCLAIMER
 }
 export const SiteLaunchPad = (): JSX.Element => {
-  const {
-    siteLaunchStatusProps,
-    setSiteLaunchStatusProps,
-  } = useSiteLaunchContext()
+  const { siteLaunchStatusProps } = useSiteLaunchContext()
 
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -7,6 +7,7 @@ import {
   ModalHeader,
   ModalBody,
   Text,
+  VStack,
 } from "@chakra-ui/react"
 import {
   Button,
@@ -19,7 +20,7 @@ import { useForm } from "react-hook-form"
 
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
-import { SiteViewLayout } from "layouts/layouts"
+import { SiteViewHeader } from "layouts/layouts/SiteViewLayout/SiteViewHeader"
 
 import { SiteLaunchStatusProps, SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
@@ -79,7 +80,9 @@ const RiskAcceptanceModal = ({
           </Text>
 
           <Checkbox {...register("isRiskAccepted")}>
-            <Text textStyle="body-1">I understand the risks</Text>
+            <Text color="text.body" textStyle="body-1">
+              I understand the risks
+            </Text>
           </Checkbox>
         </ModalBody>
 
@@ -142,13 +145,16 @@ export const SiteLaunchPad = (): JSX.Element => {
       body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
   }
   return (
-    <SiteViewLayout overflow="hidden">
-      {title}
-      {body}
-      <RiskAcceptanceModal
-        isOpen={pageNumber === SITE_LAUNCH_PAGES.RISK_ACCEPTANCE}
-        setPageNumber={setPageNumber}
-      />
-    </SiteViewLayout>
+    <>
+      <SiteViewHeader />
+      <VStack bg="white" w="100%" minH="100vh" spacing="2rem">
+        {title}
+        {body}
+        <RiskAcceptanceModal
+          isOpen={pageNumber === SITE_LAUNCH_PAGES.RISK_ACCEPTANCE}
+          setPageNumber={setPageNumber}
+        />
+      </VStack>
+    </>
   )
 }

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -28,8 +28,8 @@ import {
   SiteLaunchDisclaimerTitle,
 } from "./components/SiteLaunchDisclaimer"
 import {
-  SiteLaunchInfoGatheringTitle,
-  SiteLaunchInfoGatheringBody,
+  SiteLaunchInfoCollectorTitle,
+  SiteLaunchInfoCollectorBody,
 } from "./components/SiteLaunchInfoGathering"
 
 interface RiskAcceptanceModalProps {
@@ -132,8 +132,8 @@ export const SiteLaunchPad = (): JSX.Element => {
       break
     case SITE_LAUNCH_PAGES.INFO_GATHERING:
     case SITE_LAUNCH_PAGES.RISK_ACCEPTANCE: // Risk acceptance modal overlay
-      title = <SiteLaunchInfoGatheringTitle />
-      body = <SiteLaunchInfoGatheringBody setPageNumber={setPageNumber} />
+      title = <SiteLaunchInfoCollectorTitle />
+      body = <SiteLaunchInfoCollectorBody setPageNumber={setPageNumber} />
       break
 
     // todo case for site launch pages checklist

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
+
+import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
+import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
+
+export const SiteLaunchChecklistTitle = (): JSX.Element => {
+  const title = "Complete these tasks to launch"
+  const subTitle =
+    "The following list has been generated based on information provided on your domain"
+  return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
+}
+
+export const SiteLaunchChecklistBody = (): JSX.Element => {
+  const {
+    siteLaunchStatusProps,
+    setSiteLaunchStatusProps,
+  } = useSiteLaunchContext()
+  // todo site launch pad checklist table
+  return <SiteLaunchPadBody />
+}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -1,0 +1,87 @@
+import {
+  Box,
+  Icon,
+  ListItem,
+  OrderedList,
+  Text,
+  UnorderedList,
+} from "@chakra-ui/react"
+import { Button, BxChevronRight } from "@opengovsg/design-system-react"
+
+import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
+
+import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
+import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
+
+export const SiteLaunchDisclaimerTitle = (): JSX.Element => {
+  const title = "Welcome to the launchpad"
+  const subTitle = "Track and manage your site launch here"
+  return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
+}
+
+interface SiteLaunchDisclaimerBodyProps {
+  setPageNumber: (number: number) => void
+}
+
+export const SiteLaunchDisclaimerBody = ({
+  setPageNumber,
+}: SiteLaunchDisclaimerBodyProps): JSX.Element => {
+  return (
+    <SiteLaunchPadBody>
+      <Text textStyle="h2">What is site launch?</Text>
+      <Text>
+        It&apos;s the process to connect a domain to your Isomer site and make
+        it available to the public through the internet. Public officers would
+        need to do this outside of Isomer through a separate service called IT
+        Service Management (ITSM).
+        <br />
+        <br />
+        Isomer will provide you the necessary credentials you need to add or
+        change in ITSM, but Isomer as a product does not actually launch your
+        site for you. However you can come here to check the status of your site
+        launch.
+        <br />
+        <br />
+      </Text>
+      <Text textStyle="h2">You should only launch your site when:</Text>
+      <OrderedList>
+        <ListItem>
+          You are ready to release your site content to the public
+        </ListItem>
+        <ListItem>You already have a domain to connect to</ListItem>
+      </OrderedList>
+      <br />
+      <Text textStyle="h2">Things to note</Text>
+      <UnorderedList>
+        <ListItem>
+          Site launch is a time-sensitive process and could require the
+          coordination of actions from multiple parties. It is recommended that
+          you internally set a date with the involved parties and not do it
+          immediately.
+        </ListItem>
+        <ListItem>
+          Expect downtime of your site for at least 1 hour during site launch.
+          If site launch does not go smoothly, downtime could exponentially
+          increase up to 48 hours.
+        </ListItem>
+        <ListItem>
+          If you do not have the technical knowledge, we recommend getting
+          someone from your IT team to launch your site for you. You can add
+          them as a collaborator to your site and remove them after launching
+          your site.
+        </ListItem>
+      </UnorderedList>
+      <br />
+      <Box display="flex" justifyContent="flex-end">
+        <Button
+          rightIcon={<Icon as={BxChevronRight} fontSize="1.25rem" />}
+          iconSpacing="1rem"
+          ml="auto"
+          onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)} // going to the next page}
+        >
+          What do I have to do
+        </Button>
+      </Box>
+    </SiteLaunchPadBody>
+  )
+}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -7,7 +7,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
-import { BiArrowBack } from "react-icons/bi"
+import { BiRightArrowAlt } from "react-icons/bi"
 
 import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
@@ -29,31 +29,34 @@ export const SiteLaunchDisclaimerBody = ({
 }: SiteLaunchDisclaimerBodyProps): JSX.Element => {
   return (
     <SiteLaunchPadBody>
-      <Text textStyle="h2">What is site launch?</Text>
-      <Text>
+      <Text as="h2" textStyle="h2">
+        What is site launch?
+      </Text>
+      <Text mb="2rem">
         It&apos;s the process to connect a domain to your Isomer site and make
         it available to the public through the internet. Public officers would
         need to do this outside of Isomer through a separate service called IT
         Service Management (ITSM).
-        <br />
-        <br />
+      </Text>
+      <Text mb="2rem">
         Isomer will provide you the necessary credentials you need to add or
         change in ITSM, but Isomer as a product does not actually launch your
         site for you. However you can come here to check the status of your site
         launch.
-        <br />
-        <br />
       </Text>
-      <Text textStyle="h2">You should only launch your site when:</Text>
-      <OrderedList>
+      <Text as="h2" textStyle="h2">
+        You should only launch your site when:
+      </Text>
+      <OrderedList mb="2rem">
         <ListItem>
           You are ready to release your site content to the public
         </ListItem>
         <ListItem>You already have a domain to connect to</ListItem>
       </OrderedList>
-      <br />
-      <Text textStyle="h2">Things to note</Text>
-      <UnorderedList>
+      <Text as="h2" textStyle="h2">
+        Things to note
+      </Text>
+      <UnorderedList mb="2rem">
         <ListItem>
           Site launch is a time-sensitive process and could require the
           coordination of actions from multiple parties. It is recommended that
@@ -72,16 +75,10 @@ export const SiteLaunchDisclaimerBody = ({
           your site.
         </ListItem>
       </UnorderedList>
-      <br />
+
       <Box display="flex" justifyContent="flex-end">
         <Button
-          rightIcon={
-            <Icon
-              as={BiArrowBack}
-              fontSize="1.25rem"
-              transform="rotate(180deg)"
-            />
-          }
+          rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
           iconSpacing="1rem"
           ml="auto"
           onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)} // going to the next page}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -6,7 +6,8 @@ import {
   Text,
   UnorderedList,
 } from "@chakra-ui/react"
-import { Button, BxChevronRight } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
+import { BiArrowBack } from "react-icons/bi"
 
 import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
@@ -74,7 +75,13 @@ export const SiteLaunchDisclaimerBody = ({
       <br />
       <Box display="flex" justifyContent="flex-end">
         <Button
-          rightIcon={<Icon as={BxChevronRight} fontSize="1.25rem" />}
+          rightIcon={
+            <Icon
+              as={BiArrowBack}
+              fontSize="1.25rem"
+              transform="rotate(180deg)"
+            />
+          }
           iconSpacing="1rem"
           ml="auto"
           onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)} // going to the next page}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Icon,
-  ListItem,
-  OrderedList,
-  Text,
-  UnorderedList,
-} from "@chakra-ui/react"
+import { Box, Icon, ListItem, Text, UnorderedList } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { BiRightArrowAlt } from "react-icons/bi"
 
@@ -29,50 +22,57 @@ export const SiteLaunchDisclaimerBody = ({
 }: SiteLaunchDisclaimerBodyProps): JSX.Element => {
   return (
     <SiteLaunchPadBody>
-      <Text as="h2" textStyle="h2">
+      <Text as="h5" textStyle="h5">
         What is site launch?
       </Text>
-      <Text mb="2rem">
+      <Text textStyle="body-2" mb="2rem">
         It&apos;s the process to connect a domain to your Isomer site and make
         it available to the public through the internet. Public officers would
         need to do this outside of Isomer through a separate service called IT
         Service Management (ITSM).
       </Text>
-      <Text mb="2rem">
+      <Text textStyle="body-2" mb="2rem">
         Isomer will provide you the necessary credentials you need to add or
         change in ITSM, but Isomer as a product does not actually launch your
         site for you. However you can come here to check the status of your site
         launch.
       </Text>
-      <Text as="h2" textStyle="h2">
+      <Text as="h5" textStyle="h5">
         You should only launch your site when:
       </Text>
-      <OrderedList mb="2rem">
-        <ListItem>
-          You are ready to release your site content to the public
-        </ListItem>
-        <ListItem>You already have a domain to connect to</ListItem>
-      </OrderedList>
-      <Text as="h2" textStyle="h2">
+
+      <Text textStyle="body-2" mb="2rem">
+        1. Your site is ready to be launched
+        <br />
+        2. You already have a domain to connect to
+      </Text>
+
+      <Text as="h5" textStyle="h5">
         Things to note
       </Text>
       <UnorderedList mb="2rem">
         <ListItem>
-          Site launch is a time-sensitive process and could require the
-          coordination of actions from multiple parties. It is recommended that
-          you internally set a date with the involved parties and not do it
-          immediately.
+          <Text textStyle="body-2">
+            Site launch is a time-sensitive process and could require the
+            coordination of actions from multiple parties. It is recommended
+            that you internally set a date with the involved parties and not do
+            it immediately.
+          </Text>
         </ListItem>
         <ListItem>
-          Expect downtime of your site for at least 1 hour during site launch.
-          If site launch does not go smoothly, downtime could exponentially
-          increase up to 48 hours.
+          <Text textStyle="body-2">
+            Expect downtime of your site for at least 1 hour during site launch.
+            If site launch does not go smoothly, downtime could exponentially
+            increase up to 48 hours.
+          </Text>
         </ListItem>
         <ListItem>
-          If you do not have the technical knowledge, we recommend getting
-          someone from your IT team to launch your site for you. You can add
-          them as a collaborator to your site and remove them after launching
-          your site.
+          <Text textStyle="body-2">
+            If you do not have the technical knowledge, we recommend getting
+            someone from your IT team to launch your site for you. You can add
+            them as a collaborator to your site and remove them after launching
+            your site.
+          </Text>
         </ListItem>
       </UnorderedList>
 
@@ -83,7 +83,7 @@ export const SiteLaunchDisclaimerBody = ({
           ml="auto"
           onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)} // going to the next page}
         >
-          What do I have to do
+          I understand
         </Button>
       </Box>
     </SiteLaunchPadBody>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import { Box, Button, Icon, Text, RadioGroup } from "@chakra-ui/react"
 import { Input, Radio } from "@opengovsg/design-system-react"
 import { useState } from "react"
-import { BiArrowBack } from "react-icons/bi"
+import { useForm } from "react-hook-form"
+import { BiRightArrowAlt } from "react-icons/bi"
 
 import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
@@ -18,35 +20,44 @@ interface SiteLaunchInfoGatheringBodyProps {
   setPageNumber: (number: number) => void
 }
 
+interface SiteLaunchFormData {
+  domain: string
+  nature: "new" | "live"
+}
+
 export const SiteLaunchInfoGatheringBody = ({
   setPageNumber,
 }: SiteLaunchInfoGatheringBodyProps): JSX.Element => {
-  const [inputValue, setInputValue] = useState<string>("")
-  const [selectedRadio, setSelectedRadio] = useState<string>("")
-  const handleRadioChange = (value: string) => {
-    setSelectedRadio(value === selectedRadio ? "" : value)
-  }
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value)
-  }
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<SiteLaunchFormData>()
 
-  const isNextButtonDisabled = !inputValue || !selectedRadio
+  const onSubmit = (data: SiteLaunchFormData) => {
+    // todo update context with data
+    setPageNumber(SITE_LAUNCH_PAGES.RISK_ACCEPTANCE)
+  }
+  const [selectedRadio, setSelectedRadio] = useState("")
 
   return (
     <SiteLaunchPadBody>
       <Text textStyle="subhead-1">What domain are you launching with?</Text>
       <Input
         mt="4"
+        mb="1"
         placeholder="eg: www.isomer.gov.sg"
-        value={inputValue}
-        onChange={handleInputChange}
+        {...register("domain", { required: true })}
       />
-      <br />
-      <br />
-      <Text textStyle="subhead-1">
+      {errors.domain && <Text textStyle="subhead-2">Domain is required</Text>}
+      <Text textStyle="subhead-1" mt="4rem">
         What is the nature of the domain you are launching with?
       </Text>
-      <RadioGroup value={selectedRadio} onChange={handleRadioChange}>
+      <RadioGroup
+        {...register("nature", { required: true })}
+        onChange={(value) => setSelectedRadio(value)}
+      >
         <Radio value="new">
           <Text textStyle="body-1" color="black">
             It is a brand new domain
@@ -67,15 +78,9 @@ export const SiteLaunchInfoGatheringBody = ({
           Cancel
         </Button>
         <Button
-          rightIcon={
-            <Icon
-              as={BiArrowBack}
-              fontSize="1.25rem"
-              transform="rotate(180deg)"
-            />
-          }
-          onClick={() => setPageNumber(SITE_LAUNCH_PAGES.RISK_ACCEPTANCE)}
-          disabled={isNextButtonDisabled}
+          rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
+          onClick={handleSubmit(onSubmit)}
+          disabled={!selectedRadio || !watch("domain")}
         >
           Next
         </Button>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -10,7 +10,7 @@ import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
 import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
 
-export const SiteLaunchInfoGatheringTitle = (): JSX.Element => {
+export const SiteLaunchInfoCollectorTitle = (): JSX.Element => {
   const title = "Tell us more about your domain"
   const subTitle = "This will inform the steps you have to take for launch"
   return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
@@ -25,7 +25,7 @@ interface SiteLaunchFormData {
   nature: "new" | "live"
 }
 
-export const SiteLaunchInfoGatheringBody = ({
+export const SiteLaunchInfoCollectorBody = ({
   setPageNumber,
 }: SiteLaunchInfoGatheringBodyProps): JSX.Element => {
   const {

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Icon, Text, RadioGroup } from "@chakra-ui/react"
-import { BxChevronRight, Input, Radio } from "@opengovsg/design-system-react"
+import { Input, Radio } from "@opengovsg/design-system-react"
 import { useState } from "react"
+import { BiArrowBack } from "react-icons/bi"
 
 import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
@@ -66,7 +67,13 @@ export const SiteLaunchInfoGatheringBody = ({
           Cancel
         </Button>
         <Button
-          rightIcon={<Icon as={BxChevronRight} fontSize="1.25rem" />}
+          rightIcon={
+            <Icon
+              as={BiArrowBack}
+              fontSize="1.25rem"
+              transform="rotate(180deg)"
+            />
+          }
           onClick={() => setPageNumber(SITE_LAUNCH_PAGES.RISK_ACCEPTANCE)}
           disabled={isNextButtonDisabled}
         >

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -20,9 +20,14 @@ interface SiteLaunchInfoGatheringBodyProps {
   setPageNumber: (number: number) => void
 }
 
+const SiteNature = {
+  New: "new",
+  Live: "live",
+} as const
+
 interface SiteLaunchFormData {
   domain: string
-  nature: "new" | "live"
+  nature: typeof SiteNature[keyof typeof SiteNature]
 }
 
 export const SiteLaunchInfoCollectorBody = ({

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -1,0 +1,78 @@
+import { Box, Button, Icon, Text, RadioGroup } from "@chakra-ui/react"
+import { BxChevronRight, Input, Radio } from "@opengovsg/design-system-react"
+import { useState } from "react"
+
+import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
+
+import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
+import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
+
+export const SiteLaunchInfoGatheringTitle = (): JSX.Element => {
+  const title = "Tell us more about your domain"
+  const subTitle = "This will inform the steps you have to take for launch"
+  return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
+}
+
+interface SiteLaunchInfoGatheringBodyProps {
+  setPageNumber: (number: number) => void
+}
+
+export const SiteLaunchInfoGatheringBody = ({
+  setPageNumber,
+}: SiteLaunchInfoGatheringBodyProps): JSX.Element => {
+  const [inputValue, setInputValue] = useState<string>("")
+  const [selectedRadio, setSelectedRadio] = useState<string>("")
+  const handleRadioChange = (value: string) => {
+    setSelectedRadio(value === selectedRadio ? "" : value)
+  }
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value)
+  }
+
+  const isNextButtonDisabled = !inputValue || !selectedRadio
+
+  return (
+    <SiteLaunchPadBody>
+      <Text textStyle="subhead-1">What domain are you launching with?</Text>
+      <Input
+        mt="4"
+        placeholder="eg: www.isomer.gov.sg"
+        value={inputValue}
+        onChange={handleInputChange}
+      />
+      <br />
+      <br />
+      <Text textStyle="subhead-1">
+        What is the nature of the domain you are launching with?
+      </Text>
+      <RadioGroup value={selectedRadio} onChange={handleRadioChange}>
+        <Radio value="new">
+          <Text textStyle="body-1" color="black">
+            It is a brand new domain
+          </Text>
+        </Radio>
+        <Radio value="live">
+          <Text textStyle="body-1" color="black">
+            This domain is currently live or was previously live
+          </Text>
+        </Radio>
+      </RadioGroup>
+      <Box display="flex" justifyContent="flex-end">
+        <Button
+          variant="link"
+          mr={4}
+          onClick={() => setPageNumber(SITE_LAUNCH_PAGES.DISCLAIMER)}
+        >
+          Cancel
+        </Button>
+        <Button
+          rightIcon={<Icon as={BxChevronRight} fontSize="1.25rem" />}
+          onClick={() => setPageNumber(SITE_LAUNCH_PAGES.RISK_ACCEPTANCE)}
+          disabled={isNextButtonDisabled}
+        >
+          Next
+        </Button>
+      </Box>
+    </SiteLaunchPadBody>
+  )
+}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -51,7 +51,7 @@ export const SiteLaunchInfoCollectorBody = ({
         {...register("domain", { required: true })}
       />
       {errors.domain && <Text textStyle="subhead-2">Domain is required</Text>}
-      <Text textStyle="subhead-1" mt="4rem">
+      <Text textStyle="subhead-1" mt="1.5rem">
         What is the nature of the domain you are launching with?
       </Text>
       <RadioGroup {...register("nature")} onChange={setSelectedRadio}>
@@ -66,7 +66,7 @@ export const SiteLaunchInfoCollectorBody = ({
           </Text>
         </Radio>
       </RadioGroup>
-      <Box display="flex" justifyContent="flex-end">
+      <Box display="flex" justifyContent="flex-end" mt="2rem">
         <Button
           variant="link"
           mr={4}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -54,10 +54,7 @@ export const SiteLaunchInfoGatheringBody = ({
       <Text textStyle="subhead-1" mt="4rem">
         What is the nature of the domain you are launching with?
       </Text>
-      <RadioGroup
-        {...register("nature", { required: true })}
-        onChange={(value) => setSelectedRadio(value)}
-      >
+      <RadioGroup {...register("nature")} onChange={setSelectedRadio}>
         <Radio value="new">
           <Text textStyle="body-1" color="black">
             It is a brand new domain

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchPadBody.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchPadBody.tsx
@@ -1,0 +1,5 @@
+import { Box, StackProps } from "@chakra-ui/react"
+
+export const SiteLaunchPadBody = ({ children }: StackProps): JSX.Element => {
+  return <Box w="65%">{children}</Box>
+}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchPadTitle.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchPadTitle.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "@chakra-ui/react"
+import { Box, Center, Text } from "@chakra-ui/react"
 
 export const SiteLaunchPadTitle = ({
   title,
@@ -8,11 +8,15 @@ export const SiteLaunchPadTitle = ({
   subTitle: string
 }): JSX.Element => {
   return (
-    <Box bg="brand.illustration.50" w="65%">
-      <Text as="h2" textStyle="h2" textAlign="left">
-        {title}
-      </Text>
-      <Text textStyle="body-2">{subTitle}</Text>
+    <Box bg="base.canvas.purpleSubtle" w="100%" h="100%">
+      <Center>
+        <Box w="65%">
+          <Text as="h2" textStyle="h2" textAlign="left">
+            {title}
+          </Text>
+          <Text textStyle="body-2">{subTitle}</Text>
+        </Box>
+      </Center>
     </Box>
   )
 }

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchPadTitle.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchPadTitle.tsx
@@ -1,0 +1,18 @@
+import { Box, Text } from "@chakra-ui/react"
+
+export const SiteLaunchPadTitle = ({
+  title,
+  subTitle,
+}: {
+  title: string
+  subTitle: string
+}): JSX.Element => {
+  return (
+    <Box bg="brand.illustration.50" w="65%">
+      <Text as="h2" textStyle="h2" textAlign="left">
+        {title}
+      </Text>
+      <Text textStyle="body-2">{subTitle}</Text>
+    </Box>
+  )
+}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchPadTitle.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchPadTitle.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Text } from "@chakra-ui/react"
+import { Box, Center, Text, VStack } from "@chakra-ui/react"
 
 export const SiteLaunchPadTitle = ({
   title,
@@ -10,11 +10,13 @@ export const SiteLaunchPadTitle = ({
   return (
     <Box bg="base.canvas.purpleSubtle" w="100%" h="100%">
       <Center>
-        <Box w="65%">
+        <Box mt="3rem" mb="1.5rem" w="65%">
           <Text as="h2" textStyle="h2" textAlign="left">
             {title}
           </Text>
-          <Text textStyle="body-2">{subTitle}</Text>
+          <Text textStyle="body-2" textAlign="left">
+            {subTitle}
+          </Text>
         </Box>
       </Center>
     </Box>

--- a/src/layouts/SiteLaunchPad/index.ts
+++ b/src/layouts/SiteLaunchPad/index.ts
@@ -1,0 +1,1 @@
+export { SiteLaunchPad } from "./SiteLaunchPad"

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -21,6 +21,7 @@ import { ResourceRoom } from "layouts/ResourceRoom"
 import { ReviewRequestDashboard } from "layouts/ReviewRequest/Dashboard"
 import { Settings } from "layouts/Settings"
 import { SiteDashboard } from "layouts/SiteDashboard"
+import { SiteLaunchPad } from "layouts/SiteLaunchPad"
 import { Sites } from "layouts/Sites"
 import { Workspace } from "layouts/Workspace"
 
@@ -87,6 +88,12 @@ export const RouteSelector = () => (
       <ProtectedRouteWithProps path="/sites/:siteName/dashboard">
         <SiteLaunchProvider>
           <SiteDashboard />
+        </SiteLaunchProvider>
+      </ProtectedRouteWithProps>
+
+      <ProtectedRouteWithProps path="/sites/:siteName/siteLaunchPad">
+        <SiteLaunchProvider>
+          <SiteLaunchPad />
         </SiteLaunchProvider>
       </ProtectedRouteWithProps>
 

--- a/src/theme/foundations/colours.ts
+++ b/src/theme/foundations/colours.ts
@@ -1,4 +1,26 @@
 // Colour schemes available for isomer
+
+export type IsomerBaseColorScheme = "purple"
+
+// We are not using all the shades of the base colour scheme,
+// but this is placed here if we need them in the future.
+export const baseColourMapping: {
+  [k in IsomerBaseColorScheme]: NestedRecord
+} = {
+  purple: {
+    50: "#FBF8FF",
+    100: "#EFE7FF",
+    200: "#C9B3FF",
+    300: "#AA90FA",
+    400: "#8C73DB",
+    500: "#6D58BB",
+    600: "#5543A4",
+    700: "#493897",
+    800: "#3B2E8A",
+    900: "#271E78",
+  },
+}
+
 // There aren't any more because it should default to design system's
 export type IsomerColorScheme =
   | "primary"
@@ -65,6 +87,7 @@ export const colours: { [k in IsomerColorScheme]: NestedRecord } = {
   base: {
     canvas: {
       brandLight: "#F8FAFE",
+      purpleSubtle: baseColourMapping.purple[50],
     },
     content: {
       default: "#3C4764",

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -16,7 +16,7 @@ export type SiteLaunchFrontEndStatus = typeof SiteLaunchFrontEndStatusOptions[ke
 
 export interface SiteLaunchStatusProps {
   siteLaunchStatus: SiteLaunchFrontEndStatus
-  stepNumber: number
+  stepNumber: SiteLaunchTaskTypeIndex
   dnsRecords?: DNSRecord[]
 }
 
@@ -31,15 +31,19 @@ export interface SiteLaunchDto {
 }
 
 export const SITE_LAUNCH_TASKS = {
+  NOT_STARTED: 0,
   SET_DNS_TTL: 1,
   APPROVE_FIRST_REVIEW_REQUEST: 2,
   DROP_CLOUDFRONT: 3,
   DELETE_EXISTING_DNS_RECORDS: 4,
   WAIT_1_HOUR: 5,
   GENERATE_NEW_DNS_RECORDS: 6,
-}
+} as const
 
-export const SITE_LAUNCH_TASKS_LENGTH = Object.keys(SITE_LAUNCH_TASKS).length
+export type SiteLaunchTaskTypeIndex = typeof SITE_LAUNCH_TASKS[keyof typeof SITE_LAUNCH_TASKS]
+
+export const SITE_LAUNCH_TASKS_LENGTH = (Object.keys(SITE_LAUNCH_TASKS).length -
+  1) as SiteLaunchTaskTypeIndex // we minus one here since step 0 is not counted as a step done
 
 export const SITE_LAUNCH_PAGES = {
   DISCLAIMER: 1,


### PR DESCRIPTION
## Problem

[Figma](https://www.figma.com/file/7OtNYkc4s9BkFk05ConEbd/%E2%AD%90-V1.5?type=design&node-id=9701%3A174582&t=IxYpSgyOgFghSKmQ-1) for site launch pad, without the checklist pages

## Solution

Similar to #1296, this PR builds a storybook component on the site launch pad page. 

This is meant to be more of a UI focused PR only, the functionality + integration with backend will be introduced in a separate PR instead. Considered to be safe to merge to master since it be hidden behind a feature flag. 

## Storybook

https://github.com/isomerpages/isomercms-frontend/assets/42832651/ee6019c1-8456-4a94-a2ac-25ac40a22f9d

NOTE: The pages will loop back because the checklist page is not tackled in this PR (done in #1297)

## Tests

New Storybook page for SiteLaunchPad
To view the site launch pad directly
1. add your site name to the env var 
2. go to `http://localhost:3000/sites/<siteName>/siteLaunchPad`
3. click through the UI 

To view the entire flow within storybook:
1. `npm run storybook`
2. after building the storybook, click [here](http://localhost:6006/?path=/story/pages-sitelaunchpad--default) 

## Design Review Notes 
As discussed, arrow changed: 
<img width="242" alt="Screenshot 2023-06-19 at 9 09 06 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/39270c9d-e9eb-459f-b948-45d732c9dd65">
<img width="121" alt="Screenshot 2023-06-19 at 9 10 02 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/b843b607-4586-4993-add2-c435217c49da">

