### PR TITLE
feat(homepage): subsume site notif

### DIFF
--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -1,9 +1,15 @@
+import { FormControl, Flex, Icon, Text, VStack, Box } from "@chakra-ui/react"
 import { Droppable, Draggable } from "@hello-pangea/dnd"
-import { Button } from "@opengovsg/design-system-react"
+import {
+  Button,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+} from "@opengovsg/design-system-react"
 import PropTypes from "prop-types"
+import { BiInfoCircle } from "react-icons/bi"
 
 import { FormContext, FormError, FormTitle } from "components/Form"
-import FormField from "components/FormField"
 import FormFieldMedia from "components/FormFieldMedia"
 import HeroButton from "components/homepage/HeroButton"
 import HeroDropdown from "components/homepage/HeroDropdown"
@@ -36,41 +42,71 @@ const EditorHeroSection = ({
   displayHighlights,
   errors,
   handleHighlightDropdownToggle,
+  notification,
 }) => (
   <>
-    <FormContext isRequired hasError={!!errors.sections[0].hero.title}>
-      <FormTitle>Hero title</FormTitle>
-      <FormField
-        placeholder="Hero title"
-        id={`section-${sectionIndex}-hero-title`}
-        value={title}
-        onChange={onFieldChange}
-      />
-      <FormError>{errors.sections[0].hero.title}</FormError>
-    </FormContext>
-    <FormContext isRequired hasError={!!errors.sections[0].hero.subtitle}>
-      <FormTitle>Hero subtitle</FormTitle>
-      <FormField
-        placeholder="Hero subtitle"
-        id={`section-${sectionIndex}-hero-subtitle`}
-        value={subtitle}
-        onChange={onFieldChange}
-      />
-      <FormError>{errors.sections[0].hero.subtitle}</FormError>
-    </FormContext>
-    <FormContext
-      hasError={!!errors.sections[0].hero.background}
-      onFieldChange={onFieldChange}
-      isRequired
-    >
-      <FormTitle>Hero background image</FormTitle>
-      <FormFieldMedia
-        value={background}
-        id={`section-${sectionIndex}-hero-background`}
-        inlineButtonText="Select"
-      />
-      <FormError>{errors.sections[0].hero.background}</FormError>
-    </FormContext>
+    <VStack align="flex-start" spacing="1.25rem">
+      <FormControl>
+        <FormLabel>Notification Banner</FormLabel>
+        <Input
+          // TODO: Remove the `id/onChange`
+          // and change to react hook forms
+          id="site-notification"
+          onChange={onFieldChange}
+          value={notification}
+          placeholder="This is a notification banner"
+        />
+        <Flex flexDir="row" mt="0.75rem" alignItems="center">
+          <Icon
+            as={BiInfoCircle}
+            fill="base.content.brand"
+            mr="0.5rem"
+            fontSize="1rem"
+          />
+          <Text textStyle="caption-2">
+            Leave this blank if you don&apos;t want the banner to appear
+          </Text>
+        </Flex>
+      </FormControl>
+      <FormControl isRequired isInvalid={!!errors.sections[0].hero.title}>
+        <FormLabel>Hero title</FormLabel>
+        <Input
+          placeholder="Hero title"
+          id={`section-${sectionIndex}-hero-title`}
+          value={title}
+          onChange={onFieldChange}
+        />
+        <FormErrorMessage>{errors.sections[0].hero.title}</FormErrorMessage>
+      </FormControl>
+      <FormControl isRequired isInvalid={!!errors.sections[0].hero.subtitle}>
+        <FormLabel>Hero subtitle</FormLabel>
+        <Input
+          placeholder="Hero subtitle"
+          id={`section-${sectionIndex}-hero-subtitle`}
+          value={subtitle}
+          onChange={onFieldChange}
+        />
+        <FormErrorMessage>{errors.sections[0].hero.subtitle}</FormErrorMessage>
+      </FormControl>
+      <Box>
+        {/* TODO: migrate this to design system components */}
+        <FormContext
+          hasError={!!errors.sections[0].hero.background}
+          onFieldChange={onFieldChange}
+          isRequired
+        >
+          <Box mb="0.5rem">
+            <FormTitle>Hero background image</FormTitle>
+          </Box>
+          <FormFieldMedia
+            value={background}
+            id={`section-${sectionIndex}-hero-background`}
+            inlineButtonText="Select"
+          />
+          <FormError>{errors.sections[0].hero.background}</FormError>
+        </FormContext>
+      </Box>
+    </VStack>
     <div className={styles.card}>
       <p className={elementStyles.formLabel}>Hero Section Type</p>
       {/* Permalink or File URL */}

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -44,7 +44,7 @@ const EditorHeroSection = ({
   handleHighlightDropdownToggle,
   notification,
 }) => (
-  <>
+  <Box px="0.5rem">
     <VStack align="flex-start" spacing="1.25rem">
       <FormControl>
         <FormLabel>Notification Banner</FormLabel>
@@ -229,7 +229,7 @@ const EditorHeroSection = ({
         </>
       )}
     </div>
-  </>
+  </Box>
 )
 
 export default EditorHeroSection

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import { useDisclosure, Text, HStack, VStack, Divider } from "@chakra-ui/react"
-import { Box } from "@chakra-ui/react"
+import {
+  Box,
+  useDisclosure,
+  Text,
+  HStack,
+  VStack,
+  Divider,
+} from "@chakra-ui/react"
 import { Button, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
 import _ from "lodash"

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import {
-  useDisclosure,
-  Text,
-  HStack,
-  VStack,
-  Divider,
-  Box,
-} from "@chakra-ui/react"
-import { Button, Input, Tag } from "@opengovsg/design-system-react"
+import { useDisclosure, Text, HStack, VStack, Divider } from "@chakra-ui/react"
+import { Box } from "@chakra-ui/react"
+import { Button, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
 import _ from "lodash"
 import PropTypes from "prop-types"
@@ -959,216 +953,185 @@ const EditHomepage = ({ match }) => {
           <>
             <HStack className={elementStyles.wrapper}>
               <div className={editorStyles.homepageEditorSidebar}>
-                <div>
-                  <div
-                    className={`${elementStyles.card} ${elementStyles.siteNotificationSection}`}
+                <Editable.Sidebar
+                  title="Homepage"
+                  onChange={(idx) => {
+                    displayHandler({ target: { id: `section-${idx}` } })
+                  }}
+                >
+                  <Editable.Draggable
+                    editableId="leftPane"
+                    onDragEnd={onDragEnd}
                   >
-                    <p>
-                      <h2 className={elementStyles.notificationHeader}>
-                        Site notification
-                      </h2>
-                    </p>
-                    <Input
-                      placeholder="Notification"
-                      value={frontMatter.notification}
-                      id="site-notification"
-                      onChange={onFieldChange}
-                    />
-                    <span className={elementStyles.info}>
-                      Note: Leave text field empty if you don’t need this
-                      notification bar
-                    </span>
-                  </div>
-
-                  <Editable.Sidebar
-                    title="Homepage"
-                    onChange={(idx) => {
-                      displayHandler({ target: { id: `section-${idx}` } })
-                    }}
-                  >
-                    <Editable.Draggable
-                      editableId="leftPane"
-                      onDragEnd={onDragEnd}
+                    <Editable.Accordion
+                      onChange={(idx) => {
+                        displayHandler({ target: { id: `section-${idx}` } })
+                      }}
                     >
-                      <Editable.Accordion
-                        onChange={(idx) => {
-                          displayHandler({ target: { id: `section-${idx}` } })
-                        }}
+                      <VStack
+                        bg="base.canvas.alt"
+                        p="1.5rem"
+                        spacing="1.5rem"
+                        alignItems="flex-start"
                       >
-                        <VStack
-                          bg="base.canvas.alt"
-                          p="1.5rem"
-                          spacing="1.5rem"
-                          alignItems="flex-start"
-                        >
-                          {frontMatter.sections.map((section, sectionIndex) => (
-                            <>
-                              {/* Hero section */}
-                              {section.hero && (
-                                <>
-                                  <Editable.EditableAccordionItem title="Hero section">
-                                    <EditorHeroSection
-                                      key={`section-${sectionIndex}`}
-                                      {...section.hero}
-                                      sectionIndex={sectionIndex}
-                                      highlights={
-                                        section.hero.key_highlights ?? []
-                                      }
-                                      onFieldChange={onFieldChange}
-                                      createHandler={createHandler}
-                                      deleteHandler={(event, type) => {
-                                        onOpen()
-                                        setItemPendingForDelete({
-                                          id: event.target.id,
-                                          type,
-                                        })
-                                      }}
-                                      shouldDisplay={
-                                        displaySections[sectionIndex]
-                                      }
-                                      displayHighlights={displayHighlights}
-                                      displayDropdownElems={
-                                        displayDropdownElems
-                                      }
-                                      displayHandler={displayHandler}
-                                      errors={errors}
-                                      handleHighlightDropdownToggle={
-                                        handleHighlightDropdownToggle
-                                      }
-                                    />
-                                  </Editable.EditableAccordionItem>
-                                  <Divider />
-                                  <VStack
-                                    spacing="0.5rem"
-                                    alignItems="flex-start"
-                                  >
-                                    <CustomiseSectionsHeader />
-                                  </VStack>
-                                </>
-                              )}
-                              {section.resources && (
-                                <Editable.DraggableAccordionItem
-                                  index={sectionIndex}
-                                  tag={<Tag variant="subtle">Resources</Tag>}
-                                  title={section.resources.title}
-                                >
-                                  <EditorResourcesSection
+                        {frontMatter.sections.map((section, sectionIndex) => (
+                          <>
+                            {/* Hero section */}
+                            {section.hero && (
+                              <>
+                                <Editable.EditableAccordionItem title="Hero section">
+                                  <EditorHeroSection
                                     key={`section-${sectionIndex}`}
-                                    {...section.resources}
+                                    {...section.hero}
+                                    notification={frontMatter.notification}
                                     sectionIndex={sectionIndex}
-                                    deleteHandler={(event) => {
-                                      onOpen()
-                                      setItemPendingForDelete({
-                                        id: event.target.id,
-                                        type: "Resources Section",
-                                      })
-                                    }}
-                                    onFieldChange={onFieldChange}
-                                    errors={
-                                      errors.sections[sectionIndex].resources
+                                    highlights={
+                                      section.hero.key_highlights ?? []
                                     }
-                                  />
-                                </Editable.DraggableAccordionItem>
-                              )}
-
-                              {section.infobar && (
-                                <Editable.DraggableAccordionItem
-                                  index={sectionIndex}
-                                  tag={<Tag variant="subtle">Infobar</Tag>}
-                                  title={section.infobar.title}
-                                >
-                                  <EditorInfobarSection
-                                    key={`section-${sectionIndex}`}
-                                    {...section.infobar}
-                                    sectionIndex={sectionIndex}
-                                    deleteHandler={(event) => {
+                                    onFieldChange={onFieldChange}
+                                    createHandler={createHandler}
+                                    deleteHandler={(event, type) => {
                                       onOpen()
                                       setItemPendingForDelete({
                                         id: event.target.id,
-                                        type: "Infobar Section",
+                                        type,
                                       })
                                     }}
-                                    onFieldChange={onFieldChange}
                                     shouldDisplay={
                                       displaySections[sectionIndex]
                                     }
+                                    displayHighlights={displayHighlights}
+                                    displayDropdownElems={displayDropdownElems}
                                     displayHandler={displayHandler}
-                                    errors={
-                                      errors.sections[sectionIndex].infobar
+                                    errors={errors}
+                                    handleHighlightDropdownToggle={
+                                      handleHighlightDropdownToggle
                                     }
                                   />
-                                </Editable.DraggableAccordionItem>
-                              )}
-
-                              {section.infopic && (
-                                <Editable.DraggableAccordionItem
-                                  index={sectionIndex}
-                                  tag={<Tag variant="subtle">Infopic</Tag>}
-                                  title={section.infopic.title}
+                                </Editable.EditableAccordionItem>
+                                <Divider />
+                                <VStack
+                                  spacing="0.5rem"
+                                  alignItems="flex-start"
                                 >
-                                  <EditorInfopicSection
-                                    key={`section-${sectionIndex}`}
-                                    {...section.infopic}
-                                    sectionIndex={sectionIndex}
-                                    deleteHandler={(event) => {
-                                      onOpen()
-                                      setItemPendingForDelete({
-                                        id: event.target.id,
-                                        type: "Infopic Section",
-                                      })
-                                    }}
-                                    onFieldChange={onFieldChange}
-                                    shouldDisplay={
-                                      displaySections[sectionIndex]
-                                    }
-                                    displayHandler={displayHandler}
-                                    errors={
-                                      errors.sections[sectionIndex].infopic
-                                    }
-                                    siteName={siteName}
-                                  />
-                                </Editable.DraggableAccordionItem>
-                              )}
-                            </>
-                          ))}
-                        </VStack>
-                      </Editable.Accordion>
-                    </Editable.Draggable>
-                    {/* NOTE: Set the padding here - 
+                                  <CustomiseSectionsHeader />
+                                </VStack>
+                              </>
+                            )}
+                            {section.resources && (
+                              <Editable.DraggableAccordionItem
+                                index={sectionIndex}
+                                tag={<Tag variant="subtle">Resources</Tag>}
+                                title={section.resources.title}
+                              >
+                                <EditorResourcesSection
+                                  key={`section-${sectionIndex}`}
+                                  {...section.resources}
+                                  sectionIndex={sectionIndex}
+                                  deleteHandler={(event) => {
+                                    onOpen()
+                                    setItemPendingForDelete({
+                                      id: event.target.id,
+                                      type: "Resources Section",
+                                    })
+                                  }}
+                                  onFieldChange={onFieldChange}
+                                  errors={
+                                    errors.sections[sectionIndex].resources
+                                  }
+                                />
+                              </Editable.DraggableAccordionItem>
+                            )}
+
+                            {section.infobar && (
+                              <Editable.DraggableAccordionItem
+                                index={sectionIndex}
+                                tag={<Tag variant="subtle">Infobar</Tag>}
+                                title={section.infobar.title}
+                              >
+                                <EditorInfobarSection
+                                  key={`section-${sectionIndex}`}
+                                  {...section.infobar}
+                                  sectionIndex={sectionIndex}
+                                  deleteHandler={(event) => {
+                                    onOpen()
+                                    setItemPendingForDelete({
+                                      id: event.target.id,
+                                      type: "Infobar Section",
+                                    })
+                                  }}
+                                  onFieldChange={onFieldChange}
+                                  shouldDisplay={displaySections[sectionIndex]}
+                                  displayHandler={displayHandler}
+                                  errors={errors.sections[sectionIndex].infobar}
+                                />
+                              </Editable.DraggableAccordionItem>
+                            )}
+
+                            {section.infopic && (
+                              <Editable.DraggableAccordionItem
+                                index={sectionIndex}
+                                tag={<Tag variant="subtle">Infopic</Tag>}
+                                title={section.infopic.title}
+                              >
+                                <EditorInfopicSection
+                                  key={`section-${sectionIndex}`}
+                                  {...section.infopic}
+                                  sectionIndex={sectionIndex}
+                                  deleteHandler={(event) => {
+                                    onOpen()
+                                    setItemPendingForDelete({
+                                      id: event.target.id,
+                                      type: "Infopic Section",
+                                    })
+                                  }}
+                                  onFieldChange={onFieldChange}
+                                  shouldDisplay={displaySections[sectionIndex]}
+                                  displayHandler={displayHandler}
+                                  errors={errors.sections[sectionIndex].infopic}
+                                  siteName={siteName}
+                                />
+                              </Editable.DraggableAccordionItem>
+                            )}
+                          </>
+                        ))}
+                      </VStack>
+                    </Editable.Accordion>
+                  </Editable.Draggable>
+                  {/* NOTE: Set the padding here - 
                         We cannot let the button be part of the `Draggable` 
                         as otherwise, when dragging, 
                         the component will appear over the button
                     */}
-                    <Box p="1.5rem">
-                      <AddSectionButton>
-                        <AddSectionButton.List>
-                          <AddSectionButton.Option
-                            onClick={() => onClick("infopic")}
-                            title="Infopic"
-                            subtitle="Add an image with informational text"
-                          />
-                          <AddSectionButton.Option
-                            title="Infobar"
-                            subtitle="Add informational text"
-                            onClick={() => onClick("infobar")}
-                          />
-                          {/* NOTE: Check if the sections contain any `resources` 
+                  <Box p="1.5rem">
+                    <AddSectionButton>
+                      <AddSectionButton.List>
+                        <AddSectionButton.Option
+                          onClick={() => onClick("infopic")}
+                          title="Infopic"
+                          subtitle="Add an image with informational text"
+                        />
+                        <AddSectionButton.Option
+                          title="Infobar"
+                          subtitle="Add informational text"
+                          onClick={() => onClick("infobar")}
+                        />
+                        {/* NOTE: Check if the sections contain any `resources` 
                                 and if it does, prevent creation of another `resources` section
                             */}
-                          {!frontMatter.sections.some(
-                            ({ resources }) => !!resources
-                          ) && (
-                            <AddSectionButton.Option
-                              title="Resources"
-                              subtitle="Add a preview and link to your Resource Room"
-                              onClick={() => onClick("resources")}
-                            />
-                          )}
-                        </AddSectionButton.List>
-                      </AddSectionButton>
-                    </Box>
-                  </Editable.Sidebar>
-                </div>
+                        {!frontMatter.sections.some(
+                          ({ resources }) => !!resources
+                        ) && (
+                          <AddSectionButton.Option
+                            title="Resources"
+                            subtitle="Add a preview and link to your Resource Room"
+                            onClick={() => onClick("resources")}
+                          />
+                        )}
+                      </AddSectionButton.List>
+                    </AddSectionButton>
+                  </Box>
+                </Editable.Sidebar>
               </div>
               <div className={editorStyles.homepageEditorMain}>
                 {/* Isomer Template Pane */}


### PR DESCRIPTION
## Problem
Currently, our existing homepage has the site notification on top **as a separate block.** However, the figma wants the site notification to be shifted into the hero sectoin

Closes IS-428

## Solution
1. **Temporary measure**: shift notification section into `HeroSection` and add a prop for `notification`
2. For stuff in `HeroSection` where we were using our own home-rolled `Form` components prior to design system, shifts those to design system **with the exception of `FormFieldMedia`**. This is because `FormFieldMedia` is more involved + has modal so deferred fo rnow
3. in `EditHomepage`, removed unused code 

Screenshots: 
<img width="442" alt="Screenshot 2023-08-15 at 3 10 32 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/44049504/b2506d8a-4320-4396-9615-4555595221d2">
