### PR TITLE
chore: set pointerEvents to none for draggable icon button

### DIFF
--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -261,6 +261,7 @@ const DraggableAccordionItem = ({
           {({ isExpanded }) => (
             <>
               <IconButton
+                pointerEvents="none"
                 position="absolute"
                 top="0.5rem"
                 left="0"


### PR DESCRIPTION
Minor change to the draggable icon button to make pointer-events:none - this is required to support nested drag and drop for our current workaround