### PR TITLE
feat(site launch): recommending www domain 

### DIFF
--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -387,17 +387,22 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
               Site launch
             </DisplayCardTitle>
             <DisplayCardCaption>
-              Associate your isomer site to a domain
+              Associate your Isomer site to a domain
             </DisplayCardCaption>
           </DisplayCardHeader>
           <DisplayCardContent>
             {siteLaunchStatus === "CHECKLIST_TASKS_PENDING" && (
-              <Text textStyle="body-2">
-                {siteLaunchChecklistStepNumber}/{SITE_LAUNCH_TASKS_LENGTH}
+              <Text textStyle="body-2" mt="1rem">
+                <Text as="b">
+                  {siteLaunchChecklistStepNumber}/{SITE_LAUNCH_TASKS_LENGTH}
+                </Text>{" "}
+                site launch tasks completed
               </Text>
             )}
             {siteLaunchStatus === "LAUNCHING" && (
-              <Text textStyle="body-2">Launch status: Pending</Text>
+              <Text textStyle="body-2" mt="1rem">
+                Launch status: Pending
+              </Text>
             )}
           </DisplayCardContent>
         </Skeleton>

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -370,7 +370,7 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
                 )}
                 {siteLaunchStatus === "CHECKLIST_TASKS_PENDING" && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
-                    Visit launchpad
+                    Get started
                   </Text>
                 )}
                 {siteLaunchStatus === "LAUNCHING" && (

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -76,7 +76,7 @@ const RiskAcceptanceModal = ({
         <ModalBody mt="2rem">
           <Text textStyle="body-2" fontWeight="bold" mb="2rem">
             The biggest reason for site launch failure is because of unknown
-            Cloudfront records.
+            CloudFront records.
           </Text>
 
           <Text textStyle="body-2" mb="2rem">

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -83,14 +83,17 @@ const RiskAcceptanceModal = ({
             <Text as="b">Please do your best to find this out. </Text>
             If you are unsure, consult your ITD team on this. If your domain is
             a .gov.sg domain, you can go to{" "}
-            <Link href="https://dnschecker.org/">DNS checker</Link> and where it
-            points to. If it points to 35.201.83.130, you must contact CWP to
-            drop corresponding CloudFront records for your domain.
+            <Link href="https://dnschecker.org/" isExternal>
+              DNS checker
+            </Link>{" "}
+            and where it points to. If it points to 35.201.83.130, you must
+            contact CWP to drop corresponding CloudFront records for your
+            domain.
           </Text>
 
           <Text textStyle="body-2" mb="4rem">
             Isomer will not be held liable for any extended period of downtime
-            due to unknown cloudfront records. Downtime could happen even if
+            due to unknown CloudFront records. Downtime could happen even if
             your site is not currently using CloudFront, but has used it
             previously.
           </Text>

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -76,24 +76,22 @@ const RiskAcceptanceModal = ({
         <ModalBody mt="2rem">
           <Text textStyle="body-2" fontWeight="bold" mb="2rem">
             The biggest reason for site launch failure is because of unknown
-            cloudfront records.
+            Cloudfront records.
           </Text>
 
           <Text textStyle="body-2" mb="2rem">
             <Text as="b">Please do your best to find this out. </Text>
             If you are unsure, consult your ITD team on this. If your domain is
-            a .gov.sg domain, You can go to{" "}
-            <Link href="https://dnschecker.org/">DNS checker</Link> and check if
-            your A record points to:
-          </Text>
-          <Text textStyle="body-2" mb="2rem">
-            35.201.83.130
+            a .gov.sg domain, you can go to{" "}
+            <Link href="https://dnschecker.org/">DNS checker</Link> and where it
+            points to. If it points to 35.201.83.130, you must contact CWP to
+            drop corresponding CloudFront records for your domain.
           </Text>
 
           <Text textStyle="body-2" mb="4rem">
             Isomer will not be held liable for any extended period of downtime
             due to unknown cloudfront records. Downtime could happen even if
-            your site is not currently using cloudfront, but has used it
+            your site is not currently using CloudFront, but has used it
             previously.
           </Text>
 

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -277,6 +277,9 @@ export const SiteLaunchChecklistBody = ({
     })
   }
 
+  return (
+    <SiteLaunchPadBody>
+      <Text mb="2rem">
         <Text as="b">Tasks must be done in this order. </Text>
         Mark the task as done to enable the next task item. Once all items are
         marked done, you can proceed to the next page to track your site launch

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -277,9 +277,6 @@ export const SiteLaunchChecklistBody = ({
     })
   }
 
-  return (
-    <SiteLaunchPadBody>
-      <Text mb="2rem">
         <Text as="b">Tasks must be done in this order. </Text>
         Mark the task as done to enable the next task item. Once all items are
         marked done, you can proceed to the next page to track your site launch

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -138,9 +138,12 @@ const addSubtitlesForChecklist = (
     newTask.subTitle = (
       <>
         {tasksDone === SITE_LAUNCH_TASKS.SET_DNS_TTL - 1 && (
-          <Text fontSize="small">
+          <Text fontSize="small" textColor="base.content.medium">
             You can check your current DNS TTL through 3rd party applications
-            such as <Link href="https://www.nslookup.io/">nslookup.io</Link>
+            such as{" "}
+            <Link href="https://www.nslookup.io/" isExternal>
+              nslookup.io
+            </Link>
           </Text>
         )}
       </>
@@ -151,7 +154,7 @@ const addSubtitlesForChecklist = (
     newTask.subTitle = (
       <>
         {tasksDone === SITE_LAUNCH_TASKS.DROP_CLOUDFRONT - 1 && (
-          <Text fontSize="small">
+          <Text fontSize="small" textColor="base.content.medium">
             If you are using CWP, please contact them to do this for you
           </Text>
         )}
@@ -163,7 +166,7 @@ const addSubtitlesForChecklist = (
     newTask.subTitle = (
       <>
         {tasksDone === SITE_LAUNCH_TASKS.DELETE_EXISTING_DNS_RECORDS - 1 && (
-          <Text fontSize="small">
+          <Text fontSize="small" textColor="base.content.medium">
             This should be done as soon as domains are dropped
           </Text>
         )}
@@ -258,7 +261,7 @@ export const SiteLaunchChecklistBody = ({
           fontSize="s"
           key={i}
           textStyle="subhead-2"
-          textColor="base.content.dark"
+          textColor="base.content.strong"
           {...getTextProps(i, tasksDone)}
         >
           {siteLaunchStatusProps?.isNewDomain
@@ -301,7 +304,7 @@ export const SiteLaunchChecklistBody = ({
             <Thead>
               <Tr>
                 <Td bg="gray.100" width="70%">
-                  <Text>
+                  <Text textStyle="subhead-2">
                     Site launch tasks ({tasksDone}/{numberOfTasks})
                   </Text>
                 </Td>
@@ -364,7 +367,8 @@ export const SiteLaunchChecklistBody = ({
                     {!siteLaunchStatusProps?.dnsRecords && (
                       <>
                         <Text>
-                          Generating your DNS records will take 2 minutes.
+                          Generating your DNS records will take around 2
+                          minutes.
                         </Text>
                         <Text>
                           Do not leave or refresh this page in the meantime.

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -2,14 +2,15 @@ import { Box, Icon, ListItem, Text, UnorderedList } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { BiRightArrowAlt } from "react-icons/bi"
 
+import { typography } from "theme/foundations/typography"
 import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
 import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
 import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
 
 export const SiteLaunchDisclaimerTitle = (): JSX.Element => {
-  const title = "Welcome to the launchpad"
-  const subTitle = "Track and manage your site launch here"
+  const title = "Before you launch your site"
+  const subTitle = "Please review the information on this page carefully"
   return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
 }
 
@@ -26,7 +27,9 @@ export const SiteLaunchDisclaimerBody = ({
         What is site launch?
       </Text>
       <Text textStyle="body-2" mb="2rem">
-        Site launch is the process of connecting your Isomer site to a domain,
+        <Text as="b" fontWeight={typography.fontWeights.bold}>
+          Site launch is the process of connecting your Isomer site to a domain
+        </Text>{" "}
         and making it publicly available on the internet. You will need to do
         this using your service provider for your name server, which is separate
         from Isomer. Typically, this would be the IT Service Management (ITSM).
@@ -34,11 +37,17 @@ export const SiteLaunchDisclaimerBody = ({
       <Text textStyle="body-2" mb="2rem">
         Isomer provides the credentials you need to add or change in your name
         server (typically ITSM),{" "}
-        <Text as="b">but cannot update them on your behalf.</Text>However, you
-        can come back here after updating the credentials, to check if your
-        website is launched and publicly accessible.
+        <Text as="b" fontWeight={typography.fontWeights.bold}>
+          but cannot update them on your behalf.{" "}
+        </Text>
+        However, you can come back here after updating the credentials, to check
+        if your website is launched and publicly accessible.
       </Text>
-      <Text textStyle="body-2" as="b">
+
+      <Text
+        fontSize={typography.fontSize.sm}
+        fontWeight={typography.fontWeights.bold}
+      >
         You should only launch your site when:
       </Text>
 
@@ -77,10 +86,11 @@ export const SiteLaunchDisclaimerBody = ({
         </ListItem>
         <ListItem>
           <Text textStyle="body-2">
-            If you are unfamiliar with site launches, we recommend getting
-            someone from your IT team to launch your site for you. You can add
-            them as a collaborator to your site, and remove them after it has
-            been launched.
+            If you are unfamiliar with site launches,{" "}
+            <Text as="b">
+              we recommend getting someone from your IT team to help you launch
+              your site.
+            </Text>
           </Text>
         </ListItem>
       </UnorderedList>
@@ -92,7 +102,7 @@ export const SiteLaunchDisclaimerBody = ({
           ml="auto"
           onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)} // going to the next page}
         >
-          I understand
+          Continue
         </Button>
       </Box>
     </SiteLaunchPadBody>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -1,5 +1,6 @@
 import { Box, Icon, ListItem, Text, UnorderedList } from "@chakra-ui/react"
-import { Button } from "@opengovsg/design-system-react"
+import { Button, Checkbox } from "@opengovsg/design-system-react"
+import { useForm } from "react-hook-form"
 import { BiRightArrowAlt } from "react-icons/bi"
 
 import { typography } from "theme/foundations/typography"
@@ -21,6 +22,8 @@ interface SiteLaunchDisclaimerBodyProps {
 export const SiteLaunchDisclaimerBody = ({
   setPageNumber,
 }: SiteLaunchDisclaimerBodyProps): JSX.Element => {
+  const { register, handleSubmit, watch } = useForm({})
+  const isRequirementUnderstood = watch("isRequirementUnderstood")
   return (
     <SiteLaunchPadBody>
       <Text as="h5" textStyle="h5">
@@ -60,7 +63,7 @@ export const SiteLaunchDisclaimerBody = ({
       <Text as="h5" textStyle="h5">
         Important
       </Text>
-      <UnorderedList mb="2rem">
+      <UnorderedList>
         <ListItem>
           <Text textStyle="body-2">
             Site launch is a time-sensitive process and often requires
@@ -94,13 +97,21 @@ export const SiteLaunchDisclaimerBody = ({
           </Text>
         </ListItem>
       </UnorderedList>
-
-      <Box display="flex" justifyContent="flex-end">
+      <Checkbox mt="3rem" {...register("isRequirementUnderstood")}>
+        <Text textColor="base.content.default" textStyle="body-1">
+          I have read and understood the requirements to launch my site
+        </Text>
+      </Checkbox>
+      <Box display="flex" justifyContent="flex-end" mt="1.5rem">
         <Button
+          isDisabled={!isRequirementUnderstood}
           rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
           iconSpacing="1rem"
           ml="auto"
-          onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)} // going to the next page}
+          onClick={handleSubmit(() => {
+            // going to the next page
+            setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)
+          })}
         >
           Continue
         </Button>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -185,9 +185,6 @@ export const SiteLaunchInfoCollectorBody = ({
               Do you want to host the both the www and non-www version of your
               domain?
             </Text>
-            <Text textStyle="subhead-2">
-              Select &quot;Yes&quot; if you are not sure
-            </Text>
             <RadioGroup
               {...register("useWww")}
               onChange={handleWwwQn}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -81,7 +81,6 @@ export const SiteLaunchInfoCollectorBody = ({
       // keep the state as is, disallow unselecting
       return
     }
-    setIsWwwRecommended(recommendWwwValue(watch("domain")))
     setSelectedDomainNature(response)
     setDisplayWwwQn(true)
   }

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -115,19 +115,23 @@ export const SiteLaunchInfoCollectorBody = ({
           {...register("domain", {
             required: "Domain is required",
             validate: (value) => {
-              if (value.startsWith("www."))
-                return "Remove 'www.' at the start of your domain"
-              if (value.startsWith("."))
-                return "Remove '.' at the start of your domain"
-              if (value.startsWith("http://"))
-                return "Remove 'http://' at the start of your domain"
-              if (value.startsWith("https://"))
-                return "Remove 'https://' at the start of your domain"
-              if (value.endsWith("/"))
-                return "Remove '/' at the end of your domain"
-              if (!value.endsWith(".com") && !value.endsWith(".sg"))
-                return "Enter a valid URL that ends with a '.com' or '.sg'"
+              if (
+                value.startsWith("www.") ||
+                value.startsWith("http://") ||
+                value.startsWith("https://")
+              ) {
+                return "Your domain cannot begin with 'http://', 'https://' or 'www.'"
+              }
 
+              const invalidTld =
+                !value.endsWith(".com") && !value.endsWith(".sg")
+              if (value.endsWith("/") || invalidTld) {
+                return "Your domain must end with '.com' or '.sg'\nCheck that your domain doesn't end with '/'"
+              }
+
+              if (value.startsWith(".")) {
+                return "Check that your domain is valid and try again"
+              }
               return true
             },
           })}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -1,5 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { Box, Button, Icon, Text, RadioGroup } from "@chakra-ui/react"
+import {
+  Box,
+  Button,
+  Icon,
+  Text,
+  RadioGroup,
+  InputGroup,
+  InputLeftAddon,
+} from "@chakra-ui/react"
 import { Input, Radio } from "@opengovsg/design-system-react"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
@@ -65,13 +73,34 @@ export const SiteLaunchInfoCollectorBody = ({
   return (
     <SiteLaunchPadBody>
       <Text textStyle="subhead-1">What domain are you launching with?</Text>
-      <Input
-        mt="4"
-        mb="1"
-        placeholder="eg: www.isomer.gov.sg"
-        {...register("domain", { required: true })}
-      />
-      {errors.domain && <Text textStyle="subhead-2">Domain is required</Text>}
+      <InputGroup mt="4" mb="1">
+        <InputLeftAddon>https://</InputLeftAddon>
+        <Input
+          placeholder="eg: isomer.gov.sg"
+          {...register("domain", {
+            required: true,
+            validate: (value) => {
+              if (value.startsWith("www."))
+                return "Please remove any leading 'www.'"
+              if (value.startsWith("http://"))
+                return "Please remove any leading 'http://'"
+              if (value.startsWith("https://"))
+                return "Please remove any leading 'https://'"
+              if (value.endsWith("/")) return "Please remove any trailing '/'"
+              if (!value.endsWith(".com") && !value.endsWith(".sg"))
+                return "Please enter a valid URL that ends with '.com' or '.sg'"
+
+              return true
+            },
+          })}
+        />
+      </InputGroup>
+      {errors.domain?.type === "required" && (
+        <Text textStyle="subhead-2">Domain is required</Text>
+      )}
+      {errors.domain?.type === "validate" && (
+        <Text textStyle="subhead-2">{errors.domain.message}</Text>
+      )}
 
       <Text textStyle="subhead-1" mt="1.5rem">
         Do you want to host the both the www and non-www version of your domain?

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -8,8 +8,14 @@ import {
   InputGroup,
   InputLeftAddon,
   HStack,
+  FormControl,
 } from "@chakra-ui/react"
-import { Badge, Input, Radio } from "@opengovsg/design-system-react"
+import {
+  Badge,
+  FormErrorMessage,
+  Input,
+  Radio,
+} from "@opengovsg/design-system-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { BiRightArrowAlt } from "react-icons/bi"
@@ -106,119 +112,132 @@ export const SiteLaunchInfoCollectorBody = ({
 
   return (
     <SiteLaunchPadBody>
-      <Text textStyle="subhead-1">What domain are you launching with?</Text>
-      <InputGroup mt="4" mb="1">
-        <InputLeftAddon>https://</InputLeftAddon>
-        <Input
-          placeholder="isomer.gov.sg"
-          {...register("domain", {
-            required: "Domain is required",
-            validate: (value) => {
-              if (
-                value.startsWith("www.") ||
-                value.startsWith("http://") ||
-                value.startsWith("https://")
-              ) {
-                return "Your domain cannot begin with 'http://', 'https://' or 'www.'"
-              }
+      <FormControl isInvalid={!!errors.domain}>
+        <Text textStyle="subhead-1">What domain are you launching with?</Text>
+        <InputGroup mt="4" mb="1">
+          <InputLeftAddon>https://</InputLeftAddon>
+          <Input
+            placeholder="isomer.gov.sg"
+            {...register("domain", {
+              required: "Domain is required",
+              validate: (value) => {
+                if (
+                  value.startsWith("www.") ||
+                  value.startsWith("http://") ||
+                  value.startsWith("https://")
+                ) {
+                  return "Your domain cannot begin with 'http://', 'https://' or 'www.'"
+                }
 
-              const invalidTld =
-                !value.endsWith(".com") && !value.endsWith(".sg")
-              if (value.endsWith("/") || invalidTld) {
-                return "Your domain must end with '.com' or '.sg'\nCheck that your domain doesn't end with '/'"
-              }
+                const invalidTld =
+                  !value.endsWith(".com") && !value.endsWith(".sg")
+                if (value.endsWith("/") || invalidTld) {
+                  return `Your domain must end with '.com' or '.sg'\nCheck that your domain doesn't end with '/'`
+                }
 
-              if (value.startsWith(".")) {
-                return "Check that your domain is valid and try again"
-              }
-              return true
-            },
-          })}
-        />
-      </InputGroup>
-      {errors.domain && (
-        <Text textStyle="subhead-2">{errors.domain.message}</Text>
-      )}
+                if (value.startsWith(".")) {
+                  return "Check that your domain is valid and try again"
+                }
+                return true
+              },
+            })}
+          />
+        </InputGroup>
+        <FormErrorMessage>
+          <Box>
+            {errors.domain?.message?.split("\n").map((msg) => {
+              return (
+                <Text
+                  textStyle="subhead-2"
+                  textColor="utility.feedback.critical"
+                >
+                  {msg}
+                </Text>
+              )
+            })}
+          </Box>
+        </FormErrorMessage>
 
-      <Text textStyle="subhead-1" mt="1.5rem">
-        What is the nature of the domain you are launching with?
-      </Text>
-      <RadioGroup
-        {...register("nature")}
-        onChange={handleDomainNatureQn}
-        mt="0.25rem"
-        value={selectedDomainNature}
-      >
-        <Radio value={SiteNature.New} mb="0.25rem">
-          <Text textStyle="body-1" color="black">
-            It is a brand new domain
-          </Text>
-        </Radio>
-        <Radio value={SiteNature.Live}>
-          <Text textStyle="body-1" color="black">
-            This domain is currently live or was previously live
-          </Text>
-        </Radio>
-      </RadioGroup>
+        <Text textStyle="subhead-1" mt="1.5rem">
+          What is the nature of the domain you are launching with?
+        </Text>
+        <RadioGroup
+          {...register("nature")}
+          onChange={handleDomainNatureQn}
+          mt="0.25rem"
+          value={selectedDomainNature}
+        >
+          <Radio value={SiteNature.New} mb="0.25rem">
+            <Text textStyle="body-1" color="black">
+              It is a brand new domain
+            </Text>
+          </Radio>
+          <Radio value={SiteNature.Live}>
+            <Text textStyle="body-1" color="black">
+              This domain is currently live or was previously live
+            </Text>
+          </Radio>
+        </RadioGroup>
 
-      {displayWwwQn && (
-        <>
-          <Text textStyle="subhead-1" mt="1.5rem">
-            Do you want to host the both the www and non-www version of your
-            domain?
-          </Text>
-          <Text textStyle="subhead-2">
-            Select &quot;Yes&quot; if you are not sure
-          </Text>
-          <RadioGroup
-            {...register("useWww")}
-            onChange={handleWwwQn}
-            mt="0.25rem"
-            value={wwwSetting}
+        {displayWwwQn && (
+          <>
+            <Text textStyle="subhead-1" mt="1.5rem">
+              Do you want to host the both the www and non-www version of your
+              domain?
+            </Text>
+            <Text textStyle="subhead-2">
+              Select &quot;Yes&quot; if you are not sure
+            </Text>
+            <RadioGroup
+              {...register("useWww")}
+              onChange={handleWwwQn}
+              mt="0.25rem"
+              value={wwwSetting}
+            >
+              <Radio value="true" mb="0.25rem">
+                <HStack>
+                  <Text textStyle="body-1" color="black">
+                    Yes, host both www and non-www version
+                  </Text>
+                  {isWwwRecommended && <RecommendedBadge />}
+                </HStack>
+              </Radio>
+              <Radio value="false">
+                <HStack>
+                  <Text textStyle="body-1" color="black">
+                    No, host only the non-www version
+                  </Text>
+                  {!isWwwRecommended && <RecommendedBadge />}
+                </HStack>
+              </Radio>
+            </RadioGroup>
+          </>
+        )}
+        <Box display="flex" justifyContent="flex-end" mt="2rem">
+          <Button
+            variant="link"
+            mr={4}
+            onClick={() => setPageNumber(SITE_LAUNCH_PAGES.DISCLAIMER)}
+            height="2.75rem"
           >
-            <Radio value="true" mb="0.25rem">
-              <HStack>
-                <Text textStyle="body-1" color="black">
-                  Yes, host both www and non-www version
-                </Text>
-                {isWwwRecommended && <RecommendedBadge />}
-              </HStack>
-            </Radio>
-            <Radio value="false">
-              <HStack>
-                <Text textStyle="body-1" color="black">
-                  No, host only the non-www version
-                </Text>
-                {!isWwwRecommended && <RecommendedBadge />}
-              </HStack>
-            </Radio>
-          </RadioGroup>
-        </>
-      )}
-      <Box display="flex" justifyContent="flex-end" mt="2rem">
-        <Button
-          variant="link"
-          mr={4}
-          onClick={() => setPageNumber(SITE_LAUNCH_PAGES.DISCLAIMER)}
-          height="2.75rem"
-        >
-          <Text textColor="base.content.strong">Cancel</Text>
-        </Button>
-        <Button
-          rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
-          type="submit"
-          onClick={handleSubmit(onSubmit)}
-          isDisabled={
-            !!errors.domain ||
-            !selectedDomainNature ||
-            !watch("domain") ||
-            !wwwSetting
-          }
-          height="2.75rem"
-        >
-          Next
-        </Button>
-      </Box>
+            <Text textColor="base.content.strong">Cancel</Text>
+          </Button>
+          <Button
+            rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
+            type="submit"
+            onClick={handleSubmit(onSubmit)}
+            isDisabled={
+              !!errors.domain ||
+              !selectedDomainNature ||
+              !watch("domain") ||
+              !wwwSetting
+            }
+            height="2.75rem"
+          >
+            Next
+          </Button>
+        </Box>
+      </FormControl>
     </SiteLaunchPadBody>
   )
 }

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -76,19 +76,20 @@ export const SiteLaunchInfoCollectorBody = ({
       <InputGroup mt="4" mb="1">
         <InputLeftAddon>https://</InputLeftAddon>
         <Input
-          placeholder="eg: isomer.gov.sg"
+          placeholder="domain.gov.sg"
           {...register("domain", {
             required: true,
             validate: (value) => {
               if (value.startsWith("www."))
-                return "Please remove any leading 'www.'"
+                return "Remove 'www.' at the start of your domain"
               if (value.startsWith("http://"))
-                return "Please remove any leading 'http://'"
+                return "Remove 'http://' at the start of your domain"
               if (value.startsWith("https://"))
-                return "Please remove any leading 'https://'"
-              if (value.endsWith("/")) return "Please remove any trailing '/'"
+                return "Remove 'https://' at the start of your domain"
+              if (value.endsWith("/"))
+                return "Remove '/' at the end of your domain"
               if (!value.endsWith(".com") && !value.endsWith(".sg"))
-                return "Please enter a valid URL that ends with '.com' or '.sg'"
+                return "Enter a valid URL that ends with a '.com' or '.sg'"
 
               return true
             },

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -77,14 +77,11 @@ export const SiteLaunchInfoCollectorBody = ({
   const [isWwwRecommended, setIsWwwRecommended] = useState(true)
 
   const handleDomainNatureQn = (response: string) => {
-    console.log({ response, selectedRadio: selectedDomainNature })
     if (response === "") {
       // keep the state as is, disallow unselecting
       return
     }
-    console.log(watch("domain"))
     setIsWwwRecommended(recommendWwwValue(watch("domain")))
-    console.log(recommendWwwValue(watch("domain")))
     setSelectedDomainNature(response)
     setDisplayWwwQn(true)
   }
@@ -97,15 +94,17 @@ export const SiteLaunchInfoCollectorBody = ({
     setWwwSetting(response)
   }
 
+  const inputDomain = watch("domain")
   useEffect(() => {
-    if (displayWwwQn) setIsWwwRecommended(recommendWwwValue(watch("domain")))
-  }, [displayWwwQn, watch])
+    if (displayWwwQn) setIsWwwRecommended(recommendWwwValue(inputDomain))
+  }, [displayWwwQn, inputDomain])
 
   const RecommendedBadge = () => (
     <Badge colorScheme="success" variant="subtle">
       <Text textColor="utility.feedback.success">Recommended</Text>
     </Badge>
   )
+
   return (
     <SiteLaunchPadBody>
       <Text textStyle="subhead-1">What domain are you launching with?</Text>
@@ -204,8 +203,14 @@ export const SiteLaunchInfoCollectorBody = ({
         </Button>
         <Button
           rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
+          type="submit"
           onClick={handleSubmit(onSubmit)}
-          isDisabled={!selectedDomainNature || !watch("domain") || !wwwSetting}
+          isDisabled={
+            !!errors.domain ||
+            !selectedDomainNature ||
+            !watch("domain") ||
+            !wwwSetting
+          }
           height="2.75rem"
         >
           Next

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -80,7 +80,7 @@ export const TITLE_TEXTS_OLD_DOMAIN: Record<
   SET_DNS_TTL:
     "Set your DNS Time To Live(TTL) to 5 mins at least 24 hours before launching",
   APPROVE_FIRST_REVIEW_REQUEST: "Approve and publish your first review request",
-  DROP_CLOUDFRONT: "Drop existing domains on Cloudfront",
+  DROP_CLOUDFRONT: "Drop existing domains on CloudFront",
   DELETE_EXISTING_DNS_RECORDS:
     "Delete existing DNS records from your nameserver",
   WAIT_1_HOUR: "Wait 1 hour to flush existing records",

--- a/src/utils/site-launch/domain-nature.ts
+++ b/src/utils/site-launch/domain-nature.ts
@@ -1,0 +1,20 @@
+export const recommendWwwValue = (domain: string): boolean => {
+  const commonDomains = ["gov.sg", "com.sg", ".org.sg", ".net.sg"]
+
+  if (commonDomains.some((commonDomain) => domain.endsWith(commonDomain))) {
+    if (domain.split(".").length === 3) return true
+    return false
+  }
+
+  if (domain.endsWith("moe.edu.sg")) {
+    if (domain.split(".").length === 4) return true
+    return false
+  }
+
+  if (domain.endsWith(".sg")) {
+    if (domain.split(".").length === 2) return true
+    return false
+  }
+  // Default to true
+  return true
+}

--- a/src/utils/site-launch/domain-nature.ts
+++ b/src/utils/site-launch/domain-nature.ts
@@ -1,4 +1,6 @@
 export const recommendWwwValue = (domain: string): boolean => {
+  if (!domain) return true
+
   const commonDomains = ["gov.sg", "com.sg", ".org.sg", ".net.sg"]
 
   if (commonDomains.some((commonDomain) => domain.endsWith(commonDomain))) {
@@ -11,7 +13,7 @@ export const recommendWwwValue = (domain: string): boolean => {
     return false
   }
 
-  if (domain.endsWith(".sg")) {
+  if (domain.endsWith(".sg") || domain.endsWith(".com")) {
     if (domain.split(".").length === 2) return true
     return false
   }


### PR DESCRIPTION
## Problem

During the user trial, user was confused on the format in which to add in the url  + which option to choose regarding the `www` vs `non-www` (this was already a power user of isomer who already had experience launching numerous sites before. 

## Solution

This PR addresses that pain point to make the flow clearer. Note that the general rule of thumb here is that 3rd level domains -> have www, 4h level -> no www
The exception here are schools with `<blah>.moe.edu.sg`, which we have www at the 4th level, and no www at the 5th level and above.

This PR also adds a bit of loose URL validation (commented in the PR). My hunch here is that strict url validation is not a requirement here, and thus I rather keep this loose for flexibility + avoid false negatives. 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/0fbd93f5-9234-4fd2-b257-1603e7c10347

## Alternatives considered
Input sanitation. Opted for validation here due for a quicker solution + absolute clarity to the user and bring to attention the __**exact**__ url that is going to be launched. 


## Designer Notes 
@sehyunidaaa, as discussed now there will be 3 error states. The video was taken when this PR was created, please refer to [here](https://www.chromatic.com/build?appId=61fcc8e14c3af9003a102ac9&number=1928) for the corresponding storybooks! Need your help to accept baseline too! [Design review blocked by storybook, remove this once chromatic builds work again]