### PR TITLE
fix(e2e): fix branch to reset e2e test repo on

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -55,7 +55,7 @@ const resetRepo = async (repo, hash, branch) => {
 }
 
 const resetGithubE2eTestRepo = () =>
-  resetRepo(E2E_GITHUB_REPO_NAME, E2E_COMMIT_HASH, "master")
+  resetRepo(E2E_GITHUB_REPO_NAME, E2E_COMMIT_HASH, "staging")
 
 const resetEmailE2eTestRepo = () => {
   resetRepo(E2E_EMAIL_REPO_NAME, E2E_EMAIL_COMMIT_HASH, "staging")


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The reset e2e task was resetting an incorrect branch on e2e-test-repo, which causes e2e tests to not start from a clean slate and throws unrelated errors when running e2e tests.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The reset-e2e test was resetting the `master` branch, when it should be resetting the `staging` branch (to match with the value of `BRANCH_REF` in the backend, as that is the branch that the CMS edits).

## Tests

<!-- What tests should be run to confirm functionality? -->

- Run some e2e tests, then run `npm run reset-e2e` and verify that the e2e-test-repo has been correctly reset

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*