### PR TITLE
chore(edithomepage): shift constants out

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -11,7 +11,6 @@ import { DragDropContext } from "@hello-pangea/dnd"
 import { Button, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
 import _ from "lodash"
-import PropTypes from "prop-types"
 import { useEffect, createRef, useState } from "react"
 
 import { Footer } from "components/Footer"
@@ -55,6 +54,15 @@ import { HeroHighlightSection } from "./components/Homepage/HeroHighlightSection
 import { InfobarBody } from "./components/Homepage/InfobarBody"
 import { InfopicBody } from "./components/Homepage/InfopicBody"
 import { ResourcesBody } from "./components/Homepage/ResourcesBody"
+import {
+  DROPDOWN_ELEMENT_SECTION,
+  DROPDOWN_SECTION,
+  INFOBAR_SECTION,
+  INFOPIC_SECTION,
+  KEY_HIGHLIGHT_SECTION,
+  RESOURCES_SECTION,
+} from "./EditHomepage/constants"
+import { getErrorValues } from "./EditHomepage/utils"
 
 /* eslint-disable react/no-array-index-key */
 
@@ -88,62 +96,28 @@ const getHasErrors = (errors) => {
 // Constants
 // Section constructors
 // TODO: Export all these as const and write wrapper for error...
-const ResourcesSectionConstructor = (isErrorConstructor) => ({
-  resources: {
-    title: isErrorConstructor ? "" : "Resources Section Title",
-    subtitle: isErrorConstructor ? "" : "Resources Section Subtitle",
-    button: isErrorConstructor ? "" : "Resources Button Name",
-  },
-})
 
-const InfobarSectionConstructor = (isErrorConstructor) => ({
-  infobar: {
-    title: isErrorConstructor ? "" : "Infobar Title",
-    subtitle: isErrorConstructor ? "" : "Infobar Subtitle",
-    description: isErrorConstructor ? "" : "Infobar description",
-    button: isErrorConstructor ? "" : "Button Text",
-    url: "", // No default value so that no broken link is created
-  },
-})
-
-const InfopicSectionConstructor = (isErrorConstructor) => ({
-  infopic: {
-    title: isErrorConstructor ? "" : "Infopic Title",
-    subtitle: isErrorConstructor ? "" : "Infopic Subtitle",
-    description: isErrorConstructor ? "" : "Infopic description",
-    button: isErrorConstructor ? "" : "Button Text",
-    url: "", // No default value so that no broken link is created
-    image: "", // Always blank since the image modal handles this
-    alt: isErrorConstructor ? "" : "Image alt text",
-  },
-})
-
-const KeyHighlightConstructor = (isErrorConstructor) => ({
-  title: isErrorConstructor ? "" : "Key Highlight Title",
-  description: isErrorConstructor ? "" : "Key Highlight description",
-  url: "", // No default value so that no broken link is created
-})
-
-const DropdownElemConstructor = (isErrorConstructor) => ({
-  title: isErrorConstructor ? "" : "Hero Dropdown Element Title",
-  url: "", // No default value so that no broken link is created
-})
-
-const DropdownConstructor = () => ({
-  title: "Hero Dropdown Title",
-  options: [],
-})
-
-const enumSection = (type, isErrorConstructor) => {
+const enumSection = (type, isError) => {
   switch (type) {
     case "resources":
-      return ResourcesSectionConstructor(isErrorConstructor)
+      return isError
+        ? { resources: getErrorValues(RESOURCES_SECTION) }
+        : { resources: RESOURCES_SECTION }
+
     case "infobar":
-      return InfobarSectionConstructor(isErrorConstructor)
+      return isError
+        ? { infobar: getErrorValues(INFOBAR_SECTION) }
+        : { infobar: INFOBAR_SECTION }
+
     case "infopic":
-      return InfopicSectionConstructor(isErrorConstructor)
+      return isError
+        ? { infopic: getErrorValues(INFOPIC_SECTION) }
+        : { infopic: INFOPIC_SECTION }
+
     default:
-      return InfobarSectionConstructor(isErrorConstructor)
+      return isError
+        ? { infobar: getErrorValues(INFOBAR_SECTION) }
+        : { infobar: INFOBAR_SECTION }
   }
 }
 
@@ -260,14 +234,14 @@ const EditHomepage = ({ match }) => {
               )
               // Fill in dropdown elem errors array
               dropdownElemsErrors = _.map(dropdown.options, () =>
-                DropdownElemConstructor(true)
+                getErrorValues(DROPDOWN_ELEMENT_SECTION)
               )
             }
             if (keyHighlights) {
               displayHighlights = _.fill(Array(keyHighlights.length), false)
               // Fill in highlights errors array
               highlightsErrors = _.map(keyHighlights, () =>
-                KeyHighlightConstructor(true)
+                getErrorValues(KEY_HIGHLIGHT_SECTION)
               )
             }
             // Fill in sectionErrors for hero
@@ -276,15 +250,17 @@ const EditHomepage = ({ match }) => {
 
           // Check if there is already a resources section
           if (section.resources) {
-            sectionsErrors.push(ResourcesSectionConstructor(true))
+            sectionsErrors.push({
+              resources: getErrorValues(RESOURCES_SECTION),
+            })
           }
 
           if (section.infobar) {
-            sectionsErrors.push(InfobarSectionConstructor(true))
+            sectionsErrors.push({ infobar: getErrorValues(INFOBAR_SECTION) })
           }
 
           if (section.infopic) {
-            sectionsErrors.push(InfopicSectionConstructor(true))
+            sectionsErrors.push({ infopic: getErrorValues(INFOPIC_SECTION) })
           }
 
           // Minimize all sections by default
@@ -571,8 +547,8 @@ const EditHomepage = ({ match }) => {
           break
         }
         case "dropdownelem": {
-          const val = DropdownElemConstructor(false)
-          const err = DropdownElemConstructor(true)
+          const val = DROPDOWN_ELEMENT_SECTION
+          const err = getErrorValues(DROPDOWN_ELEMENT_SECTION)
 
           const updatedHomepageState = onCreate(
             homepageState,
@@ -587,8 +563,8 @@ const EditHomepage = ({ match }) => {
         case "highlight": {
           // depends on index to generate
           // If key highlights section exists
-          const val = KeyHighlightConstructor(false)
-          const err = KeyHighlightConstructor(true)
+          const val = KEY_HIGHLIGHT_SECTION
+          const err = getErrorValues(KEY_HIGHLIGHT_SECTION)
           const updatedHomepageState = onCreate(
             homepageState,
             elemType,
@@ -721,11 +697,11 @@ const EditHomepage = ({ match }) => {
       let dropdownErrors
       let dropdownElemErrors
       if (savedHeroElems) {
-        dropdownObj = savedHeroElems.dropdown || DropdownConstructor()
+        dropdownObj = savedHeroElems.dropdown || DROPDOWN_SECTION
         dropdownErrors = savedHeroErrors.dropdown || ""
         dropdownElemErrors = savedHeroErrors.dropdownElems || ""
       } else {
-        dropdownObj = DropdownConstructor()
+        dropdownObj = DROPDOWN_SECTION
         dropdownErrors = ""
         dropdownElemErrors = []
       }
@@ -1126,14 +1102,14 @@ const EditHomepage = ({ match }) => {
                   <AddSectionButton>
                     <AddSectionButton.List>
                       <AddSectionButton.Option
-                        onClick={() => onClick("infopic")}
-                        title="Infopic"
-                        subtitle="Add an image with informational text"
+                        onClick={() => onClick(INFOPIC_SECTION.id)}
+                        title={INFOPIC_SECTION.title}
+                        subtitle={INFOPIC_SECTION.subtitle}
                       />
                       <AddSectionButton.Option
-                        title="Infobar"
-                        subtitle="Add informational text"
-                        onClick={() => onClick("infobar")}
+                        title={INFOBAR_SECTION.title}
+                        subtitle={INFOBAR_SECTION.subtitle}
+                        onClick={() => onClick(INFOBAR_SECTION.id)}
                       />
                       {/* NOTE: Check if the sections contain any `resources` 
                                 and if it does, prevent creation of another `resources` section
@@ -1142,9 +1118,9 @@ const EditHomepage = ({ match }) => {
                         ({ resources }) => !!resources
                       ) && (
                         <AddSectionButton.Option
-                          title="Resources"
-                          subtitle="Add a preview and link to your Resource Room"
-                          onClick={() => onClick("resources")}
+                          title={RESOURCES_SECTION.title}
+                          subtitle={RESOURCES_SECTION.subtitle}
+                          onClick={() => onClick(RESOURCES_SECTION.id)}
                         />
                       )}
                     </AddSectionButton.List>
@@ -1296,11 +1272,3 @@ const EditHomepage = ({ match }) => {
 }
 
 export default EditHomepage
-
-EditHomepage.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      siteName: PropTypes.string,
-    }),
-  }).isRequired,
-}

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -24,14 +24,6 @@ import { useUpdateHomepageHook } from "hooks/homepageHooks/useUpdateHomepageHook
 import useSiteColorsHook from "hooks/useSiteColorsHook"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
-import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
-
-import TemplateHeroSection from "templates/homepage/HeroSection"
-import TemplateInfobarSection from "templates/homepage/InfobarSection"
-import TemplateInfopicLeftSection from "templates/homepage/InfopicLeftSection"
-import TemplateInfopicRightSection from "templates/homepage/InfopicRightSection"
-import TemplateResourcesSection from "templates/homepage/ResourcesSection"
-import { getClassNames } from "templates/utils/stylingUtils"
 
 import { useErrorToast } from "utils/toasts"
 import {
@@ -62,6 +54,7 @@ import {
   KEY_HIGHLIGHT_SECTION,
   RESOURCES_SECTION,
 } from "./constants"
+import { HomepagePreview } from "./HomepagePreview"
 import { getErrorValues } from "./utils"
 
 /* eslint-disable react/no-array-index-key */
@@ -144,7 +137,6 @@ const EditHomepage = ({ match }) => {
     sections: [],
   })
   const [sha, setSha] = useState(null)
-  const [dropdownIsActive, setDropdownIsActive] = useState(false)
   const [displaySections, setDisplaySections] = useState([])
   const [displayHighlights, setDisplayHighlights] = useState([])
   const [displayDropdownElems, setDisplayDropdownElems] = useState([])
@@ -763,14 +755,6 @@ const EditHomepage = ({ match }) => {
     setErrors(newErrors)
   }
 
-  const toggleDropdown = async () => {
-    try {
-      setDropdownIsActive((prevState) => !prevState)
-    } catch (err) {
-      console.log(err)
-    }
-  }
-
   const displayHandler = async (elemType, index) => {
     // NOTE: If index is less than 0,
     // this means that the accordion is being closed.
@@ -861,18 +845,6 @@ const EditHomepage = ({ match }) => {
       })
       console.log(err)
     }
-  }
-
-  const isLeftInfoPic = (sectionIndex) => {
-    // If the previous section in the list was not an infopic section
-    // or if the previous section was a right infopic section, return true
-    if (
-      !frontMatter.sections[sectionIndex - 1].infopic ||
-      !isLeftInfoPic(sectionIndex - 1)
-    )
-      return true
-
-    return false
   }
 
   // NOTE: sectionType is one of `resources`, `infopic` or `infobar`
@@ -1127,134 +1099,10 @@ const EditHomepage = ({ match }) => {
                   </AddSectionButton>
                 </Box>
               </Editable.Sidebar>
-              <div className={editorStyles.homepageEditorMain}>
-                {/* Isomer Template Pane */}
-                {/* Notification */}
-                {frontMatter.notification && (
-                  <div
-                    id="notification-bar"
-                    className={getClassNames(editorStyles, [
-                      "bp-notification",
-                      "is-marginless",
-                      "bg-secondary",
-                    ])}
-                  >
-                    <div className={editorStyles["bp-container"]}>
-                      <div className={editorStyles.row}>
-                        <div className={editorStyles.col}>
-                          <div
-                            className={getClassNames(editorStyles, [
-                              "field",
-                              "has-addons",
-                              "bp-notification-flex",
-                            ])}
-                          >
-                            <div
-                              className={getClassNames(editorStyles, [
-                                "control",
-                                "has-text-centered",
-                                "has-text-white",
-                              ])}
-                            >
-                              <h6>{frontMatter.notification}</h6>
-                            </div>
-                            <div
-                              className={getClassNames(editorStyles, [
-                                "button",
-                                "has-text-white",
-                              ])}
-                            >
-                              <span
-                                className={getClassNames(editorStyles, [
-                                  "sgds-icon",
-                                  "sgds-icon-cross",
-                                ])}
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )}
-                {/* Template preview section */}
-                {frontMatter.sections.map((section, sectionIndex) => (
-                  <>
-                    {/* Hero section */}
-                    {section.hero ? (
-                      <>
-                        <TemplateHeroSection
-                          key={`section-${sectionIndex}`}
-                          hero={section.hero}
-                          siteName={siteName}
-                          dropdownIsActive={dropdownIsActive}
-                          toggleDropdown={toggleDropdown}
-                          ref={scrollRefs[sectionIndex]}
-                        />
-                      </>
-                    ) : null}
-                    {/* Resources section */}
-                    {section.resources ? (
-                      <>
-                        <TemplateResourcesSection
-                          key={`section-${sectionIndex}`}
-                          title={section.resources.title}
-                          subtitle={section.resources.subtitle}
-                          button={section.resources.button}
-                          sectionIndex={sectionIndex}
-                          ref={scrollRefs[sectionIndex]}
-                        />
-                      </>
-                    ) : null}
-                    {/* Infobar section */}
-                    {section.infobar ? (
-                      <>
-                        <TemplateInfobarSection
-                          key={`section-${sectionIndex}`}
-                          title={section.infobar.title}
-                          subtitle={section.infobar.subtitle}
-                          description={section.infobar.description}
-                          button={section.infobar.button}
-                          sectionIndex={sectionIndex}
-                          ref={scrollRefs[sectionIndex]}
-                        />
-                      </>
-                    ) : null}
-                    {/* Infopic section */}
-                    {section.infopic ? (
-                      <>
-                        {isLeftInfoPic(sectionIndex) ? (
-                          <TemplateInfopicLeftSection
-                            key={`section-${sectionIndex}`}
-                            title={section.infopic.title}
-                            subtitle={section.infopic.subtitle}
-                            description={section.infopic.description}
-                            imageUrl={section.infopic.image}
-                            imageAlt={section.infopic.alt}
-                            button={section.infopic.button}
-                            sectionIndex={sectionIndex}
-                            siteName={siteName}
-                            ref={scrollRefs[sectionIndex]}
-                          />
-                        ) : (
-                          <TemplateInfopicRightSection
-                            key={`section-${sectionIndex}`}
-                            title={section.infopic.title}
-                            subtitle={section.infopic.subtitle}
-                            description={section.infopic.description}
-                            imageUrl={section.infopic.image}
-                            imageAlt={section.infopic.alt}
-                            button={section.infopic.button}
-                            sectionIndex={sectionIndex}
-                            siteName={siteName}
-                            ref={scrollRefs[sectionIndex]}
-                          />
-                        )}
-                      </>
-                    ) : null}
-                  </>
-                ))}
-              </div>
+              <HomepagePreview
+                frontMatter={frontMatter}
+                scrollRefs={scrollRefs}
+              />
             </HStack>
             <Footer>
               <LoadingButton

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -43,17 +43,17 @@ import {
 import { HomepageStartEditingImage } from "assets"
 import { DEFAULT_RETRY_MSG } from "utils"
 
-import { EditableContextProvider } from "../contexts/EditableContext"
-import { useDrag, onCreate, onDelete } from "../hooks/useDrag"
+import { EditableContextProvider } from "../../contexts/EditableContext"
+import { useDrag, onCreate, onDelete } from "../../hooks/useDrag"
+import { CustomiseSectionsHeader, Editable } from "../components/Editable"
+import { AddSectionButton } from "../components/Editable/AddSectionButton"
+import { HeroBody } from "../components/Homepage/HeroBody"
+import { HeroDropdownSection } from "../components/Homepage/HeroDropdownSection"
+import { HeroHighlightSection } from "../components/Homepage/HeroHighlightSection"
+import { InfobarBody } from "../components/Homepage/InfobarBody"
+import { InfopicBody } from "../components/Homepage/InfopicBody"
+import { ResourcesBody } from "../components/Homepage/ResourcesBody"
 
-import { CustomiseSectionsHeader, Editable } from "./components/Editable"
-import { AddSectionButton } from "./components/Editable/AddSectionButton"
-import { HeroBody } from "./components/Homepage/HeroBody"
-import { HeroDropdownSection } from "./components/Homepage/HeroDropdownSection"
-import { HeroHighlightSection } from "./components/Homepage/HeroHighlightSection"
-import { InfobarBody } from "./components/Homepage/InfobarBody"
-import { InfopicBody } from "./components/Homepage/InfopicBody"
-import { ResourcesBody } from "./components/Homepage/ResourcesBody"
 import {
   DROPDOWN_ELEMENT_SECTION,
   DROPDOWN_SECTION,
@@ -61,8 +61,8 @@ import {
   INFOPIC_SECTION,
   KEY_HIGHLIGHT_SECTION,
   RESOURCES_SECTION,
-} from "./EditHomepage/constants"
-import { getErrorValues } from "./EditHomepage/utils"
+} from "./constants"
+import { getErrorValues } from "./utils"
 
 /* eslint-disable react/no-array-index-key */
 

--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -1,0 +1,176 @@
+// NOTE: Below eslint disable is inherited from our legacy code :(
+/* eslint-disable react/no-array-index-key */
+import { Ref, useState } from "react"
+import { useParams } from "react-router-dom"
+
+import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
+
+import TemplateHeroSection from "templates/homepage/HeroSection"
+import TemplateInfobarSection from "templates/homepage/InfobarSection"
+import TemplateInfopicLeftSection from "templates/homepage/InfopicLeftSection"
+import TemplateInfopicRightSection from "templates/homepage/InfopicRightSection"
+import TemplateResourcesSection from "templates/homepage/ResourcesSection"
+import { getClassNames } from "templates/utils/stylingUtils"
+
+import {
+  EditorHomepageFrontmatterSection,
+  EditorHomepageState,
+  InfopicFrontmatterSection,
+} from "types/homepage"
+
+const isLeftInfoPic = (
+  sectionIndex: number,
+  frontMatter: EditorHomepageState["frontMatter"]
+): boolean => {
+  // If the previous section in the list was not an infopic section
+  // or if the previous section was a right infopic section, return true
+  return (
+    !(frontMatter.sections[sectionIndex - 1] as InfopicFrontmatterSection)
+      .infopic || !isLeftInfoPic(sectionIndex - 1, frontMatter)
+  )
+}
+
+interface HomepagePreviewProps {
+  frontMatter: EditorHomepageState["frontMatter"]
+  scrollRefs: Ref<unknown>[]
+}
+export const HomepagePreview = ({
+  frontMatter,
+  scrollRefs,
+}: HomepagePreviewProps) => {
+  const { siteName } = useParams<{ siteName: string }>()
+  const [dropdownIsActive, setDropdownIsActive] = useState(false)
+
+  const toggleDropdown = () => setDropdownIsActive((prevState) => !prevState)
+
+  return (
+    <div className={editorStyles.homepageEditorMain}>
+      {/* Isomer Template Pane */}
+      {/* Notification */}
+      {frontMatter.notification && (
+        <div
+          id="notification-bar"
+          className={getClassNames(editorStyles, [
+            "bp-notification",
+            "is-marginless",
+            "bg-secondary",
+          ])}
+        >
+          <div className={editorStyles["bp-container"]}>
+            <div className={editorStyles.row}>
+              <div className={editorStyles.col}>
+                <div
+                  className={getClassNames(editorStyles, [
+                    "field",
+                    "has-addons",
+                    "bp-notification-flex",
+                  ])}
+                >
+                  <div
+                    className={getClassNames(editorStyles, [
+                      "control",
+                      "has-text-centered",
+                      "has-text-white",
+                    ])}
+                  >
+                    <h6>{frontMatter.notification}</h6>
+                  </div>
+                  <div
+                    className={getClassNames(editorStyles, [
+                      "button",
+                      "has-text-white",
+                    ])}
+                  >
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "sgds-icon",
+                        "sgds-icon-cross",
+                      ])}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      {/* Template preview section */}
+      {frontMatter.sections.map((section, sectionIndex) => (
+        <>
+          {/* Hero section */}
+          {EditorHomepageFrontmatterSection.isHero(section) && (
+            <>
+              <TemplateHeroSection
+                key={`section-${sectionIndex}`}
+                hero={section.hero}
+                siteName={siteName}
+                dropdownIsActive={dropdownIsActive}
+                toggleDropdown={toggleDropdown}
+                ref={scrollRefs[sectionIndex]}
+              />
+            </>
+          )}
+          {/* Resources section */}
+          {EditorHomepageFrontmatterSection.isResources(section) && (
+            <>
+              <TemplateResourcesSection
+                key={`section-${sectionIndex}`}
+                title={section.resources.title}
+                subtitle={section.resources.subtitle}
+                button={section.resources.button}
+                sectionIndex={sectionIndex}
+                ref={scrollRefs[sectionIndex]}
+              />
+            </>
+          )}
+          {/* Infobar section */}
+          {EditorHomepageFrontmatterSection.isInfobar(section) && (
+            <>
+              <TemplateInfobarSection
+                key={`section-${sectionIndex}`}
+                title={section.infobar.title}
+                subtitle={section.infobar.subtitle}
+                description={section.infobar.description}
+                button={section.infobar.button}
+                sectionIndex={sectionIndex}
+                ref={scrollRefs[sectionIndex]}
+              />
+            </>
+          )}
+          {/* Infopic section */}
+          {EditorHomepageFrontmatterSection.isInfopic(section) && (
+            <>
+              {isLeftInfoPic(sectionIndex, frontMatter) ? (
+                <TemplateInfopicLeftSection
+                  key={`section-${sectionIndex}`}
+                  title={section.infopic.title}
+                  subtitle={section.infopic.subtitle}
+                  description={section.infopic.description}
+                  imageUrl={section.infopic.image}
+                  imageAlt={section.infopic.alt}
+                  button={section.infopic.button}
+                  sectionIndex={sectionIndex}
+                  siteName={siteName}
+                  ref={scrollRefs[sectionIndex]}
+                />
+              ) : (
+                <TemplateInfopicRightSection
+                  key={`section-${sectionIndex}`}
+                  title={section.infopic.title}
+                  subtitle={section.infopic.subtitle}
+                  description={section.infopic.description}
+                  imageUrl={section.infopic.image}
+                  imageAlt={section.infopic.alt}
+                  button={section.infopic.button}
+                  sectionIndex={sectionIndex}
+                  siteName={siteName}
+                  ref={scrollRefs[sectionIndex]}
+                />
+              )}
+            </>
+          )}
+        </>
+      ))}
+    </div>
+  )
+}

--- a/src/layouts/EditHomepage/constants.ts
+++ b/src/layouts/EditHomepage/constants.ts
@@ -1,0 +1,41 @@
+export const RESOURCES_SECTION = {
+  title: "Resources",
+  subtitle: "Add a preview and link to your Resource Room",
+  id: "resources",
+} as const
+
+export const INFOBAR_SECTION = {
+  title: "Infobar",
+  subtitle: "Add informational text",
+  id: "infobar",
+  description: "Infobar description",
+  button: "Button Text",
+  url: "",
+} as const
+
+export const INFOPIC_SECTION = {
+  title: "Infopic",
+  subtitle: "Add an image and text",
+  id: "infopic",
+  description: "Infopic description",
+  button: "Button Text",
+  url: "", // No default value so that no broken link is created
+  image: "", // Always blank since the image modal handles this
+  alt: "Image alt text",
+} as const
+
+export const KEY_HIGHLIGHT_SECTION = {
+  title: "Key Highlight Title",
+  description: "Key Highlight description",
+  url: "", // No default value so that no broken link is created
+} as const
+
+export const DROPDOWN_ELEMENT_SECTION = {
+  title: "Hero Dropdown Element Title",
+  url: "", // No default value so that no broken link is created
+} as const
+
+export const DROPDOWN_SECTION = {
+  title: "Hero Dropdown Title",
+  options: [],
+} as const

--- a/src/layouts/EditHomepage/index.ts
+++ b/src/layouts/EditHomepage/index.ts
@@ -1,0 +1,3 @@
+import EditHomepage from "./EditHomepage"
+
+export default EditHomepage

--- a/src/layouts/EditHomepage/utils.ts
+++ b/src/layouts/EditHomepage/utils.ts
@@ -1,0 +1,7 @@
+import _ from "lodash"
+
+export const getErrorValues = (
+  obj: Record<string, string>
+): Record<string, string> => {
+  return _.mapValues(obj, () => "")
+}

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -91,11 +91,46 @@ export type HomepageEditorHeroSection =
   | EditorHeroHighlightsSection
 
 export type HeroFrontmatterSection = { hero: HomepageEditorHeroSection }
+// TODO: add properties here instead of typing as `Record<string, unknown>`
+// we can find them in `HomepagePreview`
 export type ResourcesFrontmatterSection = { resources: Record<string, unknown> }
+
+// TODO: add properties here instead of typing as `Record<string, unknown>`
+// we can find them in `HomepagePreview`
+export type InfopicFrontmatterSection = {
+  infopic: Record<string, unknown>
+}
+
+// TODO: add properties here instead of typing as `Record<string, unknown>`
+// we can find them in `HomepagePreview`
+export type InfobarFrontmatterSection = {
+  infobar: Record<string, unknown>
+}
 
 export type EditorHomepageFrontmatterSection =
   | HeroFrontmatterSection
   | ResourcesFrontmatterSection
+  | InfopicFrontmatterSection
+  | InfobarFrontmatterSection
+
+export const EditorHomepageFrontmatterSection = {
+  isHero: (
+    section: EditorHomepageFrontmatterSection
+  ): section is HeroFrontmatterSection =>
+    !!(section as HeroFrontmatterSection).hero,
+  isResources: (
+    section: EditorHomepageFrontmatterSection
+  ): section is ResourcesFrontmatterSection =>
+    !!(section as ResourcesFrontmatterSection).resources,
+  isInfopic: (
+    section: EditorHomepageFrontmatterSection
+  ): section is InfopicFrontmatterSection =>
+    !!(section as InfopicFrontmatterSection).infopic,
+  isInfobar: (
+    section: EditorHomepageFrontmatterSection
+  ): section is InfobarFrontmatterSection =>
+    !!(section as InfobarFrontmatterSection).infobar,
+}
 
 export interface EditorHomepageState {
   frontMatter: Omit<HomepageDto["content"]["frontMatter"], "sections"> & {


### PR DESCRIPTION
## Problem
There were many constants whose reference wasn't clear in `EditHomepage`. This PR shifts them out for clarity and exposes a helper method to construct the error message.

## Solution
1. shift constants out to `ts` file. 
2. expose util method for getting error object. 