### PR TITLE
ci(Mergify): only request reviews for stale open PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,9 +25,10 @@ pull_request_rules:
       merge:
         method: squash
 
-  - name: Ping isomer members for stale PRs (>1 month since last activity)
+  - name: Ping Isomer members for stale open PRs (>1 month since last activity)
     conditions:
       - updated-at<30 days ago
+      - -closed
     actions:
       request_reviews:
         teams:


### PR DESCRIPTION
## Problem

Mergify keeps going to old PRs and pinging the team for reviews, when they have already been merged or closed.

## Solution

Fix the conditions to only ping the team for stale and open PRs.