### PR TITLE
chore: downgrade webpack-dev-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,8 @@
         "ts-jest": "^29.0.5",
         "tsconfig-paths": "^4.0.0",
         "type-fest": "^2.19.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "webpack-dev-server": "4.14.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -37248,9 +37249,10 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.1",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.14.0.tgz",
+      "integrity": "sha512-KUgiUNUZldyx5xz3uK0dnXmvsSz03TAMCLtO1cUOb5oishh9sfP3vaI4XNY3EztrPUu98WKzamNfuaydTedYWQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -37258,7 +37260,7 @@
         "@types/serve-index": "^1.9.1",
         "@types/serve-static": "^1.13.10",
         "@types/sockjs": "^0.3.33",
-        "@types/ws": "^8.5.5",
+        "@types/ws": "^8.5.1",
         "ansi-html-community": "^0.0.8",
         "bonjour-service": "^1.0.11",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "ts-jest": "^29.0.5",
     "tsconfig-paths": "^4.0.0",
     "type-fest": "^2.19.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "webpack-dev-server": "4.14.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This PR fixes an issue where errors on dev were showing up in an overlay -
![Screenshot 2023-08-15 at 9 33 49 PM](https://github.com/isomerpages/isomercms-frontend/assets/22111124/6b5aa2a2-5672-4878-921b-a2efee36d5f0)

This prevents us from running tests suites locally. It is likely that this issue was due to the default behaviour of `webpack-dev-server` changing to automatically include the overlay when errors are encountered. This PR explicitly downgrades the package so that we can run tests normally on local.