### PR TITLE
Feat/is 494 smooth scroll

### DIFF
--- a/src/hooks/useAfterFirstLoad.ts
+++ b/src/hooks/useAfterFirstLoad.ts
@@ -1,0 +1,22 @@
+import { useState } from "react"
+
+/**
+ * This custom hook is used as a helper for effects which should only take place on the second time onwards,
+ * e.g. if data is not fully populated at the time of mounting.
+ * It wraps a method in a conditional to check that it has been executed once before.
+ */
+export const useAfterFirstLoad = (
+  wrappedMethod: (...args: unknown[]) => void
+) => {
+  const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
+
+  const executeAfterFirstLoad = (...args: unknown[]) => {
+    if (isFirstLoadComplete) {
+      wrappedMethod(...args)
+    } else {
+      setIsFirstLoadComplete(true)
+    }
+  }
+
+  return executeAfterFirstLoad
+}

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -303,6 +303,7 @@ const EditHomepage = ({ match }) => {
   const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
 
   useEffect(() => {
+    if (scrollRefs.length === 0) return // Page data has not been populated
     if (!isFirstLoadComplete) {
       setIsFirstLoadComplete(true)
     } else {

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -788,7 +788,7 @@ const EditHomepage = ({ match }) => {
 
           setDisplaySections(newDisplaySections)
 
-          scrollRefs[index].current.scrollIntoView()
+          scrollTo(scrollRefs[index])
           break
         }
         case "highlight": {

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -61,6 +61,17 @@ import { getErrorValues } from "./utils"
 
 const RADIX_PARSE_INT = 10
 
+// NOTE: `scrollIntoView` does not work when called synchronously
+// to avoid this problem, we do a `setTimeout` to wrap it.
+// This calls it after 1ms, which allows it to work.
+const scrollTo = (ref) => {
+  setTimeout(() =>
+    ref.current.scrollIntoView({
+      behavior: "smooth",
+    })
+  )
+}
+
 const getHasError = (errorArray) =>
   _.some(errorArray, (err) =>
     _.some(err, (errorMessage) => errorMessage.length > 0)
@@ -289,10 +300,15 @@ const EditHomepage = ({ match }) => {
     loadPageDetails()
   }, [homepageData])
 
+  const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
+
   useEffect(() => {
-    if (scrollRefs.length > 0) {
-      scrollRefs[frontMatter.sections.length - 1].current.scrollIntoView()
+    if (!isFirstLoadComplete) {
+      setIsFirstLoadComplete(true)
+    } else {
+      scrollTo(scrollRefs[frontMatter.sections.length - 1])
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollRefs, frontMatter.sections.length])
 
   const onFieldChange = async (event) => {
@@ -381,7 +397,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[sectionIndex].current.scrollIntoView()
+          scrollTo(scrollRefs[sectionIndex])
           break
         }
         case "highlight": {
@@ -424,7 +440,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
           break
         }
         case "dropdownelem": {
@@ -469,7 +485,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
           break
         }
         default: {
@@ -506,7 +522,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
         }
       }
     } catch (err) {
@@ -787,7 +803,7 @@ const EditHomepage = ({ match }) => {
             $set: resetHighlightSections,
           })
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
           setDisplayHighlights(newDisplayHighlights)
           break
         }
@@ -801,7 +817,7 @@ const EditHomepage = ({ match }) => {
             $set: resetDropdownSections,
           })
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
           setDisplayDropdownElems(newDisplayDropdownElems)
           break
         }

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -21,6 +21,7 @@ import { WarningModal } from "components/WarningModal"
 // Import hooks
 import { useGetHomepageHook } from "hooks/homepageHooks"
 import { useUpdateHomepageHook } from "hooks/homepageHooks/useUpdateHomepageHook"
+import { useAfterFirstLoad } from "hooks/useAfterFirstLoad"
 import useSiteColorsHook from "hooks/useSiteColorsHook"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
@@ -300,15 +301,11 @@ const EditHomepage = ({ match }) => {
     loadPageDetails()
   }, [homepageData])
 
-  const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
+  const delayedScrollTo = useAfterFirstLoad(scrollTo)
 
   useEffect(() => {
     if (scrollRefs.length === 0) return // Page data has not been populated
-    if (!isFirstLoadComplete) {
-      setIsFirstLoadComplete(true)
-    } else {
-      scrollTo(scrollRefs[frontMatter.sections.length - 1])
-    }
+    delayedScrollTo(scrollRefs[frontMatter.sections.length - 1])
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollRefs, frontMatter.sections.length])
 

--- a/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
+++ b/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
@@ -299,17 +299,10 @@ const EditHomepage = ({ match }) => {
     loadPageDetails()
   }, [homepageData])
 
