### PR TITLE
test(e2e): add homepage 

### DIFF
--- a/cypress/e2e/homepage.spec.ts
+++ b/cypress/e2e/homepage.spec.ts
@@ -124,6 +124,8 @@ describe("Homepage", () => {
       )
     })
 
+    // TODO (IS-377): Disallow resource creation
+    // when a resource section already exists
     it("should limit users to a single resource component", () => {
       // Arrange
       // NOTE: Precondition here is that there are NO existing resources

--- a/cypress/e2e/homepage.spec.ts
+++ b/cypress/e2e/homepage.spec.ts
@@ -183,7 +183,7 @@ describe("Homepage", () => {
 
       // Assert
       // NOTE: Order is now Infopic -> Infobar
-      // note: not using get aliases as they where returning incorrect results
+      // note: not using get aliases as they were returning incorrect results
       cy.get(getHandleSelector()).eq(0).should("contain", "Infopic")
       cy.get(getHandleSelector()).eq(1).should("contain", "Infobar")
       cy.get(infopicPreviewSelector)

--- a/cypress/e2e/homepage.spec.ts
+++ b/cypress/e2e/homepage.spec.ts
@@ -1,4 +1,5 @@
-import { TEST_REPO_NAME } from "../fixtures/constants"
+import { keyCodes, TEST_REPO_NAME, timings } from "../fixtures/constants"
+import { getHandleSelector } from "../utils/dnd"
 
 const visitHomepage = () => {
   cy.visit(`/sites/${TEST_REPO_NAME}/homepage`)
@@ -35,29 +36,6 @@ const SECTION_DROPDOWN_OPTIONS = {
 
 const toggleSectionDropdown = (section: string) => {
   cy.contains(section).next().click()
-}
-
-const timings = {
-  outOfTheWay: 0.2,
-  // greater than the out of the way time
-  // so that when the drop ends everything will
-  // have to be out of the way
-  minDropTime: 0.33,
-  maxDropTime: 0.55,
-}
-
-const keyCodes = {
-  space: 32,
-  arrowDown: 40,
-}
-
-const REACT_DRAG_HANDLE_PROPERTY = "data-rfd-drag-handle-draggable-id" as const
-
-const getHandleSelector = (draggableId?: string) => {
-  if (draggableId) {
-    return `[${REACT_DRAG_HANDLE_PROPERTY}="${draggableId}"]`
-  }
-  return `[${REACT_DRAG_HANDLE_PROPERTY}]`
 }
 
 describe("Homepage", () => {

--- a/cypress/e2e/homepage.spec.ts
+++ b/cypress/e2e/homepage.spec.ts
@@ -1,0 +1,217 @@
+import { TEST_REPO_NAME } from "../fixtures/constants"
+
+const visitHomepage = () => {
+  cy.visit(`/sites/${TEST_REPO_NAME}/homepage`)
+}
+
+const NOTIFICATION_BAR_PREVIEW_SELECTOR = "div[id='notification-bar']"
+const NOTIFICATION_INPUT_SELECTOR = 'input[id="site-notification"]'
+
+const HERO_BUTTON_INPUT_SELECTOR = 'input[id*="hero-button"]'
+const HERO_BUTTON_PREVIEW_SELECTOR = 'div[class*="search-button"]'
+
+const HERO_SECTION_HIGHLIGHTS_SELECTOR = 'input[id="radio-highlights"]'
+const HERO_SECTION_DROPDOWN_SELECTOR = 'input[id="radio-dropdown"]'
+
+const ADD_SECTION_DROPDOWN_SELECTOR = 'select[id="section-new"]'
+
+const getAddSectionButtonSelector = (): "@addSectionButton" => {
+  cy.contains("div", "Add a new section").find("button").as("addSectionButton")
+
+  return "@addSectionButton"
+}
+
+const getPreviewSectionSelectorByTitle = (title: string): `@${string}` => {
+  cy.contains("section", title).as(`section-${title}`).should("exist")
+  return `@section-${title}`
+}
+
+const SECTION_DROPDOWN_OPTIONS = {
+  DEFAULT: "--Choose a new section--",
+  RESOURCES: "Resources",
+  INFOBAR: "Infobar",
+  INFOPIC: "Infopic",
+}
+
+const toggleSectionDropdown = (section: string) => {
+  cy.contains(section).next().click()
+}
+
+const timings = {
+  outOfTheWay: 0.2,
+  // greater than the out of the way time
+  // so that when the drop ends everything will
+  // have to be out of the way
+  minDropTime: 0.33,
+  maxDropTime: 0.55,
+}
+
+const keyCodes = {
+  space: 32,
+  arrowDown: 40,
+}
+
+const REACT_DRAG_HANDLE_PROPERTY = "data-rfd-drag-handle-draggable-id" as const
+
+const getHandleSelector = (draggableId?: string) => {
+  if (draggableId) {
+    return `[${REACT_DRAG_HANDLE_PROPERTY}="${draggableId}"]`
+  }
+  return `[${REACT_DRAG_HANDLE_PROPERTY}]`
+}
+
+describe("Homepage", () => {
+  beforeEach(() => {
+    cy.setupDefaultInterceptors()
+    cy.setGithubSessionDefaults()
+    visitHomepage()
+  })
+
+  describe("Block editing", () => {
+    it("should display the site notification correctly", () => {
+      // Arrange
+      const MOCK_NOTIFICATION_TEXT = "This is a mock notification"
+      const notificationPreviewAlias = "notificationPreview"
+      cy.get(NOTIFICATION_BAR_PREVIEW_SELECTOR).as(notificationPreviewAlias)
+      // NOTE: Clear the input first to prevent any existing text
+      // from interfering with the test
+      cy.get(NOTIFICATION_INPUT_SELECTOR).as("notificationInput").clear().blur()
+      cy.get(`@${notificationPreviewAlias}`).should("not.exist")
+
+      // Act
+      cy.get("@notificationInput").type(MOCK_NOTIFICATION_TEXT).blur()
+
+      // Assert
+
+      cy.get(`@${notificationPreviewAlias}`)
+        .should("exist")
+        .contains(MOCK_NOTIFICATION_TEXT)
+    })
+
+    it("should only allow up to 4 highlights for the hero section", () => {
+      // Arrange
+      // NOTE: Toggle the dropdown
+      toggleSectionDropdown("Hero section")
+      cy.get(HERO_SECTION_HIGHLIGHTS_SELECTOR).check()
+      cy.contains("button", "Add highlight").as("addHighlightButton")
+
+      // Act
+      // NOTE: We assume that there are 3 highlights at the start
+      // as this is the initial state post-reset.
+      // NOTE: We require this because it clicks on the center by default
+      // which is where the text is.
+      // As we search for grandparent element to trigger the state change,
+      // clicking on the text will have the wrong grandparent element
+      // leading to no state change.
+      cy.get("@addHighlightButton").click("top")
+
+      // Assert
+      cy.get("@addHighlightButton").should("be.disabled")
+    })
+
+    it("should remove the button in preview when the hero button content is not given", () => {
+      // Arrange
+      const MOCK_HERO_BUTTON_TEXT = "This is a mock hero button text"
+      toggleSectionDropdown("Hero section")
+      cy.get(HERO_BUTTON_PREVIEW_SELECTOR)
+        .as("heroButtonPreview")
+        .should("exist")
+      cy.get(HERO_BUTTON_INPUT_SELECTOR).clear().blur()
+      cy.get("@heroButtonPreview").should("not.exist")
+
+      // Act
+      cy.get(HERO_BUTTON_INPUT_SELECTOR).type(MOCK_HERO_BUTTON_TEXT).blur()
+
+      // Assert
+      cy.get("@heroButtonPreview")
+        .should("exist")
+        .contains(MOCK_HERO_BUTTON_TEXT)
+    })
+
+    it("should preserve content when swapping between highlights and dropdown for hero section", () => {
+      // Arrange
+      const UPDATED_HERO_BUTTON_TEXT = "This is changed blah blah"
+      toggleSectionDropdown("Hero section")
+
+      // Act
+      cy.get(HERO_SECTION_HIGHLIGHTS_SELECTOR).check()
+      cy.get(HERO_BUTTON_INPUT_SELECTOR).clear().type(UPDATED_HERO_BUTTON_TEXT)
+      cy.get(HERO_SECTION_DROPDOWN_SELECTOR).check()
+      cy.get(HERO_SECTION_HIGHLIGHTS_SELECTOR).check()
+
+      // Assert
+      cy.get(HERO_BUTTON_INPUT_SELECTOR).should(
+        "have.value",
+        UPDATED_HERO_BUTTON_TEXT
+      )
+    })
+
+    it("should limit users to a single resource component", () => {
+      // Arrange
+      // NOTE: Precondition here is that there are NO existing resources
+      cy.get(ADD_SECTION_DROPDOWN_SELECTOR).select(
+        SECTION_DROPDOWN_OPTIONS.DEFAULT
+      )
+      cy.contains("div", "Add a new section")
+        .find("button")
+        .as("addSectionButton")
+        .should("be.disabled")
+
+      // Act
+      cy.get(ADD_SECTION_DROPDOWN_SELECTOR).select(
+        SECTION_DROPDOWN_OPTIONS.RESOURCES
+      )
+      cy.get("@addSectionButton").click()
+
+      // Assert
+      // NOTE: This is an existing bug on `production`
+      // where adding a resource section doesn't disable.
+      cy.get("@addSectionButton").should("be.disabled")
+    })
+
+    it.skip("should snap preview to that section when clicking on the section in the editor", () => {
+      // NOTE: Not testing this because cypress doesn't support viewports checking
+    })
+
+    it("should rearrange the blocks correctly and the preview should also reflect the new order", () => {
+      // Arrange
+      cy.get(ADD_SECTION_DROPDOWN_SELECTOR).select(
+        SECTION_DROPDOWN_OPTIONS.INFOPIC
+      )
+      const addButtonSelector = getAddSectionButtonSelector()
+      cy.get(addButtonSelector).click()
+
+      // NOTE: Initial order is Infobar -> Infopic
+      cy.get(getHandleSelector()).eq(0).as("first").should("contain", "Infobar")
+      cy.get(getHandleSelector()).eq(1).should("contain", "Infopic")
+      const infobarPreviewSelector = getPreviewSectionSelectorByTitle("Infobar")
+      const infopicPreviewSelector = getPreviewSectionSelectorByTitle("Infopic")
+      cy.get(infobarPreviewSelector)
+        .parent()
+        .next()
+        .should("contain", "Infopic")
+
+      // Act
+      // reorder operation
+      cy.get("@first")
+        .focus()
+        .trigger("keydown", { keyCode: keyCodes.space })
+        // need to re-query for a clone
+        .get("@first")
+        .trigger("keydown", { keyCode: keyCodes.arrowDown, force: true })
+        // finishing before the movement time is fine - but this looks nice
+        .wait(timings.outOfTheWay * 1000)
+        .trigger("keydown", { keyCode: keyCodes.space, force: true })
+
+      // Assert
+      // NOTE: Order is now Infopic -> Infobar
+      // note: not using get aliases as they where returning incorrect results
+      cy.get(getHandleSelector()).eq(0).should("contain", "Infopic")
+      cy.get(getHandleSelector()).eq(1).should("contain", "Infobar")
+      cy.get(infopicPreviewSelector)
+        .parent()
+        .next()
+        .should("contain", "Infobar")
+    })
+  })
+})

--- a/cypress/fixtures/constants.ts
+++ b/cypress/fixtures/constants.ts
@@ -61,3 +61,17 @@ export const MOCK_REVIEW_DESCRIPTION = "Some interesting description"
 
 export const FORBIDDEN_CHARACTERS = "!@#$%^&*()"
 export const NON_ENGLISH_CHARACTERS = "文கி"
+
+export const timings = {
+  outOfTheWay: 0.2,
+  // greater than the out of the way time
+  // so that when the drop ends everything will
+  // have to be out of the way
+  minDropTime: 0.33,
+  maxDropTime: 0.55,
+}
+
+export const keyCodes = {
+  space: 32,
+  arrowDown: 40,
+}

--- a/cypress/fixtures/selectors/dnd.ts
+++ b/cypress/fixtures/selectors/dnd.ts
@@ -1,0 +1,1 @@
+export const REACT_DRAG_HANDLE_PROPERTY = "data-rfd-drag-handle-draggable-id" as const

--- a/cypress/utils/dnd.ts
+++ b/cypress/utils/dnd.ts
@@ -1,0 +1,8 @@
+import { REACT_DRAG_HANDLE_PROPERTY } from "../fixtures/selectors/dnd"
+
+export const getHandleSelector = (draggableId?: string) => {
+  if (draggableId) {
+    return `[${REACT_DRAG_HANDLE_PROPERTY}="${draggableId}"]`
+  }
+  return `[${REACT_DRAG_HANDLE_PROPERTY}]`
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@datadog/datadog-ci": "^2.17.1",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
+        "@hello-pangea/dnd": "^16.3.0",
         "@hookform/resolvers": "^2.8.2",
         "@opengovsg/design-system-react": "0.0.12",
         "@sentry/react": "^7.12.1",
@@ -4068,9 +4069,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -8407,6 +8408,72 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
       "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA=="
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-16.3.0.tgz",
+      "integrity": "sha512-RYQ/K8shtJoyNPvFWz0gfXIK7HF3P3mL9UZFGMuHB0ljRSXVgMjVFI/FxcZmakMzw6tO7NflWLriwTNBow/4vw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "css-box-model": "^1.2.1",
+        "memoize-one": "^6.0.0",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^8.1.1",
+        "redux": "^4.2.1",
+        "use-memo-one": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@hello-pangea/dnd/node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
+    "node_modules/@hello-pangea/dnd/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@hello-pangea/dnd/node_modules/react-redux": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.1.tgz",
+      "integrity": "sha512-5W0QaKtEhj+3bC0Nj0NkqkhIv8gLADH/2kYFMTHxCVqQILiWzLv6MaLuV5wJU3BQEdHKzTfcvPN0WMS6SC1oyA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "2.8.2",
@@ -16135,6 +16202,15 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -16566,6 +16642,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -35782,9 +35863,9 @@
       }
     },
     "node_modules/raf-schd": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
-      "integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -38475,12 +38556,11 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/regenerate": {
@@ -41037,14 +41117,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -42536,11 +42608,11 @@
       }
     },
     "node_modules/use-memo-one": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
-      "integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
       "peerDependencies": {
-        "react": "^16.8.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/use-resize-observer": {
@@ -42581,6 +42653,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@datadog/datadog-ci": "^2.17.1",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "@hello-pangea/dnd": "^16.3.0",
     "@hookform/resolvers": "^2.8.2",
     "@opengovsg/design-system-react": "0.0.12",
     "@sentry/react": "^7.12.1",

--- a/src/components/homepage/HeroDropdown.jsx
+++ b/src/components/homepage/HeroDropdown.jsx
@@ -1,10 +1,10 @@
+import { Droppable, Draggable } from "@hello-pangea/dnd"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import FormContext from "components/Form/FormContext"
 import FormError from "components/Form/FormError"
 import FormTitle from "components/Form/FormTitle"
 import FormField from "components/FormField"
 import PropTypes from "prop-types"
-import { Droppable, Draggable } from "react-beautiful-dnd"
 
 import styles from "styles/App.module.scss"
 import elementStyles from "styles/isomer-cms/Elements.module.scss"

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -1,3 +1,4 @@
+import { Droppable, Draggable } from "@hello-pangea/dnd"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { FormContext, FormError, FormTitle } from "components/Form"
 import FormField from "components/FormField"
@@ -6,7 +7,6 @@ import HeroButton from "components/homepage/HeroButton"
 import HeroDropdown from "components/homepage/HeroDropdown"
 import KeyHighlight from "components/homepage/KeyHighlight"
 import PropTypes from "prop-types"
-import { Droppable, Draggable } from "react-beautiful-dnd"
 
 import styles from "styles/App.module.scss"
 import elementStyles from "styles/isomer-cms/Elements.module.scss"

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { useDisclosure, Text, HStack, VStack } from "@chakra-ui/react"
+import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd"
 import { Button, Input } from "@opengovsg/design-system-react"
 import { Footer } from "components/Footer"
 import Header from "components/Header"
@@ -14,7 +15,6 @@ import update from "immutability-helper"
 import _ from "lodash"
 import PropTypes from "prop-types"
 import { useEffect, createRef, useState } from "react"
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd"
 
 // Import hooks
 import { useGetHomepageHook } from "hooks/homepageHooks"


### PR DESCRIPTION
## Problem
Previously, homepage did not have any e2e tests. This PR adds e2e tests for homepage.

## Solution
1. change dnd package - old dnd package had an issue with react strict mode, which causes it to crash on local.
2. add tests for special cases and drag/drop functionality
    - see the base drag and drop spec from react beautiful dnd [here](https://github.com/atlassian/react-beautiful-dnd/blob/master/cypress/integration/reorder.spec.js) 
    - other special cases are given on the ticket and guarntee some baseline behaviour