### PR TITLE
Fix(e2e): add support for 2 admins

### DIFF
--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -1,7 +1,7 @@
 import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   Interceptors,
   TEST_REPO_NAME,
 } from "../fixtures/constants"
@@ -20,7 +20,7 @@ import {
   removeOtherCollaborators,
 } from "../utils/collaborators"
 
-const collaborator = E2E_EMAIL_COLLAB.email
+const collaborator = E2E_EMAIL_CONTRI.email
 
 const ADD_COLLABORATOR_ERROR_MESSAGE =
   "This collaborator couldn't be added. Visit our guide for more assistance"

--- a/cypress/e2e/comments.spec.ts
+++ b/cypress/e2e/comments.spec.ts
@@ -3,7 +3,7 @@ import { createComment } from "../api"
 import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   E2E_EMAIL_TEST_SITE,
 } from "../fixtures/constants"
 import {
@@ -50,14 +50,14 @@ describe("Comments", () => {
       cy.setupDefaultInterceptors()
       api.closeReviewRequests()
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         "Email admin",
         "Email admin",
         E2E_EMAIL_TEST_SITE.name
       )
       api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
       api
-        .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+        .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
         .then((id) => {
           reviewId = id
         })
@@ -83,7 +83,7 @@ describe("Comments", () => {
       cy.contains("div", MOCK_COMMENT)
         .should("be.visible")
         .parent()
-        .contains(E2E_EMAIL_COLLAB.email)
+        .contains(E2E_EMAIL_CONTRI.email)
         .should("be.visible")
     })
     it("should be able to see comments posted by yourself", () => {
@@ -137,14 +137,14 @@ describe("Comments", () => {
       cy.setupDefaultInterceptors()
       api.closeReviewRequests()
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         "Email admin",
         "Email admin",
         E2E_EMAIL_TEST_SITE.name
       )
       api.editUnlinkedPage("faq.md", "some content", E2E_EMAIL_TEST_SITE.repo)
       api
-        .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+        .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
         .then((id) => {
           reviewId = id
         })

--- a/cypress/e2e/notifications.spec.ts
+++ b/cypress/e2e/notifications.spec.ts
@@ -2,7 +2,7 @@ import { EMPTY_NOTIFICATIONS_TEXT } from "../../src/components/Header/Notificati
 import * as api from "../api"
 import {
   E2E_EMAIL_ADMIN,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   E2E_EMAIL_TEST_SITE,
 } from "../fixtures/constants"
 import {
@@ -31,7 +31,7 @@ describe("notifications", () => {
   })
   before(() => {
     cy.createEmailUser(
-      E2E_EMAIL_COLLAB.email,
+      E2E_EMAIL_CONTRI.email,
       "Email admin",
       "Email admin",
       E2E_EMAIL_TEST_SITE.name
@@ -52,7 +52,7 @@ describe("notifications", () => {
 
     api.editUnlinkedPage("faq.md", genRandomString(), E2E_EMAIL_TEST_SITE.repo)
     api
-      .createReviewRequest("test title", [E2E_EMAIL_COLLAB.email])
+      .createReviewRequest("test title", [E2E_EMAIL_CONTRI.email])
       .then((id) => {
         reviewId = id
       })

--- a/cypress/e2e/reviewRequests.spec.ts
+++ b/cypress/e2e/reviewRequests.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../api"
 import { editUnlinkedPage } from "../api/pages.api"
 import {
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
   E2E_EMAIL_REPO_STAGING_LINK,
   E2E_EMAIL_TEST_SITE,
   MOCK_REVIEW_DESCRIPTION,
@@ -24,7 +24,7 @@ const getReviewRequestButton = () => cy.contains("button", "Request a Review")
 const getSubmitReviewButton = () => cy.contains("button", "Submit Review")
 
 const selectReviewer = (email: string) => {
-  cy.get("div[id^='react-select']").contains(E2E_EMAIL_COLLAB.email).click()
+  cy.get("div[id^='react-select']").contains(E2E_EMAIL_CONTRI.email).click()
 }
 const removeReviewers = () => cy.get('div[aria-label^="Remove"]').click()
 
@@ -70,11 +70,11 @@ describe("Review Requests", () => {
     it("should not be able to create a review request without a reviewer", () => {
       // Arrange
       cy.createEmailUser(
-        E2E_EMAIL_COLLAB.email,
+        E2E_EMAIL_CONTRI.email,
         USER_TYPES.Email.Collaborator,
         USER_TYPES.Email.Admin
       )
-      addCollaborator(E2E_EMAIL_COLLAB.email)
+      addCollaborator(E2E_EMAIL_CONTRI.email)
 
       // Act
       // NOTE: There should be at least 1 other admin to be able to create a review request
@@ -93,7 +93,7 @@ describe("Review Requests", () => {
     })
     it("should be able to create a review request successfully", () => {
       // Arrange
-      addAdmin(E2E_EMAIL_COLLAB.email)
+      addAdmin(E2E_EMAIL_CONTRI.email)
       editUnlinkedPage(
         "faq.md",
         "some asdfasdfasdf content",
@@ -108,12 +108,12 @@ describe("Review Requests", () => {
       getSubmitReviewButton().should("be.disabled")
       getAddReviewerDropdown().click()
       // select reviewer and click
-      selectReviewer(E2E_EMAIL_COLLAB.email)
+      selectReviewer(E2E_EMAIL_CONTRI.email)
       removeReviewers()
       getSubmitReviewButton().should("be.disabled")
       // add back reviewer
       getAddReviewerDropdown().click()
-      selectReviewer(E2E_EMAIL_COLLAB.email)
+      selectReviewer(E2E_EMAIL_CONTRI.email)
       cy.get(DESCRIPTION_TEXTAREA_SELECTOR).type(MOCK_REVIEW_DESCRIPTION)
 
       // Assert
@@ -123,13 +123,13 @@ describe("Review Requests", () => {
   })
   describe.skip("has pending review requests", () => {
     before(() => {
-      addAdmin(E2E_EMAIL_COLLAB.email)
+      addAdmin(E2E_EMAIL_CONTRI.email)
       // NOTE: Create a review request if none exists
       listReviewRequests().then((requests) => {
         if (!requests || !requests.length) {
           createReviewRequest(
             MOCK_REVIEW_TITLE,
-            [E2E_EMAIL_COLLAB.email],
+            [E2E_EMAIL_CONTRI.email],
             MOCK_REVIEW_DESCRIPTION
           )
         }
@@ -171,13 +171,13 @@ describe("Review Requests", () => {
   })
   describe.skip("has approved review requests", () => {
     before(() => {
-      addAdmin(E2E_EMAIL_COLLAB.email)
+      addAdmin(E2E_EMAIL_CONTRI.email)
       // NOTE: Create a review request if none exists
       listReviewRequests().then((requests) => {
         if (!requests || !requests.length) {
           createReviewRequest(
             MOCK_REVIEW_TITLE,
-            [E2E_EMAIL_COLLAB.email],
+            [E2E_EMAIL_CONTRI.email],
             MOCK_REVIEW_DESCRIPTION
           ).then((id) => approveReviewRequest(id))
         }

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -10,8 +10,8 @@ export const E2E_EMAIL_ADMIN = {
   email: "admin@e2e.gov.sg",
 } as const
 
-export const E2E_EMAIL_COLLAB = {
-  email: "collab@e2e.gov.sg",
+export const E2E_EMAIL_CONTRI = {
+  email: "contri@e2e.gov.sg",
 } as const
 
 export const E2E_EMAIL_TEST_SITE = {

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -10,6 +10,10 @@ export const E2E_EMAIL_ADMIN = {
   email: "admin@e2e.gov.sg",
 } as const
 
+export const E2E_EMAIL_ADMIN_2 = {
+  email: "admin2@e2e.gov.sg",
+} as const
+
 export const E2E_EMAIL_CONTRI = {
   email: "contri@e2e.gov.sg",
 } as const

--- a/cypress/fixtures/users.ts
+++ b/cypress/fixtures/users.ts
@@ -2,6 +2,7 @@ export const USER_TYPES = {
   Email: {
     Admin: "Email admin",
     Collaborator: "Email collaborator",
+    Admin2: "Email admin 2",
   },
   Github: "Github user",
 } as const

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -12,6 +12,7 @@ import {
   CMS_BASEURL,
   BACKEND_URL,
   E2E_EMAIL_CONTRI,
+  E2E_EMAIL_ADMIN_2,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 import { setCookieWithDomain } from "../utils/cookies"
@@ -23,14 +24,22 @@ Cypress.Commands.add("setGithubSessionDefaults", () => {
   window.localStorage.setItem(LOCAL_STORAGE_USERID_KEY, E2E_USER.userId)
 })
 
+const getEmailFromUserType = (userType: EmailUserTypes) => {
+  switch (userType) {
+    case USER_TYPES.Email.Admin:
+      return E2E_EMAIL_ADMIN.email
+    case USER_TYPES.Email.Admin2:
+      return E2E_EMAIL_ADMIN_2.email
+    default:
+      return E2E_EMAIL_CONTRI.email
+  }
+}
+
 Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
   setCookieWithDomain(COOKIE_NAME, COOKIE_VALUE)
   setCookieWithDomain(E2E_USER_TYPE_COOKIE_KEY, userType)
   setCookieWithDomain(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
-  setCookieWithDomain(
-    E2E_COOKIE.Email.key,
-    userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_CONTRI.email
-  )
+  setCookieWithDomain(E2E_COOKIE.Email.key, getEmailFromUserType(userType))
   setCookieWithDomain(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
 })
 

--- a/cypress/support/session.ts
+++ b/cypress/support/session.ts
@@ -11,7 +11,7 @@ import {
   E2E_EMAIL_ADMIN,
   CMS_BASEURL,
   BACKEND_URL,
-  E2E_EMAIL_COLLAB,
+  E2E_EMAIL_CONTRI,
 } from "../fixtures/constants"
 import { EmailUserTypes, USER_TYPES } from "../fixtures/users"
 import { setCookieWithDomain } from "../utils/cookies"
@@ -29,7 +29,7 @@ Cypress.Commands.add("setEmailSessionDefaults", (userType: EmailUserTypes) => {
   setCookieWithDomain(E2E_SITE_KEY, E2E_EMAIL_TEST_SITE.name)
   setCookieWithDomain(
     E2E_COOKIE.Email.key,
-    userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_COLLAB.email
+    userType === "Email admin" ? E2E_EMAIL_ADMIN.email : E2E_EMAIL_CONTRI.email
   )
   setCookieWithDomain(E2E_COOKIE.Site.key, E2E_COOKIE.Site.value)
 })


### PR DESCRIPTION
## Problem

Currently, e2e tests does not allow the creation of 2 admin users. 


## Solution
Allow creation of second admin 


