### PR TITLE
feat: E2E tests for dashboard

### DIFF
--- a/cypress/e2e/dashboard.spec.ts
+++ b/cypress/e2e/dashboard.spec.ts
@@ -18,6 +18,9 @@ const goToWorkspace = () => cy.contains("a", "Edit site").click()
 const REVIEW_MODAL_SUBTITLE =
   "An Admin needs to review and approve your changes before they can be published"
 
+const REVIEW_REQUEST_ALERT_MESSAGE =
+  "There’s a Review request pending approval. Any changes you make now will be added to the existing Review request, and published with the changes in it."
+
 describe("dashboard flow", () => {
   beforeEach(() => {
     cy.setupDefaultInterceptors()
@@ -103,5 +106,6 @@ describe("dashboard flow", () => {
 
     // Assert
     cy.contains("My Workspace").should("be.visible")
+    cy.contains(REVIEW_REQUEST_ALERT_MESSAGE).should("not.exist")
   })
 })

--- a/cypress/e2e/dashboard.spec.ts
+++ b/cypress/e2e/dashboard.spec.ts
@@ -1,8 +1,17 @@
 import { closeReviewRequests } from "../api"
-import { E2E_EMAIL_REPO_STAGING_LINK } from "../fixtures/constants"
+import {
+  E2E_EMAIL_REPO_MASTER_LINK,
+  E2E_EMAIL_REPO_STAGING_LINK,
+  E2E_EMAIL_TEST_SITE,
+  ISOMER_GUIDE_LINK,
+  TEST_REPO_NAME,
+} from "../fixtures/constants"
 import { getOpenStagingButton, visitE2eEmailTestRepo } from "../utils"
 
 const getReviewRequestButton = () => cy.contains("button", "Request a Review")
+
+const getOpenStagingDropdownButton = () =>
+  getOpenStagingButton().siblings("button")
 
 const goToWorkspace = () => cy.contains("a", "Edit site").click()
 
@@ -18,11 +27,12 @@ describe("dashboard flow", () => {
   })
 
   it('should open the staging site on click of the "Open staging" button', () => {
-    // Act
+    // Assert
     getOpenStagingButton()
       .should("have.attr", "href", E2E_EMAIL_REPO_STAGING_LINK)
       .should("have.attr", "target", "_blank")
   })
+
   it('should open the "Request a Review" modal on click of the "Request a Review" button', () => {
     // Act
     getReviewRequestButton().click()
@@ -30,23 +40,68 @@ describe("dashboard flow", () => {
     // Assert
     cy.contains(REVIEW_MODAL_SUBTITLE).should("be.visible")
   })
-  it.skip("should be able to navigate to the staging site using the dropdown button", () => {
-    throw new Error("Not implemented")
-  })
-  it.skip("should be able to navigate to the production site using the dropdown button", () => {
-    throw new Error("Not implemented")
-  })
-  it.skip('should navigate to the isomer guide on click of the "Get help" button', () => {
-    throw new Error("Not implemented")
-  })
-  it.skip("should navigate to the settings page when manage site settings is clicked", () => {
-    throw new Error("Not implemented")
-  })
-  it.skip("should navigate to the workspace when edit site is clicked", () => {
-    // Arrange
-    // NOTE: There shouldn't be a review request alert
+
+  it("should be able to navigate to the staging site using the dropdown button", () => {
     // Act
+    getOpenStagingDropdownButton().click()
+
     // Assert
-    throw new Error("Not implemented")
+    cy.contains("Open staging site")
+      .should("be.visible")
+      .should("have.attr", "href", E2E_EMAIL_REPO_STAGING_LINK)
+      .should("have.attr", "target", "_blank")
+  })
+
+  it("should be able to navigate to the production site using the dropdown button", () => {
+    // Act
+    getOpenStagingDropdownButton().click()
+
+    // Assert
+    cy.contains("Visit live site")
+      .should("be.visible")
+      .should("have.attr", "href", E2E_EMAIL_REPO_MASTER_LINK)
+      .should("have.attr", "target", "_blank")
+  })
+
+  it('should navigate to the isomer guide on click of the "Get help" button', () => {
+    // Act
+    cy.contains("Get help")
+      .should("be.visible")
+      .should("have.attr", "href", ISOMER_GUIDE_LINK)
+      .should("have.attr", "target", "_blank")
+  })
+
+  it("should navigate to the settings page when manage site settings is clicked", () => {
+    // Act
+    console.log(TEST_REPO_NAME)
+    cy.contains("Site settings")
+      .should("be.visible")
+      .parent()
+      .parent()
+      .siblings("a")
+      .should(
+        "have.attr",
+        "href",
+        `/sites/${E2E_EMAIL_TEST_SITE.repo}/settings`
+      )
+      .click()
+
+    // Assert
+    cy.contains("Site settings").should("be.visible")
+  })
+
+  it("should navigate to the workspace when edit site is clicked", () => {
+    // Act
+    cy.contains("Edit site")
+      .should("be.visible")
+      .should(
+        "have.attr",
+        "href",
+        `/sites/${E2E_EMAIL_TEST_SITE.repo}/workspace`
+      )
+      .click()
+
+    // Assert
+    cy.contains("My Workspace").should("be.visible")
   })
 })

--- a/cypress/e2e/dashboard.spec.ts
+++ b/cypress/e2e/dashboard.spec.ts
@@ -76,7 +76,6 @@ describe("dashboard flow", () => {
 
   it("should navigate to the settings page when manage site settings is clicked", () => {
     // Act
-    console.log(TEST_REPO_NAME)
     cy.contains("Site settings")
       .should("be.visible")
       .parent()

--- a/cypress/e2e/reviewRequests.spec.ts
+++ b/cypress/e2e/reviewRequests.spec.ts
@@ -16,7 +16,6 @@ import {
 import { USER_TYPES } from "../fixtures/users"
 import {
   addCollaborator,
-  getOpenStagingButton,
   removeOtherCollaborators,
   visitE2eEmailTestRepo,
 } from "../utils"

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -51,6 +51,11 @@ export const BACKEND_URL = Cypress.env("BACKEND_URL")
 export const E2E_EMAIL_REPO_STAGING_LINK =
   "https://staging.d2qim5mov3pptm.amplifyapp.com"
 
+export const E2E_EMAIL_REPO_MASTER_LINK =
+  "https://master.d2qim5mov3pptm.amplifyapp.com"
+
+export const ISOMER_GUIDE_LINK = "https://guide.isomer.gov.sg/"
+
 export const MOCK_REVIEW_TITLE = "Some interesting title"
 export const MOCK_REVIEW_DESCRIPTION = "Some interesting description"
 

--- a/cypress/utils/dashboard.ts
+++ b/cypress/utils/dashboard.ts
@@ -1,7 +1,7 @@
 import { E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
 import { COMMENTS_DRAWER_BUTTON_SELECTOR } from "../fixtures/selectors/dashboard"
 
-// NOTE: This is a `div` tag styled like a `button`\
+// NOTE: This is a `div` tag styled like a `button`
 export const getOpenStagingButton = (): Cypress.Chainable<
   JQuery<HTMLElement>
 > => cy.contains("Open staging")

--- a/cypress/utils/dashboard.ts
+++ b/cypress/utils/dashboard.ts
@@ -1,6 +1,11 @@
 import { E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
 import { COMMENTS_DRAWER_BUTTON_SELECTOR } from "../fixtures/selectors/dashboard"
 
+// NOTE: This is a `div` tag styled like a `button`\
+export const getOpenStagingButton = (): Cypress.Chainable<
+  JQuery<HTMLElement>
+> => cy.contains("Open staging")
+
 export const openReviewRequest = (): Cypress.Chainable<JQuery<HTMLElement>> => {
   return cy.get(`a[href^="/sites/${E2E_EMAIL_TEST_SITE.repo}/review/"]`).click()
 }

--- a/cypress/utils/header.ts
+++ b/cypress/utils/header.ts
@@ -1,9 +1,5 @@
 import { GET_HELP_LINK_SELECTOR } from "../fixtures/selectors"
 
-// NOTE: This is a `div` tag styled like a `button`
-export const getOpenStagingButton = (): Cypress.Chainable<
-  JQuery<HTMLElement>
-> => cy.contains("a", "Open staging")
 export const getNotificationsButton = (): Cypress.Chainable<
   JQuery<HTMLElement>
 > => cy.get(GET_HELP_LINK_SELECTOR).parent().next()


### PR DESCRIPTION
## Problem

Lacking E2E test for dashboard

Closes IS-260

## Solution

Adds E2E tests for dashboard

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Test

Ensure that `dashboard.spec.ts` E2E test passes successfully
