### PR TITLE
fix(e2e): reduce mem usage

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
   viewportHeight: 768,
   viewportWidth: 1366,
   projectId: "nxbty1",
-  numTestsKeptInMemory: 5,
+  numTestsKeptInMemory: 1,
+  experimentalMemoryManagement: true,
   e2e: {
     supportFile: "cypress/support/e2e.ts",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",


### PR DESCRIPTION
## Problem

E2e keeps crashing -> not productive 



## Solution

redce mem usage + enable experimental feature. Not too worries about the experimental feature since the testing of e2e is internal and as such we can be more risk adverse on this. 

Before this, I wasnt able to even complete 4 tests for `move`, after this change the entire test suite was able to run. 
<img width="520" alt="Screenshot 2023-08-17 at 9 08 54 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/f26004ba-eb1c-48a3-b1a4-fe366d97d32c">

