### PR TITLE
fix(useToastHook): don't re-render text field on focus

### DIFF
--- a/src/hooks/settingsHooks/useUpdateSettings.ts
+++ b/src/hooks/settingsHooks/useUpdateSettings.ts
@@ -23,7 +23,9 @@ const MEDIA_COLOUR_TITLES = [
 ]
 
 export const useUpdateSettings = (
-  siteName: string
+  siteName: string,
+  onSuccess: () => void,
+  onError: () => void
 ): UseMutationResult<void, AxiosError, SiteSettings> => {
   const queryClient = useQueryClient()
   return useMutation<void, AxiosError, SiteSettings>(
@@ -32,6 +34,8 @@ export const useUpdateSettings = (
       onSettled: () => {
         queryClient.invalidateQueries([SETTINGS_CONTENT_KEY, siteName])
       },
+      onSuccess,
+      onError,
     }
   )
 }

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -98,14 +98,35 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
   const { formState, reset, getValues } = methods
   const { isDirty, dirtyFields } = formState
   const successToast = useSuccessToast()
+  const errorToast = useErrorToast()
   const { setIsDirty } = useDirtyFieldContext()
   const {
     mutateAsync: updateSettings,
     error: updateSettingsError,
     isLoading,
     isSuccess,
-  } = useUpdateSettings(siteName)
-  const errorToast = useErrorToast()
+  } = useUpdateSettings(
+    siteName,
+    () => {
+      successToast({
+        id: "update-settings-success",
+        title: "Success",
+        description: "Site settings have been updated",
+      })
+    },
+    () => {
+      const errorMessage =
+        updateSettingsError?.response?.status === 409
+          ? "Your site settings have recently been changed by another user. You can choose to either override their changes, or go back to editing. We recommend you to make a copy of your changes elsewhere, and come back later to reconcile your changes."
+          : `Site settings could not be updated. ${DEFAULT_RETRY_MSG}`
+      return errorToast({
+        id: "update-settings-error",
+        title: "Error",
+        description: errorMessage,
+      })
+    }
+  )
+
   const onSubmit = methods.handleSubmit((data: SiteSettings) => {
     updateSettings(data)
   })
@@ -144,32 +165,6 @@ const SettingsForm = ({ settings, isError }: SettingsFormProps) => {
       reset(settings)
     }
   }, [isSuccess, getValues, reset, settings])
-
-  // Trigger an error toast informing the user if settings data could not be updated
-  useEffect(() => {
-    if (updateSettingsError) {
-      const errorMessage =
-        updateSettingsError?.response?.status === 409
-          ? "Your site settings have recently been changed by another user. You can choose to either override their changes, or go back to editing. We recommend you to make a copy of your changes elsewhere, and come back later to reconcile your changes."
-          : `Site settings could not be updated. ${DEFAULT_RETRY_MSG}`
-      errorToast({
-        id: "update-settings-error",
-        title: "Error",
-        description: errorMessage,
-      })
-    }
-  }, [errorToast, updateSettingsError])
-
-  // Trigger a success toast informing the user if settings data was updated successfully
-  useEffect(() => {
-    if (isSuccess) {
-      successToast({
-        id: "update-settings-success",
-        title: "Success!",
-        description: "Successfully updated settings!",
-      })
-    }
-  }, [isSuccess, successToast])
 
   return (
     <Box w="100%">


### PR DESCRIPTION
## Problem

We have a bug in production, see video here: 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/ab2ce646-ed4a-483a-89ed-a2b39705a9d7

This is not because of design system, I was able to replicate this even with chakra ui's toast. This seems to suggest the bug lies in how we are using this hook. video here:

https://github.com/isomerpages/isomercms-frontend/assets/42832651/c3023947-426c-4b45-bc94-496a7acacad4

## Solution

I think I know the cause for this, please feel free to correct me on this ya. 

1. This does not happen at all the places of the code base. 
eg.

https://github.com/isomerpages/isomercms-frontend/assets/42832651/43a853dd-daec-4fe8-9d7c-7ab2cf2eeddc

2. There exists a useEffect in `Settings.tsx` that states
```
  // Reset cache on success
  useEffect(() => {
    if (isSuccess) {
      // Update to the new form state
      initialSettings.current = getValues()
      reset(settings)
    }
  }, [isSuccess, getValues, reset, settings])

  useEffect(() => {
    if (isSuccess) {
      successToast({
        id: "update-settings-success",
        title: "Success!",
        description: "Successfully updated settings!",
      })
    }
  }, [isSuccess, successToast])
``` 

I think there are unintended side effects here as the `useUpdateSettings` hook gives us, which then leads to the model being opened again. This bug is also so far observable when using in the settings page, which this PR solely attempts to solve. 

I am ok to revert this if this should not be the best practice to do this, but I feel this should still go in to at least fix the bug in prod first. 

## Tests 
https://github.com/isomerpages/isomercms-frontend/assets/42832651/5a973b89-473f-4757-83eb-ebf2e5b9fdfa
Should be similar to what is shown in the video above. 
- [ ] open up settings page
- [ ] change anything in the site desc and click save
- [ ] wait for modal to pop out __**and**__ close 
- [ ] change anything in the text field 
- [ ] assert that modal does not pop out again 


