### PR TITLE
feat: handle V2 errors for create and update pages

### DIFF
--- a/src/hooks/pageHooks/useCreatePageHook.jsx
+++ b/src/hooks/pageHooks/useCreatePageHook.jsx
@@ -11,9 +11,10 @@ import { ServicesContext } from "contexts/ServicesContext"
 
 import useRedirectHook from "hooks/useRedirectHook"
 
+import { getAxiosErrorMessage } from "utils/axios"
 import { useErrorToast } from "utils/toasts"
 
-import { getRedirectUrl, DEFAULT_RETRY_MSG } from "utils"
+import { getRedirectUrl } from "utils"
 
 import { extractPageInfo } from "./utils"
 
@@ -54,22 +55,12 @@ export function useCreatePageHook(params, queryParams) {
         if (queryParams && queryParams.onSuccess) queryParams.onSuccess()
       },
       onError: (err) => {
-        // check for new err format
-        if (
-          err.response &&
-          err.response.data &&
-          err.response.data.error &&
-          err.response.data.error.isV2Err
-        ) {
-          const apiErr = err.response.data
-          errorToast({
-            description: `A new page could not be created. Error code: ${apiErr.error.code}. ${apiErr.error.message}.`,
-          })
-        } else {
-          errorToast({
-            description: `A new page could not be created. ${DEFAULT_RETRY_MSG}`,
-          })
-        }
+        errorToast({
+          description: `A new page could not be created. ${getAxiosErrorMessage(
+            err
+          )}`,
+        })
+
         if (queryParams && queryParams.onError) queryParams.onError()
       },
     }

--- a/src/hooks/pageHooks/useCreatePageHook.jsx
+++ b/src/hooks/pageHooks/useCreatePageHook.jsx
@@ -53,10 +53,23 @@ export function useCreatePageHook(params, queryParams) {
         )
         if (queryParams && queryParams.onSuccess) queryParams.onSuccess()
       },
-      onError: () => {
-        errorToast({
-          description: `A new page could not be created. ${DEFAULT_RETRY_MSG}`,
-        })
+      onError: (err) => {
+        // check for new err format
+        if (
+          err.response &&
+          err.response.data &&
+          err.response.data.error &&
+          err.response.data.error.isV2Err
+        ) {
+          const apiErr = err.response.data
+          errorToast({
+            description: `A new page could not be created. Error code: ${apiErr.error.code}. ${apiErr.error.message}.`,
+          })
+        } else {
+          errorToast({
+            description: `A new page could not be created. ${DEFAULT_RETRY_MSG}`,
+          })
+        }
         if (queryParams && queryParams.onError) queryParams.onError()
       },
     }

--- a/src/hooks/pageHooks/useUpdatePageHook.jsx
+++ b/src/hooks/pageHooks/useUpdatePageHook.jsx
@@ -59,10 +59,24 @@ export function useUpdatePageHook(params, queryParams) {
         if (queryParams && queryParams.onSuccess) queryParams.onSuccess()
       },
       onError: (err) => {
-        if (err.response.status !== 409)
-          errorToast({
-            description: `Your page could not be updated. ${DEFAULT_RETRY_MSG}`,
-          })
+        if (err.response.status !== 409) {
+          // check for new err format
+          if (
+            err.response &&
+            err.response.data &&
+            err.response.data.error &&
+            err.response.data.error.isV2Err
+          ) {
+            const apiErr = err.response.data
+            errorToast({
+              description: `Your page could not be updated. Error code: ${apiErr.error.code}. ${apiErr.error.message}.`,
+            })
+          } else {
+            errorToast({
+              description: `Your page could not be updated. ${DEFAULT_RETRY_MSG}`,
+            })
+          }
+        }
         if (queryParams && queryParams.onError) queryParams.onError(err)
       },
     }

