### PR TITLE
ref(homepage): adds new dropdown component for hero

### DIFF
--- a/src/contexts/DragDropContext.tsx
+++ b/src/contexts/DragDropContext.tsx
@@ -1,0 +1,33 @@
+import { OnDragEndResponder } from "@hello-pangea/dnd"
+import { createContext, PropsWithChildren, useContext } from "react"
+
+interface DragDropContextReturn {
+  onDragEnd: OnDragEndResponder
+}
+
+export const DragDropContext = createContext<null | DragDropContextReturn>(null)
+
+export const useDragDropContext = (): DragDropContextReturn => {
+  const context = useContext(DragDropContext)
+  if (context === null) {
+    throw new Error(
+      "useDragDropContext must be used within a DragDropContextProvider"
+    )
+  }
+  return context
+}
+
+export const DragDropContextProvider = ({
+  onDragEnd,
+  children,
+}: PropsWithChildren<DragDropContextReturn>) => {
+  return (
+    <DragDropContext.Provider
+      value={{
+        onDragEnd,
+      }}
+    >
+      {children}
+    </DragDropContext.Provider>
+  )
+}

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -273,7 +273,7 @@ export const onCreate = <E,>(
       return updateEditorSection(
         homepageState,
         newDisplaySections,
-        sections,
+        sections as EditorHomepageState["frontMatter"]["sections"],
         newErrorSections
       )
     }

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -43,7 +43,6 @@ import {
 import { HomepageStartEditingImage } from "assets"
 import { DEFAULT_RETRY_MSG } from "utils"
 
-import { HomepageStartEditingImage } from "../assets/images/HomepageStartEditingImage"
 import { DragDropContextProvider } from "../contexts/DragDropContext"
 import { useDrag, onCreate, onDelete } from "../hooks/useDrag"
 

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -15,7 +15,6 @@ import { useEffect, createRef, useState } from "react"
 
 import { Footer } from "components/Footer"
 import Header from "components/Header"
-import EditorHeroSection from "components/homepage/HeroSection"
 import { LoadingButton } from "components/LoadingButton"
 import { WarningModal } from "components/WarningModal"
 
@@ -43,10 +42,13 @@ import {
 
 import { DEFAULT_RETRY_MSG } from "utils"
 
+import { HomepageStartEditingImage } from "../assets/images/HomepageStartEditingImage"
+import { DragDropContextProvider } from "../contexts/DragDropContext"
 import { useDrag, onCreate, onDelete } from "../hooks/useDrag"
 
 import { CustomiseSectionsHeader, Editable } from "./components/Editable"
 import { AddSectionButton } from "./components/Editable/AddSectionButton"
+import { HeroBody } from "./components/Homepage/HeroBody"
 import { InfobarBody } from "./components/Homepage/InfobarBody"
 import { InfopicBody } from "./components/Homepage/InfopicBody"
 import { ResourcesBody } from "./components/Homepage/ResourcesBody"
@@ -181,6 +183,7 @@ const EditHomepage = ({ match }) => {
     setDisplayDropdownElems(displayDropdownElems)
     setDisplayHighlights(displayHighlights)
   }
+  const heroSection = frontMatter.sections.filter((section) => !!section.hero)
 
   const errorToast = useErrorToast()
 
@@ -956,7 +959,7 @@ const EditHomepage = ({ match }) => {
           backButtonUrl={`/sites/${siteName}/workspace`}
         />
         {hasLoaded && (
-          <>
+          <DragDropContextProvider onDragEnd={onDragEnd}>
             <HStack className={elementStyles.wrapper}>
               <div className={editorStyles.homepageEditorSidebar}>
                 <Editable.Sidebar
@@ -965,146 +968,169 @@ const EditHomepage = ({ match }) => {
                     displayHandler({ target: { id: `section-${idx}` } })
                   }}
                 >
-                  <Editable.Draggable
-                    editableId="leftPane"
-                    onDragEnd={onDragEnd}
+                  <Editable.Accordion
+                    onChange={(idx) => {
+                      displayHandler({ target: { id: `section-${idx}` } })
+                    }}
                   >
-                    <Editable.Accordion
-                      onChange={(idx) => {
-                        displayHandler({ target: { id: `section-${idx}` } })
-                      }}
+                    <VStack
+                      bg="base.canvas.alt"
+                      p="1.5rem"
+                      spacing="1.5rem"
+                      alignItems="flex-start"
                     >
-                      <VStack
-                        bg="base.canvas.alt"
-                        p="1.5rem"
-                        spacing="1.5rem"
-                        alignItems="flex-start"
-                      >
-                        {frontMatter.sections.map((section, sectionIndex) => (
+                      {heroSection.map((section, sectionIndex) => {
+                        return (
                           <>
-                            {/* Hero section */}
-                            {section.hero && (
-                              <>
-                                <Editable.EditableAccordionItem title="Hero section">
-                                  <EditorHeroSection
-                                    key={`section-${sectionIndex}`}
-                                    {...section.hero}
-                                    notification={frontMatter.notification}
-                                    sectionIndex={sectionIndex}
-                                    highlights={
-                                      section.hero.key_highlights ?? []
-                                    }
-                                    onFieldChange={onFieldChange}
-                                    createHandler={createHandler}
-                                    deleteHandler={(event, type) => {
-                                      onOpen()
-                                      setItemPendingForDelete({
-                                        id: event.target.id,
-                                        type,
-                                      })
-                                    }}
-                                    shouldDisplay={
-                                      displaySections[sectionIndex]
-                                    }
-                                    displayHighlights={displayHighlights}
-                                    displayDropdownElems={displayDropdownElems}
-                                    displayHandler={displayHandler}
-                                    errors={errors}
-                                    handleHighlightDropdownToggle={
-                                      handleHighlightDropdownToggle
-                                    }
-                                  />
-                                </Editable.EditableAccordionItem>
-                                <Divider />
-                                <VStack
-                                  spacing="0.5rem"
-                                  alignItems="flex-start"
-                                >
-                                  <CustomiseSectionsHeader />
-                                </VStack>
-                              </>
-                            )}
-                            {section.resources && (
-                              <Editable.DraggableAccordionItem
+                            <Editable.EditableAccordionItem title="Hero section">
+                              <HeroBody
+                                {...section.hero}
+                                state={homepageState}
+                                // TODO: Shift to rhf
+                                notification={frontMatter.notification}
                                 index={sectionIndex}
-                                tag={<Tag variant="subtle">Resources</Tag>}
-                                title="New resource widget"
-                                isInvalid={_.some(
-                                  errors.sections[sectionIndex].resources
-                                )}
-                              >
-                                <ResourcesBody
-                                  {...section.resources}
-                                  index={sectionIndex}
-                                  onClick={(event) => {
-                                    onOpen()
-                                    setItemPendingForDelete({
-                                      id: event.target.id,
-                                      type: "Resources Section",
-                                    })
-                                  }}
-                                  onChange={onFieldChange}
-                                  errors={
-                                    errors.sections[sectionIndex].resources
-                                  }
-                                />
-                              </Editable.DraggableAccordionItem>
-                            )}
-
-                            {section.infobar && (
-                              <Editable.DraggableAccordionItem
-                                index={sectionIndex}
-                                tag={<Tag variant="subtle">Infobar</Tag>}
-                                title={section.infobar.title ?? "New infobar"}
-                                isInvalid={_.some(
-                                  errors.sections[sectionIndex].infobar
-                                )}
-                              >
-                                <InfobarBody
-                                  {...section.infobar}
-                                  index={sectionIndex}
-                                  onClick={(event) => {
-                                    onOpen()
-                                    setItemPendingForDelete({
-                                      id: event.target.id,
-                                      type: "Infobar Section",
-                                    })
-                                  }}
-                                  onChange={onFieldChange}
-                                  errors={errors.sections[sectionIndex].infobar}
-                                />
-                              </Editable.DraggableAccordionItem>
-                            )}
-
-                            {section.infopic && (
-                              <Editable.DraggableAccordionItem
-                                index={sectionIndex}
-                                tag={<Tag variant="subtle">Infopic</Tag>}
-                                title={section.infopic.title ?? "New infopic"}
-                                isInvalid={_.some(
-                                  errors.sections[sectionIndex].infopic
-                                )}
-                              >
-                                <InfopicBody
-                                  index={sectionIndex}
-                                  onClick={(event) => {
-                                    onOpen()
-                                    setItemPendingForDelete({
-                                      id: event.target.id,
-                                      type: "Infopic Section",
-                                    })
-                                  }}
-                                  onChange={onFieldChange}
-                                  errors={errors.sections[sectionIndex].infopic}
-                                  {...section.infopic}
-                                />
-                              </Editable.DraggableAccordionItem>
-                            )}
+                                onChange={onFieldChange}
+                                createHandler={createHandler}
+                                deleteHandler={(event, type) => {
+                                  onOpen()
+                                  setItemPendingForDelete({
+                                    id: event.target.id,
+                                    type,
+                                  })
+                                }}
+                                errors={{
+                                  ...errors.sections[0].hero,
+                                  ...errors,
+                                }}
+                                handleHighlightDropdownToggle={
+                                  handleHighlightDropdownToggle
+                                }
+                              />
+                            </Editable.EditableAccordionItem>
+                            <Divider />
+                            <VStack spacing="0.5rem" alignItems="flex-start">
+                              <CustomiseSectionsHeader />
+                            </VStack>
                           </>
-                        ))}
-                      </VStack>
-                    </Editable.Accordion>
-                  </Editable.Draggable>
+                        )
+                      })}
+                      <Editable.Droppable
+                        width="100%"
+                        editableId="leftPane"
+                        onDragEnd={onDragEnd}
+                      >
+                        <Editable.EmptySection
+                          title="Sections you add will appear here"
+                          subtitle="Add informative content to your website from images to text by
+                    clicking “Add section” below"
+                          image={<HomepageStartEditingImage />}
+                          // NOTE: It's empty if there is only 1 section and it's a hero section
+                          // as the hero section displays above the custom sections
+                          // and has a fixed display
+                          isEmpty={
+                            frontMatter.sections.length === 1 &&
+                            heroSection.length === 1
+                          }
+                        >
+                          <VStack p={0} spacing="1.5rem">
+                            {frontMatter.sections.map(
+                              (section, sectionIndex) => (
+                                <>
+                                  {section.resources && (
+                                    <Editable.DraggableAccordionItem
+                                      index={sectionIndex}
+                                      tag={
+                                        <Tag variant="subtle">Resources</Tag>
+                                      }
+                                      title="New resource widget"
+                                      isInvalid={_.some(
+                                        errors.sections[sectionIndex].resources
+                                      )}
+                                    >
+                                      <ResourcesBody
+                                        {...section.resources}
+                                        index={sectionIndex}
+                                        onClick={(event) => {
+                                          onOpen()
+                                          setItemPendingForDelete({
+                                            id: event.target.id,
+                                            type: "Resources Section",
+                                          })
+                                        }}
+                                        onChange={onFieldChange}
+                                        errors={
+                                          errors.sections[sectionIndex]
+                                            .resources
+                                        }
+                                      />
+                                    </Editable.DraggableAccordionItem>
+                                  )}
+
+                                  {section.infobar && (
+                                    <Editable.DraggableAccordionItem
+                                      index={sectionIndex}
+                                      tag={<Tag variant="subtle">Infobar</Tag>}
+                                      title={
+                                        section.infobar.title || "New infobar"
+                                      }
+                                      isInvalid={_.some(
+                                        errors.sections[sectionIndex].infobar
+                                      )}
+                                    >
+                                      <InfobarBody
+                                        {...section.infobar}
+                                        index={sectionIndex}
+                                        onClick={(event) => {
+                                          onOpen()
+                                          setItemPendingForDelete({
+                                            id: event.target.id,
+                                            type: "Infobar Section",
+                                          })
+                                        }}
+                                        onChange={onFieldChange}
+                                        errors={
+                                          errors.sections[sectionIndex].infobar
+                                        }
+                                      />
+                                    </Editable.DraggableAccordionItem>
+                                  )}
+
+                                  {section.infopic && (
+                                    <Editable.DraggableAccordionItem
+                                      index={sectionIndex}
+                                      tag={<Tag variant="subtle">Infopic</Tag>}
+                                      title={
+                                        section.infopic.title || "New infopic"
+                                      }
+                                      isInvalid={_.some(
+                                        errors.sections[sectionIndex].infopic
+                                      )}
+                                    >
+                                      <InfopicBody
+                                        index={sectionIndex}
+                                        onClick={(event) => {
+                                          onOpen()
+                                          setItemPendingForDelete({
+                                            id: event.target.id,
+                                            type: "Infopic Section",
+                                          })
+                                        }}
+                                        onChange={onFieldChange}
+                                        errors={
+                                          errors.sections[sectionIndex].infopic
+                                        }
+                                        {...section.infopic}
+                                      />
+                                    </Editable.DraggableAccordionItem>
+                                  )}
+                                </>
+                              )
+                            )}
+                          </VStack>
+                        </Editable.EmptySection>
+                      </Editable.Droppable>
+                    </VStack>
+                  </Editable.Accordion>
                   {/* NOTE: Set the padding here - 
                         We cannot let the button be part of the `Draggable` 
                         as otherwise, when dragging, 
@@ -1274,7 +1300,7 @@ const EditHomepage = ({ match }) => {
                 Save
               </LoadingButton>
             </Footer>
-          </>
+          </DragDropContextProvider>
         )}
       </VStack>
     </>

--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -40,6 +40,7 @@ import {
   validateDropdownElems,
 } from "utils/validators"
 
+import { HomepageStartEditingImage } from "assets"
 import { DEFAULT_RETRY_MSG } from "utils"
 
 import { HomepageStartEditingImage } from "../assets/images/HomepageStartEditingImage"

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -54,28 +54,38 @@ export const CustomiseSectionsHeader = () => (
   </>
 )
 
-const EmptySideBarBody = () => {
-  return (
-    <VStack spacing="0.5rem" alignItems="flex-start" px="1.5rem" pt="1.5rem">
-      <CustomiseSectionsHeader />
-      <Flex
-        alignItems="center"
-        flexDir="column"
-        p="3.75rem 1.5rem"
-        justifyContent="center"
+interface EmptySectionProps {
+  image?: JSX.Element
+  title: string
+  subtitle: string
+  isEmpty?: boolean
+}
+export const EmptySection = ({
+  image,
+  children,
+  title,
+  subtitle,
+  isEmpty,
+}: PropsWithChildren<EmptySectionProps>) => {
+  return isEmpty ? (
+    <Flex
+      alignItems="center"
+      flexDir="column"
+      p="3.75rem 1.5rem"
+      justifyContent="center"
+    >
+      {image}
+      <Text>{title}</Text>
+      <Text
+        textStyle="caption-2"
+        textColor="base.content.medium"
+        textAlign="center"
       >
-        <HomepageStartEditingImage />
-        <Text>Sections you add will appear here</Text>
-        <Text
-          textStyle="caption-2"
-          textColor="base.content.medium"
-          textAlign="center"
-        >
-          Add informative content to your website from images to text by
-          clicking “Add section” below
-        </Text>
-      </Flex>
-    </VStack>
+        {subtitle}
+      </Text>
+    </Flex>
+  ) : (
+    <>{children}</>
   )
 }
 
@@ -87,7 +97,7 @@ const EditableSidebar = ({
   return (
     <Flex flexDir="column" bg="base.canvas.alt">
       <SidebarHeader title={title} />
-      {children ? <>{children}</> : <EmptySideBarBody />}
+      {children}
     </Flex>
   )
 }
@@ -281,4 +291,5 @@ export const Editable = {
   Accordion: EditableAccordion,
   DraggableAccordionItem,
   Section: EditableSection,
+  EmptySection,
 }

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -12,6 +12,8 @@ import {
   forwardRef,
   StackProps,
   Divider,
+  BoxProps,
+  Box,
 } from "@chakra-ui/react"
 import {
   OnDragEndResponder,
@@ -106,14 +108,15 @@ const getDroppableInfo = (editableId: HomepageDroppableZone): DropInfo => {
   }
 }
 
-export interface EditableDraggableProps {
+export interface EditableDraggableProps extends Omit<BoxProps, "onDragEnd"> {
   onDragEnd: OnDragEndResponder
   editableId: HomepageDroppableZone
 }
-const EditableDraggable = ({
+export const EditableDroppable = ({
   onDragEnd,
   children,
   editableId,
+  ...rest
 }: PropsWithChildren<EditableDraggableProps>) => {
   return (
     // NOTE: According to the dnd docs,
@@ -122,13 +125,14 @@ const EditableDraggable = ({
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable {...getDroppableInfo(editableId)}>
         {(droppableProvided) => (
-          <div
+          <Box
             ref={droppableProvided.innerRef}
             {...droppableProvided.droppableProps}
+            {...rest}
           >
             {children}
             {droppableProvided.placeholder}
-          </div>
+          </Box>
         )}
       </Droppable>
     </DragDropContext>
@@ -176,7 +180,7 @@ const EditableAccordionItem = ({
 }
 
 interface DraggableAccordionItemProps {
-  tag: JSX.Element
+  tag?: JSX.Element
   title: string
   // TODO: Should get these props automatically
   // rather than having us pass in manually
@@ -237,7 +241,13 @@ const DraggableAccordionItem = ({
                   bgColor: isExpanded ? "none" : "interaction.muted.main.hover",
                 }}
               >
-                <Flex px="1.5rem" pb="1rem" flex="1" flexDir="column">
+                <Flex
+                  pl="1.5rem"
+                  pb={tag ? "1rem" : "1.37rem"}
+                  pt={tag ? "0" : "0.37rem"}
+                  flex="1"
+                  flexDir="column"
+                >
                   {tag}
                   <Text textStyle="h6" textAlign="left" mt="0.25rem">
                     {title}
@@ -266,7 +276,7 @@ const EditableSection = (props: StackProps) => (
 
 export const Editable = {
   Sidebar: EditableSidebar,
-  Draggable: EditableDraggable,
+  Droppable: EditableDroppable,
   EditableAccordionItem,
   Accordion: EditableAccordion,
   DraggableAccordionItem,

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -1,0 +1,186 @@
+import {
+  FormControl,
+  Flex,
+  Icon,
+  Text,
+  Box,
+  Divider,
+  HStack,
+  RadioGroup,
+} from "@chakra-ui/react"
+import {
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Radio,
+} from "@opengovsg/design-system-react"
+import { useState } from "react"
+import { BiInfoCircle } from "react-icons/bi"
+
+import { FormContext, FormError, FormTitle } from "components/Form"
+import FormFieldMedia from "components/FormFieldMedia"
+
+import { Editable } from "layouts/components/Editable"
+
+import { EditorHeroDropdownSection, EditorHomepageState } from "types/homepage"
+
+import {
+  HeroDropdownFormFields,
+  HeroDropdownSection,
+} from "./HeroDropdownSection"
+
+export interface HeroBodyFormFields {
+  title: string
+  subtitle: string
+  background: string
+  dropdown: HeroDropdownFormFields
+}
+
+interface HeroBodyProps extends HeroBodyFormFields {
+  index: number
+  onChange: () => void
+  createHandler: (event: Record<string, unknown>) => void
+  deleteHandler: (
+    event: {
+      target: {
+        id: string
+      }
+    },
+    type: "Dropdown Element"
+  ) => void
+  errors: {
+    dropdownElems: HeroDropdownFormFields[]
+    highlights: unknown[]
+    dropdown: string
+  } & HeroBodyFormFields
+  handleHighlightDropdownToggle: (event: Record<string, unknown>) => void
+  notification: string
+  state: EditorHomepageState
+}
+
+export const HeroBody = ({
+  title,
+  subtitle,
+  dropdown,
+  background,
+  index,
+  onChange,
+  createHandler,
+  deleteHandler,
+  errors,
+  handleHighlightDropdownToggle,
+  notification,
+  state,
+}: HeroBodyProps) => {
+  const [heroSectionType, setHeroSectionType] = useState("highlight")
+  return (
+    <>
+      <Editable.Section spacing="1.25rem">
+        <FormControl>
+          <FormLabel>Notification Banner</FormLabel>
+          <Input
+            // TODO: Remove the `id/onChange`
+            // and change to react hook forms
+            id="site-notification"
+            onChange={onChange}
+            value={notification}
+            placeholder="This is a notification banner"
+          />
+          <Flex flexDir="row" mt="0.75rem" alignItems="center">
+            <Icon
+              as={BiInfoCircle}
+              fill="base.content.brand"
+              mr="0.5rem"
+              fontSize="1rem"
+            />
+            <Text textStyle="caption-2">
+              Leave this blank if you don&apos;t want the banner to appear
+            </Text>
+          </Flex>
+        </FormControl>
+        <FormControl isRequired isInvalid={!!errors.title}>
+          <FormLabel>Hero title</FormLabel>
+          <Input
+            placeholder="Hero title"
+            id={`section-${index}-hero-title`}
+            value={title}
+            onChange={onChange}
+          />
+          <FormErrorMessage>{errors.title}</FormErrorMessage>
+        </FormControl>
+        <FormControl isRequired isInvalid={!!errors.subtitle}>
+          <FormLabel>Hero subtitle</FormLabel>
+          <Input
+            placeholder="Hero subtitle"
+            id={`section-${index}-hero-subtitle`}
+            value={subtitle}
+            onChange={onChange}
+          />
+          <FormErrorMessage>{errors.subtitle}</FormErrorMessage>
+        </FormControl>
+        <Box>
+          {/* TODO: migrate this to design system components */}
+          <FormContext
+            hasError={!!errors.background}
+            onFieldChange={onChange}
+            isRequired
+          >
+            <Box mb="0.5rem">
+              <FormTitle>Hero background image</FormTitle>
+            </Box>
+            <FormFieldMedia
+              value={background}
+              id={`section-${index}-hero-background`}
+              inlineButtonText="Select"
+            />
+            <FormError>{errors.background}</FormError>
+          </FormContext>
+        </Box>
+      </Editable.Section>
+      <Divider my="1.5rem" />
+      <Editable.Section spacing="0.75rem">
+        <Box>
+          <Text textStyle="h5" mb="1rem">
+            Customise Layout
+          </Text>
+          <RadioGroup
+            onChange={(nextSectionType) => {
+              setHeroSectionType(nextSectionType)
+              handleHighlightDropdownToggle({
+                target: {
+                  value: nextSectionType,
+                },
+              })
+            }}
+            as={HStack}
+            spacing="1rem"
+            defaultValue="highlight"
+          >
+            <Radio value="highlight" size="xs" w="fit-content">
+              Button + Highlights
+            </Radio>
+            <Radio value="dropdown" size="xs" w="fit-content">
+              Dropdown
+            </Radio>
+          </RadioGroup>
+        </Box>
+
+        {heroSectionType === "dropdown" ? (
+          <HeroDropdownSection
+            title={dropdown.title}
+            state={
+              state.frontMatter.sections[0].hero as EditorHeroDropdownSection
+            }
+            errors={errors}
+            onCreate={() => createHandler({ target: { id: "dropdownelem" } })}
+            onChange={onChange}
+            onClick={(event) => deleteHandler(event, "Dropdown Element")}
+          />
+        ) : (
+          // <HeroHighlightSection />
+          <div />
+        )}
+      </Editable.Section>
+    </>
+  )
+}

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -22,7 +22,11 @@ import FormFieldMedia from "components/FormFieldMedia"
 
 import { Editable } from "layouts/components/Editable"
 
-import { EditorHeroDropdownSection, EditorHomepageState } from "types/homepage"
+import {
+  EditorHeroDropdownSection,
+  EditorHomepageState,
+  HeroFrontmatterSection,
+} from "types/homepage"
 
 import {
   HeroDropdownFormFields,
@@ -169,7 +173,8 @@ export const HeroBody = ({
           <HeroDropdownSection
             title={dropdown.title}
             state={
-              state.frontMatter.sections[0].hero as EditorHeroDropdownSection
+              (state.frontMatter.sections[0] as HeroFrontmatterSection)
+                .hero as EditorHeroDropdownSection
             }
             errors={errors}
             onCreate={() => createHandler({ target: { id: "dropdownelem" } })}

--- a/src/layouts/components/Homepage/HeroDropdownSection.tsx
+++ b/src/layouts/components/Homepage/HeroDropdownSection.tsx
@@ -1,0 +1,139 @@
+import { Text, Box, FormControl } from "@chakra-ui/react"
+import {
+  FormLabel,
+  Input,
+  FormErrorMessage,
+  Button,
+} from "@opengovsg/design-system-react"
+
+import { useDragDropContext } from "contexts/DragDropContext"
+
+import { Editable } from "layouts/components/Editable"
+
+import { EditorHeroDropdownSection, EditorHomepageState } from "types/homepage"
+
+interface HeroDropdownFormFields {
+  title: string
+  url: string
+}
+
+interface HeroDropdownSectionProps {
+  onChange: () => void
+  onClick: (event: {
+    target: {
+      id: string
+    }
+  }) => void
+  errors: { dropdownElems: HeroDropdownFormFields[] }
+  state: EditorHomepageState
+  onCreate: () => void
+  title: string
+}
+export const HeroDropdownSection = ({
+  errors,
+  onChange,
+  onClick,
+  state,
+  onCreate,
+  title,
+}: HeroDropdownSectionProps) => {
+  const dropdownState = state.frontMatter.sections[0]
+    .hero as EditorHeroDropdownSection
+
+  const { onDragEnd } = useDragDropContext()
+
+  return (
+    <Box>
+      <Editable.Droppable editableId="dropdownelem" onDragEnd={onDragEnd}>
+        <FormControl isRequired isInvalid={!!errors}>
+          <FormLabel>Title</FormLabel>
+          <Input
+            placeholder="This is a button"
+            value={title}
+            onChange={onChange}
+          />
+        </FormControl>
+        <Text mt="1.5rem" textStyle="h6">
+          Dropdown Options
+        </Text>
+        <Text mt="0.5rem">
+          Drag and drop dropdown options to rearrange them
+        </Text>
+        <Editable.Accordion>
+          <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
+            {dropdownState.dropdown?.options?.map(
+              ({ title: optionTitle, url: optionUrl }, dropdownOptionIndex) => {
+                return (
+                  <Editable.DraggableAccordionItem
+                    title={optionTitle}
+                    draggableId={`dropdownelem-${dropdownOptionIndex}-draggable`}
+                    index={dropdownOptionIndex}
+                  >
+                    <Editable.Section>
+                      <FormControl
+                        isInvalid={
+                          !!errors?.dropdownElems?.[dropdownOptionIndex].title
+                        }
+                      >
+                        <FormLabel>Title</FormLabel>
+                        <Input
+                          placeholder="Dropdown option title"
+                          id={`dropdownelem-${dropdownOptionIndex}-title`}
+                          value={optionTitle}
+                          onChange={onChange}
+                        />
+                        <FormErrorMessage>
+                          {errors?.dropdownElems?.[dropdownOptionIndex].title}
+                        </FormErrorMessage>
+                      </FormControl>
+                      <FormControl
+                        isInvalid={
+                          !!errors?.dropdownElems?.[dropdownOptionIndex].url
+                        }
+                      >
+                        <FormLabel>URL</FormLabel>
+                        <Input
+                          placeholder="Insert /page-url or https://"
+                          id={`dropdownelem-${dropdownOptionIndex}-url`}
+                          value={optionUrl}
+                          onChange={onChange}
+                        />
+                        <FormErrorMessage>
+                          {errors?.dropdownElems?.[dropdownOptionIndex].url}
+                        </FormErrorMessage>
+                      </FormControl>
+                      <Button
+                        id={`dropdownelem-${dropdownOptionIndex}-delete`}
+                        onClick={() =>
+                          onClick({
+                            target: {
+                              id: `dropdownelem-${dropdownOptionIndex}-delete`,
+                            },
+                          })
+                        }
+                        alignSelf="center"
+                        variant="clear"
+                        colorScheme="critical"
+                        mt="1rem"
+                      >
+                        Delete option
+                      </Button>
+                    </Editable.Section>
+                  </Editable.DraggableAccordionItem>
+                )
+              }
+            )}
+          </Editable.Section>
+        </Editable.Accordion>
+      </Editable.Droppable>
+      <Button
+        id={`dropdownelem-${dropdownState.dropdown?.options?.length}-create`}
+        onClick={onCreate}
+        variant="outline"
+        w="full"
+      >
+        Add option
+      </Button>
+    </Box>
+  )
+}

--- a/src/layouts/components/Homepage/HeroDropdownSection.tsx
+++ b/src/layouts/components/Homepage/HeroDropdownSection.tsx
@@ -5,14 +5,16 @@ import {
   FormErrorMessage,
   Button,
 } from "@opengovsg/design-system-react"
+import _ from "lodash"
+import { BiPlus } from "react-icons/bi"
 
 import { useDragDropContext } from "contexts/DragDropContext"
 
 import { Editable } from "layouts/components/Editable"
 
-import { EditorHeroDropdownSection, EditorHomepageState } from "types/homepage"
+import { EditorHeroDropdownSection } from "types/homepage"
 
-interface HeroDropdownFormFields {
+export interface HeroDropdownFormFields {
   title: string
   url: string
 }
@@ -24,11 +26,16 @@ interface HeroDropdownSectionProps {
       id: string
     }
   }) => void
-  errors: { dropdownElems: HeroDropdownFormFields[] }
-  state: EditorHomepageState
+  errors: {
+    dropdownElems: HeroDropdownFormFields[]
+    title: string
+    dropdown: string
+  }
+  state: EditorHeroDropdownSection
   onCreate: () => void
   title: string
 }
+
 export const HeroDropdownSection = ({
   errors,
   onChange,
@@ -37,21 +44,19 @@ export const HeroDropdownSection = ({
   onCreate,
   title,
 }: HeroDropdownSectionProps) => {
-  const dropdownState = state.frontMatter.sections[0]
-    .hero as EditorHeroDropdownSection
-
   const { onDragEnd } = useDragDropContext()
 
   return (
     <Box>
       <Editable.Droppable editableId="dropdownelem" onDragEnd={onDragEnd}>
-        <FormControl isRequired isInvalid={!!errors}>
+        <FormControl isRequired isInvalid={!!errors.dropdown}>
           <FormLabel>Title</FormLabel>
           <Input
             placeholder="This is a button"
             value={title}
             onChange={onChange}
           />
+          <FormErrorMessage>{errors.dropdown}</FormErrorMessage>
         </FormControl>
         <Text mt="1.5rem" textStyle="h6">
           Dropdown Options
@@ -61,19 +66,23 @@ export const HeroDropdownSection = ({
         </Text>
         <Editable.Accordion>
           <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
-            {dropdownState.dropdown?.options?.map(
+            {state.dropdown.options.map(
               ({ title: optionTitle, url: optionUrl }, dropdownOptionIndex) => {
                 return (
                   <Editable.DraggableAccordionItem
-                    title={optionTitle}
+                    title={optionTitle || "New dropdown option"}
                     draggableId={`dropdownelem-${dropdownOptionIndex}-draggable`}
                     index={dropdownOptionIndex}
+                    isInvalid={_.some(
+                      errors.dropdownElems[dropdownOptionIndex]
+                    )}
                   >
                     <Editable.Section>
                       <FormControl
                         isInvalid={
-                          !!errors?.dropdownElems?.[dropdownOptionIndex].title
+                          !!errors.dropdownElems[dropdownOptionIndex].title
                         }
+                        isRequired
                       >
                         <FormLabel>Title</FormLabel>
                         <Input
@@ -83,13 +92,14 @@ export const HeroDropdownSection = ({
                           onChange={onChange}
                         />
                         <FormErrorMessage>
-                          {errors?.dropdownElems?.[dropdownOptionIndex].title}
+                          {errors.dropdownElems[dropdownOptionIndex].title}
                         </FormErrorMessage>
                       </FormControl>
                       <FormControl
                         isInvalid={
-                          !!errors?.dropdownElems?.[dropdownOptionIndex].url
+                          !!errors.dropdownElems[dropdownOptionIndex].url
                         }
+                        isRequired
                       >
                         <FormLabel>URL</FormLabel>
                         <Input
@@ -99,7 +109,7 @@ export const HeroDropdownSection = ({
                           onChange={onChange}
                         />
                         <FormErrorMessage>
-                          {errors?.dropdownElems?.[dropdownOptionIndex].url}
+                          {errors.dropdownElems[dropdownOptionIndex].url}
                         </FormErrorMessage>
                       </FormControl>
                       <Button
@@ -127,10 +137,11 @@ export const HeroDropdownSection = ({
         </Editable.Accordion>
       </Editable.Droppable>
       <Button
-        id={`dropdownelem-${dropdownState.dropdown?.options?.length}-create`}
+        id={`dropdownelem-${state.dropdown.options.length}-create`}
         onClick={onCreate}
         variant="outline"
         w="full"
+        leftIcon={<BiPlus fontSize="1.5rem" />}
       >
         Add option
       </Button>

--- a/src/layouts/components/Homepage/HeroDropdownSection.tsx
+++ b/src/layouts/components/Homepage/HeroDropdownSection.tsx
@@ -65,75 +65,84 @@ export const HeroDropdownSection = ({
           Drag and drop dropdown options to rearrange them
         </Text>
         <Editable.Accordion>
-          <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
-            {state.dropdown.options.map(
-              ({ title: optionTitle, url: optionUrl }, dropdownOptionIndex) => {
-                return (
-                  <Editable.DraggableAccordionItem
-                    title={optionTitle || "New dropdown option"}
-                    draggableId={`dropdownelem-${dropdownOptionIndex}-draggable`}
-                    index={dropdownOptionIndex}
-                    isInvalid={_.some(
-                      errors.dropdownElems[dropdownOptionIndex]
-                    )}
-                  >
-                    <Editable.Section>
-                      <FormControl
-                        isInvalid={
-                          !!errors.dropdownElems[dropdownOptionIndex].title
-                        }
-                        isRequired
-                      >
-                        <FormLabel>Title</FormLabel>
-                        <Input
-                          placeholder="Dropdown option title"
-                          id={`dropdownelem-${dropdownOptionIndex}-title`}
-                          value={optionTitle}
-                          onChange={onChange}
-                        />
-                        <FormErrorMessage>
-                          {errors.dropdownElems[dropdownOptionIndex].title}
-                        </FormErrorMessage>
-                      </FormControl>
-                      <FormControl
-                        isInvalid={
-                          !!errors.dropdownElems[dropdownOptionIndex].url
-                        }
-                        isRequired
-                      >
-                        <FormLabel>URL</FormLabel>
-                        <Input
-                          placeholder="Insert /page-url or https://"
-                          id={`dropdownelem-${dropdownOptionIndex}-url`}
-                          value={optionUrl}
-                          onChange={onChange}
-                        />
-                        <FormErrorMessage>
-                          {errors.dropdownElems[dropdownOptionIndex].url}
-                        </FormErrorMessage>
-                      </FormControl>
-                      <Button
-                        id={`dropdownelem-${dropdownOptionIndex}-delete`}
-                        onClick={() =>
-                          onClick({
-                            target: {
-                              id: `dropdownelem-${dropdownOptionIndex}-delete`,
-                            },
-                          })
-                        }
-                        alignSelf="center"
-                        variant="clear"
-                        colorScheme="critical"
-                        mt="1rem"
-                      >
-                        Delete option
-                      </Button>
-                    </Editable.Section>
-                  </Editable.DraggableAccordionItem>
-                )
-              }
-            )}
-          </Editable.Section>
+          <Editable.EmptySection
+            title="Options you add will appear here"
+            subtitle="Add options to allow users to quickly navigate your site"
+            isEmpty={state.dropdown.options.length === 0}
+          >
+            <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
+              {state.dropdown.options.map(
+                (
+                  { title: optionTitle, url: optionUrl },
+                  dropdownOptionIndex
+                ) => {
+                  return (
+                    <Editable.DraggableAccordionItem
+                      title={optionTitle || "New dropdown option"}
+                      draggableId={`dropdownelem-${dropdownOptionIndex}-draggable`}
+                      index={dropdownOptionIndex}
+                      isInvalid={_.some(
+                        errors.dropdownElems[dropdownOptionIndex]
+                      )}
+                    >
+                      <Editable.Section>
+                        <FormControl
+                          isInvalid={
+                            !!errors.dropdownElems[dropdownOptionIndex].title
+                          }
+                          isRequired
+                        >
+                          <FormLabel>Title</FormLabel>
+                          <Input
+                            placeholder="Dropdown option title"
+                            id={`dropdownelem-${dropdownOptionIndex}-title`}
+                            value={optionTitle}
+                            onChange={onChange}
+                          />
+                          <FormErrorMessage>
+                            {errors.dropdownElems[dropdownOptionIndex].title}
+                          </FormErrorMessage>
+                        </FormControl>
+                        <FormControl
+                          isInvalid={
+                            !!errors.dropdownElems[dropdownOptionIndex].url
+                          }
+                          isRequired
+                        >
+                          <FormLabel>URL</FormLabel>
+                          <Input
+                            placeholder="Insert /page-url or https://"
+                            id={`dropdownelem-${dropdownOptionIndex}-url`}
+                            value={optionUrl}
+                            onChange={onChange}
+                          />
+                          <FormErrorMessage>
+                            {errors.dropdownElems[dropdownOptionIndex].url}
+                          </FormErrorMessage>
+                        </FormControl>
+                        <Button
+                          id={`dropdownelem-${dropdownOptionIndex}-delete`}
+                          onClick={() =>
+                            onClick({
+                              target: {
+                                id: `dropdownelem-${dropdownOptionIndex}-delete`,
+                              },
+                            })
+                          }
+                          alignSelf="center"
+                          variant="clear"
+                          colorScheme="critical"
+                          mt="1rem"
+                        >
+                          Delete option
+                        </Button>
+                      </Editable.Section>
+                    </Editable.DraggableAccordionItem>
+                  )
+                }
+              )}
+            </Editable.Section>
+          </Editable.EmptySection>
         </Editable.Accordion>
       </Editable.Droppable>
       <Button

--- a/src/layouts/components/Homepage/InfobarBody.tsx
+++ b/src/layouts/components/Homepage/InfobarBody.tsx
@@ -9,7 +9,7 @@ import {
 
 import { Editable } from "../Editable"
 
-interface InfobarInputs {
+interface InfobarFormFields {
   title: string
   subtitle: string
   description: string
@@ -17,11 +17,11 @@ interface InfobarInputs {
   url: string
 }
 
-interface InfobarBodyProps extends InfobarInputs {
+interface InfobarBodyProps extends InfobarFormFields {
   index: number
   onClick: () => void
   onChange: () => void
-  errors: InfobarInputs
+  errors: InfobarFormFields
 }
 
 export const InfobarBody = ({

--- a/src/layouts/components/Homepage/ResourcesBody.tsx
+++ b/src/layouts/components/Homepage/ResourcesBody.tsx
@@ -9,17 +9,17 @@ import { BiInfoCircle } from "react-icons/bi"
 
 import { Editable } from "../Editable"
 
-interface ResourcesInputs {
+interface ResourcesFormFields {
   title: string
   subtitle: string
   button: string
 }
 
-interface ResourcesBodyProps extends ResourcesInputs {
+interface ResourcesBodyProps extends ResourcesFormFields {
   index: number
   onClick: () => void
   onChange: () => void
-  errors: ResourcesInputs
+  errors: ResourcesFormFields
 }
 
 export const ResourcesBody = ({

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -113,7 +113,7 @@ export interface EditorHomepageState {
 
 export interface EditorHeroDropdownSection {
   dropdown: {
-    options: { title: string; url: string }[]
+    options: Partial<DropdownOption>[]
   }
 }
 

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -82,7 +82,8 @@ export interface HomepageDto {
 
 export type EditorHomepageElement = "section" | "dropdownelem" | "highlight"
 export type PossibleEditorSections = IterableElement<
-  EditorHomepageState["frontMatter"]["sections"]
+  | EditorHomepageState["frontMatter"]["sections"]
+  | EditorHeroDropdownSection["dropdown"]["options"]
 >
 
 export type HomepageEditorHeroSection =

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -112,7 +112,7 @@ export interface EditorHomepageState {
 
 export interface EditorHeroDropdownSection {
   dropdown: {
-    options: []
+    options: { title: string; url: string }[]
   }
 }
 


### PR DESCRIPTION
## Problem
Currently, our hero component has an outdated design. Design has a new version of the hero dropdown, which is implemented in this PR.

Closes IS-386

## Solution
1. Define new component, `HeroBody`, that wraps both `Dropdown` and `Highlights` 
    - this could potentially take `children` and only do styling + the 3 forms which, in hindsight, seems like a better solution tbh
2. Define new component, `HeroDropdownSection`, that does the actual dnd stuff + handles the form fields for the dropdown as a whole. 
3. Adds a new `DragDropContext` - we require this because `Editable.Draggable` requires a `onDragEnd` prop, which is defined _very_ high up the component tree but is the sole "source of truth" for dnd logic. This is similar in function to `react-hook-form`'s `FormProvider`, which just does a re-export of `useForm`'s return value. (also where i got the idea for the API from lmao)

**BEFORE**:
![Screenshot 2023-08-17 at 12 54 06 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/37514d25-685b-46b5-868d-a83529c6ffd6)


**AFTER**:
![Recording 2023-08-17 at 12 52 57](https://github.com/isomerpages/isomercms-frontend/assets/44049504/8c40ccd6-51eb-40fb-a5ca-e532054ced6f)

**Empty state**
![Screenshot 2023-08-17 at 12 54 34 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/5215cdf6-69e8-4ff0-89c1-7c72372832e5)

## Tests
- [ ] Go to homepage
- [ ] type in the title/subtitle fields, this should work + preview should chnage
- [ ] type in something extremely long in ^, should trigger validation with error message
- [ ] select a background image, this should work
- [ ] select dropdown
- [ ] add dropdown option
- [ ] perform steps 2-3, this should work + preview should chnage
- [ ] add another dropdown option - previwe should chnage
- [ ] drag and drop the options, preview should change + UI should reflect change

