### PR TITLE
feat: storybook improvement for site launch pad

### DIFF
--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -34,6 +34,50 @@ const SiteLaunchPadMeta = {
   ],
 } as ComponentMeta<typeof SiteLaunchPad>
 
-const Template = SiteLaunchPad
-export const Default: Story = Template.bind({})
+const Template: Story<typeof SiteLaunchPad> = (args) => (
+  <SiteLaunchPad {...args} />
+)
+
+// NOTE: This is just a mock, so no need actual functions
+const siteLaunchPadArgs = {
+  pageNumber: 1,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setPageNumber: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  handleDecrementStepNumber: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  handleIncrementStepNumber: () => {},
+}
+
+export const Default = Template.bind({})
+Default.args = siteLaunchPadArgs
+
+export const siteLaunchDisclaimer = Template.bind({})
+
+siteLaunchDisclaimer.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 1,
+}
+
+export const siteLaunchInfoGathering = Template.bind({})
+
+siteLaunchInfoGathering.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 2,
+}
+
+export const siteLaunchRiskAcceptance = Template.bind({})
+
+siteLaunchRiskAcceptance.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 3,
+}
+
+export const siteLaunchChecklist = Template.bind({})
+
+siteLaunchChecklist.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 4,
+}
+
 export default SiteLaunchPadMeta

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -1,4 +1,5 @@
-import { ComponentMeta, Story } from "@storybook/react"
+import { Meta } from "@storybook/react"
+import type { StoryFn } from "@storybook/react"
 import { MemoryRouter, Route } from "react-router-dom"
 
 import { SiteLaunchProvider } from "contexts/SiteLaunchContext"
@@ -32,9 +33,9 @@ const SiteLaunchPadMeta = {
       )
     },
   ],
-} as ComponentMeta<typeof SiteLaunchPad>
+} as Meta<typeof SiteLaunchPad>
 
