### PR TITLE
fix(legacyedithomepage): add back missing imports

### DIFF
--- a/src/layouts/FeatureFlaggedHomepage.tsx
+++ b/src/layouts/FeatureFlaggedHomepage.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom"
 import { OGP_SITES, TESTING_SITES } from "constants/sites"
 
 import EditHomepage from "./EditHomepage"
-import LegacyEditHomepage from "./LegacyEditHomepage"
+import LegacyEditHomepage from "./LegacyEditHomepage/LegacyEditHomepage"
 
 export const FeatureFlaggedHomepage = (): JSX.Element => {
   const params = useParams<{ siteName: string }>()

--- a/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
+++ b/src/layouts/LegacyEditHomepage/LegacyEditHomepage.jsx
@@ -9,11 +9,6 @@ import { useEffect, createRef, useState } from "react"
 
 import { Footer } from "components/Footer"
 import Header from "components/Header"
-import EditorHeroSection from "components/homepage/HeroSection"
-import EditorInfobarSection from "components/homepage/InfobarSection"
-import EditorInfopicSection from "components/homepage/InfopicSection"
-import NewSectionCreator from "components/homepage/NewSectionCreator"
-import EditorResourcesSection from "components/homepage/ResourcesSection"
 import { LoadingButton } from "components/LoadingButton"
 import { WarningModal } from "components/WarningModal"
 
@@ -41,7 +36,13 @@ import {
 
 import { DEFAULT_RETRY_MSG } from "utils"
 
-import { useDrag, onCreate, onDelete } from "../hooks/useDrag"
+import { useDrag, onCreate, onDelete } from "../../hooks/useDrag"
+
+import EditorHeroSection from "./components/HeroSection"
+import EditorInfobarSection from "./components/InfobarSection"
+import EditorInfopicSection from "./components/InfopicSection"
+import NewSectionCreator from "./components/NewSectionCreator"
+import EditorResourcesSection from "./components/ResourcesSection"
 
 /* eslint-disable react/no-array-index-key */
 

--- a/src/layouts/LegacyEditHomepage/components/HeroButton.jsx
+++ b/src/layouts/LegacyEditHomepage/components/HeroButton.jsx
@@ -1,0 +1,48 @@
+import PropTypes from "prop-types"
+
+import FormContext from "components/Form/FormContext"
+import FormError from "components/Form/FormError"
+import FormTitle from "components/Form/FormTitle"
+import FormField from "components/FormField"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const HeroButton = ({ button, url, sectionIndex, onFieldChange, errors }) => (
+  <>
+    <FormContext hasError={!!errors.button}>
+      <FormTitle>Hero button</FormTitle>
+      <FormField
+        placeholder="Hero button"
+        id={`section-${sectionIndex}-hero-button`}
+        value={button}
+        onChange={onFieldChange}
+      />
+      <FormError>{errors.button}</FormError>
+    </FormContext>
+    <FormContext hasError={!!errors.url}>
+      <FormTitle>Hero button URL</FormTitle>
+      <FormField
+        placeholder="Insert /page-url or https://"
+        id={`section-${sectionIndex}-hero-url`}
+        value={url}
+        onChange={onFieldChange}
+      />
+      <FormError>{errors.url}</FormError>
+    </FormContext>
+  </>
+)
+
+export default HeroButton
+
+HeroButton.propTypes = {
+  button: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  sectionIndex: PropTypes.number.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    button: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+}

--- a/src/layouts/LegacyEditHomepage/components/HeroDropdown.jsx
+++ b/src/layouts/LegacyEditHomepage/components/HeroDropdown.jsx
@@ -1,0 +1,206 @@
+import { Droppable, Draggable } from "@hello-pangea/dnd"
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+
+import FormContext from "components/Form/FormContext"
+import FormError from "components/Form/FormError"
+import FormTitle from "components/Form/FormTitle"
+import FormField from "components/FormField"
+
+import styles from "styles/App.module.scss"
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const HeroDropdownElem = ({
+  title,
+  url,
+  dropdownsIndex,
+  onFieldChange,
+  deleteHandler,
+  shouldDisplay,
+  displayHandler,
+  errors,
+}) => (
+  <div className={elementStyles.card}>
+    <div className={elementStyles.cardHeader}>
+      <h2>{title}</h2>
+      <IconButton
+        variant="clear"
+        id={`dropdownelem-${dropdownsIndex}-toggle`}
+        onClick={displayHandler}
+      >
+        <i
+          className={`bx ${
+            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
+          }`}
+          id={`dropdownelem-${dropdownsIndex}-icon`}
+        />
+      </IconButton>
+    </div>
+    {shouldDisplay ? (
+      <>
+        <div className={elementStyles.cardContent}>
+          <FormContext isRequired hasError={!!errors.title}>
+            <FormTitle>Dropdown element title</FormTitle>
+            <FormField
+              placeholder="Dropdown element title"
+              id={`dropdownelem-${dropdownsIndex}-title`}
+              value={title}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.title}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.url}>
+            <FormTitle>Dropdown element URL</FormTitle>
+            <FormField
+              placeholder="Dropdown element URL"
+              id={`dropdownelem-${dropdownsIndex}-url`}
+              value={url}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.url}</FormError>
+          </FormContext>
+        </div>
+        <div className={elementStyles.inputGroup}>
+          <Button
+            w="100%"
+            colorScheme="critical"
+            id={`dropdownelem-${dropdownsIndex}-delete`}
+            onClick={deleteHandler}
+          >
+            Delete dropdown option
+          </Button>
+        </div>
+      </>
+    ) : null}
+  </div>
+)
+
+const HeroDropdown = ({
+  title,
+  options,
+  createHandler,
+  deleteHandler,
+  onFieldChange,
+  displayHandler,
+  displayDropdownElems,
+  errors,
+}) => (
+  <div>
+    <FormContext isRequired hasError={!!errors.sections[0].hero.dropdown}>
+      <FormTitle>Hero dropdown title</FormTitle>
+      <FormField
+        placeholder="Hero dropdown title"
+        id="dropdown-title"
+        value={title}
+        onChange={onFieldChange}
+      />
+      <FormError>{errors.sections[0].hero.dropdown}</FormError>
+    </FormContext>
+    <Droppable droppableId="dropdownelem" type="dropdownelem">
+      {(droppableProvided) => (
+        <div
+          className={styles.card}
+          ref={droppableProvided.innerRef}
+          {...droppableProvided.droppableProps}
+        >
+          {options && options.length > 0 ? (
+            <>
+              <b>Hero dropdown options</b>
+              {options.map((option, dropdownsIndex) => (
+                <Draggable
+                  draggableId={`dropdownelem-${dropdownsIndex}-draggable`}
+                  index={dropdownsIndex}
+                >
+                  {(draggableProvided) => (
+                    <div
+                      className={styles.card}
+                      key={dropdownsIndex}
+                      {...draggableProvided.draggableProps}
+                      {...draggableProvided.dragHandleProps}
+                      ref={draggableProvided.innerRef}
+                    >
+                      <HeroDropdownElem
+                        key={`dropdownelem-${dropdownsIndex}`}
+                        title={option.title}
+                        url={option.url}
+                        dropdownsIndex={dropdownsIndex}
+                        onFieldChange={onFieldChange}
+                        deleteHandler={deleteHandler}
+                        createHandler={createHandler}
+                        displayHandler={displayHandler}
+                        shouldDisplay={displayDropdownElems[dropdownsIndex]}
+                        errors={errors.dropdownElems[dropdownsIndex]}
+                      />
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+            </>
+          ) : null}
+          {droppableProvided.placeholder}
+          <Button
+            w="100%"
+            id={`dropdownelem-${options.length}-create`}
+            onClick={createHandler}
+          >
+            Add dropdown option
+          </Button>
+        </div>
+      )}
+    </Droppable>
+  </div>
+)
+
+export default HeroDropdown
+
+HeroDropdownElem.propTypes = {
+  title: PropTypes.string,
+  url: PropTypes.string,
+  dropdownsIndex: PropTypes.number,
+  onFieldChange: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    title: PropTypes.string,
+    url: PropTypes.string,
+  }).isRequired,
+}
+
+HeroDropdown.propTypes = {
+  title: PropTypes.string,
+  onFieldChange: PropTypes.func.isRequired,
+  createHandler: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  displayDropdownElems: PropTypes.arrayOf(PropTypes.bool),
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      url: PropTypes.string,
+      dropdownsIndex: PropTypes.number,
+      onFieldChange: PropTypes.func.isRequired,
+      shouldDisplay: PropTypes.bool.isRequired,
+      displayHandler: PropTypes.func.isRequired,
+    })
+  ).isRequired,
+  errors: PropTypes.shape({
+    sections: PropTypes.arrayOf(
+      PropTypes.shape({
+        hero: PropTypes.shape({
+          dropdown: PropTypes.string,
+        }),
+      })
+    ),
+    dropdownElems: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        url: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+}

--- a/src/layouts/LegacyEditHomepage/components/HeroSection.jsx
+++ b/src/layouts/LegacyEditHomepage/components/HeroSection.jsx
@@ -1,0 +1,295 @@
+import { Droppable, Draggable } from "@hello-pangea/dnd"
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+
+import { FormContext, FormError, FormTitle } from "components/Form"
+import FormField from "components/FormField"
+import FormFieldMedia from "components/FormFieldMedia"
+
+import styles from "styles/App.module.scss"
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+import { isEmpty } from "utils"
+
+import HeroButton from "./HeroButton"
+import HeroDropdown from "./HeroDropdown"
+import KeyHighlight from "./KeyHighlight"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+// Constants
+const MAX_NUM_KEY_HIGHLIGHTS = 4
+
+const EditorHeroSection = ({
+  title,
+  subtitle,
+  background,
+  button,
+  url,
+  dropdown,
+  sectionIndex,
+  highlights,
+  onFieldChange,
+  createHandler,
+  deleteHandler,
+  shouldDisplay,
+  displayHandler,
+  displayDropdownElems,
+  displayHighlights,
+  errors,
+  handleHighlightDropdownToggle,
+}) => (
+  <div
+    className={`${elementStyles.card} ${
+      !shouldDisplay && !isEmpty(errors.sections[0].hero)
+        ? elementStyles.error
+        : ""
+    }`}
+  >
+    <div className={elementStyles.cardHeader}>
+      <h2>Hero section</h2>
+      <IconButton
+        variant="clear"
+        id={`section-${sectionIndex}`}
+        onClick={displayHandler}
+      >
+        <i
+          className={`bx ${
+            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
+          }`}
+          id={`section-${sectionIndex}-icon`}
+        />
+      </IconButton>
+    </div>
+    {shouldDisplay ? (
+      <>
+        <FormContext isRequired hasError={!!errors.sections[0].hero.title}>
+          <FormTitle>Hero title</FormTitle>
+          <FormField
+            placeholder="Hero title"
+            id={`section-${sectionIndex}-hero-title`}
+            value={title}
+            onChange={onFieldChange}
+          />
+          <FormError>{errors.sections[0].hero.title}</FormError>
+        </FormContext>
+        <FormContext isRequired hasError={!!errors.sections[0].hero.subtitle}>
+          <FormTitle>Hero subtitle</FormTitle>
+          <FormField
+            placeholder="Hero subtitle"
+            id={`section-${sectionIndex}-hero-subtitle`}
+            value={subtitle}
+            onChange={onFieldChange}
+          />
+          <FormError>{errors.sections[0].hero.subtitle}</FormError>
+        </FormContext>
+        <FormContext
+          hasError={!!errors.sections[0].hero.background}
+          onFieldChange={onFieldChange}
+          isRequired
+        >
+          <FormTitle>Hero background image</FormTitle>
+          <FormFieldMedia
+            value={background}
+            id={`section-${sectionIndex}-hero-background`}
+            inlineButtonText="Select"
+          />
+          <FormError>{errors.sections[0].hero.background}</FormError>
+        </FormContext>
+        <div className={styles.card}>
+          <p className={elementStyles.formLabel}>Hero Section Type</p>
+          {/* Permalink or File URL */}
+          <div className="d-flex">
+            <label htmlFor="radio-highlights" className="flex-fill">
+              <input
+                type="radio"
+                id="radio-highlights"
+                name="hero-type"
+                defaultValue="highlights"
+                onChange={handleHighlightDropdownToggle}
+                checked={!dropdown}
+              />
+              Highlights + Button
+            </label>
+            <label htmlFor="radio-dropdown" className="flex-fill">
+              <input
+                type="radio"
+                id="radio-dropdown"
+                name="hero-type"
+                defaultValue="dropdown"
+                onChange={handleHighlightDropdownToggle}
+                checked={!!dropdown}
+              />
+              Dropdown
+            </label>
+          </div>
+          <span className={elementStyles.info}>
+            Note: you can only have either Key Highlights+Hero button or a Hero
+            Dropdown
+          </span>
+        </div>
+        <div>
+          {dropdown ? (
+            <>
+              <HeroDropdown
+                title={dropdown.title}
+                options={dropdown.options}
+                sectionIndex={sectionIndex}
+                createHandler={createHandler}
+                deleteHandler={(event) =>
+                  deleteHandler(event, "Dropdown Element")
+                }
+                onFieldChange={onFieldChange}
+                displayDropdownElems={displayDropdownElems}
+                displayHandler={displayHandler}
+                errors={errors}
+              />
+            </>
+          ) : (
+            <>
+              <HeroButton
+                button={button}
+                url={url}
+                sectionIndex={sectionIndex}
+                onFieldChange={onFieldChange}
+                errors={errors.sections[0].hero}
+              />
+              <Droppable droppableId="highlight" type="highlight">
+                {(droppableProvided) => (
+                  <div
+                    className={styles.card}
+                    ref={droppableProvided.innerRef}
+                    {...droppableProvided.droppableProps}
+                  >
+                    {highlights && highlights.length > 0 ? (
+                      <>
+                        <b>Hero highlights</b>
+                        {highlights.map((highlight, highlightIndex) => (
+                          <Draggable
+                            draggableId={`highlight-${highlightIndex}-draggable`}
+                            index={highlightIndex}
+                          >
+                            {(draggableProvided) => (
+                              <div
+                                className={styles.card}
+                                key={highlightIndex}
+                                {...draggableProvided.draggableProps}
+                                {...draggableProvided.dragHandleProps}
+                                ref={draggableProvided.innerRef}
+                              >
+                                <KeyHighlight
+                                  key={`highlight-${highlightIndex}`}
+                                  title={highlight.title}
+                                  description={highlight.description}
+                                  background={highlight.background}
+                                  url={highlight.url}
+                                  highlightIndex={highlightIndex}
+                                  onFieldChange={onFieldChange}
+                                  shouldDisplay={
+                                    displayHighlights[highlightIndex]
+                                      ? displayHighlights[highlightIndex]
+                                      : false
+                                  }
+                                  displayHandler={displayHandler}
+                                  shouldAllowMoreHighlights={
+                                    highlights.length < MAX_NUM_KEY_HIGHLIGHTS
+                                  }
+                                  deleteHandler={(event) =>
+                                    deleteHandler(event, "Highlight")
+                                  }
+                                  errors={errors.highlights[highlightIndex]}
+                                />
+                              </div>
+                            )}
+                          </Draggable>
+                        ))}
+                      </>
+                    ) : null}
+                    {droppableProvided.placeholder}
+                    <Button
+                      onClick={createHandler}
+                      id={`highlight-${highlights.length}-create`}
+                      isDisabled={highlights.length >= MAX_NUM_KEY_HIGHLIGHTS}
+                      w="100%"
+                    >
+                      Add highlight
+                    </Button>
+                  </div>
+                )}
+              </Droppable>
+            </>
+          )}
+        </div>
+      </>
+    ) : null}
+  </div>
+)
+
+export default EditorHeroSection
+
+EditorHeroSection.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  background: PropTypes.string,
+  button: PropTypes.string,
+  url: PropTypes.string,
+  sectionIndex: PropTypes.number.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  createHandler: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  displayHighlights: PropTypes.arrayOf(PropTypes.bool),
+  displayDropdownElems: PropTypes.arrayOf(PropTypes.bool),
+  highlights: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      url: PropTypes.string,
+      highlightIndex: PropTypes.number,
+      createHandler: PropTypes.func,
+      deleteHandler: PropTypes.func,
+      onFieldChange: PropTypes.func,
+      allowMoreHighlights: PropTypes.bool,
+    })
+  ),
+  dropdown: PropTypes.shape({
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        url: PropTypes.string,
+        dropdownsIndex: PropTypes.number,
+        onFieldChange: PropTypes.func,
+      })
+    ),
+    title: PropTypes.string.isRequired,
+  }),
+  errors: PropTypes.shape({
+    sections: PropTypes.arrayOf(
+      PropTypes.shape({
+        hero: PropTypes.shape({
+          title: PropTypes.string,
+          subtitle: PropTypes.string,
+          background: PropTypes.string,
+          button: PropTypes.string,
+          url: PropTypes.string,
+          dropdown: PropTypes.string,
+        }),
+      })
+    ),
+    highlights: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        description: PropTypes.string,
+        url: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+}
+
+EditorHeroSection.defaultProps = {
+  highlights: undefined,
+  dropdown: undefined,
+}

--- a/src/layouts/LegacyEditHomepage/components/InfobarSection.jsx
+++ b/src/layouts/LegacyEditHomepage/components/InfobarSection.jsx
@@ -1,0 +1,139 @@
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+
+import { FormError } from "components/Form"
+import FormContext from "components/Form/FormContext"
+import FormTitle from "components/Form/FormTitle"
+import FormField from "components/FormField"
+
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+import { isEmpty } from "utils"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const EditorInfobarSection = ({
+  title,
+  subtitle,
+  description,
+  button,
+  url,
+  sectionIndex,
+  deleteHandler,
+  onFieldChange,
+  shouldDisplay,
+  displayHandler,
+  errors,
+}) => (
+  <div
+    className={`${elementStyles.card} ${
+      !shouldDisplay && !isEmpty(errors) ? elementStyles.error : ""
+    } move`}
+  >
+    <div className={elementStyles.cardHeader}>
+      <h2>Infobar section: {title}</h2>
+      <IconButton
+        variant="clear"
+        id={`section-${sectionIndex}`}
+        onClick={displayHandler}
+      >
+        <i
+          className={`bx ${
+            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
+          }`}
+          id={`section-${sectionIndex}-icon`}
+        />
+      </IconButton>
+    </div>
+    {shouldDisplay ? (
+      <>
+        <div className={elementStyles.cardContent}>
+          <FormContext isRequired hasError={!!errors.subtitle}>
+            <FormTitle>Infobar subtitle</FormTitle>
+            <FormField
+              placeholder="Infobar subtitle"
+              id={`section-${sectionIndex}-infobar-subtitle`}
+              value={subtitle}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.subtitle}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.title}>
+            <FormTitle>Infobar title</FormTitle>
+            <FormField
+              placeholder="Infobar title"
+              id={`section-${sectionIndex}-infobar-title`}
+              value={title}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.title}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.description}>
+            <FormTitle>Infobar description</FormTitle>
+            <FormField
+              placeholder="Infobar description"
+              id={`section-${sectionIndex}-infobar-description`}
+              value={description}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.description}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.button}>
+            <FormTitle>Infobar button name</FormTitle>
+            <FormField
+              placeholder="Infobar button name"
+              id={`section-${sectionIndex}-infobar-button`}
+              value={button}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.button}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.url}>
+            <FormTitle>Infobar button URL</FormTitle>
+            <FormField
+              placeholder="Insert /page-url or https://"
+              id={`section-${sectionIndex}-infobar-url`}
+              value={url}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.url}</FormError>
+          </FormContext>
+        </div>
+        <div className={elementStyles.inputGroup}>
+          <Button
+            colorScheme="critical"
+            w="100%"
+            id={`section-${sectionIndex}`}
+            onClick={deleteHandler}
+          >
+            Delete section
+          </Button>
+        </div>
+      </>
+    ) : null}
+  </div>
+)
+
+export default EditorInfobarSection
+
+EditorInfobarSection.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  description: PropTypes.string,
+  sectionIndex: PropTypes.number.isRequired,
+  button: PropTypes.string,
+  url: PropTypes.string,
+  onFieldChange: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    description: PropTypes.string,
+    button: PropTypes.string,
+    url: PropTypes.string,
+  }).isRequired,
+}

