### PR TITLE
feat: set cookies with domain

### DIFF
--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -14,23 +14,24 @@ import {
   E2E_EMAIL_COLLAB,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
+import { setCookieWithDomain } from "../utils/cookies"
 
 Cypress.Commands.add("setGithubSessionDefaults", () => {
-  cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-  cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, USER_TYPES.Github)
+  setCookieWithDomain(COOKIE_NAME, COOKIE_VALUE)
+  setCookieWithDomain(E2E_USER_TYPE_COOKIE_KEY, USER_TYPES.Github)
   window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(E2E_USER))
   window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
 })
 
 Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
-  cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-  cy.setCookie(E2E_USER_TYPE_COOKIE_KEY, userType)
-  cy.setCookie(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
-  cy.setCookie(
+  setCookieWithDomain(COOKIE_NAME, COOKIE_VALUE)
+  setCookieWithDomain(E2E_USER_TYPE_COOKIE_KEY, userType)
+  setCookieWithDomain(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
+  setCookieWithDomain(
     E2E_COOKIE.Email.key,
     userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_COLLAB.email
   )
-  cy.setCookie(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
+  setCookieWithDomain(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
 })
 
 Cypress.Commands.add(
@@ -42,11 +43,11 @@ Cypress.Commands.add(
     site = ""
   ) => {
     cy.clearCookies()
-    cy.setCookie(E2E_COOKIE.Site.key, site)
-    cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-    cy.setCookie(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
-    cy.setCookie(E2E_COOKIE.EmailUserType.key, userType)
-    cy.setCookie(E2E_COOKIE.Email.key, email)
+    setCookieWithDomain(E2E_COOKIE.Site.key, site)
+    setCookieWithDomain(COOKIE_NAME, COOKIE_VALUE)
+    setCookieWithDomain(E2E_COOKIE.Auth.key, E2E_COOKIE.Auth.value)
+    setCookieWithDomain(E2E_COOKIE.EmailUserType.key, userType)
+    setCookieWithDomain(E2E_COOKIE.Email.key, email)
     cy.request("GET", `${BACKEND_URL}/auth/whoami`)
 
     cy.setEmailSessionDefaults(initialUserType)

--- a/cypress/support/settings.ts
+++ b/cypress/support/settings.ts
@@ -8,6 +8,7 @@ import {
   TEST_PRIMARY_COLOR,
   TEST_REPO_NAME,
 } from "../fixtures/constants"
+import { setCookieWithDomain } from "../utils/cookies"
 
 Cypress.Commands.add("saveSettings", () => {
   cy.intercept("POST", "/v2/sites/e2e-test-repo/settings").as("awaitSave")

--- a/cypress/utils/cookies.ts
+++ b/cypress/utils/cookies.ts
@@ -1,0 +1,6 @@
+import { BACKEND_URL } from "../fixtures/constants"
+
+export const setCookieWithDomain = (name: string, value: string) => {
+  const baseUrl = new URL(BACKEND_URL)
+  cy.setCookie(name, value, { domain: baseUrl.host })
+}

--- a/cypress/utils/cookies.ts
+++ b/cypress/utils/cookies.ts
@@ -1,6 +1,10 @@
 import { BACKEND_URL } from "../fixtures/constants"
 
-export const setCookieWithDomain = (name: string, value: string) => {
+export const setCookieWithDomain = (
+  name: string,
+  value: string,
+  options: Partial<Cypress.SetCookieOptions> = {}
+) => {
   const baseUrl = new URL(BACKEND_URL)
-  cy.setCookie(name, value, { domain: baseUrl.host })
+  cy.setCookie(name, value, { domain: baseUrl.host, ...options })
 }

--- a/cypress/utils/session.ts
+++ b/cypress/utils/session.ts
@@ -1,11 +1,13 @@
 import { BACKEND_URL, E2E_COOKIE } from "../fixtures/constants"
 
+import { setCookieWithDomain } from "./cookies"
+
 /**
  * The backend checks to see if site exists on the cookie.
  * If it doesn't the user will not be authorised
  * and we use this to remove a users' authorisation.
  */
 export const setUserAsUnauthorised = (): void => {
-  cy.setCookie(E2E_COOKIE.Site.key, "")
+  setCookieWithDomain(E2E_COOKIE.Site.key, "")
   cy.request("GET", `${BACKEND_URL}/auth/whoami`)
 }


### PR DESCRIPTION
## Problem

With Cypress upgrade, setting cookies needs an explicit domain set. In the absence of a domain, the cookies are not forwarded from FE to BE which causes the auth checks to fail and hence log out of the E2E tests.

Closes Is-270

## Solution

Create an util function that injects domains into the cookies from the env var (`CYPRESS_BACKEND_URL`)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Tests

Ensure E2E tests run properly both against local and staging
