### PR TITLE
IS-417 - Fixing Selector Issues in E2E tests

### DIFF
--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -18,7 +18,6 @@ import {
   addCollaborator,
   getCollaboratorsModal,
   inputCollaborators,
-  removeFirstCollaborator,
 } from "../utils/collaborators"
 
 const collaborator = E2E_EMAIL_COLLAB.email

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -63,7 +63,7 @@ describe("collaborators flow", () => {
   })
 
   describe("Admin adding a collaborator", () => {
-    after(() => removeFirstCollaborator())
+    after(() => removeOtherCollaborators(E2E_EMAIL_ADMIN.email))
 
     it("should not be able to click the add collaborator button when the input is empty", () => {
       // Act

--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -1,3 +1,4 @@
+import { removeOtherCollaborators } from "../api"
 import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
@@ -137,7 +138,7 @@ describe("collaborators flow", () => {
     it("should not be able to remove the last site member", () => {
       // Act
       // NOTE: Remove all collaborators except the initial admin
-      removeFirstCollaborator()
+      removeOtherCollaborators(E2E_EMAIL_ADMIN.email)
 
       // Assert
       cy.get(DELETE_COLLABORATOR_BUTTON_SELECTOR).should("be.disabled")

--- a/cypress/e2e/comments.spec.ts
+++ b/cypress/e2e/comments.spec.ts
@@ -1,5 +1,5 @@
 import * as api from "../api"
-import { createComment } from "../api"
+import { createComment, removeOtherCollaborators } from "../api"
 import {
   CMS_BASEURL,
   E2E_EMAIL_ADMIN,
@@ -15,7 +15,6 @@ import {
   ignoreNotFoundError,
   openCommentsDrawer,
   openReviewRequest,
-  removeFirstCollaborator,
   setUserAsUnauthorised,
   visitE2eEmailTestRepo,
   getCommentInput,
@@ -201,7 +200,7 @@ describe("Comments", () => {
         .then((id) => {
           reviewId = id
         })
-      removeFirstCollaborator()
+      removeOtherCollaborators(E2E_EMAIL_COLLAB.email)
     })
 
     // This is required so that subsequent tests do not fail

--- a/cypress/e2e/resources.spec.ts
+++ b/cypress/e2e/resources.spec.ts
@@ -154,7 +154,7 @@ describe("Resources page", () => {
 
     cy.wait(Interceptors.DELETE)
 
-    cy.contains("Successfully deleted directory").should("exist")
+    cy.contains("Successfully deleted item").should("exist")
 
     cy.contains(TEST_CATEGORY_RENAMED).should("not.exist")
   })

--- a/cypress/e2e/workspace.spec.ts
+++ b/cypress/e2e/workspace.spec.ts
@@ -53,139 +53,139 @@ describe("Workspace Pages flow", () => {
     PARSED_EDITED_TEST_FOLDER_WITH_PAGES_TITLE
   )
 
-  // describe("Create page, delete page, edit page settings in Workspace", () => {
-  //   it("Test site workspace page should have unlinked pages section", () => {
-  //     cy.contains("Create page")
-  //   })
-  //   it("Should be able to create a new page with valid title and permalink", () => {
-  //     // Act
-  //     cy.get(".chakra-button")
-  //       .contains("Create page")
-  //       .should("exist")
-  //       .click({ force: true })
-  //     cy.get("#title").clear().type(TEST_PAGE_TITLE)
-  //     cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
-  //     cy.contains("Save").click()
-  //     cy.wait(Interceptors.POST)
-  //       .its("request.body")
-  //       .should("deep.equal", {
-  //         content: {
-  //           frontMatter: {
-  //             title: TEST_PAGE_TITLE,
-  //             permalink: TEST_PAGE_PERMALNK,
-  //             description: "",
-  //           },
-  //         },
-  //         newFileName: `${TEST_PAGE_TITLE}.md`,
-  //       })
-  //     // Assert
-  //     // 1. User should be redirected to correct EditPage
-  //     cy.url().should(
-  //       "include",
-  //       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/editPage/${TEST_PAGE_ENCODED}`
-  //     )
-  //     cy.contains(TEST_PAGE_TITLE).should("exist")
-  //     // 2. If user goes back to the workspace, they should be able to see that the page exists
-  //     cy.contains("Back to Workspace")
-  //       .should("exist")
-  //       .siblings("button")
-  //       .click()
-  //     cy.contains("a", TEST_PAGE_TITLE).should("exist")
-  //   })
-  //   it("Should not be able to create page with invalid title", () => {
-  //     // Arrange
-  //     const INVALID_TEST_PAGE_TITLES = [
-  //       "Ab",
-  //       "Lorem Ipsum<",
-  //       "^Lorem Ipsum",
-  //       "~%Lorem Ipsum",
-  //       "/Lorem Ipsum",
-  //       ";Lorem Ipsum",
-  //       ">Lorem Ipsum",
-  //       "[Lorem Ipsum",
-  //       "]Lorem Ipsum",
-  //     ]
-  //     // Act
-  //     cy.contains("a", "Create page").click({ force: true })
-  //     // Cannot use titles shorter than 4 characters or containing symbols ~!@#$%^&*_+-./\`:;~{}()[]"'<>,?
-  //     INVALID_TEST_PAGE_TITLES.forEach((invalidTitle) => {
-  //       cy.get("#title").clear().type(invalidTitle).blur()
-  //       cy.contains("button", "Save").should("be.disabled")
-  //     })
-  //     // Assert
-  //     // Page title must not already exist
-  //     cy.get("#title").clear().type(TEST_PAGE_TITLE).blur()
-  //     cy.contains("Title is already in use. Please choose a different title.")
-  //     cy.contains("button", "Save").should("be.disabled")
-  //   })
-  //   it("Should not be able to create page with invalid permalink", () => {
-  //     // Arrange
-  //     const INVALID_TEST_PAGE_PERMALINKS = ["/12", "test-", "/abcd?"]
-  //     // Act
-  //     cy.contains("a", "Create page").click({ force: true })
-  //     // Assert
-  //     // Permalink needs to be longer than 4 characters, should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only
-  //     INVALID_TEST_PAGE_PERMALINKS.forEach((invalidPermalink) => {
-  //       cy.get("#permalink").clear().type(invalidPermalink).blur()
-  //       cy.contains("button", "Save").should("be.disabled")
-  //     })
-  //   })
-  //   it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
-  //     // Arrange
-  //     cy.contains("button", TEST_PAGE_TITLE)
-  //       .parent()
-  //       .parent()
-  //       .as("pageCard")
-  //       .should("exist")
-  //     // Act
-  //     // User should be able edit page details
-  //     cy.clickContextMenuItem("@pageCard", "settings")
-  //     cy.get("#title").should("have.value", TEST_PAGE_TITLE)
-  //     cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE)
-  //     cy.contains("button", "Save").click()
-  //     cy.wait(Interceptors.POST)
-  //     // Assert
-  //     // New page title should be reflected in the Workspace
-  //     cy.contains(EDITED_TEST_PAGE_TITLE).should("exist")
-  //   })
-  //   it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
-  //     // Arrange
-  //     cy.contains("button", EDITED_TEST_PAGE_TITLE)
-  //       .parent()
-  //       .parent()
-  //       .as("pageCard")
-  //       .should("exist")
-  //     // Act
-  //     // User should be able edit page details
-  //     cy.clickContextMenuItem("@pageCard", "settings")
-  //     cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE)
-  //     cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE_2)
-  //     cy.contains("button", "Save").click()
-  //     cy.wait(Interceptors.POST)
-  //     // Asserts
-  //     // Should show modal
-  //     cy.contains(SUCCESSFUL_EDIT_PAGE_TOAST).should("exist")
-  //     // New page title should be reflected in Folders
-  //     cy.contains(EDITED_TEST_PAGE_TITLE_2).should("exist")
-  //   })
-  //   it("Should be able to delete existing page on workspace", () => {
-  //     // Arrange
-  //     // Ensure that the frontend has been updated
-  //     cy.contains(EDITED_TEST_PAGE_TITLE).should("not.exist")
-  //     // Act
-  //     // User should be able to remove the created test page card
-  //     cy.contains("button", EDITED_TEST_PAGE_TITLE_2)
-  //       .parent()
-  //       .parent()
-  //       .as("pageCard")
-  //       .should("exist")
-  //     cy.clickContextMenuItem("@pageCard", "Delete")
-  //     cy.contains("button", "delete").should("exist").click()
-  //     cy.wait(Interceptors.DELETE)
-  //     // Assert
-  //     cy.contains(EDITED_TEST_PAGE_TITLE_2).should("not.exist")
-  //   })
-  // })
+  describe("Create page, delete page, edit page settings in Workspace", () => {
+    it("Test site workspace page should have unlinked pages section", () => {
+      cy.contains("Create page")
+    })
+    it("Should be able to create a new page with valid title and permalink", () => {
+      // Act
+      cy.get(".chakra-button")
+        .contains("Create page")
+        .should("exist")
+        .click({ force: true })
+      cy.get("#title").clear().type(TEST_PAGE_TITLE)
+      cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
+      cy.contains("Save").click()
+      cy.wait(Interceptors.POST)
+        .its("request.body")
+        .should("deep.equal", {
+          content: {
+            frontMatter: {
+              title: TEST_PAGE_TITLE,
+              permalink: TEST_PAGE_PERMALNK,
+              description: "",
+            },
+          },
+          newFileName: `${TEST_PAGE_TITLE}.md`,
+        })
+      // Assert
+      // 1. User should be redirected to correct EditPage
+      cy.url().should(
+        "include",
+        `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/editPage/${TEST_PAGE_ENCODED}`
+      )
+      cy.contains(TEST_PAGE_TITLE).should("exist")
+      // 2. If user goes back to the workspace, they should be able to see that the page exists
+      cy.contains("Back to Workspace")
+        .should("exist")
+        .siblings("button")
+        .click()
+      cy.contains("a", TEST_PAGE_TITLE).should("exist")
+    })
+    it("Should not be able to create page with invalid title", () => {
+      // Arrange
+      const INVALID_TEST_PAGE_TITLES = [
+        "Ab",
+        "Lorem Ipsum<",
+        "^Lorem Ipsum",
+        "~%Lorem Ipsum",
+        "/Lorem Ipsum",
+        ";Lorem Ipsum",
+        ">Lorem Ipsum",
+        "[Lorem Ipsum",
+        "]Lorem Ipsum",
+      ]
+      // Act
+      cy.contains("a", "Create page").click({ force: true })
+      // Cannot use titles shorter than 4 characters or containing symbols ~!@#$%^&*_+-./\`:;~{}()[]"'<>,?
+      INVALID_TEST_PAGE_TITLES.forEach((invalidTitle) => {
+        cy.get("#title").clear().type(invalidTitle).blur()
+        cy.contains("button", "Save").should("be.disabled")
+      })
+      // Assert
+      // Page title must not already exist
+      cy.get("#title").clear().type(TEST_PAGE_TITLE).blur()
+      cy.contains("Title is already in use. Please choose a different title.")
+      cy.contains("button", "Save").should("be.disabled")
+    })
+    it("Should not be able to create page with invalid permalink", () => {
+      // Arrange
+      const INVALID_TEST_PAGE_PERMALINKS = ["/12", "test-", "/abcd?"]
+      // Act
+      cy.contains("a", "Create page").click({ force: true })
+      // Assert
+      // Permalink needs to be longer than 4 characters, should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only
+      INVALID_TEST_PAGE_PERMALINKS.forEach((invalidPermalink) => {
+        cy.get("#permalink").clear().type(invalidPermalink).blur()
+        cy.contains("button", "Save").should("be.disabled")
+      })
+    })
+    it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
+      // Arrange
+      cy.contains("button", TEST_PAGE_TITLE)
+        .parent()
+        .parent()
+        .as("pageCard")
+        .should("exist")
+      // Act
+      // User should be able edit page details
+      cy.clickContextMenuItem("@pageCard", "settings")
+      cy.get("#title").should("have.value", TEST_PAGE_TITLE)
+      cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE)
+      cy.contains("button", "Save").click()
+      cy.wait(Interceptors.POST)
+      // Assert
+      // New page title should be reflected in the Workspace
+      cy.contains(EDITED_TEST_PAGE_TITLE).should("exist")
+    })
+    it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
+      // Arrange
+      cy.contains("button", EDITED_TEST_PAGE_TITLE)
+        .parent()
+        .parent()
+        .as("pageCard")
+        .should("exist")
+      // Act
+      // User should be able edit page details
+      cy.clickContextMenuItem("@pageCard", "settings")
+      cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE)
+      cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE_2)
+      cy.contains("button", "Save").click()
+      cy.wait(Interceptors.POST)
+      // Asserts
+      // Should show modal
+      cy.contains(SUCCESSFUL_EDIT_PAGE_TOAST).should("exist")
+      // New page title should be reflected in Folders
+      cy.contains(EDITED_TEST_PAGE_TITLE_2).should("exist")
+    })
+    it("Should be able to delete existing page on workspace", () => {
+      // Arrange
+      // Ensure that the frontend has been updated
+      cy.contains(EDITED_TEST_PAGE_TITLE).should("not.exist")
+      // Act
+      // User should be able to remove the created test page card
+      cy.contains("button", EDITED_TEST_PAGE_TITLE_2)
+        .parent()
+        .parent()
+        .as("pageCard")
+        .should("exist")
+      cy.clickContextMenuItem("@pageCard", "Delete")
+      cy.contains("button", "delete").should("exist").click()
+      cy.wait(Interceptors.DELETE)
+      // Assert
+      cy.contains(EDITED_TEST_PAGE_TITLE_2).should("not.exist")
+    })
+  })
 
   describe("Create folder, rename folder, and delete folder from Workspace", () => {
     it("Test site workspace page should have folders section", () => {

--- a/cypress/e2e/workspace.spec.ts
+++ b/cypress/e2e/workspace.spec.ts
@@ -8,6 +8,8 @@ import {
 } from "../fixtures/constants"
 import { SUCCESSFUL_EDIT_PAGE_TOAST } from "../fixtures/messages"
 
+const DATA_LOAD_ASSERTION_TEXT = "You can link folders to your navigation bar."
+
 describe("Workspace Pages flow", () => {
   beforeEach(() => {
     cy.setGithubSessionDefaults()
@@ -214,9 +216,7 @@ describe("Workspace Pages flow", () => {
     it("Should be able to create a new folder with valid folder name with page", () => {
       // Act
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("You can link folders to your navigation bar.").should(
-        "be.visible"
-      )
+      cy.contains(DATA_LOAD_ASSERTION_TEXT).should("be.visible")
       cy.contains("Create page").should("exist").click()
       cy.get("#title").clear().type(TEST_PAGE_TITLE)
       cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
@@ -233,9 +233,7 @@ describe("Workspace Pages flow", () => {
         Interceptors.GET
       )
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("You can link folders to your navigation bar.").should(
-        "be.visible"
-      )
+      cy.contains(DATA_LOAD_ASSERTION_TEXT).should("be.visible")
 
       cy.contains("Create folder").should("exist").click()
       cy.get("input#newDirectoryName")
@@ -301,9 +299,7 @@ describe("Workspace Pages flow", () => {
     it("Should be able to delete a folder with no pages", () => {
       // Arrange
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("You can link folders to your navigation bar.").should(
-        "be.visible"
-      )
+      cy.contains(DATA_LOAD_ASSERTION_TEXT).should("be.visible")
       cy.contains("a", PRETTIFIED_FOLDER_NO_PAGES_TITLE)
         .parent()
         .as("emptyFolderItem")
@@ -322,9 +318,7 @@ describe("Workspace Pages flow", () => {
     it("Should be able to delete a folder with pages", () => {
       // Arrange
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("You can link folders to your navigation bar.").should(
-        "be.visible"
-      )
+      cy.contains(DATA_LOAD_ASSERTION_TEXT).should("be.visible")
       cy.contains("button", PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE)
         .parent()
         .parent()

--- a/cypress/e2e/workspace.spec.ts
+++ b/cypress/e2e/workspace.spec.ts
@@ -53,139 +53,139 @@ describe("Workspace Pages flow", () => {
     PARSED_EDITED_TEST_FOLDER_WITH_PAGES_TITLE
   )
 
-  describe("Create page, delete page, edit page settings in Workspace", () => {
-    it("Test site workspace page should have unlinked pages section", () => {
-      cy.contains("Create page")
-    })
-    it("Should be able to create a new page with valid title and permalink", () => {
-      // Act
-      cy.get(".chakra-button")
-        .contains("Create page")
-        .should("exist")
-        .click({ force: true })
-      cy.get("#title").clear().type(TEST_PAGE_TITLE)
-      cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
-      cy.contains("Save").click()
-      cy.wait(Interceptors.POST)
-        .its("request.body")
-        .should("deep.equal", {
-          content: {
-            frontMatter: {
-              title: TEST_PAGE_TITLE,
-              permalink: TEST_PAGE_PERMALNK,
-              description: "",
-            },
-          },
-          newFileName: `${TEST_PAGE_TITLE}.md`,
-        })
-      // Assert
-      // 1. User should be redirected to correct EditPage
-      cy.url().should(
-        "include",
-        `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/editPage/${TEST_PAGE_ENCODED}`
-      )
-      cy.contains(TEST_PAGE_TITLE).should("exist")
-      // 2. If user goes back to the workspace, they should be able to see that the page exists
-      cy.contains("Back to Workspace")
-        .should("exist")
-        .siblings("button")
-        .click()
-      cy.contains("a", TEST_PAGE_TITLE).should("exist")
-    })
-    it("Should not be able to create page with invalid title", () => {
-      // Arrange
-      const INVALID_TEST_PAGE_TITLES = [
-        "Ab",
-        "Lorem Ipsum<",
-        "^Lorem Ipsum",
-        "~%Lorem Ipsum",
-        "/Lorem Ipsum",
-        ";Lorem Ipsum",
-        ">Lorem Ipsum",
-        "[Lorem Ipsum",
-        "]Lorem Ipsum",
-      ]
-      // Act
-      cy.contains("a", "Create page").click({ force: true })
-      // Cannot use titles shorter than 4 characters or containing symbols ~!@#$%^&*_+-./\`:;~{}()[]"'<>,?
-      INVALID_TEST_PAGE_TITLES.forEach((invalidTitle) => {
-        cy.get("#title").clear().type(invalidTitle).blur()
-        cy.contains("button", "Save").should("be.disabled")
-      })
-      // Assert
-      // Page title must not already exist
-      cy.get("#title").clear().type(TEST_PAGE_TITLE).blur()
-      cy.contains("Title is already in use. Please choose a different title.")
-      cy.contains("button", "Save").should("be.disabled")
-    })
-    it("Should not be able to create page with invalid permalink", () => {
-      // Arrange
-      const INVALID_TEST_PAGE_PERMALINKS = ["/12", "test-", "/abcd?"]
-      // Act
-      cy.contains("a", "Create page").click({ force: true })
-      // Assert
-      // Permalink needs to be longer than 4 characters, should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only
-      INVALID_TEST_PAGE_PERMALINKS.forEach((invalidPermalink) => {
-        cy.get("#permalink").clear().type(invalidPermalink).blur()
-        cy.contains("button", "Save").should("be.disabled")
-      })
-    })
-    it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
-      // Arrange
-      cy.contains("button", TEST_PAGE_TITLE)
-        .parent()
-        .parent()
-        .as("pageCard")
-        .should("exist")
-      // Act
-      // User should be able edit page details
-      cy.clickContextMenuItem("@pageCard", "settings")
-      cy.get("#title").should("have.value", TEST_PAGE_TITLE)
-      cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE)
-      cy.contains("button", "Save").click()
-      cy.wait(Interceptors.POST)
-      // Assert
-      // New page title should be reflected in the Workspace
-      cy.contains(EDITED_TEST_PAGE_TITLE).should("exist")
-    })
-    it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
-      // Arrange
-      cy.contains("button", EDITED_TEST_PAGE_TITLE)
-        .parent()
-        .parent()
-        .as("pageCard")
-        .should("exist")
-      // Act
-      // User should be able edit page details
-      cy.clickContextMenuItem("@pageCard", "settings")
-      cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE)
-      cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE_2)
-      cy.contains("button", "Save").click()
-      cy.wait(Interceptors.POST)
-      // Asserts
-      // Should show modal
-      cy.contains(SUCCESSFUL_EDIT_PAGE_TOAST).should("exist")
-      // New page title should be reflected in Folders
-      cy.contains(EDITED_TEST_PAGE_TITLE_2).should("exist")
-    })
-    it("Should be able to delete existing page on workspace", () => {
-      // Arrange
-      // Ensure that the frontend has been updated
-      cy.contains(EDITED_TEST_PAGE_TITLE).should("not.exist")
-      // Act
-      // User should be able to remove the created test page card
-      cy.contains("button", EDITED_TEST_PAGE_TITLE_2)
-        .parent()
-        .parent()
-        .as("pageCard")
-        .should("exist")
-      cy.clickContextMenuItem("@pageCard", "Delete")
-      cy.contains("button", "delete").should("exist").click()
-      cy.wait(Interceptors.DELETE)
-      // Assert
-      cy.contains(EDITED_TEST_PAGE_TITLE_2).should("not.exist")
-    })
-  })
+  // describe("Create page, delete page, edit page settings in Workspace", () => {
+  //   it("Test site workspace page should have unlinked pages section", () => {
+  //     cy.contains("Create page")
+  //   })
+  //   it("Should be able to create a new page with valid title and permalink", () => {
+  //     // Act
+  //     cy.get(".chakra-button")
+  //       .contains("Create page")
+  //       .should("exist")
+  //       .click({ force: true })
+  //     cy.get("#title").clear().type(TEST_PAGE_TITLE)
+  //     cy.get("#permalink").clear().type(TEST_PAGE_PERMALNK)
+  //     cy.contains("Save").click()
+  //     cy.wait(Interceptors.POST)
+  //       .its("request.body")
+  //       .should("deep.equal", {
+  //         content: {
+  //           frontMatter: {
+  //             title: TEST_PAGE_TITLE,
+  //             permalink: TEST_PAGE_PERMALNK,
+  //             description: "",
+  //           },
+  //         },
+  //         newFileName: `${TEST_PAGE_TITLE}.md`,
+  //       })
+  //     // Assert
+  //     // 1. User should be redirected to correct EditPage
+  //     cy.url().should(
+  //       "include",
+  //       `${CMS_BASEURL}/sites/${TEST_REPO_NAME}/editPage/${TEST_PAGE_ENCODED}`
+  //     )
+  //     cy.contains(TEST_PAGE_TITLE).should("exist")
+  //     // 2. If user goes back to the workspace, they should be able to see that the page exists
+  //     cy.contains("Back to Workspace")
+  //       .should("exist")
+  //       .siblings("button")
+  //       .click()
+  //     cy.contains("a", TEST_PAGE_TITLE).should("exist")
+  //   })
+  //   it("Should not be able to create page with invalid title", () => {
+  //     // Arrange
+  //     const INVALID_TEST_PAGE_TITLES = [
+  //       "Ab",
+  //       "Lorem Ipsum<",
+  //       "^Lorem Ipsum",
+  //       "~%Lorem Ipsum",
+  //       "/Lorem Ipsum",
+  //       ";Lorem Ipsum",
+  //       ">Lorem Ipsum",
+  //       "[Lorem Ipsum",
+  //       "]Lorem Ipsum",
+  //     ]
+  //     // Act
+  //     cy.contains("a", "Create page").click({ force: true })
+  //     // Cannot use titles shorter than 4 characters or containing symbols ~!@#$%^&*_+-./\`:;~{}()[]"'<>,?
+  //     INVALID_TEST_PAGE_TITLES.forEach((invalidTitle) => {
+  //       cy.get("#title").clear().type(invalidTitle).blur()
+  //       cy.contains("button", "Save").should("be.disabled")
+  //     })
+  //     // Assert
+  //     // Page title must not already exist
+  //     cy.get("#title").clear().type(TEST_PAGE_TITLE).blur()
+  //     cy.contains("Title is already in use. Please choose a different title.")
+  //     cy.contains("button", "Save").should("be.disabled")
+  //   })
+  //   it("Should not be able to create page with invalid permalink", () => {
+  //     // Arrange
+  //     const INVALID_TEST_PAGE_PERMALINKS = ["/12", "test-", "/abcd?"]
+  //     // Act
+  //     cy.contains("a", "Create page").click({ force: true })
+  //     // Assert
+  //     // Permalink needs to be longer than 4 characters, should start with a slash, and contain alphanumeric characters separated by hyphens and slashes only
+  //     INVALID_TEST_PAGE_PERMALINKS.forEach((invalidPermalink) => {
+  //       cy.get("#permalink").clear().type(invalidPermalink).blur()
+  //       cy.contains("button", "Save").should("be.disabled")
+  //     })
+  //   })
+  //   it("Should be able to edit existing page details with Chinese title and valid permalink", () => {
+  //     // Arrange
+  //     cy.contains("button", TEST_PAGE_TITLE)
+  //       .parent()
+  //       .parent()
+  //       .as("pageCard")
+  //       .should("exist")
+  //     // Act
+  //     // User should be able edit page details
+  //     cy.clickContextMenuItem("@pageCard", "settings")
+  //     cy.get("#title").should("have.value", TEST_PAGE_TITLE)
+  //     cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE)
+  //     cy.contains("button", "Save").click()
+  //     cy.wait(Interceptors.POST)
+  //     // Assert
+  //     // New page title should be reflected in the Workspace
+  //     cy.contains(EDITED_TEST_PAGE_TITLE).should("exist")
+  //   })
+  //   it("Should be able to edit existing page details with Tamil title and valid permalink", () => {
+  //     // Arrange
+  //     cy.contains("button", EDITED_TEST_PAGE_TITLE)
+  //       .parent()
+  //       .parent()
+  //       .as("pageCard")
+  //       .should("exist")
+  //     // Act
+  //     // User should be able edit page details
+  //     cy.clickContextMenuItem("@pageCard", "settings")
+  //     cy.get("#title").should("have.value", EDITED_TEST_PAGE_TITLE)
+  //     cy.get("#title").clear().type(EDITED_TEST_PAGE_TITLE_2)
+  //     cy.contains("button", "Save").click()
+  //     cy.wait(Interceptors.POST)
+  //     // Asserts
+  //     // Should show modal
+  //     cy.contains(SUCCESSFUL_EDIT_PAGE_TOAST).should("exist")
+  //     // New page title should be reflected in Folders
+  //     cy.contains(EDITED_TEST_PAGE_TITLE_2).should("exist")
+  //   })
+  //   it("Should be able to delete existing page on workspace", () => {
+  //     // Arrange
+  //     // Ensure that the frontend has been updated
+  //     cy.contains(EDITED_TEST_PAGE_TITLE).should("not.exist")
+  //     // Act
+  //     // User should be able to remove the created test page card
+  //     cy.contains("button", EDITED_TEST_PAGE_TITLE_2)
+  //       .parent()
+  //       .parent()
+  //       .as("pageCard")
+  //       .should("exist")
+  //     cy.clickContextMenuItem("@pageCard", "Delete")
+  //     cy.contains("button", "delete").should("exist").click()
+  //     cy.wait(Interceptors.DELETE)
+  //     // Assert
+  //     cy.contains(EDITED_TEST_PAGE_TITLE_2).should("not.exist")
+  //   })
+  // })
 
   describe("Create folder, rename folder, and delete folder from Workspace", () => {
     it("Test site workspace page should have folders section", () => {
@@ -214,7 +214,7 @@ describe("Workspace Pages flow", () => {
     it("Should be able to create a new folder with valid folder name with page", () => {
       // Act
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("Folders impact navigation on your site.").should(
+      cy.contains("You can link folders to your navigation bar.").should(
         "be.visible"
       )
       cy.contains("Create page").should("exist").click()
@@ -233,7 +233,7 @@ describe("Workspace Pages flow", () => {
         Interceptors.GET
       )
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("Folders impact navigation on your site.").should(
+      cy.contains("You can link folders to your navigation bar.").should(
         "be.visible"
       )
 
@@ -301,7 +301,7 @@ describe("Workspace Pages flow", () => {
     it("Should be able to delete a folder with no pages", () => {
       // Arrange
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("Folders impact navigation on your site.").should(
+      cy.contains("You can link folders to your navigation bar.").should(
         "be.visible"
       )
       cy.contains("a", PRETTIFIED_FOLDER_NO_PAGES_TITLE)
@@ -322,7 +322,7 @@ describe("Workspace Pages flow", () => {
     it("Should be able to delete a folder with pages", () => {
       // Arrange
       // NOTE: Sentinel value to guarantee that the data has loaded
-      cy.contains("Folders impact navigation on your site.").should(
+      cy.contains("You can link folders to your navigation bar.").should(
         "be.visible"
       )
       cy.contains("button", PRETTIFIED_EDITED_FOLDER_WITH_PAGES_TITLE)

--- a/cypress/utils/collaborators.ts
+++ b/cypress/utils/collaborators.ts
@@ -20,21 +20,6 @@ export const getCollaboratorsModal = (): Cypress.Chainable<
   return cy.get("form").should("be.visible")
 }
 
-export const removeFirstCollaborator = (): void => {
-  // Note: only removes a single other collaborator, due to concurrency issues
-  getCollaboratorsModal()
-    .get(DELETE_BUTTON_SELECTOR)
-    .then((buttons) => {
-      if (buttons.length > 1) {
-        buttons[1].click()
-        cy.contains("button", "Remove collaborator").click()
-        cy.contains("Collaborator removed successfully").should("be.visible")
-      }
-    })
-
-  closeModal()
-}
-
 export const inputCollaborators = (user: string): void => {
   getCollaboratorsModal().get(ADD_COLLABORATOR_INPUT_SELECTOR).type(user).blur()
   // NOTE: need to ignore the 422 w/ specific error message because we haven't ack yet


### PR DESCRIPTION
## Problem

Workspace tests look for Folders impact navigation on your site. even though the string no longer exists on the workspace

Resource tests look for "Successfully deleted directory", but should be "Successfully deleted item"

Collaborator tests use removeFirstCollaborator instead of removeOtherCollaborators

Closes IS-417

## Solution

Update the assertions

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Ensure E2E tests for workspace, resources and collaborator specs pass
