### PR TITLE
fix(settings): use gh session defaults

### DIFF
--- a/cypress/support/settings.ts
+++ b/cypress/support/settings.ts
@@ -23,10 +23,7 @@ Cypress.Commands.add("visitLoadSettings", (siteName, sitePath) => {
 })
 
 Cypress.Commands.add("setDefaultSettings", () => {
-  cy.setCookie(COOKIE_NAME, COOKIE_VALUE)
-
-  window.localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(E2E_USER))
-  window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
+  cy.setGithubSessionDefaults()
 
   cy.visit(`/sites/${TEST_REPO_NAME}/settings`)
   cy.get("button[aria-label='Select colour']").first().click()


### PR DESCRIPTION
## Problem
`setDefaultSettings` was using the same session creds as github but it is separate. this lead to a divergence in behaviour when `userType` was added as validation for e2e users, which causes a 401.

## Solution
use `setGithubSessionDefaults`
