### PR TITLE
fix(preview): update styling

### DIFF
--- a/src/styles/isomer-cms/elements/breadcrumb.scss
+++ b/src/styles/isomer-cms/elements/breadcrumb.scss
@@ -1,5 +1,4 @@
 @import "./variable";
-@import "./buttons";
 
 .breadcrumb {
   display: flex;

--- a/src/styles/isomer-cms/elements/form.scss
+++ b/src/styles/isomer-cms/elements/form.scss
@@ -1,5 +1,4 @@
 @import "./variable";
-@import "./buttons";
 
 .inputGroup {
   margin-bottom: 20px;

--- a/src/styles/isomer-cms/elements/modal.scss
+++ b/src/styles/isomer-cms/elements/modal.scss
@@ -1,5 +1,4 @@
 @import "./variable";
-@import "./buttons";
 
 .overlay {
   visibility: visible;

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -3,6 +3,43 @@
 @import "../elements/variable";
 
 .preview-styles {
+  // NOTE: These css variables all come from sgds.
+  // This has to be done because the css variables will
+  // otherwise be undefined at runtime as
+  // they are not loaded by sass.
+  --font-size-h1-display: 5.25rem;
+  --font-size-h1-mobile: 2.75rem;
+  --font-size-h1-display-mobile: 3.5rem;
+  --font-size-h1: 3.375rem;
+  --font-size-h1-lh: 3.75rem;
+  --font-size-h2: 2.75rem;
+  --font-size-h2-lh: 3.75rem;
+  --font-size-h2-mobile: 2rem;
+  --font-size-h3: 2rem;
+  --font-size-h3-lh: 2.8125rem;
+  --font-size-h3-mobile: 1.75rem;
+  --font-size-h4: 1.625rem;
+  --font-size-h4-lh: 2.25rem;
+  --font-size-h4-mobile: 1.5rem;
+  --font-size-h5: 1.375rem;
+  --font-size-h5-lh: 1.875rem;
+  --font-size-h6: 1.3rem;
+  --font-size-h6-lh: 1.5rem;
+  --font-size-p: 1.125rem;
+  --font-size-p-lh: 2rem;
+  --font-size-p-lh-content: 2.2rem;
+  --font-size-small: 1rem;
+  --card-variant-highlight-margin-top: 80px;
+  --global-alignment: 1rem;
+  --global-alignment-multiplier-xs: 0.25;
+  --global-alignment-multiplier-sm: 0.5;
+  --global-alignment-multiplier-lg: 2;
+  --global-alignment-multiplier-xl: 4;
+  --timepicker-height: 70px;
+  --radius: 0;
+  --radius-sm: 2px;
+  --radius-lg: 5px;
+
   @include meta.load-css("../../preview-panel.scss");
 }
 

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -1,5 +1,4 @@
 @charset "UTF-8";
-@import "./isomer-cms/elements/variable";
 .bg-media-color-0 {
   background-color: #4b268e;
 }
@@ -11901,7 +11900,6 @@ html.has-navbar-fixed-top-widescreen {
 }
 
 #key-highlights .col {
-  cursor: default;
   transition: all 0.5s;
   border-left: 1px solid #03648d;
 }

--- a/src/styles/preview-panel.scss
+++ b/src/styles/preview-panel.scss
@@ -2,6 +2,7 @@
 
 @include meta.load-css("sgds-govtech/css/sgds");
 @include meta.load-css("./isomer-template.scss");
+
 /*! minireset.css v0.0.2 | MIT License | github.com/jgthms/minireset.css */
 blockquote,
 body,


### PR DESCRIPTION
## Problem
There are 2 user-facing problems, post design system upgrade (tbh idk why the upgrade causes it too).

Firstly, the homepage title was extremely small.
Secondly, hovering over the key-highlights section does not display the cursor as a pointer.

Closes IS-413

## Solution
1. For the homepage title, it was observed that the css variables required were missing. to fix this, the actual css file was inspected and the variables defined therein was **copied** over. Do take note that somehow, `sgds` styling is applied **over** our template styling despite the the `isomer-template` import occurring later... (see `.preview-panel`)
**Hero title post removal**
![Screenshot 2023-08-08 at 2 07 48 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/88baafa6-0e5e-4d28-a0ed-5057c7fd1651)

2. Removed `cursor: default` in our **template** styling so that the cursor will be `pointer` when hovering over key-highlights. To verify this, i checked against the actual staging site itself (ss attached below)
![Screenshot 2023-08-08 at 1 24 12 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/792531b5-d576-4973-9b5d-dbfdd51a1dee)

**NOTE: This isn't a design system issue** - checked against `master` prior to ds release, also had this ._.

Note that for `#key-highlights > .col`, there is **no** cursor styling, suggesting that our css in the CMS is out of date... 

3. removal of extra import (`buttons.scss`) - previously removed
4. removal of variable import in **template** css. This was checked by searching for css variables in the template css file and none from the variable import was found. 

## Tests 
- [ ] Go to homepage section
- [ ] Hovering over the highlights section on the preview panel should have your cursor change to pointer
- [ ] Add a hero title
- [ ] The hero title should look the same as the one on the staging site
