### PR TITLE
feat(form): add NPS modal

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,6 +3,7 @@ export REACT_APP_SENTRY_ENV=''
 export REACT_APP_SENTRY_DSN=''
 export REACT_APP_ENV='LOCAL_DEV'
 export ESLINT_NO_DEV_ERRORS=true
+export REACT_APP_SHOW_NPS_FORM=true
 
 # Cypress test environment variables
 export CYPRESS_BASEURL=''

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "prepare": "husky install",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "storybook": "source .env && REACT_APP_ENV=test && storybook dev -p 6006",
-    "build-storybook": "REACT_APP_ENV=test && storybook build -s public",
+    "build-storybook": "REACT_APP_ENV=test && storybook build",
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "sourcemaps:upload": "npx datadog-ci sourcemaps upload ./build --service=isomercms-frontend --release-version=$REACT_APP_VERSION --minified-path-prefix=$REACT_APP_URL"
   },

--- a/src/components/FeedbackModal/FeedbackModal.stories.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryFn } from "@storybook/react"
+
+import { FeedbackModal, FeedbackModalProps } from "./FeedbackModal"
+
+const FeedbackModalMeta = {
+  title: "Components/FeedbackModal",
+  component: FeedbackModal,
+} as Meta<typeof FeedbackModal>
+
+const Template: StoryFn<typeof FeedbackModal> = ({
+  onClose,
+}: FeedbackModalProps) => {
+  return <FeedbackModal isOpen onClose={onClose} />
+}
+
+export const Default = Template.bind({})
+Default.parameters = { onClose: console.log }
+
+export default FeedbackModalMeta

--- a/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.tsx
@@ -1,0 +1,76 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  Heading,
+} from "@chakra-ui/react"
+import { ModalCloseButton } from "@opengovsg/design-system-react"
+
+const FeedbackForm = () => {
+  return (
+    <>
+      <div
+        style={{
+          fontFamily: "sans-serif",
+          fontSize: "15px",
+          color: "#000",
+          opacity: "0.9",
+          paddingTop: "5px",
+          paddingBottom: "8px",
+        }}
+      >
+        If the form below is not loaded, you can also fill it in{" "}
+        <a href="https://form.gov.sg/64b76a1cb319a90012e8e8db">here</a>.
+      </div>
+
+      <iframe
+        title="FormSG Feedback form for Isomer"
+        id="iframe"
+        src="https://form.gov.sg/64b76a1cb319a90012e8e8db"
+        width="100%"
+        height="650px"
+      />
+
+      <div
+        style={{
+          fontFamily: "sans-serif",
+          fontSize: "12px",
+          color: "#999",
+          opacity: "0.5",
+          paddingTop: "5px",
+        }}
+      >
+        Powered by{" "}
+        <a href="https://form.gov.sg" color="#999">
+          Form
+        </a>
+      </div>
+    </>
+  )
+}
+
+export interface FeedbackModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+export const FeedbackModal = ({
+  isOpen,
+  onClose,
+}: FeedbackModalProps): JSX.Element => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Heading as="h4">Help make Isomer better!</Heading>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <FeedbackForm />
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.tsx
@@ -22,13 +22,13 @@ const FeedbackForm = () => {
         }}
       >
         If the form below is not loaded, you can also fill it in{" "}
-        <a href="https://form.gov.sg/64b76a1cb319a90012e8e8db">here</a>.
+        <a href="https://form.gov.sg/64b7a11823e54700118bad90">here</a>.
       </div>
 
       <iframe
         title="FormSG Feedback form for Isomer"
         id="iframe"
-        src="https://form.gov.sg/64b76a1cb319a90012e8e8db"
+        src="https://form.gov.sg/64b7a11823e54700118bad90"
         width="100%"
         height="650px"
       />

--- a/src/components/FeedbackModal/index.ts
+++ b/src/components/FeedbackModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./FeedbackModal"

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -4,4 +4,5 @@ export enum LOCAL_STORAGE_KEYS {
   Announcements = "announcements",
   DashboardFeatureTour = "dashboard-identity-feature-tour-v1",
   WorkspaceFeatureTour = "workspace-identity-feature-tour-v1",
+  Feedback = "feedback",
 }

