### PR TITLE
fix(chromatic): comment based chromatic builds

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,6 +27,8 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -65,7 +67,9 @@ jobs:
       - name: Don't run job if user is not part of Isomer core team or trigger words are not present
         if: ${{ steps.checkUserMember.outputs.isTeamMember != 'true' || !(github.event_name == 'issue_comment' && github.event.issue.pull_request && steps.check.outputs.triggered == 'true') }}
         run: exit 0
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
       # This extra step is not in the original chromatic workflow.
       # This is to pin the version of node (18.x) used.
       - name: Setup Node.js

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -67,8 +67,7 @@ jobs:
         run: exit 0
       - uses: actions/checkout@v1
       # This extra step is not in the original chromatic workflow.
-      # This is to use a specific version of node (14.x), because the default is 16.x,
-      # which is not compatible with sass
+      # This is to pin the version of node (18.x) used.
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Problem

Currently, while the GH actions pass for comment based trigger, it keep building develop. The issue stems from `actions/checkout@v1` checks out the branch that tiggered the workflow. However, the `issue-comment` seems to be a separate [trigger by itself](https://github.com/actions/checkout/issues/331), and as such this feature does not work as intended.  


## Solution

Use solution as described [here](https://github.com/actions/checkout/issues/331#issuecomment-1438220926). This leverages on the fact that "issue number" === "pr number".

## Tests
I cannot test this unless this code since [this event will only trigger a workflow run if the workflow file is on the default branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows).