### PR TITLE
feat(setup.md): add command

### DIFF
--- a/cypress/SETUP.md
+++ b/cypress/SETUP.md
@@ -20,8 +20,8 @@ In order to run the email e2e tests successfully, we need to perform the followi
 2. Run these commands:
 
 ```
-INSERT INTO sites (name, api_token_name, site_status, job_status, creator_id)
-VALUES ('e2e email test site', '', 'INITIALIZED', 'READY', '1');
+INSERT INTO sites (name, site_status, job_status, creator_id)
+VALUES ('e2e email test site', 'INITIALIZED', 'READY', '1');
 INSERT INTO repos (name, url, created_at, updated_at, site_id)
 SELECT 'e2e-email-test-repo', 'https://github.com/isomerpages/e2e-email-test-repo', NOW(), NOW(), id FROM sites WHERE name = 'e2e email test site';
 ```

--- a/cypress/SETUP.md
+++ b/cypress/SETUP.md
@@ -21,7 +21,7 @@ In order to run the email e2e tests successfully, we need to perform the followi
 
 ```
 INSERT INTO sites (name, site_status, job_status, creator_id)
-VALUES ('e2e email test site', 'INITIALIZED', 'READY', '1');
+VALUES ('e2e email test site', 'INITIALIZED', 'READY', 1);
 INSERT INTO repos (name, url, created_at, updated_at, site_id)
 SELECT 'e2e-email-test-repo', 'https://github.com/isomerpages/e2e-email-test-repo', NOW(), NOW(), id FROM sites WHERE name = 'e2e email test site';
 ```

--- a/cypress/SETUP.md
+++ b/cypress/SETUP.md
@@ -16,11 +16,15 @@ In order to run the github e2e tests successfully, we need to perform the follow
 
 In order to run the email e2e tests successfully, we need to perform the following one-off setup:
 
-1. go to the **production** database (reader instance)
-2. search for the `e2e email test site` in `sites`
-3. copy the value over to your local db in `sites`
-4. search for the `e2e-email-test-repo` in `repos`
-5. copy the value over to your local db in `repos`
+1. go to the local database
+2. Run these commands:
+
+```
+INSERT INTO sites (name, api_token_name, site_status, job_status, creator_id)
+VALUES ('e2e email test site', '', 'INITIALIZED', 'READY', '1');
+INSERT INTO repos (name, url, created_at, updated_at, site_id)
+SELECT 'e2e-email-test-repo', 'https://github.com/isomerpages/e2e-email-test-repo', NOW(), NOW(), id FROM sites WHERE name = 'e2e email test site';
+```
 
 ### Explanation
 


### PR DESCRIPTION
## Problem

Currently, we are seeding the rows manually for our e2e tests. However, writing directly to DB is generally not good eng practice and can cause problems like [Postgres's primary key sequence going out of sync](https://stackoverflow.com/questions/244243/how-to-reset-postgres-primary-key-sequence-when-it-falls-out-of-sync). 

## Solution

This PR aims to alievate that by just providing 2 commands to run instead.

## Tests 
1. run 
```
INSERT INTO sites (name, site_status, job_status, creator_id)
VALUES ('e2e email test site 2', 'INITIALIZED', 'READY', 1);
INSERT INTO repos (name, url, created_at, updated_at, site_id)
SELECT 'e2e-email-test-repo 2', 'https://github.com/isomerpages/e2e-email-test-repo-2', NOW(), NOW(), id FROM sites WHERE name = 'e2e email test site 2';
```
2. verify that rows are properly added in the `sites` and `repos` tables respectively. 
3. delete added rows from the respective tables. 



