### PR TITLE
ref(homepage): use new components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "toml": "^3.0.0",
         "turndown": "^7.1.1",
         "turndown-plugin-gfm": "^1.0.2",
-        "uuid": "^3.3.3",
+        "uuid": "^3.4.0",
         "webpack": "^5.76.1",
         "yaml": "^1.10.2",
         "yup": "^0.32.11"
@@ -104,6 +104,7 @@
         "@types/react-color": "^3.0.6",
         "@types/react-router-dom": "^5.3.3",
         "@types/turndown": "^5.0.1",
+        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^5.55.0",
         "@typescript-eslint/parser": "^5.55.0",
         "auto-changelog": "^2.4.0",
@@ -11182,6 +11183,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.5",
@@ -36792,7 +36799,9 @@
     },
     "node_modules/uuid": {
       "version": "3.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "toml": "^3.0.0",
     "turndown": "^7.1.1",
     "turndown-plugin-gfm": "^1.0.2",
-    "uuid": "^3.3.3",
+    "uuid": "^3.4.0",
     "webpack": "^5.76.1",
     "yaml": "^1.10.2",
     "yup": "^0.32.11"
@@ -150,6 +150,7 @@
     "@types/react-color": "^3.0.6",
     "@types/react-router-dom": "^5.3.3",
     "@types/turndown": "^5.0.1",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
     "auto-changelog": "^2.4.0",

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -1,5 +1,5 @@
 import { Droppable, Draggable } from "@hello-pangea/dnd"
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
 import PropTypes from "prop-types"
 
 import { FormContext, FormError, FormTitle } from "components/Form"
@@ -11,8 +11,6 @@ import KeyHighlight from "components/homepage/KeyHighlight"
 
 import styles from "styles/App.module.scss"
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
-
-import { isEmpty } from "utils"
 
 /* eslint
   react/no-array-index-key: 0
@@ -33,197 +31,169 @@ const EditorHeroSection = ({
   onFieldChange,
   createHandler,
   deleteHandler,
-  shouldDisplay,
   displayHandler,
   displayDropdownElems,
   displayHighlights,
   errors,
   handleHighlightDropdownToggle,
 }) => (
-  <div
-    className={`${elementStyles.card} ${
-      !shouldDisplay && !isEmpty(errors.sections[0].hero)
-        ? elementStyles.error
-        : ""
-    }`}
-  >
-    <div className={elementStyles.cardHeader}>
-      <h2>Hero section</h2>
-      <IconButton
-        variant="clear"
-        id={`section-${sectionIndex}`}
-        onClick={displayHandler}
-      >
-        <i
-          className={`bx ${
-            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
-          }`}
-          id={`section-${sectionIndex}-icon`}
-        />
-      </IconButton>
+  <>
+    <FormContext isRequired hasError={!!errors.sections[0].hero.title}>
+      <FormTitle>Hero title</FormTitle>
+      <FormField
+        placeholder="Hero title"
+        id={`section-${sectionIndex}-hero-title`}
+        value={title}
+        onChange={onFieldChange}
+      />
+      <FormError>{errors.sections[0].hero.title}</FormError>
+    </FormContext>
+    <FormContext isRequired hasError={!!errors.sections[0].hero.subtitle}>
+      <FormTitle>Hero subtitle</FormTitle>
+      <FormField
+        placeholder="Hero subtitle"
+        id={`section-${sectionIndex}-hero-subtitle`}
+        value={subtitle}
+        onChange={onFieldChange}
+      />
+      <FormError>{errors.sections[0].hero.subtitle}</FormError>
+    </FormContext>
+    <FormContext
+      hasError={!!errors.sections[0].hero.background}
+      onFieldChange={onFieldChange}
+      isRequired
+    >
+      <FormTitle>Hero background image</FormTitle>
+      <FormFieldMedia
+        value={background}
+        id={`section-${sectionIndex}-hero-background`}
+        inlineButtonText="Select"
+      />
+      <FormError>{errors.sections[0].hero.background}</FormError>
+    </FormContext>
+    <div className={styles.card}>
+      <p className={elementStyles.formLabel}>Hero Section Type</p>
+      {/* Permalink or File URL */}
+      <div className="d-flex">
+        <label htmlFor="radio-highlights" className="flex-fill">
+          <input
+            type="radio"
+            id="radio-highlights"
+            name="hero-type"
+            defaultValue="highlights"
+            onChange={handleHighlightDropdownToggle}
+            checked={!dropdown}
+          />
+          Highlights + Button
+        </label>
+        <label htmlFor="radio-dropdown" className="flex-fill">
+          <input
+            type="radio"
+            id="radio-dropdown"
+            name="hero-type"
+            defaultValue="dropdown"
+            onChange={handleHighlightDropdownToggle}
+            checked={!!dropdown}
+          />
+          Dropdown
+        </label>
+      </div>
+      <span className={elementStyles.info}>
+        Note: you can only have either Key Highlights+Hero button or a Hero
+        Dropdown
+      </span>
     </div>
