### PR TITLE
Fix/restrict repo privatisation to email login

### DIFF
--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -127,17 +127,26 @@ const extractPassword = (
 }
 
 export const useGetSettings = (
-  siteName: string
+  siteName: string,
+  isEmailLogin: boolean
 ): UseQueryResult<SiteSettings> => {
   return useQuery<SiteSettings>(
     [SETTINGS_CONTENT_KEY, siteName],
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
-      // TODO: reimplement actual functionality once netlify issue resolved
-      // const passwordSettings = await SettingsService.getPassword({ siteName })
-      const passwordSettings = {
-        isAmplifySite: false,
-        password: "",
+      let passwordSettings
+      if (isEmailLogin) {
+        // TODO: reimplement actual functionality once netlify issue resolved
+        // passwordSettings = await SettingsService.getPassword({ siteName })
+        passwordSettings = {
+          isAmplifySite: false,
+          password: "",
+        }
+      } else {
+        passwordSettings = {
+          isAmplifySite: false,
+          password: "",
+        }
       }
       const convertedSettings = convertFromBe(siteSettings)
       const parsedPassword = extractPassword(passwordSettings)

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -128,20 +128,19 @@ const extractPassword = (
 
 export const useGetSettings = (
   siteName: string,
-  isEmailLogin: boolean
+  isEmailLogin?: boolean
 ): UseQueryResult<SiteSettings> => {
+  const shouldGetPrivacyDetails =
+    isEmailLogin === undefined ? false : isEmailLogin
   return useQuery<SiteSettings>(
-    [SETTINGS_CONTENT_KEY, siteName],
+    [SETTINGS_CONTENT_KEY, siteName, shouldGetPrivacyDetails],
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
       let passwordSettings
-      if (isEmailLogin) {
-        // TODO: reimplement actual functionality once netlify issue resolved
-        // passwordSettings = await SettingsService.getPassword({ siteName })
-        passwordSettings = {
-          isAmplifySite: false,
-          password: "",
-        }
+      const isLaunchDarklyImplemented = false
+      if (shouldGetPrivacyDetails && isLaunchDarklyImplemented) {
+        // TODO: LaunchDarkly to allow specific groups to access this feature first
+        passwordSettings = await SettingsService.getPassword({ siteName })
       } else {
         passwordSettings = {
           isAmplifySite: false,

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -205,7 +205,7 @@ const EditContactUs = ({ match }) => {
     onClose: onDeleteModalClose,
   } = useDisclosure()
   const { data: contactUsDetails } = useGetContactUsHook(siteName)
-  const { data: settingsData } = useGetSettings(siteName)
+  const { data: settingsData } = useGetSettings(siteName, false) // Doesn't need the privatisation data, so we can always put this as a github login user
 
   const { mutateAsync: updateContactUs } = useUpdateContactUsHook(siteName)
   const { mutateAsync: updateSettings } = useUpdateSettings(siteName)

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -205,7 +205,7 @@ const EditContactUs = ({ match }) => {
     onClose: onDeleteModalClose,
   } = useDisclosure()
   const { data: contactUsDetails } = useGetContactUsHook(siteName)
-  const { data: settingsData } = useGetSettings(siteName, false) // Doesn't need the privatisation data, so we can always put this as a github login user
+  const { data: settingsData } = useGetSettings(siteName)
 
   const { mutateAsync: updateContactUs } = useUpdateContactUsHook(siteName)
   const { mutateAsync: updateSettings } = useUpdateSettings(siteName)

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -14,6 +14,8 @@ import { useEffect, useRef } from "react"
 import { useForm, FormProvider } from "react-hook-form"
 import { useParams } from "react-router-dom"
 
+import { useLoginContext } from "contexts/LoginContext"
+
 import { useGetSettings, useUpdateSettings } from "hooks/settingsHooks"
 
 import { useErrorToast, useSuccessToast } from "utils/toasts"
@@ -34,11 +36,13 @@ import { SocialMediaSettings } from "./SocialMediaSettings"
 
 export const Settings = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
+  const { userId } = useLoginContext()
+  const isGithubUser = userId !== "Unknown user" && !!userId
   const {
     data: settingsData,
     isLoading: isGetSettingsLoading,
     isError: isGetSettingsError,
-  } = useGetSettings(siteName)
+  } = useGetSettings(siteName, !isGithubUser)
   const errorToast = useErrorToast()
 
   // Trigger an error toast informing the user if settings data could not be fetched


### PR DESCRIPTION
This PR adds an additional restriction to the repo privatisation feature such that only email login users can see the feature - this is due to the prerequisite of restricting github access before being able to convert repos to private, as private repos are unable to set additional branch protection rules, meaning the PR approval requirement can be bypassed. To be reviewed in conjunction with PR #[840](https://github.com/isomerpages/isomercms-backend/pull/840) on the isomercms-backend repo.