--- a/src/layouts/LegacyEditHomepage/components/InfopicSection.jsx
+++ b/src/layouts/LegacyEditHomepage/components/InfopicSection.jsx
@@ -1,0 +1,167 @@
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+
+import { FormContext, FormError, FormTitle } from "components/Form"
+import FormField from "components/FormField"
+import FormFieldMedia from "components/FormFieldMedia"
+
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+import { isEmpty } from "utils"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const EditorInfopicSection = ({
+  title,
+  subtitle,
+  description,
+  button,
+  url,
+  imageUrl,
+  imageAlt,
+  sectionIndex,
+  deleteHandler,
+  onFieldChange,
+  shouldDisplay,
+  displayHandler,
+  errors,
+}) => (
+  <div
+    className={`${elementStyles.card} ${
+      !shouldDisplay && !isEmpty(errors) ? elementStyles.error : ""
+    } move`}
+  >
+    <div className={elementStyles.cardHeader}>
+      <h2>Infopic section: {title}</h2>
+      <IconButton
+        variant="clear"
+        id={`section-${sectionIndex}`}
+        onClick={displayHandler}
+      >
+        <i
+          className={`bx ${
+            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
+          }`}
+          id={`section-${sectionIndex}-icon`}
+        />
+      </IconButton>
+    </div>
+    {shouldDisplay ? (
+      <>
+        <div className={elementStyles.cardContent}>
+          <FormContext hasError={!!errors.subtitle}>
+            <FormTitle>Infopic subtitle</FormTitle>
+            <FormField
+              placeholder="Infopic subtitle"
+              id={`section-${sectionIndex}-infopic-subtitle`}
+              value={subtitle}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.subtitle}</FormError>
+          </FormContext>
+          <FormContext hasError={!!errors.title}>
+            <FormTitle>Infopic title</FormTitle>
+            <FormField
+              placeholder="Infopic title"
+              id={`section-${sectionIndex}-infopic-title`}
+              value={title}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.title}</FormError>
+          </FormContext>
+          <FormContext hasError={!!errors.description}>
+            <FormTitle>Infopic description</FormTitle>
+            <FormField
+              placeholder="Infopic description"
+              id={`section-${sectionIndex}-infopic-description`}
+              value={description}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.description}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.button}>
+            <FormTitle>Infopic button name</FormTitle>
+            <FormField
+              placeholder="Infopic button name"
+              id={`section-${sectionIndex}-infopic-button`}
+              value={button}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.button}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={errors.url}>
+            <FormTitle>Infopic button URL</FormTitle>
+            <FormField
+              placeholder="Insert /page-url or https://"
+              id={`section-${sectionIndex}-infopic-url`}
+              value={url}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.url}</FormError>
+          </FormContext>
+          <FormContext
+            hasError={!!errors.image}
+            onFieldChange={onFieldChange}
+            isRequired
+          >
+            <FormTitle>Infopic image URL</FormTitle>
+            <FormFieldMedia
+              value={imageUrl}
+              id={`section-${sectionIndex}-infopic-image`}
+              inlineButtonText="Select"
+            />
+            <FormError>{errors.image}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.alt}>
+            <FormTitle>Infopic image alt text</FormTitle>
+            <FormField
+              placeholder="Infopic image alt text"
+              id={`section-${sectionIndex}-infopic-alt`}
+              value={imageAlt}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.alt}</FormError>
+          </FormContext>
+        </div>
+        <div className={elementStyles.inputGroup}>
+          <Button
+            colorScheme="critical"
+            w="100%"
+            id={`section-${sectionIndex}`}
+            onClick={deleteHandler}
+          >
+            Delete section
+          </Button>
+        </div>
+      </>
+    ) : null}
+  </div>
+)
+
+export default EditorInfopicSection
+
+EditorInfopicSection.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  description: PropTypes.string,
+  sectionIndex: PropTypes.number.isRequired,
+  button: PropTypes.string,
+  url: PropTypes.string,
+  imageUrl: PropTypes.string,
+  imageAlt: PropTypes.string,
+  onFieldChange: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    description: PropTypes.string,
+    button: PropTypes.string,
+    url: PropTypes.string,
+    imageUrl: PropTypes.string,
+    imageAlt: PropTypes.string,
+  }).isRequired,
+}