-    {shouldDisplay ? (
-      <>
-        <FormContext isRequired hasError={!!errors.sections[0].hero.title}>
-          <FormTitle>Hero title</FormTitle>
-          <FormField
-            placeholder="Hero title"
-            id={`section-${sectionIndex}-hero-title`}
-            value={title}
-            onChange={onFieldChange}
+    <div>
+      {dropdown ? (
+        <>
+          <HeroDropdown
+            title={dropdown.title}
+            options={dropdown.options}
+            sectionIndex={sectionIndex}
+            createHandler={createHandler}
+            deleteHandler={(event) => deleteHandler(event, "Dropdown Element")}
+            onFieldChange={onFieldChange}
+            displayDropdownElems={displayDropdownElems}
+            displayHandler={displayHandler}
+            errors={errors}
           />
-          <FormError>{errors.sections[0].hero.title}</FormError>
-        </FormContext>
-        <FormContext isRequired hasError={!!errors.sections[0].hero.subtitle}>
-          <FormTitle>Hero subtitle</FormTitle>
-          <FormField
-            placeholder="Hero subtitle"
-            id={`section-${sectionIndex}-hero-subtitle`}
-            value={subtitle}
-            onChange={onFieldChange}
+        </>
+      ) : (
+        <>
+          <HeroButton
+            button={button}
+            url={url}
+            sectionIndex={sectionIndex}
+            onFieldChange={onFieldChange}
+            errors={errors.sections[0].hero}
           />
-          <FormError>{errors.sections[0].hero.subtitle}</FormError>
-        </FormContext>
-        <FormContext
-          hasError={!!errors.sections[0].hero.background}
-          onFieldChange={onFieldChange}
-          isRequired
-        >
-          <FormTitle>Hero background image</FormTitle>
-          <FormFieldMedia
-            value={background}
-            id={`section-${sectionIndex}-hero-background`}
-            inlineButtonText="Select"
-          />
-          <FormError>{errors.sections[0].hero.background}</FormError>
-        </FormContext>
-        <div className={styles.card}>
-          <p className={elementStyles.formLabel}>Hero Section Type</p>
-          {/* Permalink or File URL */}
-          <div className="d-flex">
-            <label htmlFor="radio-highlights" className="flex-fill">
-              <input
-                type="radio"
-                id="radio-highlights"
-                name="hero-type"
-                defaultValue="highlights"
-                onChange={handleHighlightDropdownToggle}
-                checked={!dropdown}
-              />
-              Highlights + Button
-            </label>
-            <label htmlFor="radio-dropdown" className="flex-fill">
-              <input
-                type="radio"
-                id="radio-dropdown"
-                name="hero-type"
-                defaultValue="dropdown"
-                onChange={handleHighlightDropdownToggle}
-                checked={!!dropdown}
-              />
-              Dropdown
-            </label>
-          </div>
-          <span className={elementStyles.info}>
-            Note: you can only have either Key Highlights+Hero button or a Hero
-            Dropdown
-          </span>
-        </div>
-        <div>
-          {dropdown ? (
-            <>
-              <HeroDropdown
-                title={dropdown.title}
-                options={dropdown.options}
-                sectionIndex={sectionIndex}
-                createHandler={createHandler}
-                deleteHandler={(event) =>
-                  deleteHandler(event, "Dropdown Element")
-                }
-                onFieldChange={onFieldChange}
-                displayDropdownElems={displayDropdownElems}
-                displayHandler={displayHandler}
-                errors={errors}
-              />
-            </>
-          ) : (
-            <>
-              <HeroButton
-                button={button}
-                url={url}
-                sectionIndex={sectionIndex}
-                onFieldChange={onFieldChange}
-                errors={errors.sections[0].hero}
-              />
-              <Droppable droppableId="highlight" type="highlight">
-                {(droppableProvided) => (
-                  <div
-                    className={styles.card}
-                    ref={droppableProvided.innerRef}
-                    {...droppableProvided.droppableProps}
-                  >
-                    {highlights && highlights.length > 0 ? (
-                      <>
-                        <b>Hero highlights</b>
-                        {highlights.map((highlight, highlightIndex) => (
-                          <Draggable
-                            draggableId={`highlight-${highlightIndex}-draggable`}
-                            index={highlightIndex}
+          <Droppable droppableId="highlight" type="highlight">
+            {(droppableProvided) => (
+              <div
+                className={styles.card}
+                ref={droppableProvided.innerRef}
+                {...droppableProvided.droppableProps}
+              >
+                {highlights && highlights.length > 0 ? (
+                  <>
+                    <b>Hero highlights</b>
+                    {highlights.map((highlight, highlightIndex) => (
+                      <Draggable
+                        draggableId={`highlight-${highlightIndex}-draggable`}
+                        index={highlightIndex}
+                      >
+                        {(draggableProvided) => (
+                          <div
+                            className={styles.card}
+                            key={highlightIndex}
+                            {...draggableProvided.draggableProps}
+                            {...draggableProvided.dragHandleProps}
+                            ref={draggableProvided.innerRef}
                           >
-                            {(draggableProvided) => (
-                              <div
-                                className={styles.card}
-                                key={highlightIndex}
-                                {...draggableProvided.draggableProps}
-                                {...draggableProvided.dragHandleProps}
-                                ref={draggableProvided.innerRef}
-                              >
-                                <KeyHighlight
-                                  key={`highlight-${highlightIndex}`}
-                                  title={highlight.title}
-                                  description={highlight.description}
-                                  background={highlight.background}
-                                  url={highlight.url}
-                                  highlightIndex={highlightIndex}
-                                  onFieldChange={onFieldChange}
-                                  shouldDisplay={
-                                    displayHighlights[highlightIndex]
-                                      ? displayHighlights[highlightIndex]
-                                      : false
-                                  }
-                                  displayHandler={displayHandler}
-                                  shouldAllowMoreHighlights={
-                                    highlights.length < MAX_NUM_KEY_HIGHLIGHTS
-                                  }
-                                  deleteHandler={(event) =>
-                                    deleteHandler(event, "Highlight")
-                                  }
-                                  errors={errors.highlights[highlightIndex]}
-                                />
-                              </div>
-                            )}
-                          </Draggable>
-                        ))}
-                      </>
-                    ) : null}
-                    {droppableProvided.placeholder}
-                    <Button
-                      onClick={createHandler}
-                      id={`highlight-${highlights.length}-create`}
-                      isDisabled={highlights.length >= MAX_NUM_KEY_HIGHLIGHTS}
-                      w="100%"
-                    >
-                      Add highlight
-                    </Button>
-                  </div>
-                )}
-              </Droppable>
-            </>
-          )}
-        </div>
-      </>
-    ) : null}
-  </div>
+                            <KeyHighlight
+                              key={`highlight-${highlightIndex}`}
+                              title={highlight.title}
+                              description={highlight.description}
+                              background={highlight.background}
+                              url={highlight.url}
+                              highlightIndex={highlightIndex}
+                              onFieldChange={onFieldChange}
+                              shouldDisplay={
+                                displayHighlights[highlightIndex]
+                                  ? displayHighlights[highlightIndex]
+                                  : false
+                              }
+                              displayHandler={displayHandler}
+                              shouldAllowMoreHighlights={
+                                highlights.length < MAX_NUM_KEY_HIGHLIGHTS
+                              }
+                              deleteHandler={(event) =>
+                                deleteHandler(event, "Highlight")
+                              }
+                              errors={errors.highlights[highlightIndex]}
+                            />
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                  </>
+                ) : null}
+                {droppableProvided.placeholder}
+                <Button
+                  onClick={createHandler}
+                  id={`highlight-${highlights.length}-create`}
+                  isDisabled={highlights.length >= MAX_NUM_KEY_HIGHLIGHTS}
+                  w="100%"
+                >
+                  Add highlight
+                </Button>
+              </div>
+            )}
+          </Droppable>
+        </>
+      )}
+    </div>
+  </>
 )
 
 export default EditorHeroSection

--- a/src/components/homepage/InfobarSection.jsx
+++ b/src/components/homepage/InfobarSection.jsx
@@ -1,4 +1,4 @@
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
 import PropTypes from "prop-types"
 
 import { FormError } from "components/Form"
@@ -7,8 +7,6 @@ import FormTitle from "components/Form/FormTitle"
 import FormField from "components/FormField"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
-
-import { isEmpty } from "utils"
 
 /* eslint
   react/no-array-index-key: 0
@@ -23,97 +21,72 @@ const EditorInfobarSection = ({
   sectionIndex,
   deleteHandler,
   onFieldChange,
-  shouldDisplay,
-  displayHandler,
   errors,
 }) => (
-  <div
-    className={`${elementStyles.card} ${
-      !shouldDisplay && !isEmpty(errors) ? elementStyles.error : ""
-    } move`}
-  >
-    <div className={elementStyles.cardHeader}>
-      <h2>Infobar section: {title}</h2>
-      <IconButton
-        variant="clear"
-        id={`section-${sectionIndex}`}
-        onClick={displayHandler}
-      >
-        <i
-          className={`bx ${
-            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
-          }`}
-          id={`section-${sectionIndex}-icon`}
+  <>
+    <div className={elementStyles.cardContent}>
+      <FormContext isRequired hasError={!!errors.subtitle}>
+        <FormTitle>Infobar subtitle</FormTitle>
+        <FormField
+          placeholder="Infobar subtitle"
+          id={`section-${sectionIndex}-infobar-subtitle`}
+          value={subtitle}
+          onChange={onFieldChange}
         />
-      </IconButton>
+        <FormError>{errors.subtitle}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.title}>
+        <FormTitle>Infobar title</FormTitle>
+        <FormField
+          placeholder="Infobar title"
+          id={`section-${sectionIndex}-infobar-title`}
+          value={title}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.title}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.description}>
+        <FormTitle>Infobar description</FormTitle>
+        <FormField
+          placeholder="Infobar description"
+          id={`section-${sectionIndex}-infobar-description`}
+          value={description}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.description}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.button}>
+        <FormTitle>Infobar button name</FormTitle>
+        <FormField
+          placeholder="Infobar button name"
+          id={`section-${sectionIndex}-infobar-button`}
+          value={button}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.button}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.url}>
+        <FormTitle>Infobar button URL</FormTitle>
+        <FormField
+          placeholder="Insert /page-url or https://"
+          id={`section-${sectionIndex}-infobar-url`}
+          value={url}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.url}</FormError>
+      </FormContext>
     </div>
-    {shouldDisplay ? (
-      <>
-        <div className={elementStyles.cardContent}>
-          <FormContext isRequired hasError={!!errors.subtitle}>
-            <FormTitle>Infobar subtitle</FormTitle>
-            <FormField
-              placeholder="Infobar subtitle"
-              id={`section-${sectionIndex}-infobar-subtitle`}
-              value={subtitle}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.subtitle}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.title}>
-            <FormTitle>Infobar title</FormTitle>
-            <FormField
-              placeholder="Infobar title"
-              id={`section-${sectionIndex}-infobar-title`}
-              value={title}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.title}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.description}>
-            <FormTitle>Infobar description</FormTitle>
-            <FormField
-              placeholder="Infobar description"
-              id={`section-${sectionIndex}-infobar-description`}
-              value={description}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.description}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.button}>
-            <FormTitle>Infobar button name</FormTitle>
-            <FormField
-              placeholder="Infobar button name"
-              id={`section-${sectionIndex}-infobar-button`}
-              value={button}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.button}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.url}>
-            <FormTitle>Infobar button URL</FormTitle>
-            <FormField
-              placeholder="Insert /page-url or https://"
-              id={`section-${sectionIndex}-infobar-url`}
-              value={url}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.url}</FormError>
-          </FormContext>
-        </div>
-        <div className={elementStyles.inputGroup}>
-          <Button
-            colorScheme="critical"
-            w="100%"
-            id={`section-${sectionIndex}`}
-            onClick={deleteHandler}
-          >
-            Delete section
-          </Button>
-        </div>
-      </>
-    ) : null}
-  </div>
+    <div className={elementStyles.inputGroup}>
+      <Button
+        colorScheme="critical"
+        w="100%"
+        id={`section-${sectionIndex}`}
+        onClick={deleteHandler}
+      >
+        Delete section
+      </Button>
+    </div>
+  </>
 )
 
 export default EditorInfobarSection
@@ -127,8 +100,6 @@ EditorInfobarSection.propTypes = {
   url: PropTypes.string,
   onFieldChange: PropTypes.func.isRequired,
   deleteHandler: PropTypes.func.isRequired,
-  shouldDisplay: PropTypes.bool.isRequired,
-  displayHandler: PropTypes.func.isRequired,
   errors: PropTypes.shape({
     title: PropTypes.string,
     subtitle: PropTypes.string,

--- a/src/components/homepage/InfopicSection.jsx
+++ b/src/components/homepage/InfopicSection.jsx
@@ -1,4 +1,4 @@
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
 import PropTypes from "prop-types"
 
 import { FormContext, FormError, FormTitle } from "components/Form"
@@ -6,8 +6,6 @@ import FormField from "components/FormField"
 import FormFieldMedia from "components/FormFieldMedia"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
-
-import { isEmpty } from "utils"
 
 /* eslint
   react/no-array-index-key: 0
@@ -24,120 +22,95 @@ const EditorInfopicSection = ({
   sectionIndex,
   deleteHandler,
   onFieldChange,
-  shouldDisplay,
-  displayHandler,
   errors,
 }) => (
-  <div
-    className={`${elementStyles.card} ${
-      !shouldDisplay && !isEmpty(errors) ? elementStyles.error : ""
-    } move`}
-  >
-    <div className={elementStyles.cardHeader}>
-      <h2>Infopic section: {title}</h2>
-      <IconButton
-        variant="clear"
-        id={`section-${sectionIndex}`}
-        onClick={displayHandler}
-      >
-        <i
-          className={`bx ${
-            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
-          }`}
-          id={`section-${sectionIndex}-icon`}
+  <>
+    <div className={elementStyles.cardContent}>
+      <FormContext hasError={!!errors.subtitle}>
+        <FormTitle>Infopic subtitle</FormTitle>
+        <FormField
+          placeholder="Infopic subtitle"
+          id={`section-${sectionIndex}-infopic-subtitle`}
+          value={subtitle}
+          onChange={onFieldChange}
         />
-      </IconButton>
+        <FormError>{errors.subtitle}</FormError>
+      </FormContext>
+      <FormContext hasError={!!errors.title}>
+        <FormTitle>Infopic title</FormTitle>
+        <FormField
+          placeholder="Infopic title"
+          id={`section-${sectionIndex}-infopic-title`}
+          value={title}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.title}</FormError>
+      </FormContext>
+      <FormContext hasError={!!errors.description}>
+        <FormTitle>Infopic description</FormTitle>
+        <FormField
+          placeholder="Infopic description"
+          id={`section-${sectionIndex}-infopic-description`}
+          value={description}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.description}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.button}>
+        <FormTitle>Infopic button name</FormTitle>
+        <FormField
+          placeholder="Infopic button name"
+          id={`section-${sectionIndex}-infopic-button`}
+          value={button}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.button}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={errors.url}>
+        <FormTitle>Infopic button URL</FormTitle>
+        <FormField
+          placeholder="Insert /page-url or https://"
+          id={`section-${sectionIndex}-infopic-url`}
+          value={url}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.url}</FormError>
+      </FormContext>
+      <FormContext
+        hasError={!!errors.image}
+        onFieldChange={onFieldChange}
+        isRequired
+      >
+        <FormTitle>Infopic image URL</FormTitle>
+        <FormFieldMedia
+          value={imageUrl}
+          id={`section-${sectionIndex}-infopic-image`}
+          inlineButtonText="Select"
+        />
+        <FormError>{errors.image}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.alt}>
+        <FormTitle>Infopic image alt text</FormTitle>
+        <FormField
+          placeholder="Infopic image alt text"
+          id={`section-${sectionIndex}-infopic-alt`}
+          value={imageAlt}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.alt}</FormError>
+      </FormContext>
     </div>
-    {shouldDisplay ? (
-      <>
-        <div className={elementStyles.cardContent}>
-          <FormContext hasError={!!errors.subtitle}>
-            <FormTitle>Infopic subtitle</FormTitle>
-            <FormField
-              placeholder="Infopic subtitle"
-              id={`section-${sectionIndex}-infopic-subtitle`}
-              value={subtitle}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.subtitle}</FormError>
-          </FormContext>
-          <FormContext hasError={!!errors.title}>
-            <FormTitle>Infopic title</FormTitle>
-            <FormField
-              placeholder="Infopic title"
-              id={`section-${sectionIndex}-infopic-title`}
-              value={title}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.title}</FormError>
-          </FormContext>
-          <FormContext hasError={!!errors.description}>
-            <FormTitle>Infopic description</FormTitle>
-            <FormField
-              placeholder="Infopic description"
-              id={`section-${sectionIndex}-infopic-description`}
-              value={description}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.description}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.button}>
-            <FormTitle>Infopic button name</FormTitle>
-            <FormField
-              placeholder="Infopic button name"
-              id={`section-${sectionIndex}-infopic-button`}
-              value={button}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.button}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={errors.url}>
-            <FormTitle>Infopic button URL</FormTitle>
-            <FormField
-              placeholder="Insert /page-url or https://"
-              id={`section-${sectionIndex}-infopic-url`}
-              value={url}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.url}</FormError>
-          </FormContext>
-          <FormContext
-            hasError={!!errors.image}
-            onFieldChange={onFieldChange}
-            isRequired
-          >
-            <FormTitle>Infopic image URL</FormTitle>
-            <FormFieldMedia
-              value={imageUrl}
-              id={`section-${sectionIndex}-infopic-image`}
-              inlineButtonText="Select"
-            />
-            <FormError>{errors.image}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.alt}>
-            <FormTitle>Infopic image alt text</FormTitle>
-            <FormField
-              placeholder="Infopic image alt text"
-              id={`section-${sectionIndex}-infopic-alt`}
-              value={imageAlt}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.alt}</FormError>
-          </FormContext>
-        </div>
-        <div className={elementStyles.inputGroup}>
-          <Button
-            colorScheme="critical"
-            w="100%"
-            id={`section-${sectionIndex}`}
-            onClick={deleteHandler}
-          >
-            Delete section
-          </Button>
-        </div>
-      </>
-    ) : null}
-  </div>
+    <div className={elementStyles.inputGroup}>
+      <Button
+        colorScheme="critical"
+        w="100%"
+        id={`section-${sectionIndex}`}
+        onClick={deleteHandler}
+      >
+        Delete section
+      </Button>
+    </div>
+  </>
 )
 
 export default EditorInfopicSection
@@ -153,8 +126,6 @@ EditorInfopicSection.propTypes = {
   imageAlt: PropTypes.string,
   onFieldChange: PropTypes.func.isRequired,
   deleteHandler: PropTypes.func.isRequired,
-  shouldDisplay: PropTypes.bool.isRequired,
-  displayHandler: PropTypes.func.isRequired,
   errors: PropTypes.shape({
     title: PropTypes.string,
     subtitle: PropTypes.string,

--- a/src/components/homepage/ResourcesSection.jsx
+++ b/src/components/homepage/ResourcesSection.jsx
@@ -1,4 +1,4 @@
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
 import PropTypes from "prop-types"
 
 import { FormError } from "components/Form"
@@ -7,8 +7,6 @@ import FormTitle from "components/Form/FormTitle"
 import FormField from "components/FormField"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
-
-import { isEmpty } from "utils"
 
 /* eslint
   react/no-array-index-key: 0
@@ -21,77 +19,52 @@ const EditorResourcesSection = ({
   sectionIndex,
   deleteHandler,
   onFieldChange,
-  shouldDisplay,
-  displayHandler,
   errors,
 }) => (
-  <div
-    className={`${elementStyles.card} ${
-      !shouldDisplay && !isEmpty(errors) ? elementStyles.error : ""
-    } move`}
-  >
-    <div className={elementStyles.cardHeader}>
-      <h2>Resources section: {title}</h2>
-      <IconButton
-        variant="clear"
-        id={`section-${sectionIndex}`}
-        onClick={displayHandler}
-      >
-        <i
-          className={`bx ${
-            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
-          }`}
-          id={`section-${sectionIndex}-icon`}
+  <>
+    <div className={elementStyles.cardContent}>
+      <FormContext isRequired hasError={!!errors.subtitle}>
+        <FormTitle>Resources section subtitle</FormTitle>
+        <FormField
+          placeholder="Resources section subtitle"
+          id={`section-${sectionIndex}-resources-subtitle`}
+          value={subtitle}
+          onChange={onFieldChange}
         />
-      </IconButton>
+        <FormError>{errors.subtitle}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.title}>
+        <FormTitle>Resources section title</FormTitle>
+        <FormField
+          placeholder="Resources section title"
+          id={`section-${sectionIndex}-resources-title`}
+          value={title}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.title}</FormError>
+      </FormContext>
+      <FormContext isRequired hasError={!!errors.button}>
+        <FormTitle>Resources button name</FormTitle>
+        <FormField
+          placeholder="Resources button name"
+          id={`section-${sectionIndex}-resources-button`}
+          value={button}
+          onChange={onFieldChange}
+        />
+        <FormError>{errors.button}</FormError>
+      </FormContext>
     </div>
-    {shouldDisplay ? (
-      <>
-        <div className={elementStyles.cardContent}>
-          <FormContext isRequired hasError={!!errors.subtitle}>
-            <FormTitle>Resources section subtitle</FormTitle>
-            <FormField
-              placeholder="Resources section subtitle"
-              id={`section-${sectionIndex}-resources-subtitle`}
-              value={subtitle}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.subtitle}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.title}>
-            <FormTitle>Resources section title</FormTitle>
-            <FormField
-              placeholder="Resources section title"
-              id={`section-${sectionIndex}-resources-title`}
-              value={title}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.title}</FormError>
-          </FormContext>
-          <FormContext isRequired hasError={!!errors.button}>
-            <FormTitle>Resources button name</FormTitle>
-            <FormField
-              placeholder="Resources button name"
-              id={`section-${sectionIndex}-resources-button`}
-              value={button}
-              onChange={onFieldChange}
-            />
-            <FormError>{errors.button}</FormError>
-          </FormContext>
-        </div>
-        <div className={elementStyles.inputGroup}>
-          <Button
-            colorScheme="critical"
-            w="100%"
-            id={`section-${sectionIndex}`}
-            onClick={deleteHandler}
-          >
-            Delete section
-          </Button>
-        </div>
-      </>
-    ) : null}
-  </div>
+    <div className={elementStyles.inputGroup}>
+      <Button
+        colorScheme="critical"
+        w="100%"
+        id={`section-${sectionIndex}`}
+        onClick={deleteHandler}
+      >
+        Delete section
+      </Button>
+    </div>
+  </>
 )
 
 export default EditorResourcesSection
@@ -103,8 +76,6 @@ EditorResourcesSection.propTypes = {
   button: PropTypes.string,
   onFieldChange: PropTypes.func.isRequired,
   deleteHandler: PropTypes.func.isRequired,
-  shouldDisplay: PropTypes.bool.isRequired,
-  displayHandler: PropTypes.func.isRequired,
   errors: PropTypes.shape({
     title: PropTypes.string,
     subtitle: PropTypes.string,

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -43,7 +43,7 @@ import { DEFAULT_RETRY_MSG } from "utils"
 
 import { useDrag, onCreate, onDelete } from "../hooks/useDrag"
 
-import { Editable } from "./components/Editable"
+import { CustomiseSectionHeader, Editable } from "./components/Editable"
 
 /* eslint-disable react/no-array-index-key */
 
@@ -1037,9 +1037,14 @@ const EditHomepage = ({ match }) => {
                                     />
                                   </Editable.EditableAccordionItem>
                                   <Divider />
+                                  <VStack
+                                    spacing="0.5rem"
+                                    alignItems="flex-start"
+                                  >
+                                    <CustomiseSectionHeader />
+                                  </VStack>
                                 </>
                               )}
-                              {/* TODO: Place `CustomiseSectionHeader` here */}
                               {section.resources && (
                                 <Editable.DraggableAccordionItem
                                   draggableId={`resources-${sectionIndex}-draggable`}
@@ -1065,6 +1070,36 @@ const EditHomepage = ({ match }) => {
                                   />
                                 </Editable.DraggableAccordionItem>
                               )}
+
+                              {section.infobar && (
+                                <Editable.DraggableAccordionItem
+                                  draggableId={`infobar-${sectionIndex}-draggable`}
+                                  index={sectionIndex}
+                                  tag={<Tag variant="subtle">Infobar</Tag>}
+                                  title={section.infobar.title}
+                                >
+                                  <EditorInfobarSection
+                                    key={`section-${sectionIndex}`}
+                                    {...section.infobar}
+                                    sectionIndex={sectionIndex}
+                                    deleteHandler={(event) => {
+                                      onOpen()
+                                      setItemPendingForDelete({
+                                        id: event.target.id,
+                                        type: "Infobar Section",
+                                      })
+                                    }}
+                                    onFieldChange={onFieldChange}
+                                    shouldDisplay={
+                                      displaySections[sectionIndex]
+                                    }
+                                    displayHandler={displayHandler}
+                                    errors={
+                                      errors.sections[sectionIndex].infobar
+                                    }
+                                  />
+                                </Editable.DraggableAccordionItem>
+                              )}
                             </>
                           ))}
                         </VStack>
@@ -1079,43 +1114,6 @@ const EditHomepage = ({ match }) => {
                   >
                     {frontMatter.sections.map((section, sectionIndex) => (
                       <>
-                        {/* Infobar section */}
-                        {section.infobar ? (
-                          <Draggable
-                            draggableId={`infobar-${sectionIndex}-draggable`}
-                            index={sectionIndex}
-                          >
-                            {(draggableProvided) => (
-                              <div
-                                {...draggableProvided.draggableProps}
-                                {...draggableProvided.dragHandleProps}
-                                ref={draggableProvided.innerRef}
-                              >
-                                <EditorInfobarSection
-                                  key={`section-${sectionIndex}`}
-                                  title={section.infobar.title}
-                                  subtitle={section.infobar.subtitle}
-                                  description={section.infobar.description}
-                                  button={section.infobar.button}
-                                  url={section.infobar.url}
-                                  sectionIndex={sectionIndex}
-                                  deleteHandler={(event) => {
-                                    onOpen()
-                                    setItemPendingForDelete({
-                                      id: event.target.id,
-                                      type: "Infobar Section",
-                                    })
-                                  }}
-                                  onFieldChange={onFieldChange}
-                                  shouldDisplay={displaySections[sectionIndex]}
-                                  displayHandler={displayHandler}
-                                  errors={errors.sections[sectionIndex].infobar}
-                                />
-                              </div>
-                            )}
-                          </Draggable>
-                        ) : null}
-
                         {/* Infopic section */}
                         {section.infopic ? (
                           <Draggable

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { useDisclosure, Text, HStack, VStack, Divider } from "@chakra-ui/react"
-import { Draggable } from "@hello-pangea/dnd"
 import { Button, Input, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
 import _ from "lodash"
@@ -801,7 +800,6 @@ const EditHomepage = ({ match }) => {
   const displayHandler = async (event) => {
     try {
       const { id } = event.target
-      console.log("ID: =====", id)
       const idArray = id.split("-")
       const elemType = idArray[0]
       switch (elemType) {
@@ -1100,65 +1098,43 @@ const EditHomepage = ({ match }) => {
                                   />
                                 </Editable.DraggableAccordionItem>
                               )}
+
+                              {section.infopic && (
+                                <Editable.DraggableAccordionItem
+                                  draggableId={`infopic-${sectionIndex}-draggable`}
+                                  index={sectionIndex}
+                                  tag={<Tag variant="subtle">Infopic</Tag>}
+                                  title={section.infopic.title}
+                                >
+                                  <EditorInfopicSection
+                                    key={`section-${sectionIndex}`}
+                                    {...section.infopic}
+                                    sectionIndex={sectionIndex}
+                                    deleteHandler={(event) => {
+                                      onOpen()
+                                      setItemPendingForDelete({
+                                        id: event.target.id,
+                                        type: "Infopic Section",
+                                      })
+                                    }}
+                                    onFieldChange={onFieldChange}
+                                    shouldDisplay={
+                                      displaySections[sectionIndex]
+                                    }
+                                    displayHandler={displayHandler}
+                                    errors={
+                                      errors.sections[sectionIndex].infopic
+                                    }
+                                    siteName={siteName}
+                                  />
+                                </Editable.DraggableAccordionItem>
+                              )}
                             </>
                           ))}
                         </VStack>
                       </Editable.Accordion>
                     </Editable.Draggable>
                   </Editable.Sidebar>
-
-                  {/* Homepage section configurations */}
-                  <Editable.Draggable
-                    editableId="leftPane"
-                    onDragEnd={onDragEnd}
-                  >
-                    {frontMatter.sections.map((section, sectionIndex) => (
-                      <>
-                        {/* Infopic section */}
-                        {section.infopic ? (
-                          <Draggable
-                            draggableId={`infopic-${sectionIndex}-draggable`}
-                            index={sectionIndex}
-                          >
-                            {(draggableProvided) => (
-                              <div
-                                {...draggableProvided.draggableProps}
-                                {...draggableProvided.dragHandleProps}
-                                ref={draggableProvided.innerRef}
-                              >
-                                <EditorInfopicSection
-                                  key={`section-${sectionIndex}`}
-                                  title={section.infopic.title}
-                                  subtitle={section.infopic.subtitle}
-                                  description={section.infopic.description}
-                                  button={section.infopic.button}
-                                  url={section.infopic.url}
-                                  imageUrl={section.infopic.image}
-                                  imageAlt={section.infopic.alt}
-                                  sectionIndex={sectionIndex}
-                                  deleteHandler={(event) => {
-                                    onOpen()
-                                    setItemPendingForDelete({
-                                      id: event.target.id,
-                                      type: "Infopic Section",
-                                    })
-                                  }}
-                                  onFieldChange={onFieldChange}
-                                  shouldDisplay={displaySections[sectionIndex]}
-                                  displayHandler={displayHandler}
-                                  errors={errors.sections[sectionIndex].infopic}
-                                  siteName={siteName}
-                                />
-                              </div>
-                            )}
-                          </Draggable>
-                        ) : null}
-
-                        {/* Carousel section */}
-                        {/* TO-DO */}
-                      </>
-                    ))}
-                  </Editable.Draggable>
 
                   {/* Section creator */}
                   <NewSectionCreator

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1001,9 +1001,7 @@ const EditHomepage = ({ match }) => {
                               {/* Hero section */}
                               {section.hero && (
                                 <>
-                                  <Editable.EditableAccordionItem
-                                    title={section.hero.title}
-                                  >
+                                  <Editable.EditableAccordionItem title="Hero section">
                                     <EditorHeroSection
                                       key={`section-${sectionIndex}`}
                                       {...section.hero}

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1043,7 +1043,6 @@ const EditHomepage = ({ match }) => {
                               )}
                               {section.resources && (
                                 <Editable.DraggableAccordionItem
-                                  draggableId={`resources-${sectionIndex}-draggable`}
                                   index={sectionIndex}
                                   tag={<Tag variant="subtle">Resources</Tag>}
                                   title={section.resources.title}
@@ -1069,7 +1068,6 @@ const EditHomepage = ({ match }) => {
 
                               {section.infobar && (
                                 <Editable.DraggableAccordionItem
-                                  draggableId={`infobar-${sectionIndex}-draggable`}
                                   index={sectionIndex}
                                   tag={<Tag variant="subtle">Infobar</Tag>}
                                   title={section.infobar.title}
@@ -1099,7 +1097,6 @@ const EditHomepage = ({ match }) => {
 
                               {section.infopic && (
                                 <Editable.DraggableAccordionItem
-                                  draggableId={`infopic-${sectionIndex}-draggable`}
                                   index={sectionIndex}
                                   tag={<Tag variant="subtle">Infopic</Tag>}
                                   title={section.infopic.title}

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import { useDisclosure, Text, HStack, VStack } from "@chakra-ui/react"
+import { useDisclosure, Text, HStack, VStack, Divider } from "@chakra-ui/react"
 import { Draggable } from "@hello-pangea/dnd"
-import { Button, Input } from "@opengovsg/design-system-react"
+import { Button, Input, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
 import _ from "lodash"
 import PropTypes from "prop-types"
@@ -801,6 +801,7 @@ const EditHomepage = ({ match }) => {
   const displayHandler = async (event) => {
     try {
       const { id } = event.target
+      console.log("ID: =====", id)
       const idArray = id.split("-")
       const elemType = idArray[0]
       switch (elemType) {
@@ -976,6 +977,101 @@ const EditHomepage = ({ match }) => {
                     </span>
                   </div>
 
+                  <Editable.Sidebar
+                    title="Homepage"
+                    onChange={(idx) => {
+                      displayHandler({ target: { id: `section-${idx}` } })
+                    }}
+                  >
+                    <Editable.Draggable
+                      editableId="leftPane"
+                      onDragEnd={onDragEnd}
+                    >
+                      <Editable.Accordion
+                        onChange={(idx) => {
+                          displayHandler({ target: { id: `section-${idx}` } })
+                        }}
+                      >
+                        <VStack
+                          bg="base.canvas.alt"
+                          p="1.5rem"
+                          spacing="1.5rem"
+                          alignItems="flex-start"
+                        >
+                          {frontMatter.sections.map((section, sectionIndex) => (
+                            <>
+                              {/* Hero section */}
+                              {section.hero && (
+                                <>
+                                  <Editable.EditableAccordionItem
+                                    title={section.hero.title}
+                                  >
+                                    <EditorHeroSection
+                                      key={`section-${sectionIndex}`}
+                                      {...section.hero}
+                                      sectionIndex={sectionIndex}
+                                      highlights={
+                                        section.hero.key_highlights ?? []
+                                      }
+                                      onFieldChange={onFieldChange}
+                                      createHandler={createHandler}
+                                      deleteHandler={(event, type) => {
+                                        onOpen()
+                                        setItemPendingForDelete({
+                                          id: event.target.id,
+                                          type,
+                                        })
+                                      }}
+                                      shouldDisplay={
+                                        displaySections[sectionIndex]
+                                      }
+                                      displayHighlights={displayHighlights}
+                                      displayDropdownElems={
+                                        displayDropdownElems
+                                      }
+                                      displayHandler={displayHandler}
+                                      errors={errors}
+                                      handleHighlightDropdownToggle={
+                                        handleHighlightDropdownToggle
+                                      }
+                                    />
+                                  </Editable.EditableAccordionItem>
+                                  <Divider />
+                                </>
+                              )}
+                              {/* TODO: Place `CustomiseSectionHeader` here */}
+                              {section.resources && (
+                                <Editable.DraggableAccordionItem
+                                  draggableId={`resources-${sectionIndex}-draggable`}
+                                  index={sectionIndex}
+                                  tag={<Tag variant="subtle">Resources</Tag>}
+                                  title={section.resources.title}
+                                >
+                                  <EditorResourcesSection
+                                    key={`section-${sectionIndex}`}
+                                    {...section.resources}
+                                    sectionIndex={sectionIndex}
+                                    deleteHandler={(event) => {
+                                      onOpen()
+                                      setItemPendingForDelete({
+                                        id: event.target.id,
+                                        type: "Resources Section",
+                                      })
+                                    }}
+                                    onFieldChange={onFieldChange}
+                                    errors={
+                                      errors.sections[sectionIndex].resources
+                                    }
+                                  />
+                                </Editable.DraggableAccordionItem>
+                              )}
+                            </>
+                          ))}
+                        </VStack>
+                      </Editable.Accordion>
+                    </Editable.Draggable>
+                  </Editable.Sidebar>
+
                   {/* Homepage section configurations */}
                   <Editable.Draggable
                     editableId="leftPane"
@@ -983,85 +1079,6 @@ const EditHomepage = ({ match }) => {
                   >
                     {frontMatter.sections.map((section, sectionIndex) => (
                       <>
-                        {/* Hero section */}
-                        {section.hero ? (
-                          <>
-                            <EditorHeroSection
-                              key={`section-${sectionIndex}`}
-                              title={section.hero.title}
-                              subtitle={section.hero.subtitle}
-                              background={section.hero.background}
-                              button={section.hero.button}
-                              url={section.hero.url}
-                              dropdown={
-                                section.hero.dropdown
-                                  ? section.hero.dropdown
-                                  : null
-                              }
-                              sectionIndex={sectionIndex}
-                              highlights={
-                                section.hero.key_highlights
-                                  ? section.hero.key_highlights
-                                  : []
-                              }
-                              onFieldChange={onFieldChange}
-                              createHandler={createHandler}
-                              deleteHandler={(event, type) => {
-                                onOpen()
-                                setItemPendingForDelete({
-                                  id: event.target.id,
-                                  type,
-                                })
-                              }}
-                              shouldDisplay={displaySections[sectionIndex]}
-                              displayHighlights={displayHighlights}
-                              displayDropdownElems={displayDropdownElems}
-                              displayHandler={displayHandler}
-                              errors={errors}
-                              handleHighlightDropdownToggle={
-                                handleHighlightDropdownToggle
-                              }
-                            />
-                          </>
-                        ) : null}
-
-                        {/* Resources section */}
-                        {section.resources ? (
-                          <Draggable
-                            draggableId={`resources-${sectionIndex}-draggable`}
-                            index={sectionIndex}
-                          >
-                            {(draggableProvided) => (
-                              <div
-                                {...draggableProvided.draggableProps}
-                                {...draggableProvided.dragHandleProps}
-                                ref={draggableProvided.innerRef}
-                              >
-                                <EditorResourcesSection
-                                  key={`section-${sectionIndex}`}
-                                  title={section.resources.title}
-                                  subtitle={section.resources.subtitle}
-                                  button={section.resources.button}
-                                  sectionIndex={sectionIndex}
-                                  deleteHandler={(event) => {
-                                    onOpen()
-                                    setItemPendingForDelete({
-                                      id: event.target.id,
-                                      type: "Resources Section",
-                                    })
-                                  }}
-                                  onFieldChange={onFieldChange}
-                                  shouldDisplay={displaySections[sectionIndex]}
-                                  displayHandler={displayHandler}
-                                  errors={
-                                    errors.sections[sectionIndex].resources
-                                  }
-                                />
-                              </div>
-                            )}
-                          </Draggable>
-                        ) : null}
-
                         {/* Infobar section */}
                         {section.infobar ? (
                           <Draggable

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -42,7 +42,7 @@ import { DEFAULT_RETRY_MSG } from "utils"
 
 import { useDrag, onCreate, onDelete } from "../hooks/useDrag"
 
-import { CustomiseSectionHeader, Editable } from "./components/Editable"
+import { CustomiseSectionsHeader, Editable } from "./components/Editable"
 
 /* eslint-disable react/no-array-index-key */
 
@@ -1037,7 +1037,7 @@ const EditHomepage = ({ match }) => {
                                     spacing="0.5rem"
                                     alignItems="flex-start"
                                   >
-                                    <CustomiseSectionHeader />
+                                    <CustomiseSectionsHeader />
                                   </VStack>
                                 </>
                               )}

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -20,6 +20,7 @@ import {
 } from "@hello-pangea/dnd"
 import { IconButton } from "@opengovsg/design-system-react"
 import { PropsWithChildren } from "react"
+import { v4 as uuid } from "uuid"
 
 import { BxDraggable, HomepageStartEditingImage } from "assets"
 
@@ -191,7 +192,7 @@ const DraggableAccordionItem = ({
   draggableId,
 }: PropsWithChildren<DraggableAccordionItemProps>) => {
   return (
-    <Draggable draggableId={draggableId} index={index}>
+    <Draggable draggableId={uuid()} index={index}>
       {(draggableProvided) => (
         <BaseAccordionItem
           borderRadius="0.25rem"

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -198,10 +198,13 @@ const DraggableAccordionItem = ({
           {...draggableProvided.draggableProps}
           ref={draggableProvided.innerRef}
           boxShadow="sm"
+          {...draggableProvided.dragHandleProps}
+          _hover={{
+            bgColor: "interaction.muted.main.hover",
+          }}
         >
           <Center>
             <IconButton
-              {...draggableProvided.dragHandleProps}
               variant="clear"
               cursor="grab"
               aria-label="drag item"
@@ -211,15 +214,17 @@ const DraggableAccordionItem = ({
           {/* NOTE: Check with design on styling. 
         See if entire section is button (ie, whole component hover styling)
       */}
-          <AccordionButton px="1.5rem" pb="1.5rem">
-            <Flex flex="1" flexDir="column">
+          <Flex flexDir="row">
+            <Flex px="1.5rem" pb="1.5rem" flex="1" flexDir="column">
               {tag}
               <Text textStyle="h6" textAlign="left" mt="0.25rem">
                 {title}
               </Text>
             </Flex>
-            <AccordionIcon />
-          </AccordionButton>
+            <AccordionButton w="auto" h="fit-content" py="1rem">
+              <AccordionIcon />
+            </AccordionButton>
+          </Flex>
           <AccordionPanel pb={4}>{children}</AccordionPanel>
         </BaseAccordionItem>
       )}

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -156,7 +156,7 @@ const EditableAccordionItem = ({
   children,
 }: PropsWithChildren<EditableCardProps>) => {
   return (
-    <BaseAccordionItem borderRadius="0.5rem">
+    <BaseAccordionItem>
       {/* NOTE: Check with design on styling. 
         See if entire section is button (ie, whole component hover styling)
       */}

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -189,7 +189,6 @@ const DraggableAccordionItem = ({
   title,
   children,
   index,
-  draggableId,
 }: PropsWithChildren<DraggableAccordionItemProps>) => {
   return (
     <Draggable draggableId={uuid()} index={index}>


### PR DESCRIPTION
## Problem
Previously, the new components were introduced but not used. This PR replaces the existing stuff in `EditHomepage` w/ the new components

## Solution
The steps to replacement will be listed below for clarity: 
1. Replace `Draggable` with `Editable.Draggable` as resp shifted
2. for each component, shift the creation within the `map` loop into 2 segments - first, creating the `Droppable` (this is the actual dnd stuff) and secondly, creating the body (this is the `form` - retained existing code as-is)
3. for each `<Editor_type>Section.jsx`, the code dictating the expand/collapse logic was removed. (shifted into respective `AccordionItem`)

## Tests
- see #1403 for base list
- [ ] for new draggable components, clicking on the accordion button should expand (tbc w design if only the arrow, or the whole section)
- [ ] for new draggable components, **clicking on the card** should drag the component

## Screenshots
<img width="495" alt="Screenshot 2023-08-09 at 2 29 19 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/44049504/594311fe-4ecc-494e-97d4-32654f013645">

no vid cos laze
