### PR TITLE
fix(ci): chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,8 +4,10 @@ name: "Chromatic"
 # Event for the workflow
 on:
   push:
+    branches:
+      - develop
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 # List of jobs
 jobs:


### PR DESCRIPTION
## Problem
high chromatic usage because we listen on push event for every branch

## Solution
remove `push` event for feature branches only do so for `develop`
