### PR TITLE
feat(site launch): add in refetch behvaiour

### DIFF
--- a/src/hooks/siteDashboardHooks/useGetSiteLaunchStatus.ts
+++ b/src/hooks/siteDashboardHooks/useGetSiteLaunchStatus.ts
@@ -6,6 +6,8 @@ import * as SiteLaunchService from "services/SiteLaunchService"
 
 import { SiteLaunchDto } from "types/siteLaunch"
 
+const FIVE_MINUTES = 1000 * 60 * 5
+
 export const useGetSiteLaunchStatus = (
   siteName: string
 ): UseQueryResult<SiteLaunchDto> => {
@@ -16,6 +18,11 @@ export const useGetSiteLaunchStatus = (
     },
     {
       retry: false,
+      // we want to refetch the data every 5 minutes
+      // during the site launch process. Else, it will
+      // only be updated on a hard refresh.
+      refetchInterval: FIVE_MINUTES,
+      refetchIntervalInBackground: true,
     }
   )
 }

--- a/src/hooks/siteDashboardHooks/useGetSiteLaunchStatus.ts
+++ b/src/hooks/siteDashboardHooks/useGetSiteLaunchStatus.ts
@@ -6,7 +6,7 @@ import * as SiteLaunchService from "services/SiteLaunchService"
 
 import { SiteLaunchDto } from "types/siteLaunch"
 
-const FIVE_MINUTES = 1000 * 60 * 5
+const SITE_LAUNCH_REFETCH_INTERVAL = 1000 * 60 * 5 // 5 Minutes
 
 export const useGetSiteLaunchStatus = (
   siteName: string
@@ -21,7 +21,7 @@ export const useGetSiteLaunchStatus = (
       // we want to refetch the data every 5 minutes
       // during the site launch process. Else, it will
       // only be updated on a hard refresh.
-      refetchInterval: FIVE_MINUTES,
+      refetchInterval: SITE_LAUNCH_REFETCH_INTERVAL,
       refetchIntervalInBackground: true,
     }
   )


### PR DESCRIPTION
## Problem

During the site launch process, users would have to do a hard refresh to get the lastest site launch results. This is not ideal.

## Solution

Refresh behaviour every 5 mins. tbh, the 5 mins is an arbitarary number, we can adjust this param as this feature is more used by our users in the future. This is just to prevent the need for a hard refesh when the launch is success. 

