### PR TITLE
fix(header): fix context for storybook

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,5 +1,7 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { Meta, StoryFn } from "@storybook/react"
 import { MemoryRouter, Route } from "react-router-dom"
+
+import { DirtyFieldContextProvider } from "contexts/DirtyFieldContext"
 
 import { SiteEditHeader } from "layouts/layouts/SiteEditLayout"
 
@@ -25,15 +27,17 @@ const HeaderMeta = {
       return (
         <MemoryRouter initialEntries={["/sites/storybook/header"]}>
           <Route path="/sites/:siteName/header">
-            <Story />
+            <DirtyFieldContextProvider>
+              <Story />
+            </DirtyFieldContextProvider>
           </Route>
         </MemoryRouter>
       )
     },
   ],
-} as ComponentMeta<typeof SiteEditHeader>
+} as Meta<typeof SiteEditHeader>
 
-const Template: ComponentStory<typeof SiteEditHeader> = () => {
+const Template: StoryFn<typeof SiteEditHeader> = () => {
   return <SiteEditHeader />
 }
 


### PR DESCRIPTION
## Problem

Chromatic builds are failing + keeps building dev. Not 100% sure why, but the facts are:

1. We know that the way Chromatic works is that it compares UI changes against a baseline
2. Chromatic keeps building develop when `!run-chromatic` is commented on the PRs
3. There exists errors in the current develop. 
4. By extension, our baseline (develop) has errors.

## Solution

This PR attempts to test the hypothesis that is the components are fixed, does the chromatic functionality gets back up. However, I cannot test this out until this is merged into develop. 

[Note: this is a current blocker for DS upgrades, UI review of site launch changes that affect the current sprint]


## Screenshots 

### Before 
<img width="1458" alt="Screenshot 2023-08-03 at 9 27 13 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/dd05ba13-794f-420e-81a0-d2b9c90ad628">

### After 
<img width="1449" alt="Screenshot 2023-08-03 at 9 26 56 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/78542160-44b5-4284-ad83-6441cc121328">
