### PR TITLE
Feat/site launch integration with be

### DIFF
--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -35,14 +35,14 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
 }
 
 function updateSiteLaunchStatusOnApiCall(
-  siteLaunchDto: SiteLaunchDto | undefined,
+  siteLaunchDto: SiteLaunchDto,
   siteLaunchStatusProps: SiteLaunchStatusProps,
   setSiteLaunchStatusProps: (
     siteLaunchStatusProps: SiteLaunchStatusProps
   ) => void
 ): void {
   if (
-    siteLaunchDto?.siteStatus === "NOT_LAUNCHED" &&
+    siteLaunchDto.siteStatus === "NOT_LAUNCHED" &&
     siteLaunchStatusProps.siteLaunchStatus === "LOADING"
   ) {
     setSiteLaunchStatusProps({
@@ -54,8 +54,8 @@ function updateSiteLaunchStatusOnApiCall(
   const isSiteLaunchFEAndBESynced =
     siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
   if (
-    (siteLaunchDto?.siteStatus === "LAUNCHED" ||
-      siteLaunchDto?.siteStatus === "LAUNCHING") &&
+    (siteLaunchDto.siteStatus === "LAUNCHED" ||
+      siteLaunchDto.siteStatus === "LAUNCHING") &&
     !isSiteLaunchFEAndBESynced
   ) {
     setSiteLaunchStatusProps({

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useState } from "react"
 import { useParams } from "react-router-dom"
 
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -4,7 +4,6 @@ import { useParams } from "react-router-dom"
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 
 import {
-  SiteLaunchDto,
   SiteLaunchFrontEndStatus,
   SiteLaunchStatusProps,
   SiteLaunchTaskTypeIndex,

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -4,7 +4,6 @@ import { useParams } from "react-router-dom"
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 
 import {
-  SiteLaunchDto,
   SiteLaunchFrontEndStatus,
   SiteLaunchStatusProps,
   SiteLaunchTaskTypeIndex,
@@ -32,38 +31,6 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
   if (!SiteLaunchContextData)
     throw new Error("useSiteLaunchContext must be used within an RoleProvider")
   return SiteLaunchContextData
-}
-
-function updateSiteLaunchStatusOnApiCall(
-  siteLaunchDto: SiteLaunchDto,
-  siteLaunchStatusProps: SiteLaunchStatusProps,
-  setSiteLaunchStatusProps: (
-    siteLaunchStatusProps: SiteLaunchStatusProps
-  ) => void
-): void {
-  if (
-    siteLaunchDto.siteStatus === "NOT_LAUNCHED" &&
-    siteLaunchStatusProps.siteLaunchStatus === "LOADING"
-  ) {
-    setSiteLaunchStatusProps({
-      siteLaunchStatus: "NOT_LAUNCHED",
-      stepNumber: 0,
-    })
-  }
-  // this condition is added to prevent redundant re-renders
-  const isSiteLaunchFEAndBESynced =
-    siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
-  if (
-    (siteLaunchDto.siteStatus === "LAUNCHED" ||
-      siteLaunchDto.siteStatus === "LAUNCHING") &&
-    !isSiteLaunchFEAndBESynced
-  ) {
-    setSiteLaunchStatusProps({
-      siteLaunchStatus: siteLaunchDto.siteStatus,
-      stepNumber: SITE_LAUNCH_TASKS_LENGTH,
-      dnsRecords: siteLaunchDto.dnsRecords,
-    })
-  }
 }
 
 export const SiteLaunchProvider = ({

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom"
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 
 import {
+  SiteLaunchDto,
   SiteLaunchFrontEndStatus,
   SiteLaunchStatusProps,
   SiteLaunchTaskTypeIndex,
@@ -31,6 +32,38 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
   if (!SiteLaunchContextData)
     throw new Error("useSiteLaunchContext must be used within an RoleProvider")
   return SiteLaunchContextData
+}
+
+function updateSiteLaunchStatusOnApiCall(
+  siteLaunchDto: SiteLaunchDto | undefined,
+  siteLaunchStatusProps: SiteLaunchStatusProps,
+  setSiteLaunchStatusProps: (
+    siteLaunchStatusProps: SiteLaunchStatusProps
+  ) => void
+): void {
+  if (
+    siteLaunchDto?.siteStatus === "NOT_LAUNCHED" &&
+    siteLaunchStatusProps.siteLaunchStatus === "LOADING"
+  ) {
+    setSiteLaunchStatusProps({
+      siteLaunchStatus: "NOT_LAUNCHED",
+      stepNumber: 0,
+    })
+  }
+  // this condition is added to prevent redundant re-renders
+  const isSiteLaunchFEAndBESynced =
+    siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
+  if (
+    (siteLaunchDto?.siteStatus === "LAUNCHED" ||
+      siteLaunchDto?.siteStatus === "LAUNCHING") &&
+    !isSiteLaunchFEAndBESynced
+  ) {
+    setSiteLaunchStatusProps({
+      siteLaunchStatus: siteLaunchDto.siteStatus,
+      stepNumber: SITE_LAUNCH_TASKS_LENGTH,
+      dnsRecords: siteLaunchDto.dnsRecords,
+    })
+  }
 }
 
 export const SiteLaunchProvider = ({

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react"
+import { createContext, useContext, useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
 import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -34,38 +34,6 @@ export const useSiteLaunchContext = (): SiteLaunchContextProps => {
   return SiteLaunchContextData
 }
 
-function updateSiteLaunchStatusOnApiCall(
-  siteLaunchDto: SiteLaunchDto | undefined,
-  siteLaunchStatusProps: SiteLaunchStatusProps,
-  setSiteLaunchStatusProps: (
-    siteLaunchStatusProps: SiteLaunchStatusProps
-  ) => void
-): void {
-  if (
-    siteLaunchDto?.siteStatus === "NOT_LAUNCHED" &&
-    siteLaunchStatusProps.siteLaunchStatus === "LOADING"
-  ) {
-    setSiteLaunchStatusProps({
-      siteLaunchStatus: "NOT_LAUNCHED",
-      stepNumber: 0,
-    })
-  }
-  // this condition is added to prevent redundant re-renders
-  const isSiteLaunchFEAndBESynced =
-    siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus
-  if (
-    (siteLaunchDto?.siteStatus === "LAUNCHED" ||
-      siteLaunchDto?.siteStatus === "LAUNCHING") &&
-    !isSiteLaunchFEAndBESynced
-  ) {
-    setSiteLaunchStatusProps({
-      siteLaunchStatus: siteLaunchDto.siteStatus,
-      stepNumber: SITE_LAUNCH_TASKS_LENGTH,
-      dnsRecords: siteLaunchDto.dnsRecords,
-    })
-  }
-}
-
 export const SiteLaunchProvider = ({
   children,
   initialSiteLaunchStatus,

--- a/src/hooks/siteDashboardHooks/useGetSiteLaunchStatus.ts
+++ b/src/hooks/siteDashboardHooks/useGetSiteLaunchStatus.ts
@@ -2,7 +2,7 @@ import { UseQueryResult, useQuery } from "react-query"
 
 import { SITE_DASHBOARD_LAUNCH_STATUS_KEY } from "constants/queryKeys"
 
-import * as SiteDashboardService from "services/SiteDashboardService"
+import * as SiteLaunchService from "services/SiteLaunchService"
 
 import { SiteLaunchDto } from "types/siteLaunch"
 
@@ -11,7 +11,9 @@ export const useGetSiteLaunchStatus = (
 ): UseQueryResult<SiteLaunchDto> => {
   return useQuery<SiteLaunchDto>(
     [SITE_DASHBOARD_LAUNCH_STATUS_KEY, siteName],
-    () => SiteDashboardService.getSiteLaunchStatus(siteName),
+    () => {
+      return SiteLaunchService.getSiteLaunchStatus(siteName)
+    },
     {
       retry: false,
     }

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -66,9 +66,7 @@ const SiteDashboardMeta = {
       return (
         <MemoryRouter initialEntries={["/sites/storybook/dashboard"]}>
           <Route path="/sites/:siteName/dashboard">
-            <SiteLaunchProvider>
-              <Story />
-            </SiteLaunchProvider>
+            <Story />
           </Route>
         </MemoryRouter>
       )

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -23,6 +23,7 @@ import {
   buildSiteDashboardReviewRequests,
   buildSiteLaunchDto,
 } from "mocks/utils"
+import { SITE_LAUNCH_TASKS_LENGTH } from "types/siteLaunch"
 
 import { SiteDashboard } from "./SiteDashboard"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -23,7 +23,6 @@ import {
   buildSiteDashboardReviewRequests,
   buildSiteLaunchDto,
 } from "mocks/utils"
-import { SITE_LAUNCH_TASKS_LENGTH } from "types/siteLaunch"
 
 import { SiteDashboard } from "./SiteDashboard"
 
@@ -66,7 +65,9 @@ const SiteDashboardMeta = {
       return (
         <MemoryRouter initialEntries={["/sites/storybook/dashboard"]}>
           <Route path="/sites/:siteName/dashboard">
-            <Story />
+            <SiteLaunchProvider>
+              <Story />
+            </SiteLaunchProvider>
           </Route>
         </MemoryRouter>
       )

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -58,13 +58,6 @@ import { CollaboratorsStatistics } from "./components/CollaboratorsStatistics"
 import { EmptyReviewRequest } from "./components/EmptyReviewRequest"
 import { ReviewRequestCard } from "./components/ReviewRequestCard"
 
-interface SiteLaunchDisplayCardProps {
-  siteName: string
-  siteLaunchStatus?: SiteLaunchFrontEndStatus
-  isSiteLaunchLoading: boolean
-  siteLaunchChecklistStepNumber?: number
-}
-
 export const SiteDashboard = (): JSX.Element => {
   const {
     isOpen: isCollaboratorsModalOpen,

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -58,6 +58,13 @@ import { CollaboratorsStatistics } from "./components/CollaboratorsStatistics"
 import { EmptyReviewRequest } from "./components/EmptyReviewRequest"
 import { ReviewRequestCard } from "./components/ReviewRequestCard"
 
+interface SiteLaunchDisplayCardProps {
+  siteName: string
+  siteLaunchStatus?: SiteLaunchFrontEndStatus
+  isSiteLaunchLoading: boolean
+  siteLaunchChecklistStepNumber?: number
+}
+
 export const SiteDashboard = (): JSX.Element => {
   const {
     isOpen: isCollaboratorsModalOpen,

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -29,7 +29,6 @@ import _ from "lodash"
 import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
-import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
@@ -57,13 +56,6 @@ import { SiteViewLayout } from "../layouts"
 import { CollaboratorsStatistics } from "./components/CollaboratorsStatistics"
 import { EmptyReviewRequest } from "./components/EmptyReviewRequest"
 import { ReviewRequestCard } from "./components/ReviewRequestCard"
-
-interface SiteLaunchDisplayCardProps {
-  siteName: string
-  siteLaunchStatus?: SiteLaunchFrontEndStatus
-  isSiteLaunchLoading: boolean
-  siteLaunchChecklistStepNumber?: number
-}
 
 export const SiteDashboard = (): JSX.Element => {
   const {

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -29,7 +29,6 @@ import _ from "lodash"
 import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
-import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -29,6 +29,7 @@ import _ from "lodash"
 import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
+import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -26,9 +26,10 @@ import {
   MenuDropdownItem,
 } from "components/MenuDropdownButton"
 import _ from "lodash"
-import { useEffect } from "react"
+import { useEffect, useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
+import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -26,10 +26,9 @@ import {
   MenuDropdownItem,
 } from "components/MenuDropdownButton"
 import _ from "lodash"
-import { useEffect, useEffect } from "react"
+import { useEffect } from "react"
 import { BiCheckCircle, BiCog, BiEditAlt, BiGroup } from "react-icons/bi"
 import { useParams, Link as RouterLink } from "react-router-dom"
-import { isUserUsingSiteLaunchFeature } from "services/SiteLaunchService"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -177,7 +177,6 @@ export const SiteLaunchPad = (): JSX.Element => {
       title = <SiteLaunchChecklistTitle />
       body = (
         <SiteLaunchChecklistBody
-          setPageNumber={setPageNumber}
           handleIncrementStepNumber={handleIncrementStepNumber}
           handleDecrementStepNumber={handleDecrementStepNumber}
         />

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -161,29 +161,6 @@ export const SiteLaunchPad = (): JSX.Element => {
     }
   }
 
-  const handleIncrementStepNumber = () => {
-    if (
-      siteLaunchStatusProps &&
-      siteLaunchStatusProps.stepNumber < SITE_LAUNCH_TASKS_LENGTH
-    ) {
-      setSiteLaunchStatusProps({
-        ...siteLaunchStatusProps,
-        stepNumber: (siteLaunchStatusProps.stepNumber +
-          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
-        siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
-      })
-    }
-  }
-  const handleDecrementStepNumber = () => {
-    if (siteLaunchStatusProps && siteLaunchStatusProps.stepNumber > 0) {
-      setSiteLaunchStatusProps({
-        ...siteLaunchStatusProps,
-        stepNumber: (siteLaunchStatusProps?.stepNumber -
-          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
-      })
-    }
-  }
-
   let title: JSX.Element
   let body: JSX.Element
   switch (pageNumber) {

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -134,6 +134,19 @@ export const SiteLaunchPad = (): JSX.Element => {
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)
   )
+  const handleIncrementStepNumber = () => {
+    setSiteLaunchStatusProps({
+      ...siteLaunchStatusProps,
+      stepNumber: siteLaunchStatusProps.stepNumber + 1,
+      siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
+    })
+  }
+  const handleDecrementStepNumber = () => {
+    setSiteLaunchStatusProps({
+      ...siteLaunchStatusProps,
+      stepNumber: siteLaunchStatusProps.stepNumber - 1,
+    })
+  }
 
   const handleIncrementStepNumber = () => {
     if (

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -134,18 +134,28 @@ export const SiteLaunchPad = (): JSX.Element => {
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)
   )
+
   const handleIncrementStepNumber = () => {
-    setSiteLaunchStatusProps({
-      ...siteLaunchStatusProps,
-      stepNumber: siteLaunchStatusProps.stepNumber + 1,
-      siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
-    })
+    if (
+      siteLaunchStatusProps &&
+      siteLaunchStatusProps.stepNumber < SITE_LAUNCH_TASKS_LENGTH
+    ) {
+      setSiteLaunchStatusProps({
+        ...siteLaunchStatusProps,
+        stepNumber: (siteLaunchStatusProps.stepNumber +
+          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
+        siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
+      })
+    }
   }
   const handleDecrementStepNumber = () => {
-    setSiteLaunchStatusProps({
-      ...siteLaunchStatusProps,
-      stepNumber: siteLaunchStatusProps.stepNumber - 1,
-    })
+    if (siteLaunchStatusProps && siteLaunchStatusProps.stepNumber > 0) {
+      setSiteLaunchStatusProps({
+        ...siteLaunchStatusProps,
+        stepNumber: (siteLaunchStatusProps?.stepNumber -
+          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
+      })
+    }
   }
 
   const handleIncrementStepNumber = () => {

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import {
   Modal,
   ModalOverlay,
@@ -128,10 +129,7 @@ const getInitialPageNumber = (
   return SITE_LAUNCH_PAGES.DISCLAIMER
 }
 export const SiteLaunchPad = (): JSX.Element => {
-  const {
-    siteLaunchStatusProps,
-    setSiteLaunchStatusProps,
-  } = useSiteLaunchContext()
+  const { siteLaunchStatusProps } = useSiteLaunchContext()
 
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -129,7 +129,10 @@ const getInitialPageNumber = (
   return SITE_LAUNCH_PAGES.DISCLAIMER
 }
 export const SiteLaunchPad = (): JSX.Element => {
-  const { siteLaunchStatusProps } = useSiteLaunchContext()
+  const {
+    siteLaunchStatusProps,
+    setSiteLaunchStatusProps,
+  } = useSiteLaunchContext()
 
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -30,7 +30,7 @@ import {
   Skeleton,
 } from "@chakra-ui/react"
 import { Button, Checkbox, Link } from "@opengovsg/design-system-react"
-import { useState } from "react"
+import { useForm } from "react-hook-form"
 
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -15,6 +15,23 @@ import {
 import { Button, Checkbox, Link } from "@opengovsg/design-system-react"
 import { useForm } from "react-hook-form"
 
+import {
+  Box,
+  Center,
+  Icon,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Thead,
+  Tr,
+  Text,
+  TextProps,
+  Skeleton,
+} from "@chakra-ui/react"
+import { Button, Checkbox, Link } from "@opengovsg/design-system-react"
+import { useState } from "react"
+
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
 import { BxCopy, BxLifeBuoy } from "assets"

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -14,23 +14,6 @@ import {
 } from "@chakra-ui/react"
 import { Button, Checkbox, Link } from "@opengovsg/design-system-react"
 import { useForm } from "react-hook-form"
-
-import {
-  Box,
-  Center,
-  Icon,
-  Table,
-  TableContainer,
-  Tbody,
-  Td,
-  Thead,
-  Tr,
-  Text,
-  TextProps,
-  Skeleton,
-} from "@chakra-ui/react"
-import { Button, Checkbox, Link } from "@opengovsg/design-system-react"
-import { useForm } from "react-hook-form"
 import { useParams, Link as RouterLink } from "react-router-dom"
 
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
@@ -127,7 +110,6 @@ const generateDNSTable = (dnsRecords: DNSRecord[] | undefined): JSX.Element => {
 }
 
 interface SiteLaunchChecklistBodyProps {
-  setPageNumber: (number: number) => void
   handleIncrementStepNumber: () => void
   handleDecrementStepNumber: () => void
 }
@@ -177,7 +159,6 @@ const addSubtitlesForChecklist = (
 }
 
 export const SiteLaunchChecklistBody = ({
-  setPageNumber,
   handleIncrementStepNumber,
   handleDecrementStepNumber,
 }: SiteLaunchChecklistBodyProps): JSX.Element => {

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import { Box, Button, Icon, Text, RadioGroup } from "@chakra-ui/react"
 import { Input, Radio } from "@opengovsg/design-system-react"
 import { useState } from "react"

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -30,6 +30,9 @@ const SiteNature = {
 interface SiteLaunchFormData {
   domain: string
   nature: typeof SiteNature[keyof typeof SiteNature]
+  // NOTE: this cannot be set to boolean since
+  // radio values cannot be set to boolean
+  useWww: "true" | "false"
 }
 
 export const SiteLaunchInfoCollectorBody = ({
@@ -42,8 +45,19 @@ export const SiteLaunchInfoCollectorBody = ({
     watch,
   } = useForm<SiteLaunchFormData>()
 
+  const {
+    siteLaunchStatusProps,
+    setSiteLaunchStatusProps,
+  } = useSiteLaunchContext()
+
   const onSubmit = (data: SiteLaunchFormData) => {
-    // todo update context with data
+    if (!siteLaunchStatusProps) return
+    setSiteLaunchStatusProps({
+      ...siteLaunchStatusProps,
+      siteUrl: data.domain,
+      isNewDomain: data.nature === SiteNature.New,
+      useWwwSubdomain: data.useWww === "true",
+    })
     setPageNumber(SITE_LAUNCH_PAGES.RISK_ACCEPTANCE)
   }
   const [selectedRadio, setSelectedRadio] = useState("")
@@ -58,16 +72,43 @@ export const SiteLaunchInfoCollectorBody = ({
         {...register("domain", { required: true })}
       />
       {errors.domain && <Text textStyle="subhead-2">Domain is required</Text>}
+
+      <Text textStyle="subhead-1" mt="1.5rem">
+        Do you want to host the both the www and non-www version of your domain?
+      </Text>
+      <Text textStyle="subhead-2">
+        Select &quot;Yes&quot; if you are not sure
+      </Text>
+      <RadioGroup
+        {...register("useWww")}
+        onChange={setSelectedRadio}
+        mt="0.25rem"
+      >
+        <Radio value="true">
+          <Text textStyle="body-1" color="black">
+            Yes, host both www and non-www version
+          </Text>
+        </Radio>
+        <Radio value="false">
+          <Text textStyle="body-1" color="black">
+            No, host only the non-www version
+          </Text>
+        </Radio>
+      </RadioGroup>
       <Text textStyle="subhead-1" mt="1.5rem">
         What is the nature of the domain you are launching with?
       </Text>
-      <RadioGroup {...register("nature")} onChange={setSelectedRadio}>
-        <Radio value="new">
+      <RadioGroup
+        {...register("nature")}
+        onChange={setSelectedRadio}
+        mt="0.25rem"
+      >
+        <Radio value={SiteNature.New}>
           <Text textStyle="body-1" color="black">
             It is a brand new domain
           </Text>
         </Radio>
-        <Radio value="live">
+        <Radio value={SiteNature.Live}>
           <Text textStyle="body-1" color="black">
             This domain is currently live or was previously live
           </Text>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -5,6 +5,8 @@ import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { BiRightArrowAlt } from "react-icons/bi"
 
+import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
+
 import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
 import { SiteLaunchPadBody } from "./SiteLaunchPadBody"

--- a/src/services/SiteDashboardService.ts
+++ b/src/services/SiteDashboardService.ts
@@ -3,7 +3,6 @@ import {
   SiteDashboardInfo,
   SiteDashboardReviewRequest,
 } from "types/siteDashboard"
-import { SiteLaunchDto } from "types/siteLaunch"
 
 import { apiService } from "./ApiService"
 
@@ -35,11 +34,4 @@ export const updateViewedReviewRequests = async (
 ): Promise<void> => {
   const endpoint = `/sites/${siteName}/review/viewed`
   return apiService.post(endpoint)
-}
-
-export const getSiteLaunchStatus = async (
-  siteName: string
-): Promise<SiteLaunchDto> => {
-  const endpoint = `/sites/${siteName}/launchInfo`
-  return apiService.get(endpoint).then((res) => res.data)
 }

--- a/src/services/SiteLaunchService.ts
+++ b/src/services/SiteLaunchService.ts
@@ -1,0 +1,19 @@
+import { SiteLaunchDto } from "types/siteLaunch"
+
+import { apiService } from "./ApiService"
+
+export const launchSite = async (
+  siteName: string,
+  siteUrl: string,
+  useWwwSubdomain: boolean
+): Promise<void> => {
+  const endpoint = `/sites/${siteName}/launchSite`
+  return apiService.post(endpoint, { siteUrl, useWwwSubdomain })
+}
+
+export const getSiteLaunchStatus = async (
+  siteName: string
+): Promise<SiteLaunchDto> => {
+  const endpoint = `/sites/${siteName}/launchInfo`
+  return apiService.get(endpoint).then((res) => res.data)
+}

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -14,25 +14,6 @@ const SiteLaunchFrontEndStatusOptions = {
 
 export type SiteLaunchFrontEndStatus = typeof SiteLaunchFrontEndStatusOptions[keyof typeof SiteLaunchFrontEndStatusOptions]
 
-export interface SiteLaunchStatusProps {
-  siteLaunchStatus: SiteLaunchFrontEndStatus
-  stepNumber: SiteLaunchTaskTypeIndex
-  dnsRecords?: DNSRecord[]
-  siteUrl?: string
-  isNewDomain?: boolean
-}
-
-export interface SiteLaunchDto {
-  /**
-   * Transition will be
-   * "NOT_LAUNCHED" -> User presses the Generate DNS button
-   * -> "LAUNCHING" -> wait for 90 seconds -> "LAUNCHED"
-   */
-  siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING"
-  dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
-  siteUrl?: string
-}
-
 export const SITE_LAUNCH_TASKS = {
   NOT_STARTED: 0,
   SET_DNS_TTL: 1,
@@ -44,6 +25,24 @@ export const SITE_LAUNCH_TASKS = {
 } as const
 
 export type SiteLaunchTaskTypeIndex = typeof SITE_LAUNCH_TASKS[keyof typeof SITE_LAUNCH_TASKS]
+export interface SiteLaunchStatusProps {
+  siteLaunchStatus: SiteLaunchFrontEndStatus
+  stepNumber: SiteLaunchTaskTypeIndex
+  dnsRecords?: DNSRecord[]
+  siteUrl?: string
+  isNewDomain?: boolean
+  useWwwSubdomain?: boolean
+}
+export interface SiteLaunchDto {
+  /**
+   * Transition will be
+   * "NOT_LAUNCHED" -> User presses the Generate DNS button
+   * -> "LAUNCHING" -> wait for 90 seconds -> "LAUNCHED"
+   */
+  siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING"
+  dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
+  siteUrl?: string
+}
 
 export const SITE_LAUNCH_TASKS_LENGTH = (Object.keys(SITE_LAUNCH_TASKS).length -
   1) as SiteLaunchTaskTypeIndex // we minus one here since step 0 is not counted as a step done

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -18,6 +18,8 @@ export interface SiteLaunchStatusProps {
   siteLaunchStatus: SiteLaunchFrontEndStatus
   stepNumber: SiteLaunchTaskTypeIndex
   dnsRecords?: DNSRecord[]
+  siteUrl?: string
+  isNewDomain?: boolean
 }
 
 export interface SiteLaunchDto {
@@ -28,6 +30,7 @@ export interface SiteLaunchDto {
    */
   siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING"
   dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
+  siteUrl?: string
 }
 
 export const SITE_LAUNCH_TASKS = {


### PR DESCRIPTION
## Problem

Add integration with BE 


## Solution

Note: the video is 2 mins + long, just recorded the whole thing to visualise the actual user flow for this (since it will take 2 minutes for them to get the dns records anyways). Can skip to the last portion of the video so see the end state!

https://github.com/isomerpages/isomercms-frontend/assets/42832651/46f411ff-19de-49aa-a302-cc9a0f2a42d0

add routes + invalidate query after 2mins since the call is async (by right the BE would be updated in 90 seconds, but putting 2 mins here as a buffer) 

