### PR TITLE
Fix/is 276 toast rerender

### DIFF
--- a/src/components/CollaboratorModal/components/MainSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/MainSubmodal.tsx
@@ -174,7 +174,10 @@ export const MainSubmodal = ({
 
   useEffect(() => {
     if (addCollaboratorSuccess) {
-      successToast({ description: "Collaborator added successfully" })
+      successToast({
+        id: "add-collaborator",
+        description: "Collaborator added successfully",
+      })
       collaboratorFormMethods.reset()
     }
   }, [addCollaboratorSuccess, collaboratorFormMethods, successToast])

--- a/src/components/Header/ContactModal/ContactVerificationModal.tsx
+++ b/src/components/Header/ContactModal/ContactVerificationModal.tsx
@@ -45,6 +45,7 @@ export const ContactVerificationModal = ({
   const handleSendOtp = async ({ mobile: mobileInput }: ContactProps) => {
     await sendContactOtp({ mobile: mobileInput }) // Non-2xx responses will be caught by axios and thrown as error
     successToast({
+      id: "send-otp-success",
       description: `OTP sent to ${mobileInput}`,
     })
     setMobile(mobileInput)
@@ -54,6 +55,7 @@ export const ContactVerificationModal = ({
     await verifyContactOtp({ mobile, otp })
     onClose()
     successToast({
+      id: "verify-otp-success",
       description: `Successfully changed contact number to ${mobile}!`,
     })
     verifyLoginAndGetUserDetails()

--- a/src/components/MediaCreationModal/MediaCreationModal.jsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.jsx
@@ -37,6 +37,7 @@ export const MediaCreationModal = ({
     const media = event.target?.files[0] || ""
     if (media.size > MEDIA_FILE_MAX_SIZE) {
       errorToast({
+        id: "create-media-size-error",
         description: "File size exceeds 5MB. Please upload a different file.",
       })
     } else {

--- a/src/hooks/collaboratorHooks/useDeleteCollaboratorHook.ts
+++ b/src/hooks/collaboratorHooks/useDeleteCollaboratorHook.ts
@@ -26,15 +26,20 @@ export const useDeleteCollaboratorHook = (
           SITE_DASHBOARD_COLLABORATORS_KEY,
           siteName,
         ])
-        successToast({ description: "Collaborator removed successfully" })
+        successToast({
+          id: "delete-collaborator-success",
+          description: "Collaborator removed successfully",
+        })
       },
       onError: (err) => {
         if (err?.response?.status === 422) {
           errorToast({
+            id: "delete-last-collaborator-error",
             description: `You can't be removed, because sites need at least one Admin`,
           })
         } else {
           errorToast({
+            id: "delete-collaborator-error",
             description: `Could not delete site member. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/collaboratorHooks/useGetCollaboratorRoleHook.ts
+++ b/src/hooks/collaboratorHooks/useGetCollaboratorRoleHook.ts
@@ -19,6 +19,7 @@ export const useGetCollaboratorRoleHook = (
     {
       onError: () => {
         errorToast({
+          id: "get-collaborator-role-error",
           description: `Your collaborator role could not be retrieved. ${DEFAULT_RETRY_MSG}`,
         })
       },

--- a/src/hooks/collaboratorHooks/useListCollaboratorsHook.ts
+++ b/src/hooks/collaboratorHooks/useListCollaboratorsHook.ts
@@ -33,6 +33,7 @@ export const useListCollaborators = (
           setRedirectToPage("/sites")
         } else {
           errorToast({
+            id: "get-collaborators-error",
             description: getAxiosErrorMessage(err, EXCEPTION_ERROR_MESSAGE),
           })
         }

--- a/src/hooks/collectionHooks/useCollectionHook.jsx
+++ b/src/hooks/collectionHooks/useCollectionHook.jsx
@@ -39,7 +39,8 @@ export function useCollectionHook(params) {
         setRedirectToNotFound(params.siteName)
       } else {
         errorToast({
-          description: `There was a problem trying to load your page. ${DEFAULT_RETRY_MSG}`,
+          id: "get-collection-error",
+          description: `There was a problem trying to load your directory. ${DEFAULT_RETRY_MSG}`,
         })
       }
     },

--- a/src/hooks/directoryHooks/contactUsHooks/useGetContactUsHook.ts
+++ b/src/hooks/directoryHooks/contactUsHooks/useGetContactUsHook.ts
@@ -17,6 +17,7 @@ export const useGetContactUsHook = (
     {
       onError: (err: AxiosError) => {
         errorToast({
+          id: "get-contact-us-error",
           description: `Your Contact Us page details could not be retrieved. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data.error.message}`,
         })
       },

--- a/src/hooks/directoryHooks/contactUsHooks/useUpdateContactUsHook.ts
+++ b/src/hooks/directoryHooks/contactUsHooks/useUpdateContactUsHook.ts
@@ -37,10 +37,14 @@ export const useUpdateContactUsHook = (
     {
       onSuccess: () => {
         queryClient.invalidateQueries([GET_CONTACT_US_KEY, siteName])
-        successToast({ description: "Contact Us page updated successfully" })
+        successToast({
+          id: "update-homepage-success",
+          description: "Contact Us page updated successfully",
+        })
       },
       onError: (err: AxiosError) => {
         errorToast({
+          id: "update-homepage-error",
           description: `Could not update Contact Us page. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data.error.message}`,
         })
       },

--- a/src/hooks/directoryHooks/useCreateDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useCreateDirectoryHook.jsx
@@ -32,6 +32,7 @@ export function useCreateDirectoryHook(params, queryParams) {
       retry: false,
       onError: () => {
         errorToast({
+          id: "create-directory-error",
           description: `A new directory could not be created. ${DEFAULT_RETRY_MSG}`,
         })
         if (queryParams && queryParams.onError) queryParams.onError()

--- a/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
@@ -24,12 +24,14 @@ export function useDeleteDirectoryHook(params, queryParams) {
     ...queryParams,
     onError: () => {
       errorToast({
+        id: "delete-directory-error",
         description: `Your directory could not be deleted. ${DEFAULT_RETRY_MSG}`,
       })
       if (queryParams && queryParams.onError) queryParams.onError()
     },
     onSuccess: () => {
       successToast({
+        id: "delete-directory-success",
         description: `Successfully deleted directory!`,
       })
       if (params.mediaDirectoryName)

--- a/src/hooks/directoryHooks/useGetDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useGetDirectoryHook.jsx
@@ -36,6 +36,7 @@ export function useGetDirectoryHook(params, queryParams) {
           setRedirectToNotFound()
         } else {
           errorToast({
+            id: "get-directory-error",
             description: `There was a problem retrieving directory contents. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/directoryHooks/useGetFoldersAndPages.ts
+++ b/src/hooks/directoryHooks/useGetFoldersAndPages.ts
@@ -35,6 +35,7 @@ export const useGetFoldersAndPages = (
           setRedirectToNotFound()
         } else {
           errorToast({
+            id: "get-folder-pages-error",
             description: `There was a problem retrieving directory contents. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/directoryHooks/useGetMediaFolders.ts
+++ b/src/hooks/directoryHooks/useGetMediaFolders.ts
@@ -35,6 +35,7 @@ export const useGetMediaFolders = (
           setRedirectToNotFound()
         } else {
           errorToast({
+            id: "get-media-directory-error",
             description: `There was a problem retrieving directory contents. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/directoryHooks/useGetResourceCategory.ts
+++ b/src/hooks/directoryHooks/useGetResourceCategory.ts
@@ -35,6 +35,7 @@ export const useGetResourceCategory = (
           setRedirectToNotFound()
         } else {
           errorToast({
+            id: "get-resource-category-error",
             description: `There was a problem retrieving directory contents. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/directoryHooks/useGetResourceRoom.ts
+++ b/src/hooks/directoryHooks/useGetResourceRoom.ts
@@ -32,6 +32,7 @@ export const useGetResourceRoom = (
           setRedirectToNotFound()
         } else {
           errorToast({
+            id: "get-resource-room-error",
             description: `There was a problem retrieving directory contents. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/directoryHooks/useGetWorkspacePages.ts
+++ b/src/hooks/directoryHooks/useGetWorkspacePages.ts
@@ -33,6 +33,7 @@ export const useGetWorkspacePages = (
           setRedirectToNotFound()
         } else {
           errorToast({
+            id: "get-workspace-pages-error",
             description: `There was a problem retrieving ungrouped pages. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/hooks/directoryHooks/useReorderDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useReorderDirectoryHook.jsx
@@ -18,6 +18,7 @@ export function useReorderDirectoryHook(params, queryParams) {
     ...queryParams,
     onError: () => {
       errorToast({
+        id: "reorder-directory-error",
         description: `Your directory order could not be saved. ${DEFAULT_RETRY_MSG}`,
       })
       if (queryParams && queryParams.onError) queryParams.onError()
@@ -25,6 +26,7 @@ export function useReorderDirectoryHook(params, queryParams) {
     onSuccess: () => {
       queryClient.invalidateQueries([DIR_CONTENT_KEY, { ...params }])
       successToast({
+        id: "reorder-directory-success",
         description: `Successfully updated directory order!`,
       })
       if (queryParams && queryParams.onSuccess) queryParams.onSuccess()

--- a/src/hooks/directoryHooks/useUpdateDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useUpdateDirectoryHook.jsx
@@ -26,6 +26,7 @@ export function useUpdateDirectoryHook(params, queryParams) {
       ...queryParams,
       onError: () => {
         errorToast({
+          id: "update-directory-error",
           description: `Your directory settings could not be saved. ${DEFAULT_RETRY_MSG}`,
         })
         if (queryParams && queryParams.onError) queryParams.onError()
@@ -58,6 +59,7 @@ export function useUpdateDirectoryHook(params, queryParams) {
             },
           ])
         successToast({
+          id: "update-directory-success",
           description: `Successfully updated directory settings!`,
         })
         if (queryParams && queryParams.onSuccess) queryParams.onSuccess()

--- a/src/hooks/homepageHooks/useGetHomepageHook.ts
+++ b/src/hooks/homepageHooks/useGetHomepageHook.ts
@@ -17,6 +17,7 @@ export const useGetHomepageHook = (
     {
       onError: (err: AxiosError) => {
         errorToast({
+          id: "get-homepage-error",
           description: `Your homepage could not be retrieved. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data.error.message}`,
         })
       },

--- a/src/hooks/homepageHooks/useUpdateHomepageHook.ts
+++ b/src/hooks/homepageHooks/useUpdateHomepageHook.ts
@@ -20,10 +20,14 @@ export const useUpdateHomepageHook = (
     {
       onSuccess: () => {
         queryClient.invalidateQueries([GET_HOMEPAGE_KEY, siteName])
-        successToast({ description: "Homepage updated successfully" })
+        successToast({
+          id: "update-homepage-success",
+          description: "Homepage updated successfully",
+        })
       },
       onError: (err: AxiosError) => {
         errorToast({
+          id: "update-homepage-error",
           description: `Could not update homepage. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data.error.message}`,
         })
       },

--- a/src/hooks/mediaHooks/useCreateMediaHook.jsx
+++ b/src/hooks/mediaHooks/useCreateMediaHook.jsx
@@ -26,6 +26,7 @@ export function useCreateMediaHook(params, queryParams) {
       ...queryParams,
       onSuccess: ({ data }) => {
         successToast({
+          id: "upload-media-file-success",
           description: `Media file successfully uploaded!`,
         })
         const newMedia = {
@@ -47,6 +48,7 @@ export function useCreateMediaHook(params, queryParams) {
       },
       onError: () => {
         errorToast({
+          id: "create-media-file-error",
           description: `A new media file could not be created. ${DEFAULT_RETRY_MSG}`,
         })
         if (queryParams && queryParams.onError) queryParams.onError()

--- a/src/hooks/mediaHooks/useDeleteMediaHook.jsx
+++ b/src/hooks/mediaHooks/useDeleteMediaHook.jsx
@@ -19,12 +19,14 @@ export function useDeleteMediaHook(params, queryParams) {
     ...queryParams,
     onError: () => {
       errorToast({
+        id: "delete-media-file-error",
         description: `Your media file could not be deleted successfully. ${DEFAULT_RETRY_MSG}`,
       })
       if (queryParams && queryParams.onError) queryParams.onError()
     },
     onSuccess: () => {
       successToast({
+        id: "delete-media-file-success",
         description: `Successfully deleted media file!`,
       })
       if (params.mediaRoom || params.mediaDirectoryName)

--- a/src/hooks/mediaHooks/useGetMediaHook.jsx
+++ b/src/hooks/mediaHooks/useGetMediaHook.jsx
@@ -20,6 +20,7 @@ export function useGetMediaHook(params, queryParams) {
       retry: false,
       onError: () => {
         errorToast({
+          id: "get-media-file-error",
           description: `The media file could not be retrieved. ${DEFAULT_RETRY_MSG}`,
         })
         if (queryParams && queryParams.onError) queryParams.onError()

--- a/src/hooks/mediaHooks/useUpdateMediaHook.jsx
+++ b/src/hooks/mediaHooks/useUpdateMediaHook.jsx
@@ -30,6 +30,7 @@ export function useUpdateMediaHook(params, queryParams) {
       },
       onSuccess: ({ data }) => {
         successToast({
+          id: "update-media-file-success",
           description: `Successfully updated media file!`,
         })
         if (params.mediaRoom || params.mediaDirectoryName)
@@ -59,6 +60,7 @@ export function useUpdateMediaHook(params, queryParams) {
       onError: (err) => {
         if (err.response.status !== 409)
           errorToast({
+            id: "update-media-file-error",
             description: `Your media file could not be updated. ${DEFAULT_RETRY_MSG}`,
           })
         if (queryParams && queryParams.onError) queryParams.onError(err)

--- a/src/hooks/moveHooks/useMoveHook.jsx
+++ b/src/hooks/moveHooks/useMoveHook.jsx
@@ -23,10 +23,12 @@ export function useMoveHook(params, queryParams) {
     onError: (err) => {
       if (err.response.status === 409)
         errorToast({
+          id: "move-file-duplicate-error",
           description: `A file of the same name exists in the folder you are moving to. Please rename your file before moving.`,
         })
       else
         errorToast({
+          id: "move-file-generic-error",
           description: `Your file could not be moved. ${DEFAULT_RETRY_MSG}`,
         })
       if (queryParams && queryParams.onError) queryParams.onError()
@@ -34,10 +36,12 @@ export function useMoveHook(params, queryParams) {
     onSuccess: (resp) => {
       if (!resp)
         successToast({
+          id: "move-file-present-success",
           description: `File is already in this folder`,
         })
       else
         successToast({
+          id: "move-file-success",
           description: `Successfully moved file`,
         })
       if (params.mediaRoom || params.collectionName)

--- a/src/hooks/navHooks/useUpdateNavHook.ts
+++ b/src/hooks/navHooks/useUpdateNavHook.ts
@@ -40,12 +40,16 @@ export const useUpdateNavHook = (
     {
       onSuccess: () => {
         queryClient.invalidateQueries([GET_NAV_KEY, siteName])
-        successToast({ description: "Navigation bar updated successfully" })
+        successToast({
+          id: "update-nav-success",
+          description: "Navigation bar updated successfully",
+        })
         // TODO: remove once we have v2 endpoints to support get nav bar details
         window.location.reload()
       },
       onError: (err: AxiosError) => {
         errorToast({
+          id: "update-nav-error",
           description: `Could not update navigation bar. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data.error.message}`,
         })
       },

--- a/src/hooks/notificationHooks/useGetAllNotifications.ts
+++ b/src/hooks/notificationHooks/useGetAllNotifications.ts
@@ -19,6 +19,7 @@ export const useGetAllNotifications = (
       enabled: false, // We only manually trigger this query
       onError: () => {
         errorToast({
+          id: "get-all-notifications-error",
           description: `Your notifications could not be retrieved. ${DEFAULT_RETRY_MSG}`,
         })
       },

--- a/src/hooks/notificationHooks/useGetNotifications.ts
+++ b/src/hooks/notificationHooks/useGetNotifications.ts
@@ -19,6 +19,7 @@ export const useGetNotifications = (
       enabled: false, // Manually triggered
       onError: () => {
         errorToast({
+          id: "get-notifications-error",
           description: `Your notifications could not be retrieved. ${DEFAULT_RETRY_MSG}`,
         })
       },

--- a/src/hooks/pageHooks/useCreatePageHook.jsx
+++ b/src/hooks/pageHooks/useCreatePageHook.jsx
@@ -56,6 +56,7 @@ export function useCreatePageHook(params, queryParams) {
       },
       onError: (err) => {
         errorToast({
+          id: "create-page-error",
           description: `A new page could not be created. ${getAxiosErrorMessage(
             err
           )}`,

--- a/src/hooks/pageHooks/useDeletePageHook.jsx
+++ b/src/hooks/pageHooks/useDeletePageHook.jsx
@@ -23,12 +23,14 @@ export function useDeletePageHook(params, queryParams) {
     ...queryParams,
     onError: () => {
       errorToast({
+        id: "delete-page-error",
         description: `Your page could not be deleted successfully. ${DEFAULT_RETRY_MSG}`,
       })
       if (queryParams && queryParams.onError) queryParams.onError()
     },
     onSuccess: () => {
       successToast({
+        id: "delete-page-success",
         description: `Successfully deleted page!`,
       })
       if (params.collectionName)

--- a/src/hooks/pageHooks/useGetPageHook.jsx
+++ b/src/hooks/pageHooks/useGetPageHook.jsx
@@ -20,6 +20,7 @@ export function useGetPageHook(params, queryParams) {
       retry: false,
       onError: () => {
         errorToast({
+          id: "get-page-error",
           description: `The page data could not be retrieved. ${DEFAULT_RETRY_MSG}`,
         })
         if (queryParams && queryParams.onError) queryParams.onError()

--- a/src/hooks/pageHooks/useUpdatePageHook.jsx
+++ b/src/hooks/pageHooks/useUpdatePageHook.jsx
@@ -53,6 +53,7 @@ export function useUpdatePageHook(params, queryParams) {
             { siteName: params.siteName, isUnlinked: true },
           ]) // invalidates unlinked pages
         successToast({
+          id: "update-resource-room-name-success",
           description: `Successfully updated page!`,
         })
         if (queryParams && queryParams.onSuccess) queryParams.onSuccess()
@@ -60,6 +61,7 @@ export function useUpdatePageHook(params, queryParams) {
       onError: (err) => {
         if (err.response.status !== 409) {
           errorToast({
+            id: "update-page-error",
             description: `Your page could not be updated. ${getAxiosErrorMessage(
               err
             )}`,

--- a/src/hooks/settingsHooks/useCspHook.jsx
+++ b/src/hooks/settingsHooks/useCspHook.jsx
@@ -26,6 +26,7 @@ export function useCspHook({ siteName }, queryParams) {
     initialData: new Policy(),
     onError: () => {
       errorToast({
+        id: "get-csp-error",
         description: `There was a problem trying to load your CSP. ${DEFAULT_RETRY_MSG}`,
       })
       if (queryParams && queryParams.onError) queryParams.onError()

--- a/src/hooks/settingsHooks/useGetSiteColorsHook.jsx
+++ b/src/hooks/settingsHooks/useGetSiteColorsHook.jsx
@@ -34,6 +34,7 @@ export function useGetSiteColorsHook({ siteName }, queryParams) {
       ...queryParams,
       onError: () => {
         errorToast({
+          id: "get-site-colors-error",
           description: `There was a problem loading the page theme colors. ${DEFAULT_RETRY_MSG}`,
         })
         if (queryParams && queryParams.onError) queryParams.onError()

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -742,6 +742,7 @@ const EditContactUs = ({ match }) => {
       }
     } catch (err) {
       errorToast({
+        id: "update-contact-us-error",
         description: `There was a problem trying to save your contact us page. ${DEFAULT_RETRY_MSG}`,
       })
       console.log(err)

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -251,6 +251,7 @@ const EditHomepage = ({ match }) => {
         // Set frontMatter to be same to prevent warning message when navigating away
         setFrontMatter(originalFrontMatter)
         errorToast({
+          id: "get-homepage-error",
           description: `There was a problem trying to load your homepage. ${DEFAULT_RETRY_MSG}`,
         })
         console.log(err)
@@ -1003,6 +1004,7 @@ const EditHomepage = ({ match }) => {
       await updateHomepageHandler(params)
     } catch (err) {
       errorToast({
+        id: "update-homepage-error",
         description: `There was a problem trying to save your homepage. ${DEFAULT_RETRY_MSG}`,
       })
       console.log(err)

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -138,6 +138,7 @@ const EditNavBar = ({ match }) => {
           setRedirectToNotFound(siteName)
         } else {
           errorToast({
+            id: "get-nav-error",
             description: `There was a problem trying to load your data. ${DEFAULT_RETRY_MSG}`,
           })
         }

--- a/src/layouts/Login/LoginPage.tsx
+++ b/src/layouts/Login/LoginPage.tsx
@@ -85,6 +85,7 @@ const LoginContent = (): JSX.Element => {
     const trimmedEmail = emailInput.trim()
     await sendLoginOtp({ email: trimmedEmail }) // Non-2xx responses will be caught by axios and thrown as error
     successToast({
+      id: "send-otp-success",
       description: `OTP sent to ${trimmedEmail}`,
     })
     setEmail(trimmedEmail)
@@ -98,6 +99,7 @@ const LoginContent = (): JSX.Element => {
   const handleResendOtp = async () => {
     await sendLoginOtp({ email })
     successToast({
+      id: "resend-otp-success",
       description: `OTP sent to ${email}`,
     })
   }

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -92,6 +92,7 @@ const EmptyResourceRoom = () => {
   useEffect(() => {
     if (isError) {
       errorToast({
+        id: "create-resource-room-name-error",
         title: "Error",
         description: `A new directory could not be created. ${DEFAULT_RETRY_MSG}`,
       })
@@ -259,6 +260,7 @@ const ResourceRoomContent = ({
   useEffect(() => {
     if (isUpdateResourceRoomNameError) {
       errorToast({
+        id: "update-resource-room-name-error",
         title: "",
         description:
           "Unable to update resource room settings, please try again later!",
@@ -269,6 +271,7 @@ const ResourceRoomContent = ({
   useEffect(() => {
     if (isUpdateResourceRoomNameSuccess) {
       successToast({
+        id: "update-resource-room-name-success",
         title: "",
         description: `Updated resource room settings successfully.`,
       })

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -294,6 +294,7 @@ const ApprovalButton = ({
   useEffect(() => {
     if (isUnapproveReviewRequestError) {
       errorToast({
+        id: "unapprove-review-request-error",
         description: getAxiosErrorMessage(unapproveReviewRequestError),
       })
     }
@@ -302,6 +303,7 @@ const ApprovalButton = ({
   useEffect(() => {
     if (isApproveReviewRequestError) {
       errorToast({
+        id: "approve-review-request-error",
         description: getAxiosErrorMessage(approveReviewRequestError),
       })
     }

--- a/src/layouts/ReviewRequest/components/CancelRequestModal/CancelRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/CancelRequestModal/CancelRequestModal.tsx
@@ -38,6 +38,7 @@ export const CancelRequestModal = (
   useEffect(() => {
     if (isError) {
       errorToast({
+        id: "cancel-review-request-error",
         description: getAxiosErrorMessage(error),
       })
     }

--- a/src/layouts/ReviewRequest/components/DiffView/DiffView.tsx
+++ b/src/layouts/ReviewRequest/components/DiffView/DiffView.tsx
@@ -101,7 +101,10 @@ export const DiffView = ({
 
   useEffect(() => {
     if (isError) {
-      errorToast({ description: getAxiosErrorMessage(error) })
+      errorToast({
+        id: "diff-view-error",
+        description: getAxiosErrorMessage(error),
+      })
     }
   }, [error, errorToast, isError])
 

--- a/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
+++ b/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
@@ -62,13 +62,17 @@ export const ManageReviewerModal = ({
 
   useEffect(() => {
     if (isUpdateReviewRequestSuccess) {
-      successToast({ description: "Your review request has been updated!" })
+      successToast({
+        id: "update-review-request-success",
+        description: "Your review request has been updated!",
+      })
     }
   }, [isUpdateReviewRequestSuccess, successToast])
 
   useEffect(() => {
     if (isUpdateReviewRequestError) {
       errorToast({
+        id: "update-review-request-error",
         description: getAxiosErrorMessage(updateReviewRequestError),
       })
     }

--- a/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
@@ -71,6 +71,7 @@ export const ReviewRequestModal = (
       const errorMessage =
         error.response?.data.message || "Review request could not be created!"
       errorToast({
+        id: "review-request-create-error",
         description: errorMessage,
       })
     }
@@ -80,6 +81,7 @@ export const ReviewRequestModal = (
   useEffect(() => {
     if (isSuccess) {
       successToast({
+        id: "review-request-create-success",
         description: "Review request submitted",
       })
     }

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -44,6 +44,7 @@ export const Settings = (): JSX.Element => {
   useEffect(() => {
     if (isGetSettingsError) {
       errorToast({
+        id: "get-settings-error",
         title: "Error",
         description: `Site settings could not be retrieved. ${DEFAULT_RETRY_MSG}`,
       })
@@ -122,6 +123,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   useEffect(() => {
     if (hasDiff) {
       errorToast({
+        id: "update-settings-diff-error",
         title: "Error",
         description:
           "Your site settings have recently been changed by another user. You can choose to either override their changes, or go back to editing. We recommend you to make a copy of your changes elsewhere, and come back later to reconcile your changes.",
@@ -146,6 +148,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
           ? "Your site settings have recently been changed by another user. You can choose to either override their changes, or go back to editing. We recommend you to make a copy of your changes elsewhere, and come back later to reconcile your changes."
           : `Site settings could not be updated. ${DEFAULT_RETRY_MSG}`
       errorToast({
+        id: "update-settings-error",
         title: "Error",
         description: errorMessage,
       })
@@ -156,6 +159,7 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   useEffect(() => {
     if (isSuccess) {
       successToast({
+        id: "update-settings-success",
         title: "Success!",
         description: "Successfully updated settings!",
       })

--- a/src/routing/ApprovedReviewRedirect.tsx
+++ b/src/routing/ApprovedReviewRedirect.tsx
@@ -35,6 +35,7 @@ export const ApprovedReviewRedirect = ({
   useEffect(() => {
     if (!isGithubUser && isError) {
       errorToast({
+        id: "approved-review-redirect-error",
         description: getAxiosErrorMessage(error),
       })
     }
@@ -43,6 +44,7 @@ export const ApprovedReviewRedirect = ({
   useEffect(() => {
     if (hasApprovedReviewRequest) {
       warningToast({
+        id: "approved-review-redirect-warning",
         description:
           "There is currently an approved review request! Please publish that first before making any changes.",
       })

--- a/src/utils/dropdownUtils.js
+++ b/src/utils/dropdownUtils.js
@@ -12,7 +12,7 @@ const retrieveThirdNavOptions = async (
   collectionName,
   isExistingCollection
 ) => {
-  const errorToast = useErrorToast
+  const errorToast = useErrorToast()
   try {
     let thirdNavArr = []
     let allCollectionPages = []
@@ -35,6 +35,7 @@ const retrieveThirdNavOptions = async (
   } catch (err) {
     console.log(err)
     return errorToast({
+      id: "third-nav-error",
       description: `There was a problem trying to retrieve data from your repo. ${DEFAULT_RETRY_MSG}`,
     })
   }

--- a/src/utils/toasts.ts
+++ b/src/utils/toasts.ts
@@ -1,4 +1,5 @@
-import { useToast, UseToastReturn } from "@opengovsg/design-system-react"
+import { useToast, UseToastProps } from "@opengovsg/design-system-react"
+import type { SetRequired } from "type-fest"
 
 import { DEFAULT_RETRY_MSG } from "./legacy"
 
@@ -9,22 +10,40 @@ const DEFAULT_TOAST_PROPS = {
   isClosable: true,
 }
 
-export const useErrorToast = (): UseToastReturn =>
-  useToast({
+// Not specifying return type because type is in the argument
+const useIsomerToast = (args: UseToastProps) => {
+  const toast = useToast(args)
+  const wrappedToast = ({ id, ...rest }: SetRequired<UseToastProps, "id">) => {
+    if (!toast.isActive(id))
+      return toast({
+        ...rest,
+        id,
+      })
+    return undefined
+  }
+  wrappedToast.close = toast.close
+  wrappedToast.closeAll = toast.closeAll
+  wrappedToast.isActive = toast.isActive
+  wrappedToast.update = toast.update
+  return wrappedToast
+}
+
+export const useErrorToast = () =>
+  useIsomerToast({
     ...DEFAULT_TOAST_PROPS,
     description: DEFAULT_ERROR_TOAST_MSG,
     status: "danger",
   })
 
-export const useSuccessToast = (): UseToastReturn =>
-  useToast({
+export const useSuccessToast = () =>
+  useIsomerToast({
     ...DEFAULT_TOAST_PROPS,
     description: "Success!",
     status: "success",
   })
 
-export const useWarningToast = (): UseToastReturn =>
-  useToast({
+export const useWarningToast = () =>
+  useIsomerToast({
     ...DEFAULT_TOAST_PROPS,
     status: "warning",
   })


### PR DESCRIPTION
This PR fixes an issue with multiple rerenders of the toast components - the behaviour of react-hook-form and react-query seem to have changed after our dependencies update, and this caused issues for all of our toasts which were contained within `useEffect`, as the component would get rerendered, which changed the reference to `toast` and triggered the useEffect again.

The solution to this issue is to modify the toasts to use the `id` param - this prevents duplicate toasts from appearing ([link](https://chakra-ui.com/docs/components/toast#preventing-duplicate-toast)). The components which make use of toasts have been modified to support this.

Also resolves IS-284 once the privatisation PR has been rebased onto this one.