### PR TITLE
IS-271: fix bugs on simple mde editor

### DIFF
--- a/src/components/pages/EditorModals.jsx
+++ b/src/components/pages/EditorModals.jsx
@@ -19,7 +19,10 @@ const EditorModals = ({
       setLinePos(lineAndCursor)
       simpleMde.codemirror.setSelection(lineAndCursor)
     }
-    if (lineAndCursor && lineAndCursor.line !== 0 && lineAndCursor.ch !== 0) {
+    if (
+      lineAndCursor &&
+      !(lineAndCursor.line === 0 && lineAndCursor.ch === 0)
+    ) {
       setLinePos(lineAndCursor)
     }
   }, [lineAndCursor])
@@ -80,6 +83,20 @@ EditorModals.propTypes = {
   onSave: PropTypes.func.isRequired,
   modalType: PropTypes.oneOf(["hyperlink", "media"]).isRequired,
   onClose: PropTypes.func.isRequired,
+  simpleMde: PropTypes.shape({
+    codemirror: PropTypes.shape({
+      getSelection: PropTypes.func,
+      getValue: PropTypes.func,
+      replaceSelection: PropTypes.func,
+      setCursor: PropTypes.func,
+    }),
+  }),
+  lineAndCursor: PropTypes.shape({
+    line: PropTypes.number,
+    ch: PropTypes.number,
+    sticky: PropTypes.string,
+    xRel: PropTypes.number,
+  }),
 }
 
 export default EditorModals

--- a/src/components/pages/EditorModals.jsx
+++ b/src/components/pages/EditorModals.jsx
@@ -1,18 +1,36 @@
 import HyperlinkModal from "components/HyperlinkModal"
 import MediaModal from "components/media/MediaModal"
 import PropTypes from "prop-types"