--- a/src/hooks/pageHooks/useUpdatePageHook.jsx
+++ b/src/hooks/pageHooks/useUpdatePageHook.jsx
@@ -10,9 +10,8 @@ import {
 
 import { ServicesContext } from "contexts/ServicesContext"
 
+import { getAxiosErrorMessage } from "utils/axios"
 import { useSuccessToast, useErrorToast } from "utils/toasts"
-
-import { DEFAULT_RETRY_MSG } from "utils"
 
 import { extractPageInfo } from "./utils"
 
@@ -60,22 +59,11 @@ export function useUpdatePageHook(params, queryParams) {
       },
       onError: (err) => {
         if (err.response.status !== 409) {
-          // check for new err format
-          if (
-            err.response &&
-            err.response.data &&
-            err.response.data.error &&
-            err.response.data.error.isV2Err
-          ) {
-            const apiErr = err.response.data
-            errorToast({
-              description: `Your page could not be updated. Error code: ${apiErr.error.code}. ${apiErr.error.message}.`,
-            })
-          } else {
-            errorToast({
-              description: `Your page could not be updated. ${DEFAULT_RETRY_MSG}`,
-            })
-          }
+          errorToast({
+            description: `Your page could not be updated. ${getAxiosErrorMessage(
+              err
+            )}`,
+          })
         }
         if (queryParams && queryParams.onError) queryParams.onError(err)
       },

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -15,3 +15,10 @@ export interface MiddlewareErrorDto {
     name?: string
   }
 }
+
+export interface IsomerErrorDto {
+  error: {
+    code: string
+    message: string
+  }
+}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -20,5 +20,7 @@ export interface IsomerErrorDto {
   error: {
     code: string
     message: string
+    isV2Error: boolean
+    name?: string
   }
 }

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from "axios"
 
-import { ErrorDto } from "types/error"
+import { ErrorDto, IsomerErrorDto } from "types/error"
 import { DEFAULT_RETRY_MSG } from "utils"
 
 export const isAxiosError = (err: unknown): err is AxiosError => {
@@ -13,11 +13,25 @@ const isBackendError = (
   return !!(err as AxiosError<ErrorDto>).response?.data.message
 }
 
+const isV2Error = (
+  err: AxiosError<unknown>
+): err is AxiosError<IsomerErrorDto> => {
+  return !!(err as AxiosError<IsomerErrorDto>).response?.data.error
+}
+
 export const getAxiosErrorMessage = (
   error: null | AxiosError<ErrorDto> | AxiosError,
   defaultErrorMessage = DEFAULT_RETRY_MSG
 ): string => {
   if (!error) return ""
+
+  if (isV2Error(error)) {
+    return `${
+      error.response?.data.error?.code
+        ? `${error.response?.data.error?.code}: `
+        : ""
+    }${error.response?.data.error?.message || defaultErrorMessage}`
+  }
 
   if (isBackendError(error)) {
     return error.response?.data.message || defaultErrorMessage

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -13,10 +13,16 @@ const isBackendError = (
   return !!(err as AxiosError<ErrorDto>).response?.data.message
 }
 
-const isV2Error = (
+const isIsomerExternalError = (
   err: AxiosError<unknown>
 ): err is AxiosError<IsomerErrorDto> => {
-  return !!(err as AxiosError<IsomerErrorDto>).response?.data.error
+  const errDto = err as AxiosError<IsomerErrorDto>
+  return (
+    !!errDto.response?.data.error &&
+    errDto.response?.data.error.isV2Error &&
+    !!errDto.response.data.error.code &&
+    !!errDto.response.data.error.message
+  )
 }
 
 export const getAxiosErrorMessage = (
@@ -25,12 +31,8 @@ export const getAxiosErrorMessage = (
 ): string => {
   if (!error) return ""
 
-  if (isV2Error(error)) {
-    return `${
-      error.response?.data.error?.code
-        ? `${error.response?.data.error?.code}: `
-        : ""
-    }${error.response?.data.error?.message || defaultErrorMessage}`
+  if (isIsomerExternalError(error)) {
+    return `${error.response?.data.error?.code}: ${error.response?.data.error?.message}`
   }
 
   if (isBackendError(error)) {


### PR DESCRIPTION
## Problem

This PR handles the v2 error returned by BE from CollectionPageService. Related PR: 

Closes IS-212

## Solution

Checks if the returned err is a V2 err and displays the appropriate error message in toast.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Can test by commenting out special characters validation in `src/components/PageSettingsModal/PageSettingsSchema.jsx` and try to create and update a page with invalid filename (e.g. `SampleFile~~~`)

The error toast should show the error code and description returned by BE.

## Deploy Notes

Deploy together with https://github.com/isomerpages/isomercms-backend/pull/802
