### PR TITLE
feat(sl): integrate screens with be

### DIFF
--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -133,7 +133,7 @@ export const SiteLaunchProvider = ({
   useEffect(() => {
     if (!siteLaunchDto) return
     if (
-      siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.notLaunched &&
+      siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.NotLaunched &&
       siteLaunchStatusProps.siteLaunchStatus === SiteLaunchFEStatus.Loading
     ) {
       setSiteLaunchStatusProps({
@@ -142,7 +142,7 @@ export const SiteLaunchProvider = ({
         stepNumber: 0,
       })
     }
-    if (siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.notLaunched) {
+    if (siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.NotLaunched) {
       return
     }
     // this condition is added to prevent redundant re-renders
@@ -168,8 +168,8 @@ export const SiteLaunchProvider = ({
     }
 
     if (
-      (siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.launched ||
-        siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.failed) &&
+      (siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.Launched ||
+        siteLaunchDto.siteLaunchStatus === SiteLaunchBEStatus.Failed) &&
       !isSiteLaunchFEAndBESynced
     ) {
       setPageNumber(SITE_LAUNCH_PAGES.FINAL_STATE)

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -91,14 +91,14 @@ export const SiteLaunchProvider = ({
   )
 
   const increasePageNumber = () => {
-    if (pageNumber === SITE_LAUNCH_PAGES.FINAL_STATE) {
+    if (pageNumber >= SITE_LAUNCH_PAGES.FINAL_STATE) {
       return
     }
     // safe to assert since we do an check prior
     setPageNumber((pageNumber + 1) as SiteLaunchPageIndex)
   }
   const decreasePageNumber = () => {
-    if (pageNumber === SITE_LAUNCH_PAGES.DISCLAIMER) {
+    if (pageNumber <= SITE_LAUNCH_PAGES.DISCLAIMER) {
       return
     }
 

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -75,6 +75,18 @@ export const SiteLaunchProvider = ({
     isNewDomain,
   })
 
+  //! TODO remove this bunch of code after development
+  // const [
+  //   siteLaunchStatusProps,
+  //   setSiteLaunchStatusProps,
+  // ] = useState<SiteLaunchStatusProps>({
+  //   siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
+  //   stepNumber: SITE_LAUNCH_TASKS.NOT_STARTED,
+  //   isNewDomain: true,
+  //   siteUrl: "isomer.gov.sg",
+  //   useWwwSubdomain: true,
+  // })
+
   const { data: siteLaunchDto } = useGetSiteLaunchStatus(siteName)
 
   const queryClient = useQueryClient()
@@ -121,7 +133,8 @@ export const SiteLaunchProvider = ({
       // invalidate react query key
       setTimeout(() => {
         refetchSiteLaunchStatus()
-      }, 120000)
+        //! TODO: change this back to 120000 after local dev
+      }, 5000)
     }
   }
 
@@ -165,7 +178,7 @@ export const SiteLaunchProvider = ({
 
     if (
       (siteLaunchDto.siteStatus === "LAUNCHED" ||
-        siteLaunchDto.siteStatus === "FAILURE") &&
+        siteLaunchDto.siteStatus === "FAILED") &&
       !isSiteLaunchFEAndBESynced
     ) {
       setPageNumber(SITE_LAUNCH_PAGES.FINAL_STATE)

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -104,6 +104,7 @@ export const SiteLaunchProvider = ({
     const isSiteLaunchFEAndBESynced =
       siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus &&
       siteLaunchStatusProps.dnsRecords === siteLaunchDto?.dnsRecords
+
     if (
       (siteLaunchDto.siteStatus === "LAUNCHED" ||
         siteLaunchDto.siteStatus === "LAUNCHING" ||
@@ -111,14 +112,16 @@ export const SiteLaunchProvider = ({
       !isSiteLaunchFEAndBESynced
     ) {
       setSiteLaunchStatusProps({
+        ...siteLaunchStatusProps,
         siteLaunchStatus: siteLaunchDto.siteStatus,
-        stepNumber: SITE_LAUNCH_TASKS_LENGTH,
         dnsRecords: siteLaunchDto.dnsRecords,
       })
     }
   }, [
     siteLaunchDto,
+    siteLaunchStatusProps,
     siteLaunchStatusProps.dnsRecords,
+    siteLaunchStatusProps.isNewDomain,
     siteLaunchStatusProps.siteLaunchStatus,
   ])
 

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -143,7 +143,7 @@ export const SiteLaunchProvider = ({
   useEffect(() => {
     if (!siteLaunchDto) return
     if (
-      siteLaunchDto.siteStatus === "NOT_LAUNCHED" &&
+      siteLaunchDto.siteLaunchStatus === "NOT_LAUNCHED" &&
       siteLaunchStatusProps.siteLaunchStatus === "LOADING"
     ) {
       setSiteLaunchStatusProps({
@@ -152,33 +152,34 @@ export const SiteLaunchProvider = ({
         stepNumber: 0,
       })
     }
-    if (siteLaunchDto.siteStatus === "NOT_LAUNCHED") {
+    if (siteLaunchDto.siteLaunchStatus === "NOT_LAUNCHED") {
       return
     }
     // this condition is added to prevent redundant re-renders
     const isSiteLaunchFEAndBESynced =
-      siteLaunchStatusProps.siteLaunchStatus === siteLaunchDto?.siteStatus &&
+      siteLaunchStatusProps.siteLaunchStatus ===
+        siteLaunchDto?.siteLaunchStatus &&
       siteLaunchStatusProps.dnsRecords === siteLaunchDto?.dnsRecords
 
     if (!isSiteLaunchFEAndBESynced) {
       setSiteLaunchStatusProps({
         ...siteLaunchStatusProps,
-        siteLaunchStatus: siteLaunchDto.siteStatus,
+        siteLaunchStatus: siteLaunchDto.siteLaunchStatus,
         dnsRecords: siteLaunchDto.dnsRecords,
       })
     }
 
     // We don't want to jump to the last screen immediately after the api is called
     if (
-      siteLaunchDto.siteStatus === "LAUNCHING" &&
+      siteLaunchDto.siteLaunchStatus === "LAUNCHING" &&
       !isSiteLaunchFEAndBESynced
     ) {
       setPageNumber(SITE_LAUNCH_PAGES.CHECKLIST)
     }
 
     if (
-      (siteLaunchDto.siteStatus === "LAUNCHED" ||
-        siteLaunchDto.siteStatus === "FAILED") &&
+      (siteLaunchDto.siteLaunchStatus === "LAUNCHED" ||
+        siteLaunchDto.siteLaunchStatus === "FAILED") &&
       !isSiteLaunchFEAndBESynced
     ) {
       setPageNumber(SITE_LAUNCH_PAGES.FINAL_STATE)

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -75,18 +75,6 @@ export const SiteLaunchProvider = ({
     isNewDomain,
   })
 
-  //! TODO remove this bunch of code after development
-  // const [
-  //   siteLaunchStatusProps,
-  //   setSiteLaunchStatusProps,
-  // ] = useState<SiteLaunchStatusProps>({
-  //   siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
-  //   stepNumber: SITE_LAUNCH_TASKS.NOT_STARTED,
-  //   isNewDomain: true,
-  //   siteUrl: "isomer.gov.sg",
-  //   useWwwSubdomain: true,
-  // })
-
   const { data: siteLaunchDto } = useGetSiteLaunchStatus(siteName)
 
   const queryClient = useQueryClient()
@@ -133,8 +121,7 @@ export const SiteLaunchProvider = ({
       // invalidate react query key
       setTimeout(() => {
         refetchSiteLaunchStatus()
-        //! TODO: change this back to 120000 after local dev
-      }, 5000)
+      }, 120000)
     }
   }
 

--- a/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.stories.tsx
@@ -23,6 +23,7 @@ import {
   buildSiteDashboardReviewRequests,
   buildSiteLaunchDto,
 } from "mocks/utils"
+import { SiteLaunchFEStatus } from "types/siteLaunch"
 
 import { SiteDashboard } from "./SiteDashboard"
 
@@ -162,7 +163,7 @@ SiteLaunchPartialStepsCompleted.decorators = [
     return (
       <SiteLaunchProvider
         initialStepNumber={1}
-        initialSiteLaunchStatus="CHECKLIST_TASKS_PENDING"
+        initialSiteLaunchStatus={SiteLaunchFEStatus.ChecklistTasksPending}
       >
         <Story />
       </SiteLaunchProvider>

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -373,7 +373,8 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
                     Get started
                   </Text>
                 )}
-                {siteLaunchStatus === "LAUNCHING" && (
+                {(siteLaunchStatus === "LAUNCHING" ||
+                  siteLaunchStatus === "FAILURE") && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
                     Check status
                   </Text>

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -53,6 +53,7 @@ import { FeatureTourHandler } from "features/FeatureTour/FeatureTour"
 import { DASHBOARD_FEATURE_STEPS } from "features/FeatureTour/FeatureTourSequence"
 import {
   NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH,
+  SiteLaunchFEStatus,
   SITE_LAUNCH_TASKS_LENGTH,
 } from "types/siteLaunch"
 
@@ -111,7 +112,7 @@ export const SiteDashboard = (): JSX.Element => {
     ({ status }) => status === "OPEN" || status === "APPROVED"
   )
   const siteLaunchStatus = siteLaunchStatusProps?.siteLaunchStatus
-  const isSiteLaunchLoading = siteLaunchStatus === "LOADING"
+  const isSiteLaunchLoading = siteLaunchStatus === SiteLaunchFEStatus.Loading
 
   return (
     <SiteViewLayout overflow="hidden">
@@ -209,7 +210,7 @@ export const SiteDashboard = (): JSX.Element => {
               <SiteLaunchDisplayCard />
               {/* Human image and last saved/published */}
               <Box w="100%">
-                {(siteLaunchStatus === "LAUNCHED" ||
+                {(siteLaunchStatus === SiteLaunchFEStatus.Launched ||
                   !isSiteLaunchEnabled(siteName, role)) && (
                   <SiteDashboardHumanImage />
                 )}
@@ -240,7 +241,7 @@ export const SiteDashboard = (): JSX.Element => {
 
                       <Skeleton isLoaded={!isSiteLaunchLoading} w="100%">
                         {isSiteLaunchEnabled(siteName, role) &&
-                          siteLaunchStatus === "LAUNCHED" && (
+                          siteLaunchStatus === SiteLaunchFEStatus.Launching && (
                             <Flex alignItems="center">
                               <Text
                                 textStyle="caption-2"
@@ -352,9 +353,9 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
   const totalTasks = siteLaunchStatusProps?.isNewDomain
     ? NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH
     : SITE_LAUNCH_TASKS_LENGTH
-  const isSiteLaunchLoading = siteLaunchStatus === "LOADING"
+  const isSiteLaunchLoading = siteLaunchStatus === SiteLaunchFEStatus.Loading
   if (!isSiteLaunchEnabled(siteName, role)) return <></>
-  if (siteLaunchStatus === "LAUNCHED") return <></>
+  if (siteLaunchStatus === SiteLaunchFEStatus.Launched) return <></>
 
   return (
     <Box w="100%">
@@ -369,18 +370,19 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
                 as={RouterLink}
                 to={`/sites/${siteName}/siteLaunchPad`}
               >
-                {siteLaunchStatus === "NOT_LAUNCHED" && (
+                {siteLaunchStatus === SiteLaunchFEStatus.NotLaunched && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
                     Go to Launchpad
                   </Text>
                 )}
-                {siteLaunchStatus === "CHECKLIST_TASKS_PENDING" && (
+                {siteLaunchStatus ===
+                  SiteLaunchFEStatus.ChecklistTasksPending && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
                     Manage
                   </Text>
                 )}
-                {(siteLaunchStatus === "LAUNCHING" ||
-                  siteLaunchStatus === "FAILED") && (
+                {(siteLaunchStatus === SiteLaunchFEStatus.Launching ||
+                  siteLaunchStatus === SiteLaunchFEStatus.Failed) && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
                     Check status
                   </Text>
@@ -398,7 +400,7 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
             </DisplayCardCaption>
           </DisplayCardHeader>
           <DisplayCardContent>
-            {siteLaunchStatus === "CHECKLIST_TASKS_PENDING" && (
+            {siteLaunchStatus === SiteLaunchFEStatus.ChecklistTasksPending && (
               <Text textStyle="body-2" mt="1rem">
                 <Text as="b">
                   {siteLaunchChecklistStepNumber}/{totalTasks}
@@ -406,7 +408,7 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
                 site launch tasks completed
               </Text>
             )}
-            {siteLaunchStatus === "LAUNCHING" && (
+            {siteLaunchStatus === SiteLaunchFEStatus.Launching && (
               <Text textStyle="body-2" mt="1rem">
                 Launch status: Pending
               </Text>

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -380,7 +380,7 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
                   </Text>
                 )}
                 {(siteLaunchStatus === "LAUNCHING" ||
-                  siteLaunchStatus === "FAILURE") && (
+                  siteLaunchStatus === "FAILED") && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
                     Check status
                   </Text>

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -51,7 +51,10 @@ import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
 import { BxsClearRocket, SiteDashboardHumanImage } from "assets"
 import { FeatureTourHandler } from "features/FeatureTour/FeatureTour"
 import { DASHBOARD_FEATURE_STEPS } from "features/FeatureTour/FeatureTourSequence"
-import { SITE_LAUNCH_TASKS_LENGTH } from "types/siteLaunch"
+import {
+  NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH,
+  SITE_LAUNCH_TASKS_LENGTH,
+} from "types/siteLaunch"
 
 import { SiteViewLayout } from "../layouts"
 
@@ -346,6 +349,9 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const siteLaunchStatus = siteLaunchStatusProps?.siteLaunchStatus
   const siteLaunchChecklistStepNumber = siteLaunchStatusProps?.stepNumber
+  const totalTasks = siteLaunchStatusProps?.isNewDomain
+    ? NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH
+    : SITE_LAUNCH_TASKS_LENGTH
   const isSiteLaunchLoading = siteLaunchStatus === "LOADING"
   if (!isSiteLaunchEnabled(siteName, role)) return <></>
   if (siteLaunchStatus === "LAUNCHED") return <></>
@@ -370,7 +376,7 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
                 )}
                 {siteLaunchStatus === "CHECKLIST_TASKS_PENDING" && (
                   <Text textStyle="subhead-1" whiteSpace="nowrap">
-                    Get started
+                    Manage
                   </Text>
                 )}
                 {(siteLaunchStatus === "LAUNCHING" ||
@@ -395,7 +401,7 @@ const SiteLaunchDisplayCard = (): JSX.Element => {
             {siteLaunchStatus === "CHECKLIST_TASKS_PENDING" && (
               <Text textStyle="body-2" mt="1rem">
                 <Text as="b">
-                  {siteLaunchChecklistStepNumber}/{SITE_LAUNCH_TASKS_LENGTH}
+                  {siteLaunchChecklistStepNumber}/{totalTasks}
                 </Text>{" "}
                 site launch tasks completed
               </Text>

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -20,7 +20,7 @@ const SiteLaunchPadMeta = {
     msw: {
       handlers: {
         siteLaunchStatusProps: buildSiteLaunchDto({
-          siteStatus: "NOT_LAUNCHED",
+          siteLaunchStatus: "NOT_LAUNCHED",
         }),
       },
     },

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -21,7 +21,7 @@ const SiteLaunchPadMeta = {
     msw: {
       handlers: {
         siteLaunchStatusProps: buildSiteLaunchDto({
-          siteLaunchStatus: SiteLaunchBEStatus.notLaunched,
+          siteLaunchStatus: SiteLaunchBEStatus.NotLaunched,
         }),
       },
     },

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -10,6 +10,7 @@ import {
   MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO,
 } from "mocks/constants"
 import { buildSiteLaunchDto } from "mocks/utils"
+import { SiteLaunchBEStatus, SiteLaunchFEStatus } from "types/siteLaunch"
 
 import { SiteLaunchPad } from "./SiteLaunchPad"
 
@@ -20,7 +21,7 @@ const SiteLaunchPadMeta = {
     msw: {
       handlers: {
         siteLaunchStatusProps: buildSiteLaunchDto({
-          siteLaunchStatus: "NOT_LAUNCHED",
+          siteLaunchStatus: SiteLaunchBEStatus.notLaunched,
         }),
       },
     },
@@ -98,7 +99,7 @@ siteLaunchChecklistNewDomain.decorators = [
     return (
       <SiteLaunchProvider
         initialStepNumber={1}
-        initialSiteLaunchStatus="CHECKLIST_TASKS_PENDING"
+        initialSiteLaunchStatus={SiteLaunchFEStatus.ChecklistTasksPending}
         isNewDomain
       >
         <Story />

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -220,22 +220,22 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   }
 
   return (
-    <>
-      {isLoaded ? (
-        <>
-          {isSiteLaunchEnabled(siteName, role) ? (
-            <SiteLaunchPad
-              pageNumber={pageNumber}
-              handleDecrementStepNumber={handleDecrementStepNumber}
-              handleIncrementStepNumber={handleIncrementStepNumber}
-            />
-          ) : (
-            <Redirect to={`/sites/${siteName}/dashboard`} />
-          )}
-        </>
-      ) : (
-        <Skeleton isLoaded />
-      )}
-    </>
+    <Skeleton isLoaded={isLoaded}>
+      <>
+        {isSiteLaunchEnabled(siteName, role) ? (
+          <SiteLaunchPad
+            pageNumber={pageNumber}
+            handleDecrementStepNumber={handleDecrementStepNumber}
+            handleIncrementStepNumber={handleIncrementStepNumber}
+          />
+        ) : (
+          /**
+           * Without the isLoaded check, the site will redirect prematurely.
+           * For more context, see https://github.com/isomerpages/isomercms-frontend/pull/1410#discussion_r1292910419
+           */
+          isLoaded && <Redirect to={`/sites/${siteName}/dashboard`} />
+        )}
+      </>
+    </Skeleton>
   )
 }

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -51,21 +51,28 @@ import {
 
 interface RiskAcceptanceModalProps {
   isOpen: boolean
-  setPageNumber: (number: number) => void
+  increasePageNumber: () => void
+  decreasePageNumber: () => void
+}
+
+interface SiteLaunchPadProps {
+  pageNumber: number
+  increasePageNumber: () => void
+  decreasePageNumber: () => void
+  handleDecrementStepNumber: () => void
+  handleIncrementStepNumber: () => void
 }
 
 const RiskAcceptanceModal = ({
   isOpen,
-  setPageNumber,
+  increasePageNumber,
+  decreasePageNumber,
 }: RiskAcceptanceModalProps): JSX.Element => {
   const { register, handleSubmit, watch } = useForm({})
   const isRiskAccepted = watch("isRiskAccepted")
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)}
-    >
+    <Modal isOpen={isOpen} onClose={() => decreasePageNumber()}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
@@ -107,18 +114,14 @@ const RiskAcceptanceModal = ({
         </ModalBody>
 
         <ModalFooter>
-          <Button
-            mr={3}
-            onClick={() => setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)}
-            variant="link"
-          >
+          <Button mr={3} onClick={() => decreasePageNumber()} variant="link">
             Cancel
           </Button>
           <Button
             isDisabled={!isRiskAccepted}
             type="submit"
             onClick={handleSubmit(() => {
-              setPageNumber(SITE_LAUNCH_PAGES.CHECKLIST)
+              increasePageNumber()
             })}
           >
             Continue
@@ -142,26 +145,29 @@ const getInitialPageNumber = (
 
 export const SiteLaunchPad = ({
   pageNumber,
-  setPageNumber,
+  increasePageNumber,
+  decreasePageNumber,
   handleDecrementStepNumber,
   handleIncrementStepNumber,
-}: {
-  pageNumber: number
-  setPageNumber: React.Dispatch<React.SetStateAction<number>>
-  handleDecrementStepNumber: () => void
-  handleIncrementStepNumber: () => void
-}): JSX.Element => {
+}: SiteLaunchPadProps): JSX.Element => {
   let title: JSX.Element
   let body: JSX.Element
   switch (pageNumber) {
     case SITE_LAUNCH_PAGES.DISCLAIMER:
       title = <SiteLaunchDisclaimerTitle />
-      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+      body = (
+        <SiteLaunchDisclaimerBody increasePageNumber={increasePageNumber} />
+      )
       break
     case SITE_LAUNCH_PAGES.INFO_GATHERING:
     case SITE_LAUNCH_PAGES.RISK_ACCEPTANCE: // Risk acceptance modal overlay
       title = <SiteLaunchInfoCollectorTitle />
-      body = <SiteLaunchInfoCollectorBody setPageNumber={setPageNumber} />
+      body = (
+        <SiteLaunchInfoCollectorBody
+          increasePageNumber={increasePageNumber}
+          decreasePageNumber={decreasePageNumber}
+        />
+      )
       break
     case SITE_LAUNCH_PAGES.CHECKLIST:
       title = <SiteLaunchChecklistTitle />
@@ -169,16 +175,19 @@ export const SiteLaunchPad = ({
         <SiteLaunchChecklistBody
           handleIncrementStepNumber={handleIncrementStepNumber}
           handleDecrementStepNumber={handleDecrementStepNumber}
+          increasePageNumber={increasePageNumber}
         />
       )
       break
     case SITE_LAUNCH_PAGES.FINAL_STATE:
       title = <></> // No title for final state
-      body = <SiteLaunchFinalState />
+      body = <SiteLaunchFinalState decreasePageNumber={decreasePageNumber} />
       break
     default:
       title = <SiteLaunchDisclaimerTitle />
-      body = <SiteLaunchDisclaimerBody setPageNumber={setPageNumber} />
+      body = (
+        <SiteLaunchDisclaimerBody increasePageNumber={increasePageNumber} />
+      )
   }
   return (
     <>
@@ -188,7 +197,8 @@ export const SiteLaunchPad = ({
         {body}
         <RiskAcceptanceModal
           isOpen={pageNumber === SITE_LAUNCH_PAGES.RISK_ACCEPTANCE}
-          setPageNumber={setPageNumber}
+          increasePageNumber={increasePageNumber}
+          decreasePageNumber={decreasePageNumber}
         />
       </VStack>
     </>
@@ -204,6 +214,13 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   const [pageNumber, setPageNumber] = useState(
     getInitialPageNumber(siteLaunchStatusProps)
   )
+
+  const increasePageNumber = () => {
+    setPageNumber(pageNumber + 1)
+  }
+  const decreasePageNumber = () => {
+    setPageNumber(pageNumber - 1)
+  }
 
   const errorToast = useErrorToast()
   const { data: role } = useGetCollaboratorRoleHook(siteName)
@@ -244,7 +261,8 @@ export const SiteLaunchPadPage = (): JSX.Element => {
       {isSiteLaunchEnabled(siteName, role) ? (
         <SiteLaunchPad
           pageNumber={pageNumber}
-          setPageNumber={setPageNumber}
+          increasePageNumber={increasePageNumber}
+          decreasePageNumber={decreasePageNumber}
           handleDecrementStepNumber={handleDecrementStepNumber}
           handleIncrementStepNumber={handleIncrementStepNumber}
         />

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -132,7 +132,7 @@ const RiskAcceptanceModal = ({
     </Modal>
   )
 }
-const getInitialPageNumber = (
+const getPageNumber = (
   siteLaunchStatusProps: SiteLaunchStatusProps | undefined
 ) => {
   const hasUserAlreadyStartedChecklistTasks =
@@ -141,6 +141,10 @@ const getInitialPageNumber = (
   const isSiteLaunchInProgress =
     siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHING"
   if (isSiteLaunchInProgress) return SITE_LAUNCH_PAGES.CHECKLIST
+  const isSiteLaunchEndState =
+    siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED" ||
+    siteLaunchStatusProps?.siteLaunchStatus === "FAILURE"
+  if (isSiteLaunchEndState) return SITE_LAUNCH_PAGES.FINAL_STATE
   return SITE_LAUNCH_PAGES.DISCLAIMER
 }
 
@@ -213,7 +217,7 @@ export const SiteLaunchPadPage = (): JSX.Element => {
   } = useSiteLaunchContext()
   const { siteName } = useParams<{ siteName: string }>()
   const [pageNumber, setPageNumber] = useState(
-    getInitialPageNumber(siteLaunchStatusProps)
+    getPageNumber(siteLaunchStatusProps)
   )
 
   const increasePageNumber = () => {
@@ -228,13 +232,14 @@ export const SiteLaunchPadPage = (): JSX.Element => {
 
   const isLoaded: boolean = !!siteName && !!role
   useEffect(() => {
+    setPageNumber(getPageNumber(siteLaunchStatusProps))
     if (isLoaded && !isSiteLaunchEnabled(siteName, role)) {
       errorToast({
         id: "no_access_to_launchpad",
         description: "You do not have access to this page.",
       })
     }
-  }, [siteName, errorToast, role, isLoaded])
+  }, [siteName, errorToast, role, isLoaded, siteLaunchStatusProps])
 
   const handleIncrementStepNumber = () => {
     if (

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -194,7 +194,7 @@ export const SiteLaunchPadPage = (): JSX.Element => {
         description: "You do not have access to this page.",
       })
     }
-  }, [siteName, errorToast, role, isLoaded, siteLaunchStatusProps])
+  }, [siteName, errorToast, role, isLoaded])
 
   const handleIncrementStepNumber = () => {
     if (

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -28,6 +28,7 @@ import { SiteViewHeader } from "layouts/layouts/SiteViewLayout/SiteViewHeader"
 import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
 
 import {
+  SiteLaunchFEStatus,
   SiteLaunchTaskTypeIndex,
   SITE_LAUNCH_PAGES,
   SITE_LAUNCH_TASKS_LENGTH,
@@ -204,7 +205,7 @@ export const SiteLaunchPadPage = (): JSX.Element => {
         ...siteLaunchStatusProps,
         stepNumber: (siteLaunchStatusProps.stepNumber +
           1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
-        siteLaunchStatus: "CHECKLIST_TASKS_PENDING",
+        siteLaunchStatus: SiteLaunchFEStatus.ChecklistTasksPending,
       })
     }
   }

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -7,6 +7,7 @@ import {
   ModalBody,
   Text,
   VStack,
+  Skeleton,
 } from "@chakra-ui/react"
 import {
   Button,
@@ -224,14 +225,16 @@ export const SiteLaunchPadPage = (): JSX.Element => {
 
   const errorToast = useErrorToast()
   const { data: role } = useGetCollaboratorRoleHook(siteName)
+
+  const isLoaded: boolean = !!siteName && !!role
   useEffect(() => {
-    if (!isSiteLaunchEnabled(siteName, role)) {
+    if (isLoaded && !isSiteLaunchEnabled(siteName, role)) {
       errorToast({
         id: "no_access_to_launchpad",
         description: "You do not have access to this page.",
       })
     }
-  }, [siteName, errorToast, role])
+  }, [siteName, errorToast, role, isLoaded])
 
   const handleIncrementStepNumber = () => {
     if (
@@ -258,16 +261,22 @@ export const SiteLaunchPadPage = (): JSX.Element => {
 
   return (
     <>
-      {isSiteLaunchEnabled(siteName, role) ? (
-        <SiteLaunchPad
-          pageNumber={pageNumber}
-          increasePageNumber={increasePageNumber}
-          decreasePageNumber={decreasePageNumber}
-          handleDecrementStepNumber={handleDecrementStepNumber}
-          handleIncrementStepNumber={handleIncrementStepNumber}
-        />
+      {isLoaded ? (
+        <>
+          {isSiteLaunchEnabled(siteName, role) ? (
+            <SiteLaunchPad
+              pageNumber={pageNumber}
+              increasePageNumber={increasePageNumber}
+              decreasePageNumber={decreasePageNumber}
+              handleDecrementStepNumber={handleDecrementStepNumber}
+              handleIncrementStepNumber={handleIncrementStepNumber}
+            />
+          ) : (
+            <Redirect to={`/sites/${siteName}/dashboard`} />
+          )}
+        </>
       ) : (
-        <Redirect to={`/sites/${siteName}/dashboard`} />
+        <Skeleton isLoaded />
       )}
     </>
   )

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -281,6 +281,9 @@ export const SiteLaunchChecklistBody = ({
     })
   }
 
+  return (
+    <SiteLaunchPadBody>
+      <Text mb="2rem">
         <Text as="b">Tasks must be done in this order. </Text>
         Mark the task as done to enable the next task item. Once all items are
         marked done, you can proceed to the next page to track your site launch

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -25,6 +25,7 @@ import {
   getNewDomainTaskFrmIdx,
   getOldDomainTaskFrmIdx,
   NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH,
+  SiteLaunchFEStatus,
   SITE_LAUNCH_TASKS,
   SITE_LAUNCH_TASKS_LENGTH,
   TITLE_TEXTS_NEW_DOMAIN,
@@ -215,7 +216,7 @@ export const SiteLaunchChecklistBody = ({
     setSiteLaunchStatusProps({
       ...siteLaunchStatusProps,
       stepNumber: SITE_LAUNCH_TASKS.GENERATE_NEW_DNS_RECORDS,
-      siteLaunchStatus: "LAUNCHING",
+      siteLaunchStatus: SiteLaunchFEStatus.Launching,
     })
 
     /**
@@ -236,9 +237,9 @@ export const SiteLaunchChecklistBody = ({
     }
   }
   const allTasksDone: boolean =
-    siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHING" ||
-    siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED" ||
-    siteLaunchStatusProps?.siteLaunchStatus === "FAILED"
+    siteLaunchStatusProps?.siteLaunchStatus === SiteLaunchFEStatus.Launching ||
+    siteLaunchStatusProps?.siteLaunchStatus === SiteLaunchFEStatus.Launched ||
+    siteLaunchStatusProps?.siteLaunchStatus === SiteLaunchFEStatus.Failed
 
   const checkboxes = Array.from({ length: numberOfCheckboxes }, (_, i) => (
     <Center key={i}>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -409,7 +409,12 @@ export const SiteLaunchChecklistBody = ({
               Back
             </Button>
           </Link>
-          <Button onClick={() => increasePageNumber()}>
+          <Button
+            onClick={() => increasePageNumber()}
+            // should not be able to go to next page until DNS
+            // records are displayed
+            isDisabled={!siteLaunchStatusProps?.dnsRecords}
+          >
             Track site status
           </Button>
         </HStack>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -121,6 +121,7 @@ const generateDNSTable = (dnsRecords: DNSRecord[] | undefined): JSX.Element => {
 interface SiteLaunchChecklistBodyProps {
   handleIncrementStepNumber: () => void
   handleDecrementStepNumber: () => void
+  increasePageNumber: () => void
 }
 
 interface TableMappingProps {
@@ -181,6 +182,7 @@ const addSubtitlesForChecklist = (
 export const SiteLaunchChecklistBody = ({
   handleIncrementStepNumber,
   handleDecrementStepNumber,
+  increasePageNumber,
 }: SiteLaunchChecklistBodyProps): JSX.Element => {
   const {
     siteLaunchStatusProps,
@@ -193,7 +195,6 @@ export const SiteLaunchChecklistBody = ({
   const numberOfTasks = siteLaunchStatusProps?.isNewDomain
     ? NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH
     : SITE_LAUNCH_TASKS_LENGTH
-
   const numberOfCheckboxes = numberOfTasks - 1 // last task is a button
   const { register, watch, setValue } = useForm({
     defaultValues: {
@@ -408,7 +409,9 @@ export const SiteLaunchChecklistBody = ({
               Back
             </Button>
           </Link>
-          <Button>Track site status</Button>
+          <Button onClick={() => increasePageNumber()}>
+            Track site status
+          </Button>
         </HStack>
       </Box>
     </SiteLaunchPadBody>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -281,9 +281,6 @@ export const SiteLaunchChecklistBody = ({
     })
   }
 
-  return (
-    <SiteLaunchPadBody>
-      <Text mb="2rem">
         <Text as="b">Tasks must be done in this order. </Text>
         Mark the task as done to enable the next task item. Once all items are
         marked done, you can proceed to the next page to track your site launch

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -238,7 +238,7 @@ export const SiteLaunchChecklistBody = ({
   const allTasksDone: boolean =
     siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHING" ||
     siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED" ||
-    siteLaunchStatusProps?.siteLaunchStatus === "FAILURE"
+    siteLaunchStatusProps?.siteLaunchStatus === "FAILED"
 
   const checkboxes = Array.from({ length: numberOfCheckboxes }, (_, i) => (
     <Center key={i}>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -4,7 +4,6 @@ import { useForm } from "react-hook-form"
 import { BiRightArrowAlt } from "react-icons/bi"
 
 import { typography } from "theme/foundations/typography"
-import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 
 import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
 import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
@@ -108,9 +107,7 @@ export const SiteLaunchDisclaimerBody = ({
           rightIcon={<Icon as={BiRightArrowAlt} fontSize="1.25rem" />}
           iconSpacing="1rem"
           ml="auto"
-          onClick={handleSubmit(() => {
-            increasePageNumber()
-          })}
+          onClick={handleSubmit(increasePageNumber)}
         >
           Continue
         </Button>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -3,6 +3,8 @@ import { Button, Checkbox } from "@opengovsg/design-system-react"
 import { useForm } from "react-hook-form"
 import { BiRightArrowAlt } from "react-icons/bi"
 
+import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
+
 import { typography } from "theme/foundations/typography"
 
 import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
@@ -14,14 +16,9 @@ export const SiteLaunchDisclaimerTitle = (): JSX.Element => {
   return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
 }
 
-interface SiteLaunchDisclaimerBodyProps {
-  increasePageNumber: () => void
-}
-
-export const SiteLaunchDisclaimerBody = ({
-  increasePageNumber,
-}: SiteLaunchDisclaimerBodyProps): JSX.Element => {
+export const SiteLaunchDisclaimerBody = (): JSX.Element => {
   const { register, handleSubmit, watch } = useForm({})
+  const { increasePageNumber } = useSiteLaunchContext()
   const isRequirementUnderstood = watch("isRequirementUnderstood")
   return (
     <SiteLaunchPadBody>

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchDisclaimer.tsx
@@ -16,11 +16,11 @@ export const SiteLaunchDisclaimerTitle = (): JSX.Element => {
 }
 
 interface SiteLaunchDisclaimerBodyProps {
-  setPageNumber: (number: number) => void
+  increasePageNumber: () => void
 }
 
 export const SiteLaunchDisclaimerBody = ({
-  setPageNumber,
+  increasePageNumber,
 }: SiteLaunchDisclaimerBodyProps): JSX.Element => {
   const { register, handleSubmit, watch } = useForm({})
   const isRequirementUnderstood = watch("isRequirementUnderstood")
@@ -109,8 +109,7 @@ export const SiteLaunchDisclaimerBody = ({
           iconSpacing="1rem"
           ml="auto"
           onClick={handleSubmit(() => {
-            // going to the next page
-            setPageNumber(SITE_LAUNCH_PAGES.INFO_GATHERING)
+            increasePageNumber()
           })}
         >
           Continue

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -9,16 +9,12 @@ import {
   SiteLaunchSuccessImage,
 } from "assets"
 
-interface SiteLaunchFinalStateProps {
-  decreasePageNumber: () => void
-}
-
-const SiteLaunchSuccessState = ({
-  decreasePageNumber,
-}: SiteLaunchFinalStateProps): JSX.Element => {
-  const { siteLaunchStatusProps } = useSiteLaunchContext()
+const SiteLaunchSuccessState = (): JSX.Element => {
+  const { siteLaunchStatusProps, decreasePageNumber } = useSiteLaunchContext()
   let siteUrl: string = siteLaunchStatusProps?.siteUrl || ""
   if (siteLaunchStatusProps?.useWwwSubdomain) {
+    // We append the `www` since the root might
+    // take time to propagate
     siteUrl = `www.${siteUrl}`
   }
   return (
@@ -45,7 +41,7 @@ const SiteLaunchSuccessState = ({
         >
           Back to tasklist
         </Button>
-        <Link href={siteUrl}>
+        <Link href={`https://${siteUrl}`} isExternal>
           <Button>Visit live site</Button>
         </Link>
       </HStack>
@@ -90,9 +86,8 @@ const SiteLaunchFailureState = (): JSX.Element => {
   )
 }
 
-const SiteLaunchInProgressState = ({
-  decreasePageNumber,
-}: SiteLaunchFinalStateProps): JSX.Element => {
+const SiteLaunchInProgressState = (): JSX.Element => {
+  const { decreasePageNumber } = useSiteLaunchContext()
   return (
     <>
       <Text
@@ -126,18 +121,16 @@ const SiteLaunchInProgressState = ({
   )
 }
 
-export const SiteLaunchFinalState = ({
-  decreasePageNumber,
-}: SiteLaunchFinalStateProps): JSX.Element => {
+export const SiteLaunchFinalState = (): JSX.Element => {
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const State = () => {
     if (siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED") {
-      return <SiteLaunchSuccessState decreasePageNumber={decreasePageNumber} />
+      return <SiteLaunchSuccessState />
     }
     if (siteLaunchStatusProps?.siteLaunchStatus === "FAILURE") {
       return <SiteLaunchFailureState />
     }
-    return <SiteLaunchInProgressState decreasePageNumber={decreasePageNumber} />
+    return <SiteLaunchInProgressState />
   }
 
   return (

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -8,6 +8,7 @@ import {
   SiteLaunchPendingImage,
   SiteLaunchSuccessImage,
 } from "assets"
+import { SiteLaunchFEStatus } from "types/siteLaunch"
 
 const SiteLaunchSuccessState = (): JSX.Element => {
   const { siteLaunchStatusProps, decreasePageNumber } = useSiteLaunchContext()
@@ -124,10 +125,12 @@ const SiteLaunchInProgressState = (): JSX.Element => {
 export const SiteLaunchFinalState = (): JSX.Element => {
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const State = () => {
-    if (siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED") {
+    if (
+      siteLaunchStatusProps?.siteLaunchStatus === SiteLaunchFEStatus.Launched
+    ) {
       return <SiteLaunchSuccessState />
     }
-    if (siteLaunchStatusProps?.siteLaunchStatus === "FAILED") {
+    if (siteLaunchStatusProps?.siteLaunchStatus === SiteLaunchFEStatus.Failed) {
       return <SiteLaunchFailureState />
     }
     return <SiteLaunchInProgressState />

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -9,6 +9,10 @@ import {
   SiteLaunchSuccessImage,
 } from "assets"
 
+interface SiteLaunchFinalStateProps {
+  decreasePageNumber: () => void
+}
+
 const SiteLaunchSuccessState = (): JSX.Element => {
   return (
     <>
@@ -76,7 +80,9 @@ const SiteLaunchFailureState = (): JSX.Element => {
   )
 }
 
-const SiteLaunchInProgressState = (): JSX.Element => {
+const SiteLaunchInProgressState = ({
+  decreasePageNumber,
+}: SiteLaunchFinalStateProps): JSX.Element => {
   return (
     <>
       <Text
@@ -98,14 +104,21 @@ const SiteLaunchInProgressState = (): JSX.Element => {
         when visiting your domain at this moment. Leave this window open or exit
         and come back later.
       </Text>
-      <Button variant="link" colorScheme="neutral" mt="3rem">
+      <Button
+        variant="link"
+        colorScheme="neutral"
+        mt="3rem"
+        onClick={decreasePageNumber}
+      >
         Back to tasklist
       </Button>
     </>
   )
 }
 
-export const SiteLaunchFinalState = (): JSX.Element => {
+export const SiteLaunchFinalState = ({
+  decreasePageNumber,
+}: SiteLaunchFinalStateProps): JSX.Element => {
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const State = () => {
     if (siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED") {
@@ -114,7 +127,7 @@ export const SiteLaunchFinalState = (): JSX.Element => {
     if (siteLaunchStatusProps?.siteLaunchStatus === "FAILURE") {
       return <SiteLaunchFailureState />
     }
-    return <SiteLaunchInProgressState />
+    return <SiteLaunchInProgressState decreasePageNumber={decreasePageNumber} />
   }
 
   return (

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -127,7 +127,7 @@ export const SiteLaunchFinalState = (): JSX.Element => {
     if (siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED") {
       return <SiteLaunchSuccessState />
     }
-    if (siteLaunchStatusProps?.siteLaunchStatus === "FAILURE") {
+    if (siteLaunchStatusProps?.siteLaunchStatus === "FAILED") {
       return <SiteLaunchFailureState />
     }
     return <SiteLaunchInProgressState />

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -1,4 +1,4 @@
-import { HStack, Text, VStack } from "@chakra-ui/react"
+import { HStack, Link, Text, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
@@ -13,7 +13,9 @@ interface SiteLaunchFinalStateProps {
   decreasePageNumber: () => void
 }
 
-const SiteLaunchSuccessState = (): JSX.Element => {
+const SiteLaunchSuccessState = ({
+  decreasePageNumber,
+}: SiteLaunchFinalStateProps): JSX.Element => {
   return (
     <>
       <Text
@@ -34,9 +36,16 @@ const SiteLaunchSuccessState = (): JSX.Element => {
         You can find your site&apos;s DNS records in the settings page.
       </Text>
       <HStack spacing="3rem">
-        <Button variant="link" colorScheme="neutral">
+        <Button
+          variant="link"
+          colorScheme="neutral"
+          onClick={decreasePageNumber}
+        >
           Back to tasklist
         </Button>
+        <Link href="google.com">
+          <Button>Visit live site</Button>
+        </Link>
         <Button>Visit live site</Button>
       </HStack>
     </>
@@ -122,7 +131,7 @@ export const SiteLaunchFinalState = ({
   const { siteLaunchStatusProps } = useSiteLaunchContext()
   const State = () => {
     if (siteLaunchStatusProps?.siteLaunchStatus === "LAUNCHED") {
-      return <SiteLaunchSuccessState />
+      return <SiteLaunchSuccessState decreasePageNumber={decreasePageNumber} />
     }
     if (siteLaunchStatusProps?.siteLaunchStatus === "FAILURE") {
       return <SiteLaunchFailureState />

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -16,6 +16,11 @@ interface SiteLaunchFinalStateProps {
 const SiteLaunchSuccessState = ({
   decreasePageNumber,
 }: SiteLaunchFinalStateProps): JSX.Element => {
+  const { siteLaunchStatusProps } = useSiteLaunchContext()
+  let siteUrl: string = siteLaunchStatusProps?.siteUrl || ""
+  if (siteLaunchStatusProps?.useWwwSubdomain) {
+    siteUrl = `www.${siteUrl}`
+  }
   return (
     <>
       <Text
@@ -40,10 +45,9 @@ const SiteLaunchSuccessState = ({
         >
           Back to tasklist
         </Button>
-        <Link href="google.com">
+        <Link href={siteUrl}>
           <Button>Visit live site</Button>
         </Link>
-        <Button>Visit live site</Button>
       </HStack>
     </>
   )

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchFinalState.tsx
@@ -32,9 +32,6 @@ const SiteLaunchSuccessState = ({
       <Text textStyle="body-1" textColor="base.content.default" mt="1.5rem">
         View your site status from the Dashboard.
       </Text>
-      <Text textStyle="body-1" textColor="base.content.default" mb="3rem">
-        You can find your site&apos;s DNS records in the settings page.
-      </Text>
       <HStack spacing="3rem">
         <Button
           variant="link"

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -32,11 +32,6 @@ export const SiteLaunchInfoCollectorTitle = (): JSX.Element => {
   return <SiteLaunchPadTitle title={title} subTitle={subTitle} />
 }
 
-interface SiteLaunchInfoGatheringBodyProps {
-  increasePageNumber: () => void
-  decreasePageNumber: () => void
-}
-
 const SiteNature = {
   New: "new",
   Live: "live",
@@ -50,10 +45,7 @@ interface SiteLaunchFormData {
   useWww: "true" | "false"
 }
 
-export const SiteLaunchInfoCollectorBody = ({
-  increasePageNumber,
-  decreasePageNumber,
-}: SiteLaunchInfoGatheringBodyProps): JSX.Element => {
+export const SiteLaunchInfoCollectorBody = (): JSX.Element => {
   const {
     register,
     handleSubmit,
@@ -64,6 +56,8 @@ export const SiteLaunchInfoCollectorBody = ({
   const {
     siteLaunchStatusProps,
     setSiteLaunchStatusProps,
+    increasePageNumber,
+    decreasePageNumber,
   } = useSiteLaunchContext()
 
   const onSubmit = (data: SiteLaunchFormData) => {

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchInfoGathering.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import {
   Box,
   Button,
@@ -24,8 +23,6 @@ import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
 import { recommendWwwValue } from "utils/site-launch/domain-nature"
 
-import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
-
 import { SiteLaunchPadBody } from "./SiteLaunchPadBody"
 import { SiteLaunchPadTitle } from "./SiteLaunchPadTitle"
 
@@ -36,7 +33,8 @@ export const SiteLaunchInfoCollectorTitle = (): JSX.Element => {
 }
 
 interface SiteLaunchInfoGatheringBodyProps {
-  setPageNumber: (number: number) => void
+  increasePageNumber: () => void
+  decreasePageNumber: () => void
 }
 
 const SiteNature = {
@@ -53,7 +51,8 @@ interface SiteLaunchFormData {
 }
 
 export const SiteLaunchInfoCollectorBody = ({
-  setPageNumber,
+  increasePageNumber,
+  decreasePageNumber,
 }: SiteLaunchInfoGatheringBodyProps): JSX.Element => {
   const {
     register,
@@ -75,7 +74,7 @@ export const SiteLaunchInfoCollectorBody = ({
       isNewDomain: data.nature === SiteNature.New,
       useWwwSubdomain: data.useWww === "true",
     })
-    setPageNumber(SITE_LAUNCH_PAGES.RISK_ACCEPTANCE)
+    increasePageNumber()
   }
   const [selectedDomainNature, setSelectedDomainNature] = useState("")
   const [wwwSetting, setWwwSetting] = useState("")
@@ -214,7 +213,7 @@ export const SiteLaunchInfoCollectorBody = ({
           <Button
             variant="link"
             mr={4}
-            onClick={() => setPageNumber(SITE_LAUNCH_PAGES.DISCLAIMER)}
+            onClick={() => decreasePageNumber()}
             height="2.75rem"
           >
             <Text textColor="base.content.strong">Cancel</Text>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -20,7 +20,7 @@ import {
   SiteDashboardInfo,
   SiteDashboardReviewRequest,
 } from "types/siteDashboard"
-import { SiteLaunchDto } from "types/siteLaunch"
+import { SiteLaunchBEStatus, SiteLaunchDto } from "types/siteLaunch"
 import { SiteDataRequest } from "types/sites"
 import { LoggedInUser } from "types/user"
 
@@ -501,11 +501,11 @@ export const OLD_DIFF_VALUE = generateDiffValues()
 export const NEW_DIFF_VALUE = generateDiffValues().toUpperCase()
 
 export const MOCK_UNLAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: "NOT_LAUNCHED",
+  siteLaunchStatus: SiteLaunchBEStatus.notLaunched,
 }
 
 export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: "LAUNCHED",
+  siteLaunchStatus: SiteLaunchBEStatus.launched,
   dnsRecords: [
     {
       source: "sourceURL",
@@ -516,7 +516,7 @@ export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: "FAILED",
+  siteLaunchStatus: SiteLaunchBEStatus.failed,
   dnsRecords: [
     {
       source: "sourceURL",
@@ -527,7 +527,7 @@ export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_LAUNCHING_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: "LAUNCHING",
+  siteLaunchStatus: SiteLaunchBEStatus.launching,
   dnsRecords: [
     {
       source: "sourceURL",

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -501,11 +501,11 @@ export const OLD_DIFF_VALUE = generateDiffValues()
 export const NEW_DIFF_VALUE = generateDiffValues().toUpperCase()
 
 export const MOCK_UNLAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: SiteLaunchBEStatus.notLaunched,
+  siteLaunchStatus: SiteLaunchBEStatus.NotLaunched,
 }
 
 export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: SiteLaunchBEStatus.launched,
+  siteLaunchStatus: SiteLaunchBEStatus.Launched,
   dnsRecords: [
     {
       source: "sourceURL",
@@ -516,7 +516,7 @@ export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: SiteLaunchBEStatus.failed,
+  siteLaunchStatus: SiteLaunchBEStatus.Failed,
   dnsRecords: [
     {
       source: "sourceURL",
@@ -527,7 +527,7 @@ export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_LAUNCHING_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteLaunchStatus: SiteLaunchBEStatus.launching,
+  siteLaunchStatus: SiteLaunchBEStatus.Launching,
   dnsRecords: [
     {
       source: "sourceURL",

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -516,7 +516,7 @@ export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteStatus: "FAILURE",
+  siteStatus: "FAILED",
   dnsRecords: [
     {
       source: "sourceURL",

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -501,11 +501,11 @@ export const OLD_DIFF_VALUE = generateDiffValues()
 export const NEW_DIFF_VALUE = generateDiffValues().toUpperCase()
 
 export const MOCK_UNLAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteStatus: "NOT_LAUNCHED",
+  siteLaunchStatus: "NOT_LAUNCHED",
 }
 
 export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteStatus: "LAUNCHED",
+  siteLaunchStatus: "LAUNCHED",
   dnsRecords: [
     {
       source: "sourceURL",
@@ -516,7 +516,7 @@ export const MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteStatus: "FAILED",
+  siteLaunchStatus: "FAILED",
   dnsRecords: [
     {
       source: "sourceURL",
@@ -527,7 +527,7 @@ export const MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO: SiteLaunchDto = {
 }
 
 export const MOCK_LAUNCHING_SITE_LAUNCH_DTO: SiteLaunchDto = {
-  siteStatus: "LAUNCHING",
+  siteLaunchStatus: "LAUNCHING",
   dnsRecords: [
     {
       source: "sourceURL",

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -6,16 +6,16 @@ export interface DNSRecord {
   target: string
 }
 
-const SiteLaunchFrontEndStatusOptions = {
+export const SiteLaunchFEStatus = {
   Launched: "LAUNCHED",
   NotLaunched: "NOT_LAUNCHED",
   Launching: "LAUNCHING",
   ChecklistTasksPending: "CHECKLIST_TASKS_PENDING", // not to be confused with with Infra level launching step
   Loading: "LOADING",
-  Failure: "FAILED",
+  Failed: "FAILED",
 } as const
 
-export type SiteLaunchFrontEndStatus = typeof SiteLaunchFrontEndStatusOptions[keyof typeof SiteLaunchFrontEndStatusOptions]
+export type SiteLaunchFEStatusType = typeof SiteLaunchFEStatus[keyof typeof SiteLaunchFEStatus]
 
 export const NEW_DOMAIN_SITE_LAUNCH_TASKS = {
   NOT_STARTED: 0,
@@ -46,20 +46,27 @@ export const SITE_LAUNCH_PAGES = {
 export type SiteLaunchPageIndex = typeof SITE_LAUNCH_PAGES[keyof typeof SITE_LAUNCH_PAGES]
 
 export interface SiteLaunchStatusProps {
-  siteLaunchStatus: SiteLaunchFrontEndStatus
+  siteLaunchStatus: SiteLaunchFEStatusType
   stepNumber: SiteLaunchTaskTypeIndex
   dnsRecords?: DNSRecord[]
   siteUrl?: string
   isNewDomain?: boolean
   useWwwSubdomain?: boolean
 }
+
+export const SiteLaunchBEStatus = {
+  notLaunched: "NOT_LAUNCHED",
+  launching: "LAUNCHING",
+  launched: "LAUNCHED",
+  failed: "FAILED",
+} as const
 export interface SiteLaunchDto {
   /**
    * Transition will be
    * "NOT_LAUNCHED" -> User presses the Generate DNS button
    * -> "LAUNCHING" -> wait for 90 seconds -> "LAUNCHED"
    */
-  siteLaunchStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING" | "FAILED"
+  siteLaunchStatus: typeof SiteLaunchBEStatus[keyof typeof SiteLaunchBEStatus]
   dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
   siteUrl?: string
 }

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -59,7 +59,7 @@ export interface SiteLaunchDto {
    * "NOT_LAUNCHED" -> User presses the Generate DNS button
    * -> "LAUNCHING" -> wait for 90 seconds -> "LAUNCHED"
    */
-  siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING" | "FAILED"
+  siteLaunchStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING" | "FAILED"
   dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
   siteUrl?: string
 }

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -12,7 +12,7 @@ const SiteLaunchFrontEndStatusOptions = {
   Launching: "LAUNCHING",
   ChecklistTasksPending: "CHECKLIST_TASKS_PENDING", // not to be confused with with Infra level launching step
   Loading: "LOADING",
-  Failure: "FAILURE",
+  Failure: "FAILED",
 } as const
 
 export type SiteLaunchFrontEndStatus = typeof SiteLaunchFrontEndStatusOptions[keyof typeof SiteLaunchFrontEndStatusOptions]
@@ -59,7 +59,7 @@ export interface SiteLaunchDto {
    * "NOT_LAUNCHED" -> User presses the Generate DNS button
    * -> "LAUNCHING" -> wait for 90 seconds -> "LAUNCHED"
    */
-  siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING" | "FAILURE"
+  siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING" | "FAILED"
   dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
   siteUrl?: string
 }

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -35,6 +35,16 @@ export const SITE_LAUNCH_TASKS = {
 
 export type SiteLaunchTaskTypeIndex = typeof SITE_LAUNCH_TASKS[keyof typeof SITE_LAUNCH_TASKS]
 
+export const SITE_LAUNCH_PAGES = {
+  DISCLAIMER: 1,
+  INFO_GATHERING: 2,
+  RISK_ACCEPTANCE: 3,
+  CHECKLIST: 4,
+  FINAL_STATE: 5,
+} as const
+
+export type SiteLaunchPageIndex = typeof SITE_LAUNCH_PAGES[keyof typeof SITE_LAUNCH_PAGES]
+
 export interface SiteLaunchStatusProps {
   siteLaunchStatus: SiteLaunchFrontEndStatus
   stepNumber: SiteLaunchTaskTypeIndex
@@ -49,7 +59,6 @@ export interface SiteLaunchDto {
    * "NOT_LAUNCHED" -> User presses the Generate DNS button
    * -> "LAUNCHING" -> wait for 90 seconds -> "LAUNCHED"
    */
-  // TODO: create a corresponding BE PR to incorporate this extra type
   siteStatus: "LAUNCHED" | "NOT_LAUNCHED" | "LAUNCHING" | "FAILURE"
   dnsRecords?: DNSRecord[] // only present iff siteStatus is LAUNCHED
   siteUrl?: string
@@ -61,14 +70,6 @@ export const SITE_LAUNCH_TASKS_LENGTH = (Object.keys(SITE_LAUNCH_TASKS).length -
 export const NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH = (Object.keys(
   NEW_DOMAIN_SITE_LAUNCH_TASKS
 ).length - 1) as SiteLaunchTaskTypeIndex
-
-export const SITE_LAUNCH_PAGES = {
-  DISCLAIMER: 1,
-  INFO_GATHERING: 2,
-  RISK_ACCEPTANCE: 3,
-  CHECKLIST: 4,
-  FINAL_STATE: 5,
-}
 
 type OldDomainSiteLaunchTaskTitles = Exclude<
   keyof typeof SITE_LAUNCH_TASKS,

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -55,10 +55,10 @@ export interface SiteLaunchStatusProps {
 }
 
 export const SiteLaunchBEStatus = {
-  notLaunched: "NOT_LAUNCHED",
-  launching: "LAUNCHING",
-  launched: "LAUNCHED",
-  failed: "FAILED",
+  NotLaunched: "NOT_LAUNCHED",
+  Launching: "LAUNCHING",
+  Launched: "LAUNCHED",
+  Failed: "FAILED",
 } as const
 export interface SiteLaunchDto {
   /**


### PR DESCRIPTION
## Problem

There exists integration work to get the functionality of the final screens to work. This PR addresses this. 

## Solution

The page logic is shifted over to the main dashboard page. This is because the behaviour of when the final screens are shown is dependent on the api call + it was needed throughout multiple components, and this this approach was taken to prevent prop drilling.  

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible


## Tests

There are 4 main cases I am testing this flow on. For ease of testing, I am manually refetching the react query key, but in reality this is refetched once every 5 mins. I am also mutating the database entries directly cuz actual site launch is slow.

concretely, these are the mapped DB values to what the `siteLaunchDto` will have: 

`site_status` = `INITALIZED` and `job_status` = `READY` -> `siteLaunchStatus = NOT_LAUNCHED`

`site_status` = `LAUNCHED` and `job_status` = `RUNNING` -> `siteLaunchStatus = LAUNCHING`

`site_status` = `LAUNCHED` and `job_status` = `FAILED` -> `siteLaunchStatus = FAILED`

`site_status` = `LAUNCHED` and `job_status` = `READY` -> `siteLaunchStatus = LAUNCHED`

So to get the corresponding UI in the FE, I directly mutate the values for the `siteStatus` + `jobStatus` to get the desired screens for the UI demo in this PR. 



 Will be doing a full run tmr on staging for sanity checks. 

A -> new domain, www 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/4d66c03c-6a20-4a3d-9768-cb4742ed4c52

B -> old domain, www 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/535c157f-9ec9-4245-8744-68369d84d705

C -> new domain, non-www 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/d65db755-1c04-4848-8d9b-40e051d2f260

D -> old domain, non-www 


https://github.com/isomerpages/isomercms-frontend/assets/42832651/438de940-ac44-44e3-819b-0c66c973cd4b


## Limitations 

While testing I realised that the site launch details might be better off stored in local storage/stored somehow in the BE. This is because if the user were to go into edit site, we do a hard refresh to the site dashboard and since some of the state (specifically the checklist tasks), this information gets lost. 

^ This limitation would not be tackled until the next iteration due to time constraints (+ while this is annoying, user can still  launch site by redoing already done work) 

