### PR TITLE
fix(comments): disable comment drawer if rr has invalid status

### DIFF
--- a/src/hooks/reviewHooks/useGetReviewRequest.ts
+++ b/src/hooks/reviewHooks/useGetReviewRequest.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios"
 import { useQuery } from "react-query"
 import type { UseQueryResult } from "react-query"
 
@@ -5,13 +6,14 @@ import { REVIEW_REQUEST_QUERY_KEY } from "constants/queryKeys"
 
 import * as ReviewService from "services/ReviewService"
 
+import { ErrorDto } from "types/error"
 import { ReviewRequest } from "types/reviewRequest"
 
 export const useGetReviewRequest = (
   siteName: string,
   reviewId: number
-): UseQueryResult<ReviewRequest> => {
-  return useQuery<ReviewRequest>(
+): UseQueryResult<ReviewRequest, AxiosError<ErrorDto>> => {
+  return useQuery<ReviewRequest, AxiosError<ErrorDto>>(
     [REVIEW_REQUEST_QUERY_KEY, siteName, reviewId],
     () => ReviewService.getReviewRequest(siteName, reviewId),
     {

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -80,7 +80,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
 
   const { onCopy, hasCopied } = useClipboard(data?.reviewUrl || "")
   const reviewStatus = data?.status
-  const reviewStatusNotLoaded = !reviewStatus
+  const isReviewStatusLoading = !reviewStatus
   const hasInvalidReviewRequest =
     reviewStatus === ReviewRequestStatus.CLOSED ||
     reviewStatus === ReviewRequestStatus.MERGED
@@ -200,7 +200,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
           <Flex h="100%" w="7.25rem" pt="2rem" justifyContent="end">
             {/* TODO: swap this to a slide out component and not a drawer */}
             <CommentsDrawer
-              isDisabled={hasInvalidReviewRequest || reviewStatusNotLoaded}
+              isDisabled={hasInvalidReviewRequest || isReviewStatusLoading}
               siteName={siteName}
               requestId={prNumber}
             />

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -80,18 +80,24 @@ export const ReviewRequestDashboard = (): JSX.Element => {
 
   const { onCopy, hasCopied } = useClipboard(data?.reviewUrl || "")
   const reviewStatus = data?.status
+  const hasInvalidReviewRequest =
+    reviewStatus === ReviewRequestStatus.CLOSED ||
+    reviewStatus === ReviewRequestStatus.MERGED
 
   useEffect(() => {
-    if (
-      reviewStatus === ReviewRequestStatus.CLOSED ||
-      reviewStatus === ReviewRequestStatus.MERGED
-    ) {
+    if (hasInvalidReviewRequest) {
       setRedirectToPage(`/sites/${siteName}/dashboard`)
     }
     if (reviewStatus && isApproved === null) {
       setIsApproved(reviewStatus === ReviewRequestStatus.APPROVED)
     }
-  }, [isApproved, reviewStatus, setRedirectToPage, siteName])
+  }, [
+    isApproved,
+    hasInvalidReviewRequest,
+    reviewStatus,
+    setRedirectToPage,
+    siteName,
+  ])
 
   useEffect(() => {
     updateReviewRequestViewed({ siteName, prNumber })
@@ -192,7 +198,11 @@ export const ReviewRequestDashboard = (): JSX.Element => {
           </VStack>
           <Flex h="100%" w="7.25rem" pt="2rem" justifyContent="end">
             {/* TODO: swap this to a slide out component and not a drawer */}
-            <CommentsDrawer siteName={siteName} requestId={prNumber} />
+            <CommentsDrawer
+              isDisabled={hasInvalidReviewRequest}
+              siteName={siteName}
+              requestId={prNumber}
+            />
           </Flex>
         </HStack>
         <Box pl="9.25rem" pr="2rem">

--- a/src/layouts/ReviewRequest/Dashboard.tsx
+++ b/src/layouts/ReviewRequest/Dashboard.tsx
@@ -80,6 +80,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
 
   const { onCopy, hasCopied } = useClipboard(data?.reviewUrl || "")
   const reviewStatus = data?.status
+  const reviewStatusNotLoaded = !reviewStatus
   const hasInvalidReviewRequest =
     reviewStatus === ReviewRequestStatus.CLOSED ||
     reviewStatus === ReviewRequestStatus.MERGED
@@ -199,7 +200,7 @@ export const ReviewRequestDashboard = (): JSX.Element => {
           <Flex h="100%" w="7.25rem" pt="2rem" justifyContent="end">
             {/* TODO: swap this to a slide out component and not a drawer */}
             <CommentsDrawer
-              isDisabled={hasInvalidReviewRequest}
+              isDisabled={hasInvalidReviewRequest || reviewStatusNotLoaded}
               siteName={siteName}
               requestId={prNumber}
             />

--- a/src/layouts/ReviewRequest/components/Comments/CommentsDrawer.tsx
+++ b/src/layouts/ReviewRequest/components/Comments/CommentsDrawer.tsx
@@ -64,15 +64,13 @@ const CommentItem = ({
   )
 }
 
-export type CommentsDrawerProps = Pick<
-  UseDisclosureReturn,
-  "onClose" | "isOpen"
->
+export type CommentsDrawerProps = CommentProps & { isDisabled?: boolean }
 
 export const CommentsDrawer = ({
   siteName,
   requestId,
-}: CommentProps): JSX.Element => {
+  isDisabled,
+}: CommentsDrawerProps): JSX.Element => {
   const {
     isOpen: isCommentsOpen,
     onOpen: onCommentsOpen,
@@ -99,6 +97,7 @@ export const CommentsDrawer = ({
         variant="clear"
         boxShadow="0 0 4px var(--chakra-colors-gray-100)"
         borderRadius="4px 0 0 4px"
+        isDisabled={isDisabled}
       />
       <Drawer
         isOpen={isCommentsOpen}


### PR DESCRIPTION
## Problem
Previously, we relied on redirection of users away from the review request to prevent them from taking any action when the review request is invalid. However, this leads to a delay between content paint and redirection (as we want the user to be able to interact with elements on the page), which results in users being able to access a old merged or closed rr, open the comments and see the comments prior to redirect. 

## Solution
pass an `isDisabled` prop. technically we could ping the server using `getReviewRequest` and check status in `CommentsDrawer` but because the component seems like its state should be controlled by the parent, prop passing is preferred instead (same computed data used for redir + disablign icon button)

next, if a rr fails to fetch from backend, we get the error message and redirect them to the dashboard.

## Manual tests
- [ ] Enter a link where the PR is previously merged/closed directly into your browser
- [ ] the icon button for comments drawer should be disabled