--- a/src/layouts/LegacyEditHomepage/components/KeyHighlight.jsx
+++ b/src/layouts/LegacyEditHomepage/components/KeyHighlight.jsx
@@ -1,0 +1,109 @@
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+
+import FormContext from "components/Form/FormContext"
+import FormError from "components/Form/FormError"
+import FormTitle from "components/Form/FormTitle"
+import FormField from "components/FormField"
+
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const KeyHighlight = ({
+  title,
+  description,
+  url,
+  highlightIndex,
+  onFieldChange,
+  shouldDisplay,
+  displayHandler,
+  deleteHandler,
+  errors,
+}) => (
+  <div className={elementStyles.card}>
+    <div className={elementStyles.cardHeader}>
+      <h2>{title}</h2>
+      <IconButton
+        variant="clear"
+        id={`highlight-${highlightIndex}-toggle`}
+        onClick={displayHandler}
+      >
+        <i
+          className={`bx ${
+            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
+          }`}
+          id={`highlight-${highlightIndex}-icon`}
+        />
+      </IconButton>
+    </div>
+    {/* Core highlight fields */}
+    {shouldDisplay && (
+      <>
+        <div className={elementStyles.cardContent}>
+          <FormContext isRequired hasError={!!errors.title}>
+            <FormTitle>Highlight title</FormTitle>
+            <FormField
+              placeholder="Highlight title"
+              id={`highlight-${highlightIndex}-title`}
+              value={title}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.title}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.description}>
+            <FormTitle>Highlight description</FormTitle>
+            <FormField
+              placeholder="Highlight description"
+              id={`highlight-${highlightIndex}-description`}
+              value={description}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.description}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.url}>
+            <FormTitle>Highlight URL</FormTitle>
+            <FormField
+              placeholder="Insert permalink or external URL"
+              id={`highlight-${highlightIndex}-url`}
+              value={url}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.url}</FormError>
+          </FormContext>
+        </div>
+        <div className={elementStyles.inputGroup}>
+          <Button
+            id={`highlight-${highlightIndex}-delete`}
+            onClick={deleteHandler}
+            colorScheme="critical"
+            key={`${highlightIndex}-delete`}
+            w="100%"
+          >
+            Delete highlight
+          </Button>
+        </div>
+      </>
+    )}
+  </div>
+)
+
+export default KeyHighlight
+
+KeyHighlight.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  highlightIndex: PropTypes.number.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+}

