### PR TITLE
Feat/fixSLStyling

### DIFF
--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -83,7 +83,6 @@ export const SiteLaunchProvider = ({
   })
 
   const { data: siteLaunchDto } = useGetSiteLaunchStatus(siteName)
-  console.log({ siteLaunchDto })
   const queryClient = useQueryClient()
   const refetchSiteLaunchStatus = () => {
     /**

--- a/src/contexts/SiteLaunchContext.tsx
+++ b/src/contexts/SiteLaunchContext.tsx
@@ -9,6 +9,7 @@ import { useGetSiteLaunchStatus } from "hooks/siteDashboardHooks"
 import { launchSite } from "services/SiteLaunchService"
 
 import {
+  NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH,
   SiteLaunchBEStatus,
   SiteLaunchFEStatus,
   SiteLaunchFEStatusType,
@@ -17,6 +18,7 @@ import {
   SiteLaunchTaskTypeIndex,
   SITE_LAUNCH_PAGES,
   SITE_LAUNCH_TASKS,
+  SITE_LAUNCH_TASKS_LENGTH,
 } from "types/siteLaunch"
 
 interface SiteLaunchContextProps {
@@ -29,6 +31,8 @@ interface SiteLaunchContextProps {
   increasePageNumber: () => void
   decreasePageNumber: () => void
   pageNumber: SiteLaunchPageIndex
+  handleIncrementStepNumber: () => void
+  handleDecrementStepNumber: () => void
 }
 
 interface SiteLaunchProviderProps {
@@ -79,7 +83,7 @@ export const SiteLaunchProvider = ({
   })
 
   const { data: siteLaunchDto } = useGetSiteLaunchStatus(siteName)
-
+  console.log({ siteLaunchDto })
   const queryClient = useQueryClient()
   const refetchSiteLaunchStatus = () => {
     /**
@@ -107,6 +111,29 @@ export const SiteLaunchProvider = ({
 
     // safe to assert since we do an check prior
     setPageNumber((pageNumber - 1) as SiteLaunchPageIndex)
+  }
+
+  const handleIncrementStepNumber = () => {
+    if (
+      siteLaunchStatusProps &&
+      siteLaunchStatusProps.stepNumber < SITE_LAUNCH_TASKS_LENGTH
+    ) {
+      setSiteLaunchStatusProps({
+        ...siteLaunchStatusProps,
+        stepNumber: (siteLaunchStatusProps.stepNumber +
+          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
+        siteLaunchStatus: SiteLaunchFEStatus.ChecklistTasksPending,
+      })
+    }
+  }
+  const handleDecrementStepNumber = () => {
+    if (siteLaunchStatusProps && siteLaunchStatusProps.stepNumber > 0) {
+      setSiteLaunchStatusProps({
+        ...siteLaunchStatusProps,
+        stepNumber: (siteLaunchStatusProps?.stepNumber -
+          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
+      })
+    }
   }
 
   const generateDNSRecords = async () => {
@@ -165,6 +192,12 @@ export const SiteLaunchProvider = ({
       !isSiteLaunchFEAndBESynced
     ) {
       setPageNumber(SITE_LAUNCH_PAGES.CHECKLIST)
+      setSiteLaunchStatusProps((prevStatusProps) => ({
+        ...prevStatusProps,
+        stepNumber: prevStatusProps.isNewDomain
+          ? NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH
+          : SITE_LAUNCH_TASKS_LENGTH,
+      }))
     }
 
     if (
@@ -185,6 +218,8 @@ export const SiteLaunchProvider = ({
   return (
     <SiteLaunchContext.Provider
       value={{
+        handleDecrementStepNumber,
+        handleIncrementStepNumber,
         siteLaunchStatusProps,
         setSiteLaunchStatusProps,
         generateDNSRecords,

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.stories.tsx
@@ -7,7 +7,9 @@ import { SiteLaunchProvider } from "contexts/SiteLaunchContext"
 import {
   MOCK_FAILURE_LAUNCHED_SITE_LAUNCH_DTO,
   MOCK_LAUNCHING_SITE_LAUNCH_DTO,
+  MOCK_NON_WWW_LAUNCHING_SITE_LAUNCH_DTO,
   MOCK_SUCCESS_LAUNCHED_SITE_LAUNCH_DTO,
+  MOCK_WWW_LAUNCHING_SITE_LAUNCH_DTO,
 } from "mocks/constants"
 import { buildSiteLaunchDto } from "mocks/utils"
 import { SiteLaunchBEStatus, SiteLaunchFEStatus } from "types/siteLaunch"
@@ -48,12 +50,6 @@ const Template: StoryFn<typeof SiteLaunchPad> = (args) => (
 // NOTE: This is just a mock, so no need actual functions
 const siteLaunchPadArgs = {
   pageNumber: 1,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setPageNumber: () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  handleDecrementStepNumber: () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  handleIncrementStepNumber: () => {},
 }
 
 export const Default = Template.bind({})
@@ -87,6 +83,20 @@ siteLaunchChecklistOldDomain.args = {
   pageNumber: 4,
 }
 
+siteLaunchChecklistOldDomain.decorators = [
+  (Story) => {
+    return (
+      <SiteLaunchProvider
+        initialStepNumber={0}
+        initialSiteLaunchStatus={SiteLaunchFEStatus.ChecklistTasksPending}
+        isNewDomain={false}
+      >
+        <Story />
+      </SiteLaunchProvider>
+    )
+  },
+]
+
 export const siteLaunchChecklistNewDomain = Template.bind({})
 
 siteLaunchChecklistNewDomain.args = {
@@ -98,9 +108,125 @@ siteLaunchChecklistNewDomain.decorators = [
   (Story) => {
     return (
       <SiteLaunchProvider
-        initialStepNumber={1}
+        initialStepNumber={0}
         initialSiteLaunchStatus={SiteLaunchFEStatus.ChecklistTasksPending}
         isNewDomain
+      >
+        <Story />
+      </SiteLaunchProvider>
+    )
+  },
+]
+
+export const NewDomainNonWwwDnsRecords = Template.bind({})
+
+NewDomainNonWwwDnsRecords.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 4,
+}
+NewDomainNonWwwDnsRecords.parameters = {
+  msw: {
+    handlers: {
+      siteLaunchStatusProps: buildSiteLaunchDto(
+        MOCK_NON_WWW_LAUNCHING_SITE_LAUNCH_DTO
+      ),
+    },
+  },
+}
+
+NewDomainNonWwwDnsRecords.decorators = [
+  (Story) => {
+    return (
+      <SiteLaunchProvider
+        initialSiteLaunchStatus={SiteLaunchFEStatus.Loading}
+        isNewDomain
+      >
+        <Story />
+      </SiteLaunchProvider>
+    )
+  },
+]
+
+export const NewDomainWwwDnsRecords = Template.bind({})
+
+NewDomainWwwDnsRecords.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 4,
+}
+NewDomainWwwDnsRecords.parameters = {
+  msw: {
+    handlers: {
+      siteLaunchStatusProps: buildSiteLaunchDto(
+        MOCK_WWW_LAUNCHING_SITE_LAUNCH_DTO
+      ),
+    },
+  },
+}
+
+NewDomainWwwDnsRecords.decorators = [
+  (Story) => {
+    return (
+      <SiteLaunchProvider
+        initialSiteLaunchStatus={SiteLaunchFEStatus.Loading}
+        isNewDomain
+      >
+        <Story />
+      </SiteLaunchProvider>
+    )
+  },
+]
+
+export const OldDomainWwwDnsRecords = Template.bind({})
+
+OldDomainWwwDnsRecords.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 4,
+}
+OldDomainWwwDnsRecords.parameters = {
+  msw: {
+    handlers: {
+      siteLaunchStatusProps: buildSiteLaunchDto(
+        MOCK_WWW_LAUNCHING_SITE_LAUNCH_DTO
+      ),
+    },
+  },
+}
+
+OldDomainWwwDnsRecords.decorators = [
+  (Story) => {
+    return (
+      <SiteLaunchProvider
+        initialSiteLaunchStatus={SiteLaunchFEStatus.Loading}
+        isNewDomain={false}
+      >
+        <Story />
+      </SiteLaunchProvider>
+    )
+  },
+]
+
+export const OldDomainNonWwwDnsRecords = Template.bind({})
+
+OldDomainNonWwwDnsRecords.args = {
+  ...siteLaunchPadArgs,
+  pageNumber: 4,
+}
+OldDomainNonWwwDnsRecords.parameters = {
+  msw: {
+    handlers: {
+      siteLaunchStatusProps: buildSiteLaunchDto(
+        MOCK_NON_WWW_LAUNCHING_SITE_LAUNCH_DTO
+      ),
+    },
+  },
+}
+
+OldDomainNonWwwDnsRecords.decorators = [
+  (Story) => {
+    return (
+      <SiteLaunchProvider
+        initialSiteLaunchStatus={SiteLaunchFEStatus.Loading}
+        isNewDomain={false}
       >
         <Story />
       </SiteLaunchProvider>

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -27,12 +27,7 @@ import { SiteViewHeader } from "layouts/layouts/SiteViewLayout/SiteViewHeader"
 
 import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
 
-import {
-  SiteLaunchFEStatus,
-  SiteLaunchTaskTypeIndex,
-  SITE_LAUNCH_PAGES,
-  SITE_LAUNCH_TASKS_LENGTH,
-} from "types/siteLaunch"
+import { SITE_LAUNCH_PAGES } from "types/siteLaunch"
 import { useErrorToast } from "utils"
 
 import {
@@ -55,9 +50,6 @@ interface RiskAcceptanceModalProps {
 
 interface SiteLaunchPadProps {
   pageNumber: number
-
-  handleDecrementStepNumber: () => void
-  handleIncrementStepNumber: () => void
 }
 
 const RiskAcceptanceModal = ({
@@ -129,8 +121,6 @@ const RiskAcceptanceModal = ({
 
 export const SiteLaunchPad = ({
   pageNumber,
-  handleDecrementStepNumber,
-  handleIncrementStepNumber,
 }: SiteLaunchPadProps): JSX.Element => {
   let title: JSX.Element
   let body: JSX.Element
@@ -146,12 +136,7 @@ export const SiteLaunchPad = ({
       break
     case SITE_LAUNCH_PAGES.CHECKLIST:
       title = <SiteLaunchChecklistTitle />
-      body = (
-        <SiteLaunchChecklistBody
-          handleIncrementStepNumber={handleIncrementStepNumber}
-          handleDecrementStepNumber={handleDecrementStepNumber}
-        />
-      )
+      body = <SiteLaunchChecklistBody />
       break
     case SITE_LAUNCH_PAGES.FINAL_STATE:
       title = <></> // No title for final state
@@ -176,11 +161,7 @@ export const SiteLaunchPad = ({
 }
 
 export const SiteLaunchPadPage = (): JSX.Element => {
-  const {
-    siteLaunchStatusProps,
-    setSiteLaunchStatusProps,
-    pageNumber,
-  } = useSiteLaunchContext()
+  const { pageNumber } = useSiteLaunchContext()
   const { siteName } = useParams<{ siteName: string }>()
 
   const errorToast = useErrorToast()
@@ -196,38 +177,11 @@ export const SiteLaunchPadPage = (): JSX.Element => {
     }
   }, [siteName, errorToast, role, isLoaded])
 
-  const handleIncrementStepNumber = () => {
-    if (
-      siteLaunchStatusProps &&
-      siteLaunchStatusProps.stepNumber < SITE_LAUNCH_TASKS_LENGTH
-    ) {
-      setSiteLaunchStatusProps({
-        ...siteLaunchStatusProps,
-        stepNumber: (siteLaunchStatusProps.stepNumber +
-          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
-        siteLaunchStatus: SiteLaunchFEStatus.ChecklistTasksPending,
-      })
-    }
-  }
-  const handleDecrementStepNumber = () => {
-    if (siteLaunchStatusProps && siteLaunchStatusProps.stepNumber > 0) {
-      setSiteLaunchStatusProps({
-        ...siteLaunchStatusProps,
-        stepNumber: (siteLaunchStatusProps?.stepNumber -
-          1) as SiteLaunchTaskTypeIndex, // safe to assert since we do a check
-      })
-    }
-  }
-
   return (
     <Skeleton isLoaded={isLoaded}>
       <>
         {isSiteLaunchEnabled(siteName, role) ? (
-          <SiteLaunchPad
-            pageNumber={pageNumber}
-            handleDecrementStepNumber={handleDecrementStepNumber}
-            handleIncrementStepNumber={handleIncrementStepNumber}
-          />
+          <SiteLaunchPad pageNumber={pageNumber} />
         ) : (
           /**
            * Without the isLoaded check, the site will redirect prematurely.

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -83,10 +83,11 @@ const textWithCopyIcon = (text: string): JSX.Element => {
           <Box display="flex" alignItems="center" maxW="16rem">
             <Text
               textStyle="body-2"
-              color="black"
+              textColor="base.content.default"
               whiteSpace="nowrap"
               overflow="hidden"
               textOverflow="ellipsis"
+              noOfLines={1}
             >
               {text}
             </Text>
@@ -141,7 +142,7 @@ const DnsTable = ({
                 {textWithCopyIcon(record.source)}
               </Td>
               <Td textStyle="body-2" color="text.label.secondary">
-                <Text>{record.type}</Text>
+                <Text textColor="base.content.default">{record.type}</Text>
               </Td>
               <Td textStyle="body-2" color="text.label.secondary">
                 {textWithCopyIcon(record.target)}

--- a/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
+++ b/src/layouts/SiteLaunchPad/components/SiteLaunchCheckList.tsx
@@ -244,7 +244,9 @@ export const SiteLaunchChecklistBody = (): JSX.Element => {
   const handleGenerateDNSRecordsOnClick = () => {
     setSiteLaunchStatusProps({
       ...siteLaunchStatusProps,
-      stepNumber: SITE_LAUNCH_TASKS.GENERATE_NEW_DNS_RECORDS,
+      stepNumber: siteLaunchStatusProps?.isNewDomain
+        ? NEW_DOMAIN_SITE_LAUNCH_TASKS_LENGTH
+        : SITE_LAUNCH_TASKS_LENGTH,
       siteLaunchStatus: SiteLaunchFEStatus.Launching,
     })
 

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -530,9 +530,39 @@ export const MOCK_LAUNCHING_SITE_LAUNCH_DTO: SiteLaunchDto = {
   siteLaunchStatus: SiteLaunchBEStatus.Launching,
   dnsRecords: [
     {
-      source: "sourceURL",
+      source: "www.isomer.gov.sg",
       type: "CNAME",
-      target: "targetURL",
+      target: "d2fdsaf8ft15h.cloudfront.net",
+    },
+    {
+      source: "_123456787202a1b56dd8a5545efee05.isomer.gov.sg",
+      type: "CNAME",
+      target:
+        "_fae940f7aa0gfd51754f18ed50bgf521.wrfxpmntfs.acm-validations.aws",
+    },
+    {
+      source: "isomer.gov.sg",
+      type: "A Record",
+      target: "18.136.36.203",
+    },
+  ],
+}
+
+export const MOCK_WWW_LAUNCHING_SITE_LAUNCH_DTO: SiteLaunchDto = MOCK_LAUNCHING_SITE_LAUNCH_DTO
+
+export const MOCK_NON_WWW_LAUNCHING_SITE_LAUNCH_DTO: SiteLaunchDto = {
+  siteLaunchStatus: SiteLaunchBEStatus.Launching,
+  dnsRecords: [
+    {
+      source: "isomer.gov.sg",
+      type: "CNAME",
+      target: "d2fdsaf8ft15h.cloudfront.net",
+    },
+    {
+      source: "_123456787202a1b56dd8a5545efee05.isomer.gov.sg",
+      type: "CNAME",
+      target:
+        "_fae940f7aa0gfd51754f18ed50bgf521.wrfxpmntfs.acm-validations.aws",
     },
   ],
 }

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -185,5 +185,11 @@ export const buildDiffData = apiDataBuilder<BlobDiff>(
 )
 
 export const buildSiteLaunchDto = apiDataBuilder<SiteLaunchDto>(
-  "*/sites/:siteName/launchInfo"
+  "*/sites/:siteName/launchInfo",
+  "get"
+)
+
+export const buildLaunchSite = apiDataBuilder(
+  "*/sites/:siteName/launch",
+  "post"
 )


