### PR TITLE
fix(editable): shift out context to allow nested dnd

### DIFF
--- a/src/layouts/EditHomepage.jsx
+++ b/src/layouts/EditHomepage.jsx
@@ -7,6 +7,7 @@ import {
   VStack,
   Divider,
 } from "@chakra-ui/react"
+import { DragDropContext } from "@hello-pangea/dnd"
 import { Button, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
 import _ from "lodash"
@@ -1021,88 +1022,99 @@ const EditHomepage = ({ match }) => {
                         </>
                       )
                     })}
-                    <Editable.Droppable
-                      width="100%"
-                      editableId="leftPane"
-                      onDragEnd={onDragEnd}
-                    >
-                      <Editable.EmptySection
-                        title="Sections you add will appear here"
-                        subtitle="Add informative content to your website from images to text by
-                    clicking “Add section” below"
-                        image={<HomepageStartEditingImage />}
-                        // NOTE: It's empty if there is only 1 section and it's a hero section
-                        // as the hero section displays above the custom sections
-                        // and has a fixed display
-                        isEmpty={
-                          frontMatter.sections.length === 1 &&
-                          heroSection.length === 1
-                        }
+                    <DragDropContext onDragEnd={onDragEnd}>
+                      <Editable.Droppable
+                        width="100%"
+                        editableId="leftPane"
+                        onDragEnd={onDragEnd}
                       >
