### PR TITLE
fix(announcement modal): only show when otp is not

### DIFF
--- a/src/layouts/Sites.tsx
+++ b/src/layouts/Sites.tsx
@@ -140,7 +140,7 @@ const SitesContent = ({ siteNames }: { siteNames?: SiteData[] }) => {
 }
 
 export const Sites = (): JSX.Element => {
-  const { email, userId } = useLoginContext()
+  const { email, userId, contactNumber } = useLoginContext()
   const { data: siteRequestData } = useGetAllSites(email)
   const { announcements, link } = useAnnouncements()
   const [isOpen, setIsOpen] = useState(announcements.length > 0 && !userId)
@@ -159,9 +159,15 @@ export const Sites = (): JSX.Element => {
     )
   }, [siteRequestData])
 
+  /**
+   * Currently the announcement modal takes in all the keyboard events,
+   * thus preventing the user from typing in the verify otp input field.
+   */
+  const shouldShowAnnouncementModel =
+    announcements.length > 0 && !!contactNumber && !!email
   return (
     <>
-      {announcements.length > 0 && (
+      {shouldShowAnnouncementModel && (
         <AnnouncementModal
           isOpen={isOpen}
           announcements={announcements}


### PR DESCRIPTION
## Problem

Currently, when annoucement modal + verify otp modal pops up, users are not able to input anything into the modal.



## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
