### PR TITLE
fix: conditional for checkCSP 

### DIFF
--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@opengovsg/design-system-react"
 import axios from "axios"
 import DOMPurify from "dompurify"
+import _ from "lodash"
 import { marked } from "marked"
 import PropTypes from "prop-types"
 import { useEffect, useState } from "react"
@@ -143,7 +144,7 @@ const EditPage = ({ match }) => {
 
   useEffect(() => {
     async function editorValueToHtml() {
-      if (!csp || !editorValue) return
+      if (!csp || _.isEmpty(csp) || !editorValue) return
       const html = marked.parse(editorValue)
       const {
         isCspViolation: checkedIsCspViolation,

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -143,6 +143,7 @@ const EditPage = ({ match }) => {
 
   useEffect(() => {
     async function editorValueToHtml() {
+      if (!csp || !editorValue) return
       const html = marked.parse(editorValue)
       const {
         isCspViolation: checkedIsCspViolation,
@@ -164,7 +165,7 @@ const EditPage = ({ match }) => {
       setHtmlChunk(processedChunk)
     }
     editorValueToHtml()
-  }, [editorValue])
+  }, [csp, siteName, editorValue])
 
   return (
     <VStack>

--- a/src/utils/cspUtils.js
+++ b/src/utils/cspUtils.js
@@ -29,7 +29,7 @@ function toRegExp(string) {
 
 /* Helper functions to check if elemSrc satisfies each CSP source specification: host-source, schema-source and 'self' */
 function checkHostsourcePolicy(elemSrc, policy) {
-  if (policy.includes("\\*")) return true
+  if (policy.includes("*")) return true
 
   const specialValues = [
     "http:",


### PR DESCRIPTION
This PR fixes an issue where `checkCSP` could be run before the csp was retrieved. This PR adds an additional check that both csp and editorvalue have loaded before the editPage content is populated.

Also fixes an issue where we were searching for the wrong string for *

This issue doesn't seem to occur consistently - it seems that the cause might be a delay in retrieving csp, so we can trigger it by setting an extra delay on the getCsp hook. 


Before: content loads immediately, images show up as blocked

https://github.com/isomerpages/isomercms-frontend/assets/22111124/7388554d-823e-4dc9-9045-8843b9f6e4f9

Before (even longer delay for csp to load): 

https://github.com/isomerpages/isomercms-frontend/assets/22111124/4cce1d2b-430f-4e7b-a9a7-d7f3f94231b4


After: content takes time to load in (waiting for csp to be retrieved), images show up properly

https://github.com/isomerpages/isomercms-frontend/assets/22111124/51bb539f-9aa4-48e1-878e-3bc77473b4c1
