### PR TITLE
IS-349-FE-only-admins-can-launch-sites

### DIFF
--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -35,6 +35,7 @@ import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 import { useLoginContext } from "contexts/LoginContext"
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
+import { useGetCollaboratorRoleHook } from "hooks/collaboratorHooks"
 import {
   useGetSiteInfo,
   useGetReviewRequests,
@@ -64,8 +65,9 @@ export const SiteDashboard = (): JSX.Element => {
     onClose: onCollaboratorsModalClose,
   } = useDisclosure()
   const { siteName } = useParams<{ siteName: string }>()
+  const { data: role } = useGetCollaboratorRoleHook(siteName)
   const { setRedirectToPage } = useRedirectHook()
-  const { userId, email } = useLoginContext()
+  const { userId } = useLoginContext()
   const { siteLaunchStatusProps } = useSiteLaunchContext()
 
   const {
@@ -204,7 +206,7 @@ export const SiteDashboard = (): JSX.Element => {
               {/* Human image and last saved/published */}
               <Box w="100%">
                 {(siteLaunchStatus === "LAUNCHED" ||
-                  !isSiteLaunchEnabled(siteName, email)) && (
+                  !isSiteLaunchEnabled(siteName, role)) && (
                   <SiteDashboardHumanImage />
                 )}
                 <DisplayCard variant="content">
@@ -233,7 +235,7 @@ export const SiteDashboard = (): JSX.Element => {
                       </Skeleton>
 
                       <Skeleton isLoaded={!isSiteLaunchLoading} w="100%">
-                        {isSiteLaunchEnabled(siteName, email) &&
+                        {isSiteLaunchEnabled(siteName, role) &&
                           siteLaunchStatus === "LAUNCHED" && (
                             <Flex alignItems="center">
                               <Text
@@ -339,12 +341,12 @@ export const SiteDashboard = (): JSX.Element => {
 
 const SiteLaunchDisplayCard = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
-  const { email } = useLoginContext()
+  const { data: role } = useGetCollaboratorRoleHook(siteName)
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const siteLaunchStatus = siteLaunchStatusProps?.siteLaunchStatus
   const siteLaunchChecklistStepNumber = siteLaunchStatusProps?.stepNumber
   const isSiteLaunchLoading = siteLaunchStatus === "LOADING"
-  if (!isSiteLaunchEnabled(siteName, email)) return <></>
+  if (!isSiteLaunchEnabled(siteName, role)) return <></>
   if (siteLaunchStatus === "LAUNCHED") return <></>
 
   return (

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -44,7 +44,7 @@ import {
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { getDateTimeFromUnixTime } from "utils/date"
-import { shouldUseSiteLaunchFeature } from "utils/siteLaunchUtils"
+import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
 
 import { BxsClearRocket, SiteDashboardHumanImage } from "assets"
 import { FeatureTourHandler } from "features/FeatureTour/FeatureTour"
@@ -65,7 +65,7 @@ export const SiteDashboard = (): JSX.Element => {
   } = useDisclosure()
   const { siteName } = useParams<{ siteName: string }>()
   const { setRedirectToPage } = useRedirectHook()
-  const { userId } = useLoginContext()
+  const { userId, email } = useLoginContext()
   const { siteLaunchStatusProps } = useSiteLaunchContext()
 
   const {
@@ -204,7 +204,7 @@ export const SiteDashboard = (): JSX.Element => {
               {/* Human image and last saved/published */}
               <Box w="100%">
                 {(siteLaunchStatus === "LAUNCHED" ||
-                  !shouldUseSiteLaunchFeature(siteName)) && (
+                  !isSiteLaunchEnabled(siteName, email)) && (
                   <SiteDashboardHumanImage />
                 )}
                 <DisplayCard variant="content">
@@ -233,7 +233,7 @@ export const SiteDashboard = (): JSX.Element => {
                       </Skeleton>
 
                       <Skeleton isLoaded={!isSiteLaunchLoading} w="100%">
-                        {shouldUseSiteLaunchFeature(siteName) &&
+                        {isSiteLaunchEnabled(siteName, email) &&
                           siteLaunchStatus === "LAUNCHED" && (
                             <Flex alignItems="center">
                               <Text
@@ -339,11 +339,12 @@ export const SiteDashboard = (): JSX.Element => {
 
 const SiteLaunchDisplayCard = (): JSX.Element => {
   const { siteName } = useParams<{ siteName: string }>()
+  const { email } = useLoginContext()
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const siteLaunchStatus = siteLaunchStatusProps?.siteLaunchStatus
   const siteLaunchChecklistStepNumber = siteLaunchStatusProps?.stepNumber
   const isSiteLaunchLoading = siteLaunchStatus === "LOADING"
-  if (!shouldUseSiteLaunchFeature(siteName)) return <></>
+  if (!isSiteLaunchEnabled(siteName, email)) return <></>
   if (siteLaunchStatus === "LAUNCHED") return <></>
 
   return (

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -21,6 +21,8 @@ import { Redirect, useParams } from "react-router-dom"
 import { useLoginContext } from "contexts/LoginContext"
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
+import { useGetCollaboratorRoleHook } from "hooks/collaboratorHooks"
+
 import { SiteViewHeader } from "layouts/layouts/SiteViewLayout/SiteViewHeader"
 
 import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
@@ -193,15 +195,15 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   )
 
   const errorToast = useErrorToast()
-
+  const { data: role } = useGetCollaboratorRoleHook(siteName)
   useEffect(() => {
-    if (!isSiteLaunchEnabled(siteName, email)) {
+    if (!isSiteLaunchEnabled(siteName, role)) {
       errorToast({
         id: "no_access_to_launchpad",
         description: "You do not have access to this page.",
       })
     }
-  }, [siteName, errorToast, email])
+  }, [siteName, errorToast, role])
 
   const handleIncrementStepNumber = () => {
     if (
@@ -229,7 +231,7 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   return (
     <>
       <SiteViewHeader />
-      {isSiteLaunchEnabled(siteName, email) ? (
+      {isSiteLaunchEnabled(siteName, role) ? (
         <SiteLaunchPad
           pageNumber={pageNumber}
           setPageNumber={setPageNumber}

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -18,11 +18,12 @@ import { useState, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { Redirect, useParams } from "react-router-dom"
 
+import { useLoginContext } from "contexts/LoginContext"
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
 import { SiteViewHeader } from "layouts/layouts/SiteViewLayout/SiteViewHeader"
 
-import { shouldUseSiteLaunchFeature } from "utils/siteLaunchUtils"
+import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
 
 import {
   SiteLaunchStatusProps,
@@ -186,6 +187,7 @@ export const SiteLaunchPadPage = (): JSX.Element => {
     setSiteLaunchStatusProps,
   } = useSiteLaunchContext()
   const { siteName } = useParams<{ siteName: string }>()
+  const { email } = useLoginContext()
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)
   )
@@ -193,13 +195,13 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   const errorToast = useErrorToast()
 
   useEffect(() => {
-    if (!shouldUseSiteLaunchFeature(siteName)) {
+    if (!isSiteLaunchEnabled(siteName, email)) {
       errorToast({
         id: "no_access_to_launchpad",
         description: "You do not have access to this page.",
       })
     }
-  }, [siteName, errorToast])
+  }, [siteName, errorToast, email])
 
   const handleIncrementStepNumber = () => {
     if (
@@ -227,7 +229,7 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   return (
     <>
       <SiteViewHeader />
-      {shouldUseSiteLaunchFeature(siteName) ? (
+      {isSiteLaunchEnabled(siteName, email) ? (
         <SiteLaunchPad
           pageNumber={pageNumber}
           setPageNumber={setPageNumber}

--- a/src/utils/siteLaunchUtils.ts
+++ b/src/utils/siteLaunchUtils.ts
@@ -1,6 +1,6 @@
 import { WHITELISTED_REPOS } from "constants/siteLaunch"
 
-export const shouldUseSiteLaunchFeature = (siteName: string): boolean => {
+const isRepoWhitelistedForSiteLaunch = (siteName: string): boolean => {
   // The name of our sites for our storybooks is "storybook".
   // Therefore, to allow the storybook to use the site launch feature, we need to
   // explicitly check for it.
@@ -8,4 +8,15 @@ export const shouldUseSiteLaunchFeature = (siteName: string): boolean => {
     return true
   }
   return WHITELISTED_REPOS ? WHITELISTED_REPOS.includes(siteName) : false
+}
+
+const isAdminUser = (email: string): boolean => {
+  return email.endsWith(".gov.sg")
+}
+
+export const isSiteLaunchEnabled = (
+  siteName: string,
+  email: string
+): boolean => {
+  return isRepoWhitelistedForSiteLaunch(siteName) && isAdminUser(email)
 }

--- a/src/utils/siteLaunchUtils.ts
+++ b/src/utils/siteLaunchUtils.ts
@@ -1,5 +1,7 @@
 import { WHITELISTED_REPOS } from "constants/siteLaunch"
 
+import { SiteMemberRole } from "types/collaborators"
+
 const isRepoWhitelistedForSiteLaunch = (siteName: string): boolean => {
   // The name of our sites for our storybooks is "storybook".
   // Therefore, to allow the storybook to use the site launch feature, we need to
@@ -10,13 +12,13 @@ const isRepoWhitelistedForSiteLaunch = (siteName: string): boolean => {
   return WHITELISTED_REPOS ? WHITELISTED_REPOS.includes(siteName) : false
 }
 
-const isAdminUser = (email: string): boolean => {
-  return email.endsWith(".gov.sg")
+const isAdminUser = (role?: SiteMemberRole): boolean => {
+  return role === `ADMIN`
 }
 
 export const isSiteLaunchEnabled = (
   siteName: string,
-  email: string
+  role?: SiteMemberRole
 ): boolean => {
-  return isRepoWhitelistedForSiteLaunch(siteName) && isAdminUser(email)
+  return isRepoWhitelistedForSiteLaunch(siteName) && isAdminUser(role)
 }


### PR DESCRIPTION
## Problem

No access controls for site launch feature. 


## Solution

Only allow site admins to launch sites. Currently, our CMS defines admins as someone whose email ends with a `.gov.sg`. Can be reviewed with [be pr](https://github.com/isomerpages/isomercms-backend/pull/873)

## Screenshot

View of non-admin email user: 
<img width="1060" alt="Screenshot 2023-08-02 at 9 30 53 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/50b42024-1c2f-4f89-beca-2f56ca60f82d">


View of contributor access site launch pad page: 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/8f294c51-1510-4cfe-ae2b-5eb0872c01cb


