### PR TITLE
Chore/remove ua from settings

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,7 +1,5 @@
 export const ANALYTICS_SETUP_LINK =
   "https://guide.isomer.gov.sg/analytics-and-tracking/google-analytics"
-export const GA_DEPRECATION_LINK =
-  "https://support.google.com/analytics/answer/11583528?hl=en"
 export const TERMS_OF_USE_LINK =
   "https://guide.isomer.gov.sg/terms-and-privacy/terms-of-use"
 export const PRIVACY_POLICY_LINK =

--- a/src/hooks/settingsHooks/constants.ts
+++ b/src/hooks/settingsHooks/constants.ts
@@ -11,7 +11,6 @@ export const BE_TO_FE: {
   shareicon: "shareicon",
   favicon: "favicon",
   facebook_pixel: "pixel",
-  google_analytics: "ga",
   google_analytics_ga4: "ga4",
   linkedin_insights: "insights",
   is_government: "displayGovMasthead",

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -26,7 +26,6 @@ const DEFAULT_BE_STATE = {
   favicon: "/images/isomer-logo.svg",
   shareicon: "/images/isomer-logo.svg",
   facebook_pixel: "",
-  google_analytics: "",
   google_analytics_ga4: "",
   linkedin_insights: "",
   is_government: false,

--- a/src/layouts/Settings/AnalyticsSettings.tsx
+++ b/src/layouts/Settings/AnalyticsSettings.tsx
@@ -7,7 +7,7 @@ import {
 import { useFormContext, useFormState } from "react-hook-form"
 import { BiInfoCircle } from "react-icons/bi"
 
-import { ANALYTICS_SETUP_LINK, GA_DEPRECATION_LINK } from "constants/config"
+import { ANALYTICS_SETUP_LINK } from "constants/config"
 
 import { Section, SectionHeader, SectionCaption } from "layouts/components"
 
@@ -53,18 +53,6 @@ export const AnalyticsSettings = ({
             {/* @ts-ignore */}
             {errors.pixel && errors.pixel.message}
           </FormErrorMessage>
-        </FormControl>
-
-        <FormControl isDisabled={isError}>
-          <FormLabel>Google Analytics (UA)</FormLabel>
-          <SectionCaption icon={BiInfoCircle}>
-            This field will be removed following the deprecation of Universal
-            Analytics on 1 July 2023.{" "}
-            <Link href={GA_DEPRECATION_LINK} isExternal>
-              Read more
-            </Link>
-          </SectionCaption>
-          <Input isDisabled w="100%" {...register("ga")} />
         </FormControl>
 
         <FormControl isDisabled={isError}>

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -160,7 +160,6 @@ export const MOCK_BE_SETTINGS: BackendSiteSettings = {
   description: "isomer is a website builder",
   // NOTE: No shareicon/logo/favicon as no uploaded img within the story
   facebook_pixel: "many pixel",
-  google_analytics: "some analytics",
   google_analytics_ga4: "some ga4 analytics",
   linkedin_insights: "some insightful comment",
   is_government: true,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -78,8 +78,6 @@ export interface BackendSiteSettings {
   // eslint-disable-next-line camelcase
   facebook_pixel?: string
   // eslint-disable-next-line camelcase
-  google_analytics?: string
-  // eslint-disable-next-line camelcase
   google_analytics_ga4?: string
   // eslint-disable-next-line camelcase
   linkedin_insights?: string


### PR DESCRIPTION
This PR removes the deprecated UA field from settings as it has been deprecated by google (no further data being sent to the tag). To be reviewed in conjunction with PR [#915](https://github.com/isomerpages/isomercms-backend/pull/915) on the isomercms-backend repo.