### PR TITLE
fix(chromatic): trigger build for push to develop for Chromatic baseline

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,13 +6,15 @@ on:
   issue_comment:
     types: [created, edited]
 
+  push:
+    branches:
+      - develop
+
 env:
   # The full comment text to match to trigger this workflow
   ISOMER_TRIGGER_COMMENT: "!run-chromatic"
   # The slug for the Isomer core team
   ISOMER_CORE_TEAM_SLUG: core
-  # The file name of this workflow, should match this file name
-  ISOMER_COMMENT_WORKFLOW_NAME: chromatic.yml
   # Use GitHub Token
   GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   # Required for the chromatic action
@@ -26,10 +28,18 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository branch (PR comment)
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+        uses: actions/checkout@v3
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
-      - uses: dorny/paths-filter@v2
+
+      - name: Checkout repository branch (push)
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v3
+
+      - name: Check for changes
+        uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |
@@ -49,6 +59,7 @@ jobs:
     steps:
       # Determine if the PR comment should trigger the Chromatic build
       - name: Check if user is part of Isomer core team
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
         uses: tspascoal/get-user-teams-membership@v1
         id: checkUserMember
         with:
@@ -66,14 +77,20 @@ jobs:
           reaction: "+1"
 
       - name: Set environment variable to run Chromatic build
-        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' && (github.event_name == 'issue_comment' && github.event.issue.pull_request && steps.check.outputs.triggered == 'true') }}
+        if: ${{ steps.check.outputs.triggered == 'true' && (github.event_name == 'push' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && steps.checkUserMember.outputs.isTeamMember == 'true')) }}
         run: echo "ISOMER_RUN_CHROMATIC_BUILD=true" >> $GITHUB_ENV
 
-      - name: Checkout repository
-        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
+      - name: Checkout repository (pull request)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
         uses: actions/checkout@v3
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0 # 👈 Required to retrieve git history
+
+      - name: Checkout repository (push)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'push' }}
+        uses: actions/checkout@v3
+        with:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
       # This extra step is not in the original chromatic workflow.
@@ -89,14 +106,22 @@ jobs:
         if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
         run: npm ci
 
-      - name: Get pull request information
-        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
+      - name: Get pull request information (for pull requests)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
         uses: octokit/request-action@v2.x
         id: get_pull_request
         with:
           route: GET /repos/{repository}/pulls/{pull_number}
           repository: ${{ github.repository }} # isomerpages/isomercms-frontend
           pull_number: ${{ github.event.issue.number }}
+
+      - name: Save branch name as environment variable (for pull requests)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
+        run: echo "ISOMER_BRANCH_NAME=${{ fromJSON(steps.get_branch_name.outputs.data).head.ref }}" >> $GITHUB_ENV
+
+      - name: Save branch name as environment variable (for push)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'push' }}
+        run: echo "ISOMER_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
@@ -108,4 +133,4 @@ jobs:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
-          branchName: ${{ fromJSON(steps.get_pull_request.outputs.data).head.ref }}
+          branchName: ${{ env.ISOMER_BRANCH_NAME }}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Chromatic builds do not run on pushes to the `develop` branch, which causes Chromatic to be unable to update its baseline.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Chromatic now builds for pushes to the `develop` branch, so that the baseline can be updated on Chromatic
    - It is important that this gets done, as we no longer build Chromatic automatically on every pull request. This means that there may be frontend changes that land into the `develop` branch, but Chromatic does not know. We cannot guarantee that everyone will force a Chromatic build for their PRs, which may cause the baseline to be incorrect over time.

## Tests

<!-- What tests should be run to confirm functionality? -->

I hope it works, can only know after merging.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*