### PR TITLE
fix: move removeOtherCollaborators to use api call directly

### DIFF
--- a/cypress/api/collaborators.api.ts
+++ b/cypress/api/collaborators.api.ts
@@ -19,10 +19,10 @@ export const listCollaborators = (): Cypress.Chainable<CollaboratorDto[]> => {
   return cy.request("GET", `${BASE_URL}`).then(({ body }) => body.collaborators)
 }
 
-export const removeOtherCollaborators = (): void => {
+export const removeOtherCollaborators = (remainingEmail: string): void => {
   listCollaborators().then((collaborators) => {
     collaborators.forEach((collaborator) => {
-      if (collaborator.email === E2E_EMAIL_ADMIN.email) return
+      if (collaborator.email === remainingEmail) return
       const { id } = collaborator
       cy.request("DELETE", `${BASE_URL}/${id}`)
     })

--- a/cypress/api/collaborators.api.ts
+++ b/cypress/api/collaborators.api.ts
@@ -1,5 +1,10 @@
-import { E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
+import { CollaboratorDto } from "../../src/types/collaborators"
+import { E2E_EMAIL_ADMIN, E2E_EMAIL_TEST_SITE } from "../fixtures/constants"
 import { USER_TYPES } from "../fixtures/users"
+
+import { E2E_EMAIL_SITE_API_URL } from "./constants"
+
+const BASE_URL = `${E2E_EMAIL_SITE_API_URL}/collaborators`
 
 export const addAdmin = (admin: string): void => {
   cy.createEmailUser(
@@ -8,4 +13,18 @@ export const addAdmin = (admin: string): void => {
     USER_TYPES.Email.Admin,
     E2E_EMAIL_TEST_SITE.name
   )
+}
+
+export const listCollaborators = (): Cypress.Chainable<CollaboratorDto[]> => {
+  return cy.request("GET", `${BASE_URL}`).then(({ body }) => body.collaborators)
+}
+
+export const removeOtherCollaborators = (): void => {
+  listCollaborators().then((collaborators) => {
+    collaborators.forEach((collaborator) => {
+      if (collaborator.email === E2E_EMAIL_ADMIN.email) return
+      const { id } = collaborator
+      cy.request("DELETE", `${BASE_URL}/${id}`)
+    })
+  })
 }

--- a/cypress/e2e/reviewRequests.spec.ts
+++ b/cypress/e2e/reviewRequests.spec.ts
@@ -99,7 +99,7 @@ describe("Review Requests", () => {
       cy.setupDefaultInterceptors()
       cy.setEmailSessionDefaults("Email admin")
       visitE2eEmailTestRepo()
-      removeOtherCollaborators()
+      removeOtherCollaborators(E2E_EMAIL_ADMIN.email)
     })
 
     it("should not be able to create a review request when there are no changes", () => {
@@ -174,7 +174,7 @@ describe("Review Requests", () => {
     before(() => {
       cy.setupDefaultInterceptors()
       cy.setEmailSessionDefaults("Email admin")
-      removeOtherCollaborators()
+      removeOtherCollaborators(E2E_EMAIL_ADMIN.email)
       addAdmin(E2E_EMAIL_ADMIN_2.email)
       addCollaborator(E2E_EMAIL_COLLAB_NON_GOV.email)
       editUnlinkedPage(

--- a/cypress/e2e/reviewRequests.spec.ts
+++ b/cypress/e2e/reviewRequests.spec.ts
@@ -5,6 +5,7 @@ import {
   closeReviewRequests,
   createReviewRequest,
   mergeReviewRequest,
+  removeOtherCollaborators,
 } from "../api"
 import {
   addUnlinkedPage,
@@ -29,7 +30,6 @@ import {
   addCollaborator,
   awaitDashboardLoad,
   awaitReviewRequestSummary,
-  removeOtherCollaborators,
   visitE2eEmailTestRepo,
 } from "../utils"
 

--- a/cypress/utils/collaborators.ts
+++ b/cypress/utils/collaborators.ts
@@ -35,13 +35,6 @@ export const removeFirstCollaborator = (): void => {
   closeModal()
 }
 
-export const removeOtherCollaborators = (): void => {
-  // We have up to 3 other collaborators - this ensures all are removed
-  removeFirstCollaborator()
-  removeFirstCollaborator()
-  removeFirstCollaborator()
-}
-
 export const inputCollaborators = (user: string): void => {
   getCollaboratorsModal().get(ADD_COLLABORATOR_INPUT_SELECTOR).type(user).blur()
   // NOTE: need to ignore the 422 w/ specific error message because we haven't ack yet


### PR DESCRIPTION
This PR fixes our review request tests so that it's no longer dependent on the number of collaborators - previously we were removing collaborators via the UI, which caused the tests to break if we did not have the correct number of collaborators. This PR modifies the util method `removeOtherCollaborators` to make an api call to our backend directly in order to bypass this issue.