### PR TITLE
fix(eslint): warn for exhausive deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/no-shadow": "error",
     "react/jsx-props-no-spreading": "off",
     "react/require-default-props": "off",
+    "react-hooks/exhaustive-deps": "warn",
     "import/prefer-default-export": "off",
     "react/prop-types": "warn",
     "no-param-reassign": "warn",


### PR DESCRIPTION
## Problem

Currently, eslint is not configured to warn properly. Suspect this is due to the recent change of made to eslint config in package.json. 


## Solution

add warning