-  const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
-
   useEffect(() => {
     if (scrollRefs.length > 0) {
-      if (!isFirstLoadComplete) {
-        setIsFirstLoadComplete(true)
-      } else {
-        scrollTo(scrollRefs[frontMatter.sections.length - 1])
-      }
+      scrollTo(scrollRefs[frontMatter.sections.length - 1])
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollRefs, frontMatter.sections.length])
 
   useEffect(() => {

--- a/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
+++ b/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
@@ -50,18 +50,6 @@ import EditorResourcesSection from "./components/ResourcesSection"
 // ==========
 const RADIX_PARSE_INT = 10
 
-// NOTE: `scrollIntoView` does not work when called synchronously
-// to avoid this problem, we do a `setTimeout` to wrap it.
-// This calls it after 1ms, which allows it to work.
-const scrollTo = (ref) => {
-  setTimeout(() =>
-    ref.current.scrollIntoView({
-      behavior: "smooth",
-    })
-  )
-}
-
-// Constants
 // Section constructors
 const ResourcesSectionConstructor = (isErrorConstructor) => ({
   resources: {
@@ -301,7 +289,7 @@ const EditHomepage = ({ match }) => {
 
   useEffect(() => {
     if (scrollRefs.length > 0) {
-      scrollTo(scrollRefs[frontMatter.sections.length - 1])
+      scrollRefs[frontMatter.sections.length - 1].current.scrollIntoView()
     }
   }, [scrollRefs, frontMatter.sections.length])
 
@@ -424,7 +412,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollTo(scrollRefs[sectionIndex])
+          scrollRefs[sectionIndex].current.scrollIntoView()
           break
         }
         case "highlight": {
@@ -467,7 +455,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollTo(scrollRefs[0])
+          scrollRefs[0].current.scrollIntoView()
           break
         }
         case "dropdownelem": {
@@ -512,7 +500,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollTo(scrollRefs[0])
+          scrollRefs[0].current.scrollIntoView()
           break
         }
         default: {
@@ -549,7 +537,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollTo(scrollRefs[0])
+          scrollRefs[0].current.scrollIntoView()
         }
       }
     } catch (err) {
@@ -828,7 +816,7 @@ const EditHomepage = ({ match }) => {
 
           setDisplaySections(newDisplaySections)
 
-          scrollTo(scrollRefs[index])
+          scrollRefs[sectionId].current.scrollIntoView()
           break
         }
         case "highlight": {
@@ -844,7 +832,6 @@ const EditHomepage = ({ match }) => {
             $set: resetHighlightSections,
           })
 
-          scrollTo(scrollRefs[0])
           setDisplayHighlights(newDisplayHighlights)
           break
         }
@@ -861,7 +848,6 @@ const EditHomepage = ({ match }) => {
             $set: resetDropdownSections,
           })
 
-          scrollTo(scrollRefs[0])
           setDisplayDropdownElems(newDisplayDropdownElems)
           break
         }

--- a/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
+++ b/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
@@ -50,6 +50,18 @@ import EditorResourcesSection from "./components/ResourcesSection"
 // ==========
 const RADIX_PARSE_INT = 10
 
+// NOTE: `scrollIntoView` does not work when called synchronously
+// to avoid this problem, we do a `setTimeout` to wrap it.
+// This calls it after 1ms, which allows it to work.
+const scrollTo = (ref) => {
+  setTimeout(() =>
+    ref.current.scrollIntoView({
+      behavior: "smooth",
+    })
+  )
+}
+
+// Constants
 // Section constructors
 const ResourcesSectionConstructor = (isErrorConstructor) => ({
   resources: {
@@ -289,7 +301,7 @@ const EditHomepage = ({ match }) => {
 
   useEffect(() => {
     if (scrollRefs.length > 0) {
-      scrollRefs[frontMatter.sections.length - 1].current.scrollIntoView()
+      scrollTo(scrollRefs[frontMatter.sections.length - 1])
     }
   }, [scrollRefs, frontMatter.sections.length])
 
@@ -412,7 +424,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[sectionIndex].current.scrollIntoView()
+          scrollTo(scrollRefs[sectionIndex])
           break
         }
         case "highlight": {
@@ -455,7 +467,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
           break
         }
         case "dropdownelem": {
@@ -500,7 +512,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
           break
         }
         default: {
@@ -537,7 +549,7 @@ const EditHomepage = ({ match }) => {
           })
           setErrors(newErrors)
 
-          scrollRefs[0].current.scrollIntoView()
+          scrollTo(scrollRefs[0])
         }
       }
     } catch (err) {
@@ -816,7 +828,7 @@ const EditHomepage = ({ match }) => {
 
           setDisplaySections(newDisplaySections)
 
-          scrollRefs[sectionId].current.scrollIntoView()
+          scrollTo(scrollRefs[index])
           break
         }
         case "highlight": {
@@ -832,6 +844,7 @@ const EditHomepage = ({ match }) => {
             $set: resetHighlightSections,
           })
 
+          scrollTo(scrollRefs[0])
           setDisplayHighlights(newDisplayHighlights)
           break
         }
@@ -848,6 +861,7 @@ const EditHomepage = ({ match }) => {
             $set: resetDropdownSections,
           })
 
+          scrollTo(scrollRefs[0])
           setDisplayDropdownElems(newDisplayDropdownElems)
           break
         }

--- a/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
+++ b/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
@@ -299,10 +299,17 @@ const EditHomepage = ({ match }) => {
     loadPageDetails()
   }, [homepageData])
 
+  const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
+
   useEffect(() => {
     if (scrollRefs.length > 0) {
-      scrollTo(scrollRefs[frontMatter.sections.length - 1])
+      if (!isFirstLoadComplete) {
+        setIsFirstLoadComplete(true)
+      } else {
+        scrollTo(scrollRefs[frontMatter.sections.length - 1])
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollRefs, frontMatter.sections.length])
 
   useEffect(() => {


### PR DESCRIPTION
(edited by @alexanderleegs)
## Problem

Building off the work @seaerchin for smooth scroll - the issue we were facing was that we wanted to scroll to newly created sections by checking for times when `scrollRefs`/`frontMatter.sections.length` change, but only after the first paint. However, since we populate `scrollRefs`/`frontMatter.sections.length` via its own useEffect hook (from legacy code), this means that we also can't rely on a pure `hasLoaded` variable which is toggled on mount.

The solution is to have the check for first load inside the useEffect which controls the scrolling. Note that this variable cannot be included in the dependency array, otherwise it would immediately trigger twice and cause the scroll to the end.

Testing

- [ ] Navigate to homepage
  - [ ]  Preview should remain at hero and not scroll down