### PR TITLE
feat(e2e): e2e tests for comments

### DIFF
--- a/cypress/api/reviewRequest.api.ts
+++ b/cypress/api/reviewRequest.api.ts
@@ -35,24 +35,20 @@ export const closeReviewRequests = (): void => {
   })
 }
 
-function removeResponse(response: any) {
-  // Do nothing
-}
-
 export const approveReviewRequest = (
   id: number
 ): Cypress.Chainable<Cypress.Response<void>> => {
-  return cy.request("POST", `${BASE_URL}/${id}/approve`).then(removeResponse)
+  return cy.request("POST", `${BASE_URL}/${id}/approve`)
 }
 
 export const mergeReviewRequest = (
   id: number
 ): Cypress.Chainable<Cypress.Response<void>> => {
-  return cy.request("POST", `${BASE_URL}/${id}/merge`).then(removeResponse)
+  return cy.request("POST", `${BASE_URL}/${id}/merge`)
 }
 
 export const closeReviewRequest = (
   id: number
 ): Cypress.Chainable<Cypress.Response<void>> => {
-  return cy.request("DELETE", `${BASE_URL}/${id}`).then(removeResponse)
+  return cy.request("DELETE", `${BASE_URL}/${id}`)
 }

--- a/cypress/api/reviewRequest.api.ts
+++ b/cypress/api/reviewRequest.api.ts
@@ -35,20 +35,24 @@ export const closeReviewRequests = (): void => {
   })
 }
 
+function removeResponse(response: any) {
+  // Do nothing
+}
+
 export const approveReviewRequest = (
   id: number
-): Cypress.Chainable<Cypress.Response<any>> => {
-  return cy.request("POST", `${BASE_URL}/${id}/approve`)
+): Cypress.Chainable<Cypress.Response<void>> => {
+  return cy.request("POST", `${BASE_URL}/${id}/approve`).then(removeResponse)
 }
 
 export const mergeReviewRequest = (
   id: number
-): Cypress.Chainable<Cypress.Response<any>> => {
-  return cy.request("POST", `${BASE_URL}/${id}/merge`)
+): Cypress.Chainable<Cypress.Response<void>> => {
+  return cy.request("POST", `${BASE_URL}/${id}/merge`).then(removeResponse)
 }
 
 export const closeReviewRequest = (
   id: number
-): Cypress.Chainable<Cypress.Response<any>> => {
-  return cy.request("DELETE", `${BASE_URL}/${id}`)
+): Cypress.Chainable<Cypress.Response<void>> => {
+  return cy.request("DELETE", `${BASE_URL}/${id}`).then(removeResponse)
 }

