### PR TITLE
feat: update text to be Open Staging

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -146,7 +146,7 @@ const Header = ({
             colorScheme="primary"
             isDisabled={!stagingUrl}
           >
-            View Staging
+            Open Staging
           </Button>
           {userId ? (
             // Github user

--- a/src/components/MenuDropdownButton/MenuDropdownButton.stories.tsx
+++ b/src/components/MenuDropdownButton/MenuDropdownButton.stories.tsx
@@ -33,7 +33,7 @@ const menuDropdownButtonTemplate: Story<MenuDropdownButtonTemplateArgs> = ({
 
 export const buttonWithoutIcons = menuDropdownButtonTemplate.bind({})
 buttonWithoutIcons.args = {
-  mainButtonText: "View staging",
+  mainButtonText: "Open staging",
   variant: "outline",
   items: (
     <>

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -95,7 +95,7 @@ export const SiteEditHeader = (): JSX.Element => {
             colorScheme="primary"
             isDisabled={!stagingUrl}
           >
-            View Staging
+            Open Staging
           </Button>
           {userId ? (
             // Github user


### PR DESCRIPTION
## Problem

Following up from @NatMaeTan 's comments from [Reviewing Build 1439 • isomerpages/isomercms-frontend](https://www.chromatic.com/test?appId=61fcc8e14c3af9003a102ac9&id=64382b0ca3055f62d610a93c)

Closes IS-225

## Solution

Update button text

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Test Plan

- Ensure that the buttons for all staging reads as "Open Staging"

## Screenshots

![Screenshot 2023-07-12 at 3 48 44 PM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/eeac4660-bc33-4a85-95cc-8b24474d87fc)
![Screenshot 2023-07-12 at 3 48 29 PM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/a29e0416-fb9e-4091-9bcf-555b0344408c)
![Screenshot 2023-07-12 at 3 48 22 PM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/62e604cc-07fe-41ea-833a-8b2f072d527f)
