### PR TITLE
ref(editable): style fixes + error hover

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1055,7 +1055,7 @@ const EditHomepage = ({ match }) => {
                               <Editable.DraggableAccordionItem
                                 index={sectionIndex}
                                 tag={<Tag variant="subtle">Infobar</Tag>}
-                                title={section.infobar.title}
+                                title={section.infobar.title ?? "New infobar"}
                                 isInvalid={_.some(
                                   errors.sections[sectionIndex].infobar
                                 )}
@@ -1080,7 +1080,7 @@ const EditHomepage = ({ match }) => {
                               <Editable.DraggableAccordionItem
                                 index={sectionIndex}
                                 tag={<Tag variant="subtle">Infopic</Tag>}
-                                title={section.infopic.title}
+                                title={section.infopic.title ?? "New infopic"}
                                 isInvalid={_.some(
                                   errors.sections[sectionIndex].infopic
                                 )}

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -1029,6 +1029,9 @@ const EditHomepage = ({ match }) => {
                                 index={sectionIndex}
                                 tag={<Tag variant="subtle">Resources</Tag>}
                                 title="New resource widget"
+                                isInvalid={_.some(
+                                  errors.sections[sectionIndex].resources
+                                )}
                               >
                                 <ResourcesBody
                                   {...section.resources}
@@ -1053,6 +1056,9 @@ const EditHomepage = ({ match }) => {
                                 index={sectionIndex}
                                 tag={<Tag variant="subtle">Infobar</Tag>}
                                 title={section.infobar.title}
+                                isInvalid={_.some(
+                                  errors.sections[sectionIndex].infobar
+                                )}
                               >
                                 <InfobarBody
                                   {...section.infobar}
@@ -1075,6 +1081,9 @@ const EditHomepage = ({ match }) => {
                                 index={sectionIndex}
                                 tag={<Tag variant="subtle">Infopic</Tag>}
                                 title={section.infopic.title}
+                                isInvalid={_.some(
+                                  errors.sections[sectionIndex].infopic
+                                )}
                               >
                                 <InfopicBody
                                   index={sectionIndex}

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -202,9 +202,6 @@ const DraggableAccordionItem = ({
           ref={draggableProvided.innerRef}
           boxShadow="sm"
           {...draggableProvided.dragHandleProps}
-          _hover={{
-            bgColor: "interaction.muted.main.hover",
-          }}
           position="relative"
         >
           {({ isExpanded }) => (

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -1,5 +1,4 @@
 import {
-  Center,
   Flex,
   Text,
   VStack,
@@ -12,6 +11,7 @@ import {
   AccordionItemProps,
   forwardRef,
   StackProps,
+  Divider,
 } from "@chakra-ui/react"
 import {
   OnDragEndResponder,
@@ -182,6 +182,7 @@ interface DraggableAccordionItemProps {
   // rather than having us pass in manually
   index: number
   draggableId: string
+  isInvalid?: boolean
 }
 // NOTE: Separating editable/draggable
 // due to semantics on `Draggables`
@@ -190,12 +191,13 @@ const DraggableAccordionItem = ({
   title,
   children,
   index,
+  isInvalid,
 }: PropsWithChildren<DraggableAccordionItemProps>) => {
   return (
     <Draggable draggableId={uuid()} index={index}>
       {(draggableProvided) => (
         <BaseAccordionItem
-          borderRadius="0.25rem"
+          borderRadius="0.5rem"
           {...draggableProvided.draggableProps}
           ref={draggableProvided.innerRef}
           boxShadow="sm"
@@ -203,30 +205,59 @@ const DraggableAccordionItem = ({
           _hover={{
             bgColor: "interaction.muted.main.hover",
           }}
+          position="relative"
         >
-          <Center>
-            <IconButton
-              variant="clear"
-              cursor="grab"
-              aria-label="drag item"
-              icon={<BxDraggable />}
-            />
-          </Center>
-          {/* NOTE: Check with design on styling. 
-        See if entire section is button (ie, whole component hover styling)
-      */}
-          <Flex flexDir="row">
-            <Flex px="1.5rem" pb="1rem" flex="1" flexDir="column">
-              {tag}
-              <Text textStyle="h6" textAlign="left" mt="0.25rem">
-                {title}
-              </Text>
-            </Flex>
-            <AccordionButton w="auto" h="fit-content" py="1rem">
-              <AccordionIcon />
-            </AccordionButton>
-          </Flex>
-          <AccordionPanel pb={4}>{children}</AccordionPanel>
+          {({ isExpanded }) => (
+            <>
+              <IconButton
+                position="absolute"
+                top="0.5rem"
+                left="0"
+                right="0"
+                variant="clear"
+                cursor="grab"
+                aria-label="drag item"
+                margin="0 auto"
+                w="fit-content"
+                icon={<BxDraggable />}
+              />
+              {/* 
+               NOTE: Check with design on styling. 
+               See if entire section is
+               button (ie, whole component hover styling)  
+               */}
+              {!isExpanded && isInvalid && (
+                <Divider
+                  border="4px solid"
+                  borderColor="utility.feedback.critical"
+                  orientation="vertical"
+                  left={0}
+                  position="absolute"
+                  borderLeftRadius="0.5rem"
+                  h="-webkit-fill-available"
+                />
+              )}
+              <Flex
+                flexDir="row"
+                pt="1.88rem"
+                pb={isExpanded ? "0rem" : "0.88rem"}
+                _hover={{
+                  bgColor: isExpanded ? "none" : "interaction.muted.main.hover",
+                }}
+              >
+                <Flex px="1.5rem" pb="1rem" flex="1" flexDir="column">
+                  {tag}
+                  <Text textStyle="h6" textAlign="left" mt="0.25rem">
+                    {title}
+                  </Text>
+                </Flex>
+                <AccordionButton w="auto" h="fit-content" py="1rem">
+                  <AccordionIcon />
+                </AccordionButton>
+              </Flex>
+              <AccordionPanel pb={4}>{children}</AccordionPanel>
+            </>
+          )}
         </BaseAccordionItem>
       )}
     </Draggable>

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -221,11 +221,6 @@ const DraggableAccordionItem = ({
                 w="fit-content"
                 icon={<BxDraggable />}
               />
-              {/* 
-               NOTE: Check with design on styling. 
-               See if entire section is
-               button (ie, whole component hover styling)  
-               */}
               {!isExpanded && isInvalid && (
                 <Divider
                   border="4px solid"


### PR DESCRIPTION
## Problem
There are a couple of styling issues which do not line up with design. These will be described below. In addition, an error border is added to the accordion when collapsed.

**Design issues**
1. Hover states are applied across the **whole accordion** - this means that on expansion, the hover state is applied to the body also
2. padding issues wrt the `DragHandle` 

## Solution
1. For hover states, apply the `hover` conditionally only on the `Flex` wrapper for the accordion header (idk if this term makes sense). This necessitates the render prop pattern to access internal state on the `AccordionItem` - see [here](https://chakra-ui.com/docs/components/accordion#accessing-the-internal-state) 
    - current (and correct) behaviour is to have `hover` **only on collapsed states**
2. For the `DragHandle`, it has to display over the accordion such that when it is clicked/hovered, the interaction states on the accordion header does not trigger. Hence, this was given `position: absolute` + styling to fix it in place.
3. For the error border, we cannot use an actual border due to it cutting into the card, causing the items to realign themselves and throw alignment between acc

## Screenshots
**Jiggling items with border**
![Recording 2023-08-16 at 13 27 50](https://github.com/isomerpages/isomercms-frontend/assets/44049504/e0cc3196-bd5b-472d-b672-bde437aa8373)

**current behaviour**
![Recording 2023-08-22 at 00 57 58](https://github.com/isomerpages/isomercms-frontend/assets/44049504/4164f74b-8476-4ee9-ab59-b8ca31d6316e)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to homepage
- [ ] Add/expand infobar
- [ ] for each field, type >30 chars (or if textarea, >160) to trigger error state
- [ ] toggle close
- [ ] border should appear
