### PR TITLE
fix(settings): show warning modal on leaving when there are dirty fields

### DIFF
--- a/src/contexts/DirtyFieldContext.tsx
+++ b/src/contexts/DirtyFieldContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, PropsWithChildren, useContext, useState } from "react"
+
+interface DirtyFieldContextReturn {
+  isDirty: boolean
+  setIsDirty: (isDirty: boolean) => void
+}
+
+export const DirtyFieldContext = createContext<null | DirtyFieldContextReturn>(
+  null
+)
+
+export const useDirtyFieldContext = (): DirtyFieldContextReturn => {
+  const context = useContext(DirtyFieldContext)
+  if (context === null) {
+    throw new Error(
+      "useDirtyFieldContext must be used within a DirtyFieldContextProvider"
+    )
+  }
+  return context
+}
+
+export const DirtyFieldContextProvider = ({
+  children,
+}: PropsWithChildren<Record<string, unknown>>) => {
+  const [isDirty, setIsDirty] = useState(false)
+  return (
+    <DirtyFieldContext.Provider
+      value={{
+        isDirty,
+        setIsDirty,
+      }}
+    >
+      {children}
+    </DirtyFieldContext.Provider>
+  )
+}

--- a/src/contexts/DirtyFieldContext.tsx
+++ b/src/contexts/DirtyFieldContext.tsx
@@ -27,7 +27,16 @@ export const DirtyFieldContextProvider = ({
     <DirtyFieldContext.Provider
       value={{
         isDirty,
-        setIsDirty,
+        // NOTE: Call the update only when the state changes
+        // We do this optimisation because the context wraps
+        // a form component.
+        // The child components are re-rendered on every keystroke
+        // which we want to minimise for performance reasons.
+        setIsDirty: (newDirtyState) => {
+          if (newDirtyState !== isDirty) {
+            setIsDirty(newDirtyState)
+          }
+        },
       }}
     >
       {children}

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -13,6 +13,8 @@ import { useEffect, useRef } from "react"
 import { useForm, FormProvider } from "react-hook-form"
 import { useParams } from "react-router-dom"
 
+import { useDirtyFieldContext } from "contexts/DirtyFieldContext"
+
 import { useGetSettings, useUpdateSettings } from "hooks/settingsHooks"
 
 import { useErrorToast, useSuccessToast } from "utils/toasts"
@@ -94,8 +96,9 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
     defaultValues: settings,
   })
   const { formState, reset, getValues } = methods
-  const { dirtyFields } = formState
+  const { isDirty, dirtyFields } = formState
   const successToast = useSuccessToast()