+import { useEffect, useState } from "react"
 
 const EditorModals = ({
-  mdeRef,
+  // mdeRef,
   onSave,
   modalType,
   onClose,
   mediaType,
   simpleMde,
+  lineAndCursor,
 }) => {
+  const [linePos, setLinePos] = useState({ line: 0, ch: 0, sticky: null })
+
+  console.log(`Current linepos`, linePos)
+
+  useEffect(() => {
+    if (!lineAndCursor && simpleMde) {
+      setLinePos(lineAndCursor)
+      simpleMde.codemirror.setSelection(lineAndCursor)
+    }
+    if (lineAndCursor && lineAndCursor.line !== 0 && lineAndCursor.ch !== 0) {
+      setLinePos(lineAndCursor)
+    }
+  }, [lineAndCursor])
+
   const onHyperlinkSave = (text, link) => {
     // const cm = mdeRef.current.simpleMde.codemirror
     const cm = simpleMde.codemirror
+    cm.setCursor(linePos)
+    cm.setSelection(linePos)
     cm.replaceSelection(`[${text}](${link})`)
     // set state so that rerender is triggered and path is shown
     // onSave(mdeRef.current.simpleMde.codemirror.getValue())
@@ -20,13 +38,23 @@ const EditorModals = ({
     onClose()
   }
 
-  console.log(`MDE REF`, mdeRef)
+  // console.log(`MDE REF`, mdeRef)
   console.log(`Simple MDE`, simpleMde)
+  console.log(`Line Cursor`, lineAndCursor)
 
   const onMediaSave = (data) => {
     const { selectedMediaPath, altText } = data
+    console.log(`DATA`, data)
     // const cm = mdeRef.current.simpleMde.codemirror
     const cm = simpleMde.codemirror
+
+    console.log(`Setting selection to `, lineAndCursor)
+    cm.setCursor(linePos)
+    cm.setSelection(linePos)
+
+    console.log(`Current cursor`, cm.getCursor())
+
+    console.log(`SELECTIONS`, cm.getSelections())
     if (mediaType === "files")
       cm.replaceSelection(
         `[${altText}](${selectedMediaPath.replaceAll(" ", "%20")})`
@@ -53,7 +81,7 @@ const EditorModals = ({
       )}
       {modalType === "hyperlink" && (
         <HyperlinkModal
-          text={mdeRef.current.simpleMde.codemirror.getSelection()}
+          text={simpleMde.codemirror.getSelection()}
           onSave={onHyperlinkSave}
           onClose={onClose}
         />
@@ -63,11 +91,11 @@ const EditorModals = ({
 }
 
 EditorModals.propTypes = {
-  mdeRef: PropTypes.oneOfType([
-    // https://stackoverflow.com/questions/48007326/what-is-the-correct-proptype-for-a-ref-in-react
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-  ]),
+  // mdeRef: PropTypes.oneOfType([
+  //   // https://stackoverflow.com/questions/48007326/what-is-the-correct-proptype-for-a-ref-in-react
+  //   PropTypes.func,
+  //   PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  // ]),
   onSave: PropTypes.func.isRequired,
   modalType: PropTypes.oneOf(["hyperlink", "media"]).isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/components/pages/EditorModals.jsx
+++ b/src/components/pages/EditorModals.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types"
 import { useEffect, useState } from "react"
 
 const EditorModals = ({
-  // mdeRef,
   onSave,
   modalType,
   onClose,
@@ -14,8 +13,7 @@ const EditorModals = ({
 }) => {
   const [linePos, setLinePos] = useState({ line: 0, ch: 0, sticky: null })
 
-  console.log(`Current linepos`, linePos)
-
+  // this fixes the issue where line and cursor are being reset to 0 upon opening modals
   useEffect(() => {
     if (!lineAndCursor && simpleMde) {
       setLinePos(lineAndCursor)
@@ -27,34 +25,22 @@ const EditorModals = ({
   }, [lineAndCursor])
 
   const onHyperlinkSave = (text, link) => {
-    // const cm = mdeRef.current.simpleMde.codemirror
     const cm = simpleMde.codemirror
     cm.setCursor(linePos)
     cm.setSelection(linePos)
     cm.replaceSelection(`[${text}](${link})`)
     // set state so that rerender is triggered and path is shown
-    // onSave(mdeRef.current.simpleMde.codemirror.getValue())
     onSave(simpleMde.codemirror.getValue())
     onClose()
   }
 
-  // console.log(`MDE REF`, mdeRef)
-  console.log(`Simple MDE`, simpleMde)
-  console.log(`Line Cursor`, lineAndCursor)
-
   const onMediaSave = (data) => {
     const { selectedMediaPath, altText } = data
-    console.log(`DATA`, data)
-    // const cm = mdeRef.current.simpleMde.codemirror
     const cm = simpleMde.codemirror
 
-    console.log(`Setting selection to `, lineAndCursor)
     cm.setCursor(linePos)
     cm.setSelection(linePos)
 
-    console.log(`Current cursor`, cm.getCursor())
-
-    console.log(`SELECTIONS`, cm.getSelections())
     if (mediaType === "files")
       cm.replaceSelection(
         `[${altText}](${selectedMediaPath.replaceAll(" ", "%20")})`
@@ -91,11 +77,6 @@ const EditorModals = ({
 }
 
 EditorModals.propTypes = {
-  // mdeRef: PropTypes.oneOfType([
-  //   // https://stackoverflow.com/questions/48007326/what-is-the-correct-proptype-for-a-ref-in-react
-  //   PropTypes.func,
-  //   PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-  // ]),
   onSave: PropTypes.func.isRequired,
   modalType: PropTypes.oneOf(["hyperlink", "media"]).isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/components/pages/EditorModals.jsx
+++ b/src/components/pages/EditorModals.jsx
@@ -2,28 +2,42 @@ import HyperlinkModal from "components/HyperlinkModal"
 import MediaModal from "components/media/MediaModal"
 import PropTypes from "prop-types"
 
-const EditorModals = ({ mdeRef, onSave, modalType, onClose, mediaType }) => {
+const EditorModals = ({
+  mdeRef,
+  onSave,
+  modalType,
+  onClose,
+  mediaType,
+  simpleMde,
+}) => {
   const onHyperlinkSave = (text, link) => {
-    const cm = mdeRef.current.simpleMde.codemirror
+    // const cm = mdeRef.current.simpleMde.codemirror
+    const cm = simpleMde.codemirror
     cm.replaceSelection(`[${text}](${link})`)
     // set state so that rerender is triggered and path is shown
-    onSave(mdeRef.current.simpleMde.codemirror.getValue())
+    // onSave(mdeRef.current.simpleMde.codemirror.getValue())
+    onSave(simpleMde.codemirror.getValue())
     onClose()
   }
 
+  console.log(`MDE REF`, mdeRef)
+  console.log(`Simple MDE`, simpleMde)
+
   const onMediaSave = (data) => {
     const { selectedMediaPath, altText } = data
-    const cm = mdeRef.current.simpleMde.codemirror
+    // const cm = mdeRef.current.simpleMde.codemirror
+    const cm = simpleMde.codemirror
     if (mediaType === "files")
       cm.replaceSelection(
         `[${altText}](${selectedMediaPath.replaceAll(" ", "%20")})`
       )
-    if (mediaType === "images")
+    if (mediaType === "images") {
       cm.replaceSelection(
         `![${altText}](${selectedMediaPath.replaceAll(" ", "%20")})`
       )
+    }
     // set state so that rerender is triggered and image is shown
-    onSave(mdeRef.current.simpleMde.codemirror.getValue())
+    onSave(simpleMde.codemirror.getValue())
     onClose()
   }
 

--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -21,7 +21,7 @@ import {
 
 const MarkdownEditor = ({
   siteName,
-  mdeRef,
+  // mdeRef,
   onChange,
   value,
   isDisabled,
@@ -32,6 +32,9 @@ const MarkdownEditor = ({
   const { toMarkdown } = useMarkdown()
   const options = useMemo(
     () => ({
+      autosave: { enabled: true },
+      autoRefresh: true,
+      styleSelectedText: true,
       toolbar: [
         headingButton,
         boldButton,
@@ -105,6 +108,17 @@ const MarkdownEditor = ({
       console.info("Hey I'm editor instance!", simpleMdeInstance)
   }, [simpleMdeInstance])
 
+  const [lineAndCursor, setLineAndCursor] = useState(null)
+
+  const getLineAndCursorCallback = useCallback((position) => {
+    setLineAndCursor(position)
+  }, [])
+
+  useEffect(() => {
+    lineAndCursor &&
+      console.info("Hey I'm line and cursor info!", lineAndCursor)
+  }, [lineAndCursor])
+
   const StatusIcon = () => {
     if (isDisabled) {
       return (
@@ -131,7 +145,7 @@ const MarkdownEditor = ({
     <>
       <EditorModals
         siteName={siteName}
-        mdeRef={mdeRef}
+        // mdeRef={mdeRef}
         modalType={editorModalType}
         onSave={onChange}
         onClose={() => {
@@ -140,6 +154,7 @@ const MarkdownEditor = ({
         }}
         mediaType={insertingMediaType}
         simpleMde={simpleMdeInstance}
+        lineAndCursor={lineAndCursor}
       />
       <div
         className={`${editorStyles.pageEditorSidebar} ${
@@ -151,12 +166,24 @@ const MarkdownEditor = ({
           id="simplemde-editor"
           className="h-100"
           onChange={onChange}
-          ref={mdeRef}
+          // ref={mdeRef}
           value={value}
           options={options}
           events={events}
           getMdeInstance={getMdeInstanceCallback}
+          getLineAndCursor={getLineAndCursorCallback}
         />
+        {/* <SimpleMDE
+          // id="simplemde-editor2"
+          className="h-100"
+          // onChange={onChange}
+          // ref={mdeRef}
+          value={value}
+          options={options}
+          // events={events}
+          getMdeInstance={getMdeInstanceCallback}
+          getLineAndCursor={getLineAndCursorCallback}
+        /> */}
       </div>
     </>
   )

--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -21,7 +21,6 @@ import {
 
 const MarkdownEditor = ({
   siteName,
-  // mdeRef,
   onChange,
   value,
   isDisabled,
@@ -145,7 +144,6 @@ const MarkdownEditor = ({
     <>
       <EditorModals
         siteName={siteName}
-        // mdeRef={mdeRef}
         modalType={editorModalType}
         onSave={onChange}
         onClose={() => {
@@ -166,24 +164,12 @@ const MarkdownEditor = ({
           id="simplemde-editor"
           className="h-100"
           onChange={onChange}
-          // ref={mdeRef}
           value={value}
           options={options}
           events={events}
           getMdeInstance={getMdeInstanceCallback}
           getLineAndCursor={getLineAndCursorCallback}
         />
-        {/* <SimpleMDE
-          // id="simplemde-editor2"
-          className="h-100"
-          // onChange={onChange}
-          // ref={mdeRef}
-          value={value}
-          options={options}
-          // events={events}
-          getMdeInstance={getMdeInstanceCallback}
-          getLineAndCursor={getLineAndCursorCallback}
-        /> */}
       </div>
     </>
   )

--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -1,5 +1,5 @@
 import EditorModals from "components/pages/EditorModals"
-import { useMemo, useState } from "react"
+import { useMemo, useState, useCallback, useEffect } from "react"
 import SimpleMDE from "react-simplemde-editor"
 
 import { useMarkdown } from "hooks/useMarkdown"
@@ -94,6 +94,17 @@ const MarkdownEditor = ({
     }
   })
 
+  const [simpleMdeInstance, setMdeInstance] = useState(null)
+
+  const getMdeInstanceCallback = useCallback((simpleMde) => {
+    setMdeInstance(simpleMde)
+  }, [])
+
+  useEffect(() => {
+    simpleMdeInstance &&
+      console.info("Hey I'm editor instance!", simpleMdeInstance)
+  }, [simpleMdeInstance])
+
   const StatusIcon = () => {
     if (isDisabled) {
       return (
@@ -128,6 +139,7 @@ const MarkdownEditor = ({
           setInsertingMediaType("")
         }}
         mediaType={insertingMediaType}
+        simpleMde={simpleMdeInstance}
       />
       <div
         className={`${editorStyles.pageEditorSidebar} ${
@@ -143,6 +155,7 @@ const MarkdownEditor = ({
           value={value}
           options={options}
           events={events}
+          getMdeInstance={getMdeInstanceCallback}
         />
       </div>
     </>

--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -1,5 +1,5 @@
 import EditorModals from "components/pages/EditorModals"
-import { useMemo, useState, useCallback, useEffect } from "react"
+import { useMemo, useState, useCallback } from "react"
 import SimpleMDE from "react-simplemde-editor"
 
 import { useMarkdown } from "hooks/useMarkdown"
@@ -31,7 +31,6 @@ const MarkdownEditor = ({
   const { toMarkdown } = useMarkdown()
   const options = useMemo(
     () => ({
-      autosave: { enabled: true },
       autoRefresh: true,
       styleSelectedText: true,
       toolbar: [
@@ -102,21 +101,11 @@ const MarkdownEditor = ({
     setMdeInstance(simpleMde)
   }, [])
 
-  useEffect(() => {
-    simpleMdeInstance &&
-      console.info("Hey I'm editor instance!", simpleMdeInstance)
-  }, [simpleMdeInstance])
-
   const [lineAndCursor, setLineAndCursor] = useState(null)
 
   const getLineAndCursorCallback = useCallback((position) => {
     setLineAndCursor(position)
   }, [])
-
-  useEffect(() => {
-    lineAndCursor &&
-      console.info("Hey I'm line and cursor info!", lineAndCursor)
-  }, [lineAndCursor])
 
   const StatusIcon = () => {
     if (isDisabled) {

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -16,7 +16,7 @@ import { WarningModal } from "components/WarningModal"
 import DOMPurify from "dompurify"
 import { marked } from "marked"
 import PropTypes from "prop-types"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { useCollectionHook } from "hooks/collectionHooks"
 import { useGetPageHook, useUpdatePageHook } from "hooks/pageHooks"
@@ -98,7 +98,7 @@ const EditPage = ({ match }) => {
 
   const { setRedirectToNotFound } = useRedirectHook()
 
-  const mdeRef = useRef()
+  // const mdeRef = useRef()
 
   const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
     onError: () => setRedirectToNotFound(siteName),
@@ -275,7 +275,7 @@ const EditPage = ({ match }) => {
         {/* Editor */}
         <MarkdownEditor
           siteName={siteName}
-          mdeRef={mdeRef}
+          // mdeRef={mdeRef}
           onChange={(value) => setEditorValue(value)}
           value={editorValue}
           isLoading={isLoadingPage}

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -98,8 +98,6 @@ const EditPage = ({ match }) => {
 
   const { setRedirectToNotFound } = useRedirectHook()
 
-  // const mdeRef = useRef()
-
   const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
     onError: () => setRedirectToNotFound(siteName),
   })
@@ -275,7 +273,6 @@ const EditPage = ({ match }) => {
         {/* Editor */}
         <MarkdownEditor
           siteName={siteName}
-          // mdeRef={mdeRef}
           onChange={(value) => setEditorValue(value)}
           value={editorValue}
           isLoading={isLoadingPage}


### PR DESCRIPTION
## Problem

With the upgrade of mde editor to v5 in core-deps PR (https://github.com/isomerpages/isomercms-frontend/pull/1202/), the editor’s insert image and hyperlink does not seem to work.

Closes IS-271

## Solution

I removed the use of `mdeRef` which no long contained the `codemirror` object we were looking for inside the ref. I suppose this is due to breaking changes from v4 to v5. See https://www.npmjs.com/package/react-simplemde-editor?activeTab=readme#autosaving for more information.

From docs, the new suggested method to retrieve the editor or codemirror is to use the hooks & callbacks provided.

Have tested this locally via E2E on editPage. Results show all tests are passing:
![Screenshot 2023-06-26 at 11 30 48 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/4225948a-3f31-4032-82f9-c3c61e58b633)

Note: Due to React's Strict Mode, the file selection dialog (`MediaCreationModal`) gets re-rendered twice in development. However, this should not occur on production-ready builds.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

<!-- What tests should be run to confirm functionality? -->

- Ensure E2E tests, specifically `editPage.spec.ts` runs successfully
- Perform visual inspection by:
    - adding/removing images, 
    - inserting hyperlinks via editor and ensure it comes up fine on preview. 
    - Also test image names with spaces in between.
    - Test inserting files