--- a/src/hooks/useFeedbackDisclosure.ts
+++ b/src/hooks/useFeedbackDisclosure.ts
@@ -23,15 +23,15 @@ type UseFeedbackStorageReturn = readonly [number, () => void]
 
 // NOTE: Wrapper to handle get/set of individual keys
 const useFeedbackStorage = (): UseFeedbackStorageReturn => {
-  const { userId } = useLoginContext()
+  const { displayedName } = useLoginContext()
   const [
     userMappings,
     setUserMappings,
   ] = useLocalStorage<FeedbackStorageMappings>(LOCAL_STORAGE_KEYS.Feedback, {})
 
-  const lastSeen = userMappings[userId]
+  const lastSeen = userMappings[displayedName]
   const setLastSeen = () => {
-    setUserMappings({ ...userMappings, [userId]: Date.now() })
+    setUserMappings({ ...userMappings, [displayedName]: Date.now() })
   }
   // NOTE: `const` cast to infer types properly
   // so that it knows that the return value is a tuple

--- a/src/hooks/useFeedbackDisclosure.ts
+++ b/src/hooks/useFeedbackDisclosure.ts
@@ -1,0 +1,66 @@
+import { useDisclosure } from "@chakra-ui/react"
+import { useLocation } from "react-router-dom"
+
+import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
+
+import { useLoginContext } from "contexts/LoginContext"
+
+import { isEditPageUrl, isSpecialPagesUrl } from "utils/pages"
+
+import { useLocalStorage } from "./useLocalStorage"
+
+type LastSeenFeedbackTime = number
+type UserId = string
+
+type FeedbackStorageMappings = Record<UserId, LastSeenFeedbackTime>
+
+const NPS_SURVEY_INTERVAL = 1814400000 as const // 3 weeks
+
+const { REACT_APP_SHOW_NPS_FORM } = process.env
+
+// NOTE: Wrapper to handle get/set of individual keys
+const useFeedbackStorage = () => {
+  const { userId } = useLoginContext()
+  const [
+    userMappings,
+    setUserMappings,
+  ] = useLocalStorage<FeedbackStorageMappings>(LOCAL_STORAGE_KEYS.Feedback, {})
+
+  const lastSeen = userMappings[userId]
+  const setLastSeen = () => {
+    setUserMappings({ ...userMappings, [userId]: Date.now() })
+  }
+  // NOTE: `const` cast to infer types properly
+  // so that it knows that the return value is a tuple
+  return [lastSeen, setLastSeen] as const
+}
+
+export const useFeedbackDisclosure = () => {
+  const location = useLocation<{ from?: string }>()
+  // NOTE: Despite the typing from the library,
+  // state is NOT guaranteed to exist.
+  const from = location.state?.from ?? ""
+  // NOTE: We show the feedback modal to the users iff
+  // they are navigating away from the editor
+  const isLeavingContentPage = isEditPageUrl(from) || isSpecialPagesUrl(from)
+
+  const [lastSeen, setLastSeen] = useFeedbackStorage()
+  // NOTE: Either this is the first time the user has ever seen the survey
+  // or that the user has seen the survey but it has been more than 3 weeks.
+  // Because we toggle the survey on every month, this indicates that they should
+  // do the survey if the toggle is on + sufficient time has elapsed
+  const isSurveyRequired =
+    !lastSeen ||
+    (lastSeen + NPS_SURVEY_INTERVAL < Date.now() && REACT_APP_SHOW_NPS_FORM)
+
+  const { onOpen, onClose } = useDisclosure()
+
+  return {
+    isOpen: isLeavingContentPage && !!isSurveyRequired,
+    onOpen,
+    onClose: () => {
+      onClose()
+      setLastSeen()
+    },
+  }
+}

--- a/src/hooks/useFeedbackDisclosure.ts
+++ b/src/hooks/useFeedbackDisclosure.ts
@@ -14,7 +14,7 @@ type UserId = string
 
 type FeedbackStorageMappings = Record<UserId, LastSeenFeedbackTime>
 
-const NPS_SURVEY_INTERVAL = 1814400000 as const // 3 weeks
+const NPS_SURVEY_INTERVAL = 1814400000 as const // 3 weeks - 3 * 7 * 24 * 60 * 60 * 1000
 
 const { REACT_APP_SHOW_NPS_FORM } = process.env
 
@@ -50,8 +50,8 @@ export const useFeedbackDisclosure = () => {
   // Because we toggle the survey on every month, this indicates that they should
   // do the survey if the toggle is on + sufficient time has elapsed
   const isSurveyRequired =
-    !lastSeen ||
-    (lastSeen + NPS_SURVEY_INTERVAL < Date.now() && REACT_APP_SHOW_NPS_FORM)
+    (!lastSeen || lastSeen + NPS_SURVEY_INTERVAL < Date.now()) &&
+    REACT_APP_SHOW_NPS_FORM
 
   const { onOpen, onClose } = useDisclosure()
 

--- a/src/hooks/useRedirectHook.jsx
+++ b/src/hooks/useRedirectHook.jsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react"
-import { useHistory } from "react-router-dom"
+import { useHistory, useLocation } from "react-router-dom"
 
 // Import contexts
 const { LoginContext } = require("contexts/LoginContext")
@@ -9,6 +9,7 @@ const useRedirectHook = () => {
   const [redirectUrl, setRedirectUrl] = useState("")
   const [redirectComponentState, setRedirectComponentState] = useState({})
   const history = useHistory()
+  const location = useLocation()
   const { logout } = useContext(LoginContext)
 
   useEffect(() => {
@@ -16,10 +17,10 @@ const useRedirectHook = () => {
       setShouldRedirect(false)
       history.push({
         pathname: redirectUrl,
-        state: redirectComponentState,
+        state: { ...redirectComponentState, from: location.pathname },
       })
     }
-  }, [shouldRedirect])
+  }, [history, location, redirectComponentState, redirectUrl, shouldRedirect])
 
   const setRedirectToNotFound = (siteName) => {
     setRedirectUrl("/not-found")

--- a/src/layouts/layouts/SiteEditLayout/SiteEditLayout.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditLayout.tsx
@@ -6,9 +6,12 @@ import {
   Grid,
   GridProps,
 } from "@chakra-ui/react"
+import { FeedbackModal } from "components/FeedbackModal"
 import { Sidebar } from "components/Sidebar"
 
 import { DirtyFieldContextProvider } from "contexts/DirtyFieldContext"
+
+import { useFeedbackDisclosure } from "hooks/useFeedbackDisclosure"
 
 import { SiteEditHeader } from "./SiteEditHeader"
 
@@ -27,8 +30,10 @@ const GRID_LAYOUT: Pick<
  * This means that this component has to be used within the main CMS section after clicking the site card
  */
 export const SiteEditLayout = ({ children }: StackProps): JSX.Element => {
+  const { isOpen, onClose } = useFeedbackDisclosure()
   return (
     <DirtyFieldContextProvider>
+      <FeedbackModal isOpen={isOpen} onClose={onClose} />
       <Grid {...GRID_LAYOUT}>
         <GridItem
           area="header"

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -1,0 +1,12 @@
+import _ from "lodash"
+
+export const SPECIAL_PAGES = ["homepage", "navbar", "contact-us"]
+
+export const isEditPageUrl = (url: string): boolean => {
+  // NOTE: Lowercase here because `/editpage` also works
+  return url.toLowerCase().includes("/editpage") && url.endsWith(".md")
+}
+
+export const isSpecialPagesUrl = (url: string): boolean => {
+  return _.some(SPECIAL_PAGES, (page) => url.toLowerCase().includes(page))
+}

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -4,7 +4,7 @@ export const SPECIAL_PAGES = ["homepage", "navbar", "contact-us"]
 
 export const isEditPageUrl = (url: string): boolean => {
   // NOTE: Lowercase here because `/editpage` also works
-  return url.toLowerCase().includes("/editpage") && url.endsWith(".md")
+  return url.toLowerCase().includes("/editpage/") && url.endsWith(".md")
 }
 
 export const isSpecialPagesUrl = (url: string): boolean => {


### PR DESCRIPTION
## Problem
right now isomer has no way of collecting feedback from users. this adds a modal that shows an embedded form, with some additional logic to avoid repetitive pings on the user.\

see the modal [here](https://www.chromatic.com/component?appId=61fcc8e14c3af9003a102ac9&csfId=components-feedbackmodal&buildNumber=1868&k=64ba05a458dfcb14aa7fc25f-1200-interactive-true&h=12&b=-3)

Closes IS-324

## Solution
1. add modal, set it on `SiteEditLayout` -> this is because the `SiteEditLayout` is set on almost all editing layouts for our CMS
2. write hook to determine when to trigger the modal
    - currently, this is in intervals of 3 wks since the last seen timing (or if it's the first ever view) + whether the env var is set. the interval of 1 wk was chosen so that there's enough time lapse between toggles and so that we can distinguish between runs of showing our modal. (ie, if the env var is set but you've prev done the survey within a time interval of 3 wks, we don't show again)
    - we will trigger the modal every time the user navigates away from an editing page. (agreed w/ PM -> want to make sure that they have done something) 

**New environment variables**:

- `REACT_APP_SHOW_NPS_FORM` : decides whether to show the NPS form. leave empty if not required.