+  const { setIsDirty } = useDirtyFieldContext()
   const {
     mutateAsync: updateSettings,
     error: updateSettingsError,
@@ -106,6 +109,8 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   const onSubmit = methods.handleSubmit((data: SiteSettings) => {
     updateSettings(data)
   })
+
+  setIsDirty(isDirty)
 
   const dirtyFieldKeys = _.keys(dirtyFields)
   const hasDiff = !_.isEqual(

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -8,7 +8,6 @@ import {
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { Footer } from "components/Footer"
-import { WarningModal } from "components/WarningModal"
 import _ from "lodash"
 import { useEffect, useRef } from "react"
 import { useForm, FormProvider } from "react-hook-form"
@@ -26,6 +25,7 @@ import { SiteEditLayout } from "../layouts"
 
 import { AnalyticsSettings } from "./AnalyticsSettings"
 import { ColourSettings } from "./ColourSettings"
+import { OverrideWarningModal } from "./components/OverrideWarningModal"
 import { FooterSettings } from "./FooterSettings"
 import { GeneralSettings } from "./GeneralSettings"
 import { LogoSettings } from "./LogoSettings"
@@ -195,52 +195,22 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
             <Button
               isLoading={isLoading}
               onClick={() => {
-                hasDiff ? onOpen() : onSubmit()
+                if (hasDiff) {
+                  onOpen()
+                } else {
+                  onSubmit()
+                }
               }}
             >
               Save
             </Button>
           </Footer>
-          <WarningModal
-            isCentered
-            // NOTE: The second conditional is required as the wrapped method by react hook form
-            // terminates earlier than the actual call to the BE API.
-            // Hence, the model is open if it was triggered manually or if the warning in the modal was acknowledged
-            // and the user still chose to proceed (this only occurs when there is a diff)
+          <OverrideWarningModal
             isOpen={isOpen || (hasDiff && isLoading)}
             onClose={onClose}
-            displayTitle="Override Changes"
-            displayText={
-              <Text>
-                Your site settings have recently been changed by another user.
-                You can choose to either override their changes, or go back to
-                editing.
-                {/*
-                 * NOTE: We have 2 line breaks here because we want a line spacing between the 2 <paragraphs.
-                 * Only have 1 br would cause the second paragraph to begin on a new line but without the line spacing.
-                 */}
-                <br />
-                <br />
-                We recommend you to make a copy of your changes elsewhere, and
-                come back later to reconcile your changes.
-              </Text>
-            }
-          >
-            <Button variant="outline" onClick={onClose}>
-              Back to editing
-            </Button>
-            <Button
-              colorScheme="danger"
-              type="submit"
-              isLoading={isLoading}
-              onClick={async () => {
-                await onSubmit()
-                onClose()
-              }}
-            >
-              Override
-            </Button>
-          </WarningModal>
+            isLoading={isLoading}
+            onSubmit={onSubmit}
+          />
         </form>
       </FormProvider>
     </Box>

--- a/src/layouts/Settings/components/OverrideWarningModal.tsx
+++ b/src/layouts/Settings/components/OverrideWarningModal.tsx
@@ -1,0 +1,59 @@
+import { Text } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import { WarningModal } from "components/WarningModal"
+
+interface OverrideWarningModalProps {
+  isOpen: boolean
+  onClose: () => void
+  isLoading: boolean
+  onSubmit: () => void
+}
+
+export const OverrideWarningModal = ({
+  isOpen,
+  onClose,
+  isLoading,
+  onSubmit,
+}: OverrideWarningModalProps) => {
+  return (
+    <WarningModal
+      isCentered
+      // NOTE: The second conditional is required as the wrapped method by react hook form
+      // terminates earlier than the actual call to the BE API.
+      // Hence, the model is open if it was triggered manually or if the warning in the modal was acknowledged
+      // and the user still chose to proceed (this only occurs when there is a diff)
+      isOpen={isOpen}
+      onClose={onClose}
+      displayTitle="Override Changes"
+      displayText={
+        <Text>
+          Your site settings have recently been changed by another user. You can
+          choose to either override their changes, or go back to editing.
+          {/*
+           * NOTE: We have 2 line breaks here because we want a line spacing between the 2 <paragraphs.
+           * Only have 1 br would cause the second paragraph to begin on a new line but without the line spacing.
+           */}
+          <br />
+          <br />
+          We recommend you to make a copy of your changes elsewhere, and come
+          back later to reconcile your changes.
+        </Text>
+      }
+    >
+      <Button variant="outline" onClick={onClose}>
+        Back to editing
+      </Button>
+      <Button
+        colorScheme="danger"
+        type="submit"
+        isLoading={isLoading}
+        onClick={async () => {
+          await onSubmit()
+          onClose()
+        }}
+      >
+        Override
+      </Button>
+    </WarningModal>
+  )
+}

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -93,12 +93,12 @@ export const SiteEditHeader = (): JSX.Element => {
             icon={
               <Icon as={BiArrowBack} fontSize="1.25rem" fill="icon.secondary" />
             }
-            // need to change -> conditionally do this
+            // NOTE: Conditionally do this because we need to show the modal
+            // when there are dirty fields, which could result in user
+            // not navigating away.
             onClick={() =>
               isDirty ? onDirtyWarningModalOpen() : onBackButtonClick()
             }
-            // as={RouterLink}
-            // to={isGithubUser ? "/sites" : `/sites/${siteName}/dashboard`}
           />
           <Text color="text.label" textStyle="body-1">
             {isGithubUser ? "My sites" : "Site dashboard"}

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -19,9 +19,11 @@ import {
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { ButtonLink } from "components/ButtonLink"
 import { NotificationMenu } from "components/Header/NotificationMenu"
+import { WarningModal } from "components/WarningModal"
 import { BiArrowBack, BiCheckCircle } from "react-icons/bi"
-import { Link as RouterLink, useParams } from "react-router-dom"
+import { useParams, useHistory } from "react-router-dom"
 
+import { useDirtyFieldContext } from "contexts/DirtyFieldContext"
 import { useLoginContext } from "contexts/LoginContext"
 
 import { useStagingUrl } from "hooks/settingsHooks"
@@ -33,6 +35,12 @@ import { NavImage } from "assets"
 
 export const SiteEditHeader = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const {
+    isOpen: isDirtyWarningModalOpen,
+    onOpen: onDirtyWarningModalOpen,
+    onClose: onDirtyWarningModalClose,
+  } = useDisclosure()
+  const { isDirty } = useDirtyFieldContext()
   const {
     isOpen: isReviewRequestModalOpen,
     onOpen: onReviewRequestModalOpen,
@@ -48,6 +56,7 @@ export const SiteEditHeader = (): JSX.Element => {
     data: reviewRequests,
     isLoading: isReviewRequestsLoading,
   } = useGetReviewRequests(siteName)
+  const history = useHistory()
 
   // Note: if PR is in APPROVED status, it will auto-redirect to dashboard as no edits should happen
   // But have added here to be explicit of the status checks
@@ -59,6 +68,11 @@ export const SiteEditHeader = (): JSX.Element => {
 
   const shouldDisableReviewRequestButton =
     isReviewRequestsLoading || openReviewRequests.length > 0
+
+  const onBackButtonClick = () => {
+    const redirPath = isGithubUser ? "/sites" : `/sites/${siteName}/dashboard`
+    history.push(redirPath)
+  }
 
   return (
     <>
@@ -79,8 +93,12 @@ export const SiteEditHeader = (): JSX.Element => {
             icon={
               <Icon as={BiArrowBack} fontSize="1.25rem" fill="icon.secondary" />
             }
-            as={RouterLink}
-            to={isGithubUser ? "/sites" : `/sites/${siteName}/dashboard`}
+            // need to change -> conditionally do this
+            onClick={() =>
+              isDirty ? onDirtyWarningModalOpen() : onBackButtonClick()
+            }
+            // as={RouterLink}
+            // to={isGithubUser ? "/sites" : `/sites/${siteName}/dashboard`}
           />
           <Text color="text.label" textStyle="body-1">
             {isGithubUser ? "My sites" : "Site dashboard"}
@@ -151,6 +169,42 @@ export const SiteEditHeader = (): JSX.Element => {
         isOpen={isReviewRequestModalOpen}
         onClose={onReviewRequestModalClose}
       />
+      <DirtyWarningModal
+        isOpen={isDirtyWarningModalOpen}
+        onClose={onDirtyWarningModalClose}
+        onClick={onBackButtonClick}
+      />
     </>
+  )
+}
+
+interface DirtyWarningModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onClick: () => void
+}
+
+const DirtyWarningModal = ({
+  isOpen,
+  onClose,
+  onClick,
+}: DirtyWarningModalProps): JSX.Element => {
+  return (
+    <WarningModal
+      isOpen={isOpen}
+      onClose={onClose}
+      displayTitle="Warning"
+      displayText={
+        <Text>
+          You have unsaved changes. Are you sure you want to navigate away from
+          this page?
+        </Text>
+      }
+    >
+      <Button colorScheme="danger" onClick={onClose}>
+        No
+      </Button>
+      <Button onClick={onClick}>Yes</Button>
+    </WarningModal>
   )
 }

--- a/src/layouts/layouts/SiteEditLayout/SiteEditLayout.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditLayout.tsx
@@ -8,6 +8,8 @@ import {
 } from "@chakra-ui/react"
 import { Sidebar } from "components/Sidebar"
 
+import { DirtyFieldContextProvider } from "contexts/DirtyFieldContext"
+
 import { SiteEditHeader } from "./SiteEditHeader"
 
 const GRID_LAYOUT: Pick<
@@ -26,7 +28,7 @@ const GRID_LAYOUT: Pick<
  */
 export const SiteEditLayout = ({ children }: StackProps): JSX.Element => {
   return (
-    <>
+    <DirtyFieldContextProvider>
       <Grid {...GRID_LAYOUT}>
         <GridItem
           area="header"
@@ -49,7 +51,7 @@ export const SiteEditLayout = ({ children }: StackProps): JSX.Element => {
         </GridItem>
         <SiteEditContent p="2rem">{children}</SiteEditContent>
       </Grid>
-    </>
+    </DirtyFieldContextProvider>
   )
 }
 


### PR DESCRIPTION
## Problem
See [IS-263](https://isomeropengov.atlassian.net/browse/IS-263?atlOrigin=eyJpIjoiZjI4NzA5YzA4ZjFmNGU0OWIwOWNjN2Q2NTM2MDMzZjgiLCJwIjoiaiJ9)

## Solution
1. add context between child component that knows the state (`Settings`) and the component that triggers the modal warning. We require the context because the `set/get` have a few degrees of separation + we need to pass data from the child back up 
2. render modal when state is `dirty` and trigger redirect only on ack

## Tests 
- [ ] edit a field in settings
- [ ] click the back button
- [ ] the modal should show
- [ ] click no
- [ ] nothing should happen
- [ ] click back button again
- [ ] modal should show
- [ ] click the yes button
- [ ] should redirect to sites
- [ ] go back to settings
- [ ] edit a field 
- [ ] click back button
- [ ] modal should show
- [ ] click no
- [ ] edit the field **to its original state**
- [ ] click back button
- [ ] shuold redirect back to sites

[IS-263]: https://isomeropengov.atlassian.net/browse/IS-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