--- a/src/layouts/LegacyEditHomepage/components/NewSectionCreator.jsx
+++ b/src/layouts/LegacyEditHomepage/components/NewSectionCreator.jsx
@@ -1,0 +1,53 @@
+import { Button } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+import { useState } from "react"
+
+import Dropdown from "components/Dropdown"
+
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+const NewSectionCreator = ({ createHandler, hasResources }) => {
+  const [newSectionType, setNewSectionType] = useState()
+  const onFormSubmit = () => {
+    const event = {
+      target: {
+        id: "section-new",
+        value: newSectionType,
+      },
+    }
+    createHandler(event)
+  }
+  const options = hasResources
+    ? ["Infobar", "Infopic"]
+    : ["Infobar", "Infopic", "Resources"]
+  const defaultText = "--Choose a new section--"
+  return (
+    <div
+      className={`d-flex flex-column ${elementStyles.card} ${elementStyles.addNewHomepageSection}`}
+    >
+      <h2>Add a new section</h2>
+      <div className="d-flex justify-content-between">
+        <Dropdown
+          options={options}
+          defaultOption={defaultText}
+          emptyDefault
+          name="newSection"
+          id="section-new"
+          onFieldChange={(e) => setNewSectionType(e.target.value)}
+        />
+        <div>
+          <Button onClick={onFormSubmit} isDisabled={!newSectionType}>
+            Select
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default NewSectionCreator
+
+NewSectionCreator.propTypes = {
+  createHandler: PropTypes.func.isRequired,
+  hasResources: PropTypes.bool.isRequired,
+}

--- a/src/layouts/LegacyEditHomepage/components/ResourcesSection.jsx
+++ b/src/layouts/LegacyEditHomepage/components/ResourcesSection.jsx
@@ -1,0 +1,113 @@
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import PropTypes from "prop-types"
+
+import { FormError } from "components/Form"
+import FormContext from "components/Form/FormContext"
+import FormTitle from "components/Form/FormTitle"
+import FormField from "components/FormField"
+
+import elementStyles from "styles/isomer-cms/Elements.module.scss"
+
+import { isEmpty } from "utils"
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+
+const EditorResourcesSection = ({
+  title,
+  subtitle,
+  button,
+  sectionIndex,
+  deleteHandler,
+  onFieldChange,
+  shouldDisplay,
+  displayHandler,
+  errors,
+}) => (
+  <div
+    className={`${elementStyles.card} ${
+      !shouldDisplay && !isEmpty(errors) ? elementStyles.error : ""
+    } move`}
+  >
+    <div className={elementStyles.cardHeader}>
+      <h2>Resources section: {title}</h2>
+      <IconButton
+        variant="clear"
+        id={`section-${sectionIndex}`}
+        onClick={displayHandler}
+      >
+        <i
+          className={`bx ${
+            shouldDisplay ? "bx-chevron-down" : "bx-chevron-right"
+          }`}
+          id={`section-${sectionIndex}-icon`}
+        />
+      </IconButton>
+    </div>
+    {shouldDisplay ? (
+      <>
+        <div className={elementStyles.cardContent}>
+          <FormContext isRequired hasError={!!errors.subtitle}>
+            <FormTitle>Resources section subtitle</FormTitle>
+            <FormField
+              placeholder="Resources section subtitle"
+              id={`section-${sectionIndex}-resources-subtitle`}
+              value={subtitle}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.subtitle}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.title}>
+            <FormTitle>Resources section title</FormTitle>
+            <FormField
+              placeholder="Resources section title"
+              id={`section-${sectionIndex}-resources-title`}
+              value={title}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.title}</FormError>
+          </FormContext>
+          <FormContext isRequired hasError={!!errors.button}>
+            <FormTitle>Resources button name</FormTitle>
+            <FormField
+              placeholder="Resources button name"
+              id={`section-${sectionIndex}-resources-button`}
+              value={button}
+              onChange={onFieldChange}
+            />
+            <FormError>{errors.button}</FormError>
+          </FormContext>
+        </div>
+        <div className={elementStyles.inputGroup}>
+          <Button
+            colorScheme="critical"
+            w="100%"
+            id={`section-${sectionIndex}`}
+            onClick={deleteHandler}
+          >
+            Delete section
+          </Button>
+        </div>
+      </>
+    ) : null}
+  </div>
+)
+
+export default EditorResourcesSection
+
+EditorResourcesSection.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  sectionIndex: PropTypes.number.isRequired,
+  button: PropTypes.string,
+  onFieldChange: PropTypes.func.isRequired,
+  deleteHandler: PropTypes.func.isRequired,
+  shouldDisplay: PropTypes.bool.isRequired,
+  displayHandler: PropTypes.func.isRequired,
+  errors: PropTypes.shape({
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    button: PropTypes.string,
+  }).isRequired,
+}


### PR DESCRIPTION
## Problem
Previously, when we merged the feature flagged PR, i only copy pasted the `EditHomepage.jsx` file. however, within `EditHomepage.jsx`, it was also referencing other files that had been previously deleted. This wasn't an issue as it branched off a base that had said legacy files, but on merge back to `develop`, the legacy files got deleted, which led to an error.

## Solution
1. add legacy files in
2. fix import

## Tests
- [ ] go to [this](http://localhost:3000/sites/a-test-v4/homepage) site. it should display the new components
- [ ] go to [this](http://localhost:3000/sites/ogp-designers/homepage) site. toggle the dropdown/highlight in `HeroSection` - it should be ok. 
