### PR TITLE
IS-398: Write retrieve images from disk and return as base 64

### DIFF
--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -103,7 +103,7 @@ export const MediaSettingsModal = ({
             <p>
               For {mediaRoom} other than
               {mediaRoom === "images"
-                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'`
+                ? ` 'png', 'jpg', '.jpeg', 'gif', 'tif', '.tiff', 'bmp', 'ico', 'svg'`
                 : ` 'pdf'`}
               , please use{" "}
               <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">
@@ -124,6 +124,7 @@ export const MediaSettingsModal = ({
     }
 
     if (mediaRoom === "images") {
+      console.log(`Displaying`, watch("mediaUrl"))
       return (
         <div className={mediaStyles.editImagePreview}>
           <img

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -90,7 +90,7 @@ const MediasSelectModal = ({
           <p>
             For {mediaRoom} other than
             {mediaRoom === "images"
-              ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'`
+              ? ` 'png', 'jpg', '.jpeg', 'gif', 'tif', '.tiff', 'bmp', 'ico', 'svg'`
               : ` 'pdf'`}
             , please use
             <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -122,7 +122,7 @@ export const Media = (): JSX.Element => {
               <br />
               For {pluralMediaLabel} other than
               {mediaType === "images"
-                ? ` 'png', 'jpg', 'gif', 'tif', 'bmp', 'ico', 'svg'`
+                ? ` 'png', 'jpg', '.jpeg', 'gif', 'tif', '.tiff', 'bmp', 'ico', 'svg'`
                 : ` 'pdf'`}
               , please use
               <Link to={{ pathname: `https://go.gov.sg` }} target="_blank">

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -52,7 +52,7 @@ export const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX)
 export const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 export const jekyllFirstCharacterRegexTest = /^[._#~]/
 export const mediaSpecialCharactersRegexTest = /[~%^?*+#./\\`;~{}[\]"<>]/
-export const imagesSuffixRegexTest = /^.+\.(svg|jpg|jpeg|png|gif|tif|bmp|ico)$/
+export const imagesSuffixRegexTest = /^.+\.(svg|jpg|jpeg|png|gif|tif|tiff|bmp|ico)$/
 export const filesSuffixRegexTest = /^.+\.(pdf)$/
 
 const ISOMER_TEMPLATE_PROTECTED_DIRS = [

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -900,7 +900,7 @@ const validateFileName = (value) => {
     return "Invalid filename: filename can only contain one full stop and must follow the structure {name}.{extension}"
   }
   if (!fileNameExtensionRegexTest.test(fileNameArr[1])) {
-    return "Invalid filename: filename must end with a valid file extension (.JPG, .png, .pdf, etc.)"
+    return "Invalid filename: filename must end with a valid file extension (.jpg, .png, .pdf, etc.)"
   }
   if (fileNameArr[0] === "")
     return "Invalid filename: please specify a filename"


### PR DESCRIPTION
## Problem

We added additional image extensions as they are valid too, specifically: .jpeg and .tiff

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types for more info

Closes IS-398

## Solution

Add the above 2 extensions to our validator and copy

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible
