### PR TITLE
fix(edithomepage): remove optional tags

### DIFF
--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -71,7 +71,7 @@ export const HeroBody = ({
   return (
     <>
       <Editable.Section spacing="1.25rem">
-        <FormControl>
+        <FormControl isRequired>
           <FormLabel>Notification Banner</FormLabel>
           <Input
             // TODO: Remove the `id/onChange`

--- a/src/layouts/components/Homepage/InfopicBody.tsx
+++ b/src/layouts/components/Homepage/InfopicBody.tsx
@@ -46,7 +46,7 @@ export const InfopicBody = ({
 
   return (
     <Editable.Section>
-      <FormControl isInvalid={!!errors.subtitle}>
+      <FormControl isRequired isInvalid={!!errors.subtitle}>
         <FormLabel>Subtitle</FormLabel>
         <Input
           placeholder="This subtitle appears above the title"
@@ -56,7 +56,7 @@ export const InfopicBody = ({
         />
         <FormErrorMessage>{errors.subtitle}</FormErrorMessage>
       </FormControl>
-      <FormControl isInvalid={!!errors.title}>
+      <FormControl isRequired isInvalid={!!errors.title}>
         <FormLabel>Title</FormLabel>
         <Input
           placeholder="Your infopic title goes here"
@@ -66,7 +66,7 @@ export const InfopicBody = ({
         />
         <FormErrorMessage>{errors.title}</FormErrorMessage>
       </FormControl>
-      <FormControl isInvalid={!!errors.description}>
+      <FormControl isRequired isInvalid={!!errors.description}>
         <FormLabel>Description</FormLabel>
         <Textarea
           placeholder="This paragraph appears below the title and conveys information"


### PR DESCRIPTION
## Problem
`notifications` and `infopic` had `optional` tags, which should be removed per design

## Solution
set `isRequired` to `true` even though it isn't really :(

# Screenshots
## Before
![Screenshot 2023-08-30 at 2 09 03 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/cdb42ae0-ac1e-4945-ab82-47bf2174364f)


## After
<img width="374" alt="Screenshot 2023-08-24 at 1 01 37 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/44049504/03acbe4e-4cd6-4979-91fa-56613cca74e6">

## Tests

- [ ] open hero section
- [ ] notification should not have `optional` tag after the form's label
- [ ] add `infobar` 
- [ ] infobar should not have `optional` tag after the form's label