### PR DESCRIPTION
## Problem

Currently storybooks cannot toggle the steps, design found it harder to review + write a guide for SL 
This also fixes trivial copy issues. 


## Solution

Change API so the `increaseStepNumber` and the `decreaseStepNumber` both come from the context directly, similar to the `increasePageNumber` + `decreaseStepNumber`. 
For Verbosity, I have also added 4 screens for design to review + increase possibilities of catching regression when other devs develop SL in the future.  

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible


## Before & After Screenshots


**AFTER**:
Storybook check boxes should work

New Domain:
https://github.com/isomerpages/isomercms-frontend/assets/42832651/981f7417-4c6f-48d8-a34c-61d2609f38c9

Old Domain:
https://github.com/isomerpages/isomercms-frontend/assets/42832651/6cee2d80-3afe-4609-b2b3-c01844e59661


4 added storybooks: 
A: `new-domain-non-www-dns-records`
<img width="1459" alt="Screenshot 2023-08-23 at 3 34 43 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/ecaf8dda-b05d-41cb-93a4-2cf7765b38ec">

B: `new-domain-www-dns-records`
<img width="1459" alt="Screenshot 2023-08-23 at 3 34 59 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/c7d9e71b-8f18-4834-8536-a7c5096b8950">

C: `old-domain-non-www-dns-records`
<img width="1456" alt="Screenshot 2023-08-23 at 3 35 09 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/64f00e42-7c18-411b-8447-8d3cb7145499">

D: `old-domain-www-dns-records`
<img width="1455" alt="Screenshot 2023-08-23 at 3 35 20 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/eaf8f152-964d-4075-b81d-be1944068d5e">

Now copied got tooltip:
<img width="454" alt="Screenshot 2023-08-23 at 3 32 35 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/0a248fa1-b393-4f30-86ef-6c3c18979649">

## Tests

None, mostly to sped up reviewal + trivial copy changes