--- a/cypress/api/reviewRequest.api.ts
+++ b/cypress/api/reviewRequest.api.ts
@@ -30,11 +30,25 @@ export const listReviewRequests = (): Cypress.Chainable<{ id: number }[]> => {
 export const closeReviewRequests = (): void => {
   listReviewRequests().then((reviewRequests) => {
     reviewRequests.forEach(({ id }) => {
-      cy.request("DELETE", `${BASE_URL}/${id}`)
+      closeReviewRequest(id)
     })
   })
 }
 
-export const approveReviewRequest = (id: number): void => {
-  cy.request("POST", `${BASE_URL}/${id}/approve`)
+export const approveReviewRequest = (
+  id: number
+): Cypress.Chainable<Cypress.Response<any>> => {
+  return cy.request("POST", `${BASE_URL}/${id}/approve`)
+}
+
+export const mergeReviewRequest = (
+  id: number
+): Cypress.Chainable<Cypress.Response<any>> => {
+  return cy.request("POST", `${BASE_URL}/${id}/merge`)
+}
+
+export const closeReviewRequest = (
+  id: number
+): Cypress.Chainable<Cypress.Response<any>> => {
+  return cy.request("DELETE", `${BASE_URL}/${id}`)
 }

--- a/cypress/e2e/comments.spec.ts
+++ b/cypress/e2e/comments.spec.ts
@@ -45,11 +45,6 @@ const checkCommentVisible = (
 const checkCommentDisabled = () =>
   cy.get(COMMENTS_DRAWER_BUTTON_SELECTOR).should("be.disabled")
 
-const USER_NOT_AUTHORISED_COMMENT_ERROR_MESSAGE =
-  "Only collaborators of a site can view review request comments!"
-const NOTIFICATION_CANNOT_BE_RETRIVED_ERROR_MESSAGE =
-  "Your notifications could not be retrieved. Please try again or check your internet connection"
-
 const COMMENT_INTERCEPTOR = "getComments"
 
 describe("Comments", () => {
@@ -57,6 +52,7 @@ describe("Comments", () => {
     cy.setEmailSessionDefaults("Email admin")
     cy.intercept("GET", "**/comments").as(COMMENT_INTERCEPTOR)
     cy.setupDefaultInterceptors()
+    visitE2eEmailTestRepo()
   })
 
   describe("common", () => {
@@ -123,6 +119,7 @@ describe("Comments", () => {
 
       // Act
       openReviewRequest()
+      checkCommentDisabled()
       cy.wait(`@${COMMENT_INTERCEPTOR}`)
       ignoreResizeError()
       openCommentsDrawer()
@@ -208,12 +205,12 @@ describe("Comments", () => {
     describe("not a site member", () => {
       before(() => {
         removeOtherCollaborators()
-        cy.setEmailSessionDefaults("Email collaborator")
-        setUserAsUnauthorised()
       })
 
       it("should not be able to create comments for a site which one is not a site member", () => {
         // Arrange
+        cy.setEmailSessionDefaults("Email collaborator")
+        setUserAsUnauthorised()
         cy.visit(
           `${CMS_BASEURL}/sites/${E2E_EMAIL_TEST_SITE.repo}/review/${reviewId}`
         )
@@ -229,7 +226,7 @@ describe("Comments", () => {
         // to execute the commands + assertion
         // before the redirect is done
 
-        // // Assert
+        // Assert
         cy.get(COMMENTS_DRAWER_BUTTON_SELECTOR).should("be.disabled")
       })
       it("should not be able to see comments for a site for which one is not a site member", () => {
@@ -254,7 +251,7 @@ describe("Comments", () => {
         // to execute the commands + assertion
         // before the redirect is done
 
-        // // Assert
+        // Assert
         cy.get(COMMENTS_DRAWER_BUTTON_SELECTOR).should("be.disabled")
       })
     })
@@ -281,7 +278,7 @@ describe("Comments", () => {
           .then((id) => {
             reviewId = id
             cy.setEmailSessionDefaults("Email collaborator")
-            api.approveReviewRequest(reviewId).then((response) => {
+            api.approveReviewRequest(reviewId).then((_response) => {
               cy.setEmailSessionDefaults("Email admin")
               api.mergeReviewRequest(reviewId)
             })
@@ -319,7 +316,7 @@ describe("Comments", () => {
           .then((id) => {
             reviewId = id
             cy.setEmailSessionDefaults("Email collaborator")
-            api.approveReviewRequest(reviewId).then((response) => {
+            api.approveReviewRequest(reviewId).then((_response) => {
               cy.setEmailSessionDefaults("Email admin")
               api.mergeReviewRequest(reviewId)
             })

--- a/cypress/e2e/comments.spec.ts
+++ b/cypress/e2e/comments.spec.ts
@@ -349,13 +349,13 @@ describe("Comments", () => {
       it("should not be able to see/create comments for non-existent review requests", () => {
         // Arrange
         visitE2eEmailTestRepo()
-
         // Act
 
         // Assert
-        cy.contains(
-          `a[href^="/sites/${E2E_EMAIL_TEST_SITE.repo}/review/"]`
-        ).should("not.exist")
+        // Since there is no open review request, visiting the sites dashboard
+        // should not show a link to an open review request
+        const linkToReviewRequest = `a[href^="/sites/${E2E_EMAIL_TEST_SITE.repo}/review/"]`
+        cy.contains(linkToReviewRequest).should("not.exist")
       })
     })
   })

--- a/cypress/utils/dashboard.ts
+++ b/cypress/utils/dashboard.ts
@@ -1,5 +1,9 @@
 import { E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
-import { COMMENTS_DRAWER_BUTTON_SELECTOR } from "../fixtures/selectors/dashboard"
+import {
+  COMMENTS_DRAWER_BUTTON_SELECTOR,
+  COMMENTS_INPUT_SELECTOR,
+  SUBMIT_COMMENT_BUTTON_SELECTOR,
+} from "../fixtures/selectors/dashboard"
 
 // NOTE: This is a `div` tag styled like a `button`
 export const getOpenStagingButton = (): Cypress.Chainable<
@@ -14,4 +18,12 @@ export const openCommentsDrawer = (): Cypress.Chainable<
   JQuery<HTMLElement>
 > => {
   return cy.get(COMMENTS_DRAWER_BUTTON_SELECTOR).click()
+}
+
+export const getCommentInput = (): Cypress.Chainable<JQuery<HTMLElement>> => {
+  return cy.get(COMMENTS_INPUT_SELECTOR)
+}
+
+export const submitNewComment = (): Cypress.Chainable<JQuery<HTMLElement>> => {
+  return cy.get(SUBMIT_COMMENT_BUTTON_SELECTOR).click()
 }


### PR DESCRIPTION
Added E2E tests for comments feature of review requests.

Closes IS-258

**Note**

Occasionally `cy.request` fails and return undefined for reasons unknown. This will cause the tests to break.

## Tests

- [ ] Unit tests (using `npm run tests`)
- [x] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

Requires #1338 to be merged first.
