### PR TITLE
feat(review): add placeholder filetype and hide them in dashboard

### DIFF
--- a/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
@@ -174,9 +174,6 @@ export const RequestOverview = ({
   const [path, setPath] = useState<string[]>([])
   const [title, setTitle] = useState("")
   const [itemStagingUrl, setItemStagingUrl] = useState<string | false>("")
-  const itemsWithoutPlaceholder = items.filter(
-    (item) => item.type !== "placeholder"
-  )
 
   return fileName ? (
     <DiffView
@@ -197,7 +194,7 @@ export const RequestOverview = ({
         setTitle(displayedName)
         setItemStagingUrl(selectedItemStagingUrl)
       }}
-      items={itemsWithoutPlaceholder}
+      items={items}
       allowEditing={allowEditing}
     />
   )

--- a/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
@@ -88,6 +88,10 @@ const getIcon = (iconType: EditedItemProps["type"]): JSX.Element => {
     case "image": {
       return <Icon {...ICON_STYLE_PROPS} as={BiImage} />
     }
+    case "placeholder": {
+      // NOTE: should be unreachable as placeholder has already been filtered out
+      return <></>
+    }
     default: {
       // NOTE: This is done to ensure exhaustive type matching
       const error: never = iconType
@@ -170,6 +174,10 @@ export const RequestOverview = ({
   const [path, setPath] = useState<string[]>([])
   const [title, setTitle] = useState("")
   const [itemStagingUrl, setItemStagingUrl] = useState<string | false>("")
+  const itemsWithoutPlaceholder = items.filter(
+    (item) => item.type !== "placeholder"
+  )
+
   return fileName ? (
     <DiffView
       title={title}
@@ -189,7 +197,7 @@ export const RequestOverview = ({
         setTitle(displayedName)
         setItemStagingUrl(selectedItemStagingUrl)
       }}
-      items={items}
+      items={itemsWithoutPlaceholder}
       allowEditing={allowEditing}
     />
   )

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -300,6 +300,14 @@ export const MOCK_ITEMS: EditedItemProps[] = [
     lastEditedBy: "asdf",
     lastEditedTime: 129823094,
   },
+  {
+    title: ".keep",
+    type: "placeholder",
+    name: ".keep",
+    path: ["some", "thing"],
+    lastEditedBy: "asdf",
+    lastEditedTime: 12123498294,
+  },
 ]
 
 export const MOCK_ADMINS = [

--- a/src/types/reviewRequest.ts
+++ b/src/types/reviewRequest.ts
@@ -12,7 +12,7 @@ export interface User {
   label: string
 }
 
-type FileType = "page" | "nav" | "setting" | "file" | "image"
+type FileType = "page" | "nav" | "setting" | "file" | "image" | "placeholder"
 
 export interface BaseEditedItemDto {
   name: string
@@ -40,8 +40,12 @@ export interface EditedMediaDto extends BaseEditedItemDto {
   type: "file" | "image"
 }
 
+export interface EditedPlaceholderDto extends BaseEditedItemDto {
+  type: "placeholder"
+}
+
 export type EditedItemProps = WithEditMeta<
-  EditedPageDto | EditedConfigDto | EditedMediaDto
+  EditedPageDto | EditedConfigDto | EditedMediaDto | EditedPlaceholderDto
 >
 
 export interface ReviewRequestInfo {


### PR DESCRIPTION
This is the mirroring PR of https://github.com/isomerpages/isomercms-backend/pull/815 for frontend.

## Problem

Frontend does not have a filetype for the new placeholder `.keep` files. Review request dashboard preview currently shows changes to `.keep` files, which are implementation details that we would want to hide. 

Closes IS-236

## Solution

Add placeholder filetype into frontend. Hide placeholder files in review request dashboard previews. 

## Issues
As Github returns number of files changes with the placeholder file, the number of files change shown in the main dashboard and in the review request page is different (it does not have placeholder files). Possible solution can be a line of text is added to show `and X number of hidden files changed` to account for the difference. 