-const Template: Story<typeof SiteLaunchPad> = (args) => (
+const Template: StoryFn<typeof SiteLaunchPad> = (args) => (
   <SiteLaunchPad {...args} />
 )
 

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -131,7 +131,56 @@ const getInitialPageNumber = (
   if (isSiteLaunchInProgress) return SITE_LAUNCH_PAGES.CHECKLIST
   return SITE_LAUNCH_PAGES.DISCLAIMER
 }
-export const SiteLaunchPad = (): JSX.Element => {
+
+export const SiteLaunchPad = ({
+  pageNumber,
+  setPageNumber,
+  handleDecrementStepNumber,
+  handleIncrementStepNumber,
+}: {
+  pageNumber: number
+  setPageNumber: React.Dispatch<React.SetStateAction<number>>
+  handleDecrementStepNumber: () => void
+  handleIncrementStepNumber: () => void
+}): JSX.Element => {
+  let title: JSX.Element
+  let body: JSX.Element
+  switch (pageNumber) {
+    case SITE_LAUNCH_PAGES.DISCLAIMER:
+      title = <SiteLaunchDisclaimerTitle />
+      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+      break
+    case SITE_LAUNCH_PAGES.INFO_GATHERING:
+    case SITE_LAUNCH_PAGES.RISK_ACCEPTANCE: // Risk acceptance modal overlay
+      title = <SiteLaunchInfoCollectorTitle />
+      body = <SiteLaunchInfoCollectorBody setPageNumber={setPageNumber} />
+      break
+    case SITE_LAUNCH_PAGES.CHECKLIST:
+      title = <SiteLaunchChecklistTitle />
+      body = (
+        <SiteLaunchChecklistBody
+          handleIncrementStepNumber={handleIncrementStepNumber}
+          handleDecrementStepNumber={handleDecrementStepNumber}
+        />
+      )
+      break
+    default:
+      title = <SiteLaunchDisclaimerTitle />
+      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+  }
+  return (
+    <VStack bg="white" w="100%" minH="100vh" spacing="2rem">
+      {title}
+      {body}
+      <RiskAcceptanceModal
+        isOpen={pageNumber === SITE_LAUNCH_PAGES.RISK_ACCEPTANCE}
+        setPageNumber={setPageNumber}
+      />
+    </VStack>
+  )
+}
+
+export const SiteLaunchPadPage = (): JSX.Element => {
   const {
     siteLaunchStatusProps,
     setSiteLaunchStatusProps,
@@ -175,43 +224,16 @@ export const SiteLaunchPad = (): JSX.Element => {
     }
   }
 
-  let title: JSX.Element
-  let body: JSX.Element
-  switch (pageNumber) {
-    case SITE_LAUNCH_PAGES.DISCLAIMER:
-      title = <SiteLaunchDisclaimerTitle />
-      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
-      break
-    case SITE_LAUNCH_PAGES.INFO_GATHERING:
-    case SITE_LAUNCH_PAGES.RISK_ACCEPTANCE: // Risk acceptance modal overlay
-      title = <SiteLaunchInfoCollectorTitle />
-      body = <SiteLaunchInfoCollectorBody setPageNumber={setPageNumber} />
-      break
-    case SITE_LAUNCH_PAGES.CHECKLIST:
-      title = <SiteLaunchChecklistTitle />
-      body = (
-        <SiteLaunchChecklistBody
-          handleIncrementStepNumber={handleIncrementStepNumber}
-          handleDecrementStepNumber={handleDecrementStepNumber}
-        />
-      )
-      break
-    default:
-      title = <SiteLaunchDisclaimerTitle />
-      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
-  }
   return (
     <>
       <SiteViewHeader />
       {shouldUseSiteLaunchFeature(siteName) ? (
-        <VStack bg="white" w="100%" minH="100vh" spacing="2rem">
-          {title}
-          {body}
-          <RiskAcceptanceModal
-            isOpen={pageNumber === SITE_LAUNCH_PAGES.RISK_ACCEPTANCE}
-            setPageNumber={setPageNumber}
-          />
-        </VStack>
+        <SiteLaunchPad
+          pageNumber={pageNumber}
+          setPageNumber={setPageNumber}
+          handleDecrementStepNumber={handleDecrementStepNumber}
+          handleIncrementStepNumber={handleIncrementStepNumber}
+        />
       ) : (
         <Redirect to={`/sites/${siteName}/dashboard`} />
       )}

--- a/src/layouts/SiteLaunchPad/index.ts
+++ b/src/layouts/SiteLaunchPad/index.ts
@@ -1,1 +1,1 @@
-export { SiteLaunchPad } from "./SiteLaunchPad"
+export { SiteLaunchPad, SiteLaunchPadPage } from "./SiteLaunchPad"

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -22,7 +22,7 @@ import { ResourceRoom } from "layouts/ResourceRoom"
 import { ReviewRequestDashboard } from "layouts/ReviewRequest/Dashboard"
 import { Settings } from "layouts/Settings"
 import { SiteDashboard } from "layouts/SiteDashboard"
-import { SiteLaunchPad } from "layouts/SiteLaunchPad"
+import { SiteLaunchPadPage } from "layouts/SiteLaunchPad"
 import { Sites } from "layouts/Sites"
 import { Workspace } from "layouts/Workspace"
 
@@ -104,7 +104,7 @@ export const RouteSelector = () => (
 
       <ProtectedRouteWithProps path="/sites/:siteName/siteLaunchPad">
         <SiteLaunchProvider>
-          <SiteLaunchPad />
+          <SiteLaunchPadPage />
         </SiteLaunchProvider>
       </ProtectedRouteWithProps>
 


### PR DESCRIPTION
## Problem

Now that there are different flows for the site launch flow, it would make sense to have various flows for the corresponding storybooks for faster reviewal process for upcoming PRs. 

## Solution

Individual pages have their own storybook.

<img width="1456" alt="Screenshot 2023-08-01 at 11 35 48 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/0d759eaf-0137-414e-bbc6-25d118558bd9">
<img width="1451" alt="Screenshot 2023-08-01 at 11 35 37 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/285363c6-f20d-4a77-9e0f-2a5654272f52">
<img width="1457" alt="Screenshot 2023-08-01 at 11 35 28 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/1d2b947a-50d5-41cc-ba2c-7629e1f476f6">
<img width="1456" alt="Screenshot 2023-08-01 at 11 35 14 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/f906b2b7-082a-407e-b731-18cb51068263">


