### PR TITLE
fix(e2e): dont show error overlay

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -43,6 +43,11 @@ export default defineConfig({
                 },
               ],
             },
+            devServer: {
+              client: {
+                overlay: true,
+              },
+            },
           },
         })
       )


### PR DESCRIPTION
## Problem

Linked to #1418, where there are annoying overlays. This PR does not need to be merged, we can discuss the approach and decide if which solution we want to go towards.
 


## Solution

change webpack config to ignore overlay. This will only affect e2e tests, but not local dev, while #1418 impacts both local dev + e2e tests. 

<img width="520" alt="Screenshot 2023-08-17 at 9 08 54 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/9e22fe17-5a15-4ec2-a53d-0ff6f9e9d719">

