### PR TITLE
Fix: parse env var from string to boolean

### DIFF
--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -16,6 +16,10 @@ import {
 
 import { BE_TO_FE } from "./constants"
 
+const IS_SITE_PRIVATISATION_ACTIVE =
+  process.env.REACT_APP_IS_SITE_PRIVATISATION_ACTIVE &&
+  process.env.REACT_APP_IS_SITE_PRIVATISATION_ACTIVE.toLowerCase() === "true"
+
 const DEFAULT_BE_STATE = {
   title: "",
   description: "",
@@ -137,10 +141,7 @@ export const useGetSettings = (
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
       let passwordSettings
-      if (
-        shouldGetPrivacyDetails &&
-        process.env.REACT_APP_IS_SITE_PRIVATISATION_ACTIVE
-      ) {
+      if (shouldGetPrivacyDetails && IS_SITE_PRIVATISATION_ACTIVE) {
         // TODO: LaunchDarkly to allow specific groups to access this feature first
         passwordSettings = await SettingsService.getPassword({ siteName })
       } else {


### PR DESCRIPTION
This PR fixes an issue with our env vars - netlify passes env vars as strings, which means that interpreting it as a boolean value does not work as expected. This PR modifies the way we parse the `REACT_APP_IS_SITE_PRIVATISATION_ACTIVE` to ensure we parse the boolean value correctly.