-                        <VStack p={0} spacing="1.5rem">
-                          {frontMatter.sections.map((section, sectionIndex) => (
-                            <>
-                              {section.resources && (
-                                <Editable.DraggableAccordionItem
-                                  index={sectionIndex}
-                                  tag={<Tag variant="subtle">Resources</Tag>}
-                                  title="New resource widget"
-                                  isInvalid={_.some(
-                                    errors.sections[sectionIndex].resources
+                        <Editable.EmptySection
+                          title="Sections you add will appear here"
+                          subtitle="Add informative content to your website from images to text by
+                    clicking “Add section” below"
+                          image={<HomepageStartEditingImage />}
+                          // NOTE: It's empty if there is only 1 section and it's a hero section
+                          // as the hero section displays above the custom sections
+                          // and has a fixed display
+                          isEmpty={
+                            frontMatter.sections.length === 1 &&
+                            heroSection.length === 1
+                          }
+                        >
+                          <VStack p={0} spacing="1.5rem">
+                            {frontMatter.sections.map(
+                              (section, sectionIndex) => (
+                                <>
+                                  {section.resources && (
+                                    <Editable.DraggableAccordionItem
+                                      index={sectionIndex}
+                                      tag={
+                                        <Tag variant="subtle">Resources</Tag>
+                                      }
+                                      title="New resource widget"
+                                      isInvalid={_.some(
+                                        errors.sections[sectionIndex].resources
+                                      )}
+                                    >
+                                      <ResourcesBody
+                                        {...section.resources}
+                                        index={sectionIndex}
+                                        errors={
+                                          errors.sections[sectionIndex]
+                                            .resources
+                                        }
+                                      />
+                                    </Editable.DraggableAccordionItem>
                                   )}
-                                >
-                                  <ResourcesBody
-                                    {...section.resources}
-                                    index={sectionIndex}
-                                    errors={
-                                      errors.sections[sectionIndex].resources
-                                    }
-                                  />
-                                </Editable.DraggableAccordionItem>
-                              )}
 
-                              {section.infobar && (
-                                <Editable.DraggableAccordionItem
-                                  index={sectionIndex}
-                                  tag={<Tag variant="subtle">Infobar</Tag>}
-                                  title={section.infobar.title || "New infobar"}
-                                  isInvalid={_.some(
-                                    errors.sections[sectionIndex].infobar
+                                  {section.infobar && (
+                                    <Editable.DraggableAccordionItem
+                                      index={sectionIndex}
+                                      tag={<Tag variant="subtle">Infobar</Tag>}
+                                      title={
+                                        section.infobar.title || "New infobar"
+                                      }
+                                      isInvalid={_.some(
+                                        errors.sections[sectionIndex].infobar
+                                      )}
+                                    >
+                                      <InfobarBody
+                                        {...section.infobar}
+                                        index={sectionIndex}
+                                        errors={
+                                          errors.sections[sectionIndex].infobar
+                                        }
+                                      />
+                                    </Editable.DraggableAccordionItem>
                                   )}
-                                >
-                                  <InfobarBody
-                                    {...section.infobar}
-                                    index={sectionIndex}
-                                    errors={
-                                      errors.sections[sectionIndex].infobar
-                                    }
-                                  />
-                                </Editable.DraggableAccordionItem>
-                              )}
 
-                              {section.infopic && (
-                                <Editable.DraggableAccordionItem
-                                  index={sectionIndex}
-                                  tag={<Tag variant="subtle">Infopic</Tag>}
-                                  title={section.infopic.title || "New infopic"}
-                                  isInvalid={_.some(
-                                    errors.sections[sectionIndex].infopic
+                                  {section.infopic && (
+                                    <Editable.DraggableAccordionItem
+                                      index={sectionIndex}
+                                      tag={<Tag variant="subtle">Infopic</Tag>}
+                                      title={
+                                        section.infopic.title || "New infopic"
+                                      }
+                                      isInvalid={_.some(
+                                        errors.sections[sectionIndex].infopic
+                                      )}
+                                    >
+                                      <InfopicBody
+                                        index={sectionIndex}
+                                        errors={
+                                          errors.sections[sectionIndex].infopic
+                                        }
+                                        {...section.infopic}
+                                      />
+                                    </Editable.DraggableAccordionItem>
                                   )}
-                                >
-                                  <InfopicBody
-                                    index={sectionIndex}
-                                    errors={
-                                      errors.sections[sectionIndex].infopic
-                                    }
-                                    {...section.infopic}
-                                  />
-                                </Editable.DraggableAccordionItem>
-                              )}
-                            </>
-                          ))}
-                        </VStack>
-                      </Editable.EmptySection>
-                    </Editable.Droppable>
+                                </>
+                              )
+                            )}
+                          </VStack>
+                        </Editable.EmptySection>
+                      </Editable.Droppable>
+                    </DragDropContext>
                   </VStack>
                 </Editable.Accordion>
                 {/* NOTE: Set the padding here - 

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -16,12 +16,7 @@ import {
   Box,
   FlexProps,
 } from "@chakra-ui/react"
-import {
-  OnDragEndResponder,
-  Droppable,
-  DragDropContext,
-  Draggable,
-} from "@hello-pangea/dnd"
+import { Droppable, Draggable } from "@hello-pangea/dnd"
 import { IconButton } from "@opengovsg/design-system-react"
 import { PropsWithChildren } from "react"
 import { v4 as uuid } from "uuid"
@@ -130,8 +125,7 @@ const getDroppableInfo = (editableId: HomepageDroppableZone): DropInfo => {
   }
 }
 
-export interface EditableDraggableProps extends Omit<BoxProps, "onDragEnd"> {
-  onDragEnd: OnDragEndResponder
+export interface EditableDraggableProps extends BoxProps {
   editableId: HomepageDroppableZone
 }
 /**
@@ -145,29 +139,23 @@ export interface EditableDraggableProps extends Omit<BoxProps, "onDragEnd"> {
  * @param editableId this determines the zone that the child draggables will be in.
  */
 export const EditableDroppable = ({
-  onDragEnd,
-  children,
   editableId,
+  children,
   ...rest
 }: PropsWithChildren<EditableDraggableProps>) => {
   return (
-    // NOTE: According to the dnd docs,
-    // there CANNOT be more than 1
-    // `DragDropContext` in the component tree.
-    <DragDropContext onDragEnd={onDragEnd}>
-      <Droppable {...getDroppableInfo(editableId)}>
-        {(droppableProvided) => (
-          <Box
-            ref={droppableProvided.innerRef}
-            {...droppableProvided.droppableProps}
-            {...rest}
-          >
-            {children}
-            {droppableProvided.placeholder}
-          </Box>
-        )}
-      </Droppable>
-    </DragDropContext>
+    <Droppable {...getDroppableInfo(editableId)}>
+      {(droppableProvided) => (
+        <Box
+          ref={droppableProvided.innerRef}
+          {...droppableProvided.droppableProps}
+          {...rest}
+        >
+          {children}
+          {droppableProvided.placeholder}
+        </Box>
+      )}
+    </Droppable>
   )
 }
 

--- a/src/layouts/components/Homepage/HeroDropdownSection.tsx
+++ b/src/layouts/components/Homepage/HeroDropdownSection.tsx
@@ -1,4 +1,5 @@
 import { Text, Box, FormControl } from "@chakra-ui/react"
+import { DragDropContext } from "@hello-pangea/dnd"
 import {
   FormLabel,
   Input,
@@ -44,103 +45,105 @@ export const HeroDropdownSection = ({
 
   return (
     <Box>
-      <Editable.Droppable editableId="dropdownelem" onDragEnd={onDragEnd}>
-        <FormControl isRequired isInvalid={!!errors.dropdown}>
-          <FormLabel>Title</FormLabel>
-          <Input
-            placeholder="This is a button"
-            value={title}
-            onChange={onChange}
-          />
-          <FormErrorMessage>{errors.dropdown}</FormErrorMessage>
-        </FormControl>
-        <Text mt="1.5rem" textStyle="h6">
-          Dropdown Options
-        </Text>
-        <Text mt="0.5rem" textStyle="body-2" textColor="base.content.medium">
-          Drag and drop dropdown options to rearrange them
-        </Text>
-        {/* TODO: Add `displayHandler` */}
-        <Editable.Accordion onChange={() => onDisplay("dropdownelem")}>
-          <Editable.EmptySection
-            title="Options you add will appear here"
-            subtitle="Add options to allow users to quickly navigate your site"
-            isEmpty={state.dropdown.options.length === 0}
-          >
-            <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
-              {state.dropdown.options.map(
-                (
-                  { title: optionTitle, url: optionUrl },
-                  dropdownOptionIndex
-                ) => {
-                  return (
-                    <Editable.DraggableAccordionItem
-                      title={optionTitle || "New dropdown option"}
-                      draggableId={`dropdownelem-${dropdownOptionIndex}-draggable`}
-                      index={dropdownOptionIndex}
-                      isInvalid={_.some(
-                        errors.dropdownElems[dropdownOptionIndex]
-                      )}
-                    >
-                      <Editable.Section>
-                        <FormControl
-                          isInvalid={
-                            !!errors.dropdownElems[dropdownOptionIndex].title
-                          }
-                          isRequired
-                        >
-                          <FormLabel>Title</FormLabel>
-                          <Input
-                            placeholder="Dropdown option title"
-                            id={`dropdownelem-${dropdownOptionIndex}-title`}
-                            value={optionTitle}
-                            onChange={onChange}
-                          />
-                          <FormErrorMessage>
-                            {errors.dropdownElems[dropdownOptionIndex].title}
-                          </FormErrorMessage>
-                        </FormControl>
-                        <FormControl
-                          isInvalid={
-                            !!errors.dropdownElems[dropdownOptionIndex].url
-                          }
-                          isRequired
-                        >
-                          <FormLabel>URL</FormLabel>
-                          <Input
-                            placeholder="Insert /page-url or https://"
-                            id={`dropdownelem-${dropdownOptionIndex}-url`}
-                            value={optionUrl}
-                            onChange={onChange}
-                          />
-                          <FormErrorMessage>
-                            {errors.dropdownElems[dropdownOptionIndex].url}
-                          </FormErrorMessage>
-                        </FormControl>
-                        <Button
-                          id={`dropdownelem-${dropdownOptionIndex}-delete`}
-                          onClick={() =>
-                            onDelete(
-                              `dropdownelem-${dropdownOptionIndex}-delete`,
-                              "Dropdown Element"
-                            )
-                          }
-                          alignSelf="center"
-                          variant="clear"
-                          colorScheme="critical"
-                          mt="1rem"
-                        >
-                          Delete option
-                        </Button>
-                      </Editable.Section>
-                    </Editable.DraggableAccordionItem>
-                  )
-                }
-              )}
-            </Editable.Section>
-          </Editable.EmptySection>
-        </Editable.Accordion>
-      </Editable.Droppable>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Editable.Droppable editableId="dropdownelem">
+          <FormControl isRequired isInvalid={!!errors.dropdown}>
+            <FormLabel>Title</FormLabel>
+            <Input
+              placeholder="This is a button"
+              value={title}
+              onChange={onChange}
+            />
+            <FormErrorMessage>{errors.dropdown}</FormErrorMessage>
+          </FormControl>
+          <Text mt="1.5rem" textStyle="h6">
+            Dropdown Options
+          </Text>
+          <Text mt="0.5rem" textStyle="body-2" textColor="base.content.medium">
+            Drag and drop dropdown options to rearrange them
+          </Text>
+          {/* TODO: Add `displayHandler` */}
+          <Editable.Accordion onChange={() => onDisplay("dropdownelem")}>
+            <Editable.EmptySection
+              title="Options you add will appear here"
+              subtitle="Add options to allow users to quickly navigate your site"
+              isEmpty={state.dropdown.options.length === 0}
+            >
+              <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
+                {state.dropdown.options.map(
+                  (
+                    { title: optionTitle, url: optionUrl },
+                    dropdownOptionIndex
+                  ) => {
+                    return (
+                      <Editable.DraggableAccordionItem
+                        title={optionTitle || "New dropdown option"}
+                        draggableId={`dropdownelem-${dropdownOptionIndex}-draggable`}
+                        index={dropdownOptionIndex}
+                        isInvalid={_.some(
+                          errors.dropdownElems[dropdownOptionIndex]
+                        )}
+                      >
+                        <Editable.Section>
+                          <FormControl
+                            isInvalid={
+                              !!errors.dropdownElems[dropdownOptionIndex].title
+                            }
+                            isRequired
+                          >
+                            <FormLabel>Title</FormLabel>
+                            <Input
+                              placeholder="Dropdown option title"
+                              id={`dropdownelem-${dropdownOptionIndex}-title`}
+                              value={optionTitle}
+                              onChange={onChange}
+                            />
+                            <FormErrorMessage>
+                              {errors.dropdownElems[dropdownOptionIndex].title}
+                            </FormErrorMessage>
+                          </FormControl>
+                          <FormControl
+                            isInvalid={
+                              !!errors.dropdownElems[dropdownOptionIndex].url
+                            }
+                            isRequired
+                          >
+                            <FormLabel>URL</FormLabel>
+                            <Input
+                              placeholder="Insert /page-url or https://"
+                              id={`dropdownelem-${dropdownOptionIndex}-url`}
+                              value={optionUrl}
+                              onChange={onChange}
+                            />
+                            <FormErrorMessage>
+                              {errors.dropdownElems[dropdownOptionIndex].url}
+                            </FormErrorMessage>
+                          </FormControl>
+                          <Button
+                            id={`dropdownelem-${dropdownOptionIndex}-delete`}
+                            onClick={() =>
+                              onDelete(
+                                `dropdownelem-${dropdownOptionIndex}-delete`,
+                                "Dropdown Element"
+                              )
+                            }
+                            alignSelf="center"
+                            variant="clear"
+                            colorScheme="critical"
+                            mt="1rem"
+                          >
+                            Delete option
+                          </Button>
+                        </Editable.Section>
+                      </Editable.DraggableAccordionItem>
+                    )
+                  }
+                )}
+              </Editable.Section>
+            </Editable.EmptySection>
+          </Editable.Accordion>
+        </Editable.Droppable>
+      </DragDropContext>
       <Button
         id={`dropdownelem-${state.dropdown.options.length}-create`}
         onClick={() => onCreate({ target: { id: "dropdownelem" } })}

--- a/src/layouts/components/Homepage/HeroHighlightSection.tsx
+++ b/src/layouts/components/Homepage/HeroHighlightSection.tsx
@@ -1,4 +1,5 @@
 import { Text, Box, FormControl, VStack } from "@chakra-ui/react"
+import { DragDropContext } from "@hello-pangea/dnd"
 import {
   FormLabel,
   Input,
@@ -43,135 +44,139 @@ export const HeroHighlightSection = ({
 
   return (
     <Box w="full">
-      <Editable.Droppable editableId="highlight" onDragEnd={onDragEnd}>
-        <VStack spacing="1.25rem" align="flex-start" p={0}>
-          <FormControl isRequired isInvalid={!!errors.button}>
-            <FormLabel>Button Text</FormLabel>
-            <Input
-              id="section-0-hero-button"
-              placeholder="This is a button"
-              value={button}
-              onChange={onChange}
-            />
-            {/* TODO: Validate button.  
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Editable.Droppable editableId="highlight">
+          <VStack spacing="1.25rem" align="flex-start" p={0}>
+            <FormControl isRequired isInvalid={!!errors.button}>
+              <FormLabel>Button Text</FormLabel>
+              <Input
+                id="section-0-hero-button"
+                placeholder="This is a button"
+                value={button}
+                onChange={onChange}
+              />
+              {/* TODO: Validate button.  
               This isn't being done on prod also.
              */}
-            <FormErrorMessage>{errors.button}</FormErrorMessage>
-          </FormControl>
-          <FormControl isRequired isInvalid={!!errors.url}>
-            <FormLabel>Button URL</FormLabel>
-            <Input
-              placeholder="Insert /page-url or https://"
-              value={url}
-              onChange={onChange}
-              id="section-0-hero-url"
-            />
-            <FormErrorMessage>{errors.url}</FormErrorMessage>
-          </FormControl>
-        </VStack>
-        <Text mt="1.5rem" textStyle="h6">
-          Highlights
-        </Text>
-        <Text mt="0.5rem" textStyle="body-2" textColor="base.content.medium">
-          Drag and drop highlights to rearrange them. On a desktop screen,
-          highlights are shown side-by-side
-        </Text>
-        {/* TODO: Add `displayHandler` */}
-        <Editable.Accordion onChange={() => onDisplay("highlight")}>
-          <Editable.EmptySection
-            isEmpty={highlights.length === 0}
-            title="Highlights you add will appear here"
-            subtitle="You can call out informative links using highlights"
-          >
-            <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
-              {highlights.map(
-                (
-                  {
-                    title: highlightTitle,
-                    url: highlightUrl,
-                    description: highlightDescription,
-                  },
-                  highlightIndex
-                ) => {
-                  return (
-                    <Editable.DraggableAccordionItem
-                      title={highlightTitle || "New highlight"}
-                      draggableId={`highlight-${highlightIndex}-draggable`}
-                      index={highlightIndex}
-                      isInvalid={_.some(errors.highlights[highlightIndex])}
-                    >
-                      <Editable.Section>
-                        <FormControl
-                          isInvalid={!!errors.highlights[highlightIndex].title}
-                          isRequired
-                        >
-                          <FormLabel>Title</FormLabel>
-                          <Input
-                            placeholder="Highlight title"
-                            id={`highlight-${highlightIndex}-title`}
-                            value={highlightTitle}
-                            onChange={onChange}
-                          />
-                          <FormErrorMessage>
-                            {errors.highlights[highlightIndex].title}
-                          </FormErrorMessage>
-                        </FormControl>
-                        <FormControl
-                          isInvalid={
-                            !!errors.highlights[highlightIndex].description
-                          }
-                          isRequired
-                        >
-                          <FormLabel>Description</FormLabel>
-                          <Input
-                            placeholder="Highlight description"
-                            id={`highlight-${highlightIndex}-description`}
-                            value={highlightDescription}
-                            onChange={onChange}
-                          />
-                          <FormErrorMessage>
-                            {errors.highlights[highlightIndex].description}
-                          </FormErrorMessage>
-                        </FormControl>
-                        <FormControl
-                          isInvalid={!!errors.highlights[highlightIndex].url}
-                          isRequired
-                        >
-                          <FormLabel>URL</FormLabel>
-                          <Input
-                            placeholder="Insert /page-url or https://"
-                            id={`highlight-${highlightIndex}-url`}
-                            value={highlightUrl}
-                            onChange={onChange}
-                          />
-                          <FormErrorMessage>
-                            {errors.highlights[highlightIndex].url}
-                          </FormErrorMessage>
-                        </FormControl>
-                        <Button
-                          id={`highlight-${highlightIndex}-delete`}
-                          onClick={() =>
-                            onDelete(
-                              `highlight-${highlightIndex}-delete`,
-                              "Highlight"
-                            )
-                          }
-                          alignSelf="center"
-                          variant="clear"
-                          colorScheme="critical"
-                          mt="1rem"
-                        >
-                          Delete option
-                        </Button>
-                      </Editable.Section>
-                    </Editable.DraggableAccordionItem>
-                  )
-                }
-              )}
-            </Editable.Section>
-          </Editable.EmptySection>
-        </Editable.Accordion>
-      </Editable.Droppable>
+              <FormErrorMessage>{errors.button}</FormErrorMessage>
+            </FormControl>
+            <FormControl isRequired isInvalid={!!errors.url}>
+              <FormLabel>Button URL</FormLabel>
+              <Input
+                placeholder="Insert /page-url or https://"
+                value={url}
+                onChange={onChange}
+                id="section-0-hero-url"
+              />
+              <FormErrorMessage>{errors.url}</FormErrorMessage>
+            </FormControl>
+          </VStack>
+          <Text mt="1.5rem" textStyle="h6">
+            Highlights
+          </Text>
+          <Text mt="0.5rem" textStyle="body-2" textColor="base.content.medium">
+            Drag and drop highlights to rearrange them. On a desktop screen,
+            highlights are shown side-by-side
+          </Text>
+          {/* TODO: Add `displayHandler` */}
+          <Editable.Accordion onChange={() => onDisplay("highlight")}>
+            <Editable.EmptySection
+              isEmpty={highlights.length === 0}
+              title="Highlights you add will appear here"
+              subtitle="You can call out informative links using highlights"
+            >
+              <Editable.Section px={0} spacing="1.25rem" py="1.5rem">
+                {highlights.map(
+                  (
+                    {
+                      title: highlightTitle,
+                      url: highlightUrl,
+                      description: highlightDescription,
+                    },
+                    highlightIndex
+                  ) => {
+                    return (
+                      <Editable.DraggableAccordionItem
+                        title={highlightTitle || "New highlight"}
+                        draggableId={`highlight-${highlightIndex}-draggable`}
+                        index={highlightIndex}
+                        isInvalid={_.some(errors.highlights[highlightIndex])}
+                      >
+                        <Editable.Section>
+                          <FormControl
+                            isInvalid={
+                              !!errors.highlights[highlightIndex].title
+                            }
+                            isRequired
+                          >
+                            <FormLabel>Title</FormLabel>
+                            <Input
+                              placeholder="Highlight title"
+                              id={`highlight-${highlightIndex}-title`}
+                              value={highlightTitle}
+                              onChange={onChange}
+                            />
+                            <FormErrorMessage>
+                              {errors.highlights[highlightIndex].title}
+                            </FormErrorMessage>
+                          </FormControl>
+                          <FormControl
+                            isInvalid={
+                              !!errors.highlights[highlightIndex].description
+                            }
+                            isRequired
+                          >
+                            <FormLabel>Description</FormLabel>
+                            <Input
+                              placeholder="Highlight description"
+                              id={`highlight-${highlightIndex}-description`}
+                              value={highlightDescription}
+                              onChange={onChange}
+                            />
+                            <FormErrorMessage>
+                              {errors.highlights[highlightIndex].description}
+                            </FormErrorMessage>
+                          </FormControl>
+                          <FormControl
+                            isInvalid={!!errors.highlights[highlightIndex].url}
+                            isRequired
+                          >
+                            <FormLabel>URL</FormLabel>
+                            <Input
+                              placeholder="Insert /page-url or https://"
+                              id={`highlight-${highlightIndex}-url`}
+                              value={highlightUrl}
+                              onChange={onChange}
+                            />
+                            <FormErrorMessage>
+                              {errors.highlights[highlightIndex].url}
+                            </FormErrorMessage>
+                          </FormControl>
+                          <Button
+                            id={`highlight-${highlightIndex}-delete`}
+                            onClick={() =>
+                              onDelete(
+                                `highlight-${highlightIndex}-delete`,
+                                "Highlight"
+                              )
+                            }
+                            alignSelf="center"
+                            variant="clear"
+                            colorScheme="critical"
+                            mt="1rem"
+                          >
+                            Delete option
+                          </Button>
+                        </Editable.Section>
+                      </Editable.DraggableAccordionItem>
+                    )
+                  }
+                )}
+              </Editable.Section>
+            </Editable.EmptySection>
+          </Editable.Accordion>
+        </Editable.Droppable>
+      </DragDropContext>
       <Button
         id={`highlight-${highlights.length}-create`}
         onClick={() => onCreate({ target: { id: "highlight" } })}


### PR DESCRIPTION
## Problem
Previously, we hid the `DragDropContext` inside our `Droppable` to allow simpler api for devs, as only 1 level of drag and drop was supported. However, new pages require nested dnd, which means that this is no longer feasible.

## Solution
- shift out the context.

## Tests
- [ ] add a infobar/pic/resource
- [ ] rearrange them
- [ ] it should work
- [ ] go to hero section
- [ ] add 2 dropdown element
- [ ] rearrange them
- [ ] it should wrok
- [ ] repeat ^ but for highlights
