### PR TITLE
chore(e2e): change naming for clarity

### DIFF
--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -1,7 +1,7 @@
 import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   Interceptors,
   TEST_REPO_NAME,
 } from "../fixtures/constants"
@@ -20,7 +20,7 @@ import {
   removeOtherCollaborators,
 } from "../utils/collaborators"
 
-const collaborator = E2E_EMAIL_COLLAB.email
+const collaborator = E2E_EMAIL_CONTRI.email
 
 const ADD_COLLABORATOR_ERROR_MESSAGE =
   "This collaborator couldn't be added. Visit our guide for more assistance"

--- a/cypress/e2e/comments.spec.ts
+++ b/cypress/e2e/comments.spec.ts
@@ -3,7 +3,7 @@ import { createComment } from "../api"
 import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   E2E_EMAIL_TEST_SITE,
 } from "../fixtures/constants"
 import {
@@ -65,14 +65,14 @@ describe("Comments", () => {
       cy.setupDefaultInterceptors()
       api.closeReviewRequests()
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         "Email admin",
         "Email admin",
         E2E_EMAIL_TEST_SITE.name
       )
       api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
       api
-        .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+        .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
         .then((id) => {
           reviewId = id
         })
@@ -95,7 +95,7 @@ describe("Comments", () => {
       openCommentsDrawer()
 
       // Assert
-      checkCommentVisible(MOCK_COMMENT, E2E_EMAIL_COLLAB.email)
+      checkCommentVisible(MOCK_COMMENT, E2E_EMAIL_CONTRI.email)
     })
     it("should be able to see comments posted by yourself", () => {
       // Arrange
@@ -139,13 +139,13 @@ describe("Comments", () => {
       cy.setupDefaultInterceptors()
       api.closeReviewRequests()
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         "Email admin",
         "Email admin",
         E2E_EMAIL_TEST_SITE.name
       )
       api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
-      api.createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+      api.createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
     })
 
     it("should be able to post comments if you are an admin of the site", () => {
@@ -178,7 +178,7 @@ describe("Comments", () => {
       submitNewComment()
 
       // Assert
-      checkCommentVisible(MOCK_COMMENT, E2E_EMAIL_COLLAB.email)
+      checkCommentVisible(MOCK_COMMENT, E2E_EMAIL_CONTRI.email)
     })
   })
 
@@ -190,14 +190,14 @@ describe("Comments", () => {
       cy.setupDefaultInterceptors()
       api.closeReviewRequests()
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         "Email admin",
         "Email admin",
         E2E_EMAIL_TEST_SITE.name
       )
       api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
       api
-        .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+        .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
         .then((id) => {
           reviewId = id
         })
@@ -274,14 +274,14 @@ describe("Comments", () => {
         cy.setupDefaultInterceptors()
         api.closeReviewRequests()
         cy.createEmailUser(
-          E2E_EMAIL_COLLAB.email,
+          E2E_EMAIL_CONTRI.email,
           "Email admin",
           "Email admin",
           E2E_EMAIL_TEST_SITE.name
         )
         api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
         api
-          .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+          .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
           .then((id) => {
             reviewId = id
           })
@@ -313,14 +313,14 @@ describe("Comments", () => {
         cy.setupDefaultInterceptors()
         api.closeReviewRequests()
         cy.createEmailUser(
-          E2E_EMAIL_COLLAB.email,
+          E2E_EMAIL_CONTRI.email,
           "Email admin",
           "Email admin",
           E2E_EMAIL_TEST_SITE.name
         )
         api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
         api
-          .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+          .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
           .then((id) => {
             reviewId = id
           })

--- a/cypress/e2e/notifications.spec.ts
+++ b/cypress/e2e/notifications.spec.ts
@@ -2,7 +2,7 @@ import { EMPTY_NOTIFICATIONS_TEXT } from "../../src/components/Header/Notificati
 import * as api from "../api"
 import {
   E2E_EMAIL_ADMIN,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   E2E_EMAIL_TEST_SITE,
 } from "../fixtures/constants"
 import {
@@ -31,7 +31,7 @@ describe("notifications", () => {
   })
   before(() => {
     cy.createEmailUser(
-      E2E_EMAIL_COLLAB.email,
+      E2E_EMAIL_CONTRI.email,
       "Email admin",
       "Email admin",
       E2E_EMAIL_TEST_SITE.name
@@ -52,7 +52,7 @@ describe("notifications", () => {
 
     api.editUnlinkedPage("faq.md", genRandomString(), E2E_EMAIL_TEST_SITE.repo)
     api
-      .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+      .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
       .then((id) => {
         reviewId = id
       })

--- a/cypress/e2e/reviewRequests.spec.ts
+++ b/cypress/e2e/reviewRequests.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../api"
 import { editUnlinkedPage } from "../api/pages.api"
 import {
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   E2E_EMAIL_REPO_STAGING_LINK,
   E2E_EMAIL_TEST_SITE,
   MOCK_REVIEW_DESCRIPTION,
@@ -24,7 +24,7 @@ const getReviewRequestButton = () => cy.contains("button", "Request a Review")
 const getSubmitReviewButton = () => cy.contains("button", "Submit Review")
 
 const selectReviewer = (email: string) => {
-  cy.get("div[id^='react-select']").contains(E2E_EMAIL_COLLAB.email).click()
+  cy.get("div[id^='react-select']").contains(E2E_EMAIL_CONTRI.email).click()
 }
 const removeReviewers = () => cy.get('div[aria-label^="Remove"]').click()
 
@@ -70,11 +70,11 @@ describe("Review Requests", () => {
     it("should not be able to create a review request without a reviewer", () => {
       // Arrange
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         USER_TYPES.Email.Collaborator,
         USER_TYPES.Email.Admin
       )
-      addCollaborator(E2E_EMAIL_COLLAB.email)
+      addCollaborator(E2E_EMAIL_CONTRI.email)
 
       // Act
       // NOTE: There should be at least 1 other admin to be able to create a review request
@@ -93,7 +93,7 @@ describe("Review Requests", () => {
     })
     it("should be able to create a review request successfully", () => {
       // Arrange
-      addAdmin(E2E_EMAIL_COLLAB.email)
+      addAdmin(E2E_EMAIL_CONTRI.email)
       editUnlinkedPage(
         "faq.md",
         "some asdfasdfasdf content",
@@ -108,12 +108,12 @@ describe("Review Requests", () => {
       getSubmitReviewButton().should("be.disabled")
       getAddReviewerDropdown().click()
       // select reviewer and click
-      selectReviewer(E2E_EMAIL_COLLAB.email)
+      selectReviewer(E2E_EMAIL_CONTRI.email)
       removeReviewers()
       getSubmitReviewButton().should("be.disabled")
       // add back reviewer
       getAddReviewerDropdown().click()
-      selectReviewer(E2E_EMAIL_COLLAB.email)
+      selectReviewer(E2E_EMAIL_CONTRI.email)
       cy.get(DESCRIPTION_TEXTAREA_SELECTOR).type(MOCK_REVIEW_DESCRIPTION)
 
       // Assert
@@ -123,13 +123,13 @@ describe("Review Requests", () => {
   })
   describe.skip("has pending review requests", () => {
     before(() => {
-      addAdmin(E2E_EMAIL_COLLAB.email)
+      addAdmin(E2E_EMAIL_CONTRI.email)
       // NOTE: Create a review request if none exists
       listReviewRequests().then((requests) => {
         if (!requests || !requests.length) {
           createReviewRequest(
             MOCK_REVIEW_TITLE,
-            [E2E_EMAIL_COLLAB.email],
+            [E2E_EMAIL_CONTRI.email],
             MOCK_REVIEW_DESCRIPTION
           )
         }
@@ -171,13 +171,13 @@ describe("Review Requests", () => {
   })
   describe.skip("has approved review requests", () => {
     before(() => {
-      addAdmin(E2E_EMAIL_COLLAB.email)
+      addAdmin(E2E_EMAIL_CONTRI.email)
       // NOTE: Create a review request if none exists
       listReviewRequests().then((requests) => {
         if (!requests || !requests.length) {
           createReviewRequest(
             MOCK_REVIEW_TITLE,
-            [E2E_EMAIL_COLLAB.email],
+            [E2E_EMAIL_CONTRI.email],
             MOCK_REVIEW_DESCRIPTION
           ).then((id) => approveReviewRequest(id))
         }

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -10,8 +10,8 @@ export const E2E_EMAIL_ADMIN = {
   email: "admin@e2e.gov.sg",
 } as const
 
-export const E2E_EMAIL_COLLAB = {
-  email: "collab@e2e.gov.sg",
+export const E2E_EMAIL_CONTRI = {
+  email: "contri@e2e.gov.sg",
 } as const
 
 export const E2E_EMAIL_TEST_SITE = {

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -11,7 +11,7 @@ import {
   E2E_EMAIL_ADMIN,
   CMS_BASEURL,
   BACKEND_URL,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 import { setCookieWithDomain } from "../utils/cookies"
@@ -29,7 +29,7 @@ Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
   setCookieWithDomain(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
   setCookieWithDomain(
     E2E_COOKIE.Email.key,
-    userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_COLLAB.email
+    userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_CONTRI.email
   )
   setCookieWithDomain(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
 })


### PR DESCRIPTION
## Problem

The terms collaborator and contributor has semantic differences our our code base.
To be reviewed tgt with [be pr](https://github.com/isomerpages/isomercms-backend/pull/857)

## Solution

 Changing collab to contri naming here for calrity. 
**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Ran collaborator tests spec here, same result as last week during release. 
<img width="460" alt="Screenshot 2023-07-24 at 11 49 33 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/d121fce5-f411-4b98-9741-5bc308bf557b">
<img width="1134" alt="Screenshot 2023-07-24 at 11 49 25 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/5aa4903b-88d6-45b2-ad31-5fdeef40390a">



 