### PR TITLE
Fix/homepage images on private repos

### DIFF
--- a/src/hooks/useFetchPreviewMedia.ts
+++ b/src/hooks/useFetchPreviewMedia.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react"
+import { useParams } from "react-router-dom"
+
+import { getImageDetails } from "utils/images"
+
+import { useGetMediaHook } from "./mediaHooks"
+
+export const useFetchPreviewMedia = (imageUrl = ""): string => {
+  const { siteName } = useParams<{ siteName: string }>()
+  const [loadedImageURL, setLoadedImageURL] = useState(imageUrl)
+  const { fileName, imageDirectory } = getImageDetails(imageUrl)
+  const { data: mediaData } = useGetMediaHook({
+    siteName,
+    mediaDirectoryName: imageDirectory || "images",
+    fileName,
+  })
+
+  useEffect(() => {
+    if (mediaData) {
+      setLoadedImageURL(mediaData.mediaUrl)
+    }
+  }, [mediaData])
+
+  return loadedImageURL
+}

--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -103,7 +103,6 @@ export const HomepagePreview = ({
               <TemplateHeroSection
                 key={`section-${sectionIndex}`}
                 hero={section.hero}
-                siteName={siteName}
                 dropdownIsActive={dropdownIsActive}
                 toggleDropdown={toggleDropdown}
                 ref={scrollRefs[sectionIndex]}
@@ -150,7 +149,6 @@ export const HomepagePreview = ({
                   imageAlt={section.infopic.alt}
                   button={section.infopic.button}
                   sectionIndex={sectionIndex}
-                  siteName={siteName}
                   ref={scrollRefs[sectionIndex]}
                 />
               ) : (
@@ -163,7 +161,6 @@ export const HomepagePreview = ({
                   imageAlt={section.infopic.alt}
                   button={section.infopic.button}
                   sectionIndex={sectionIndex}
-                  siteName={siteName}
                   ref={scrollRefs[sectionIndex]}
                 />
               )}

--- a/src/templates/homepage/HeroSection.jsx
+++ b/src/templates/homepage/HeroSection.jsx
@@ -4,15 +4,13 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
 import PropTypes from "prop-types"
-import { forwardRef, useState, useEffect } from "react"
+import { forwardRef } from "react"
 
-import { useGetMediaHook } from "hooks/mediaHooks"
+import { useFetchPreviewMedia } from "hooks/useFetchPreviewMedia"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
-
-import { getImageDetails } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
@@ -176,22 +174,10 @@ const KeyHighlights = ({ highlights }) => (
 )
 
 const TemplateHeroSection = (
-  { hero, siteName, dropdownIsActive, toggleDropdown },
+  { hero, dropdownIsActive, toggleDropdown },
   ref
 ) => {
-  const [loadedImageURL, setLoadedImageURL] = useState("")
-  const { fileName, imageDirectory } = getImageDetails(hero.background)
-  const { data: mediaData } = useGetMediaHook({
-    siteName,
-    mediaDirectoryName: imageDirectory || "images",
-    fileName,
-  })
-
-  useEffect(() => {
-    if (mediaData) {
-      setLoadedImageURL(mediaData.mediaUrl)
-    }
-  }, [mediaData])
+  const loadedImageURL = useFetchPreviewMedia(hero.background)
 
   const heroStyle = {
     // See j08691's answer at https://stackoverflow.com/questions/21388712/background-size-doesnt-work
@@ -337,7 +323,6 @@ TemplateHeroSection.propTypes = {
       })
     ),
   }).isRequired,
-  siteName: PropTypes.string.isRequired,
   dropdownIsActive: PropTypes.bool.isRequired,
   toggleDropdown: PropTypes.func.isRequired,
 }

--- a/src/templates/homepage/HeroSection.jsx
+++ b/src/templates/homepage/HeroSection.jsx
@@ -4,14 +4,15 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
 import PropTypes from "prop-types"
-import { forwardRef } from "react"
-import { useQuery } from "react-query"
+import { forwardRef, useState, useEffect } from "react"
+
+import { useGetMediaHook } from "hooks/mediaHooks"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { fetchImageURL } from "utils"
+import { getImagePath } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
@@ -178,14 +179,19 @@ const TemplateHeroSection = (
   { hero, siteName, dropdownIsActive, toggleDropdown },
   ref
 ) => {
-  const { data: loadedImageURL } = useQuery(
-    `${siteName}/${hero.background}`,
-    () => fetchImageURL(siteName, decodeURI(hero.background)),
-    {
-      refetchOnWindowFocus: false,
-      staleTime: Infinity, // Never automatically refetch image unless query is invalidated
+  const [loadedImageURL, setLoadedImageURL] = useState("")
+  const fileName = getImagePath(hero.background)
+  const { data: mediaData } = useGetMediaHook({
+    siteName,
+    mediaDirectoryName: "images",
+    fileName,
+  })
+
+  useEffect(() => {
+    if (mediaData) {
+      setLoadedImageURL(mediaData.mediaUrl)
     }
-  )
+  }, [mediaData])
 
   const heroStyle = {
     // See j08691's answer at https://stackoverflow.com/questions/21388712/background-size-doesnt-work

--- a/src/templates/homepage/HeroSection.jsx
+++ b/src/templates/homepage/HeroSection.jsx
@@ -12,7 +12,7 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { getImagePath } from "utils/images"
+import { getImageDetails } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
@@ -180,10 +180,10 @@ const TemplateHeroSection = (
   ref
 ) => {
   const [loadedImageURL, setLoadedImageURL] = useState("")
-  const fileName = getImagePath(hero.background)
+  const { fileName, imageDirectory } = getImageDetails(hero.background)
   const { data: mediaData } = useGetMediaHook({
     siteName,
-    mediaDirectoryName: "images",
+    mediaDirectoryName: imageDirectory || "images",
     fileName,
   })
 

--- a/src/templates/homepage/InfopicLeftSection.jsx
+++ b/src/templates/homepage/InfopicLeftSection.jsx
@@ -7,7 +7,7 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { getImagePath } from "utils/images"
+import { getImageDetails } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
@@ -31,10 +31,10 @@ const TemplateInfopicLeftSection = (
   }
 
   const [loadedImageURL, setLoadedImageURL] = useState("")
-  const fileName = getImagePath(imageUrl)
+  const { fileName, imageDirectory } = getImageDetails(imageUrl)
   const { data: mediaData } = useGetMediaHook({
     siteName,
-    mediaDirectoryName: "images",
+    mediaDirectoryName: imageDirectory || "images",
     fileName,
   })
 

--- a/src/templates/homepage/InfopicLeftSection.jsx
+++ b/src/templates/homepage/InfopicLeftSection.jsx
@@ -1,12 +1,14 @@
 import PropTypes from "prop-types"
-import { forwardRef } from "react"
-import { useQuery } from "react-query"
+import { forwardRef, useState, useEffect } from "react"
+
+import { useGetMediaHook } from "hooks/mediaHooks"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { fetchImageURL } from "utils"
+import { getImagePath } from "utils/images"
+
 /* eslint
   react/no-array-index-key: 0
  */
@@ -28,14 +30,19 @@ const TemplateInfopicLeftSection = (
     e.target.src = "/placeholder_no_image.png"
   }
 
-  const { data: loadedImageURL } = useQuery(
-    `${siteName}/${imageUrl}`,
-    () => fetchImageURL(siteName, decodeURI(imageUrl)),
-    {
-      refetchOnWindowFocus: false,
-      staleTime: Infinity, // Never automatically refetch image unless query is invalidated
+  const [loadedImageURL, setLoadedImageURL] = useState("")
+  const fileName = getImagePath(imageUrl)
+  const { data: mediaData } = useGetMediaHook({
+    siteName,
+    mediaDirectoryName: "images",
+    fileName,
+  })
+
+  useEffect(() => {
+    if (mediaData) {
+      setLoadedImageURL(mediaData.mediaUrl)
     }
-  )
+  }, [mediaData])
 
   return (
     <div ref={ref}>

--- a/src/templates/homepage/InfopicLeftSection.jsx
+++ b/src/templates/homepage/InfopicLeftSection.jsx
@@ -1,48 +1,25 @@
 import PropTypes from "prop-types"
-import { forwardRef, useState, useEffect } from "react"
+import { forwardRef } from "react"
 
-import { useGetMediaHook } from "hooks/mediaHooks"
+import { useFetchPreviewMedia } from "hooks/useFetchPreviewMedia"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
-
-import { getImageDetails } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
  */
 
 const TemplateInfopicLeftSection = (
-  {
-    title,
-    subtitle,
-    description,
-    button,
-    sectionIndex,
-    imageUrl,
-    imageAlt,
-    siteName,
-  },
+  { title, subtitle, description, button, sectionIndex, imageUrl, imageAlt },
   ref
 ) => {
   const addDefaultSrc = (e) => {
     e.target.src = "/placeholder_no_image.png"
   }
 
-  const [loadedImageURL, setLoadedImageURL] = useState("")
-  const { fileName, imageDirectory } = getImageDetails(imageUrl)
-  const { data: mediaData } = useGetMediaHook({
-    siteName,
-    mediaDirectoryName: imageDirectory || "images",
-    fileName,
-  })
-
-  useEffect(() => {
-    if (mediaData) {
-      setLoadedImageURL(mediaData.mediaUrl)
-    }
-  }, [mediaData])
+  const loadedImageURL = useFetchPreviewMedia(imageUrl)
 
   return (
     <div ref={ref}>
@@ -269,7 +246,6 @@ TemplateInfopicLeftSection.propTypes = {
   imageUrl: PropTypes.string,
   imageAlt: PropTypes.string,
   sectionIndex: PropTypes.number.isRequired,
-  siteName: PropTypes.string.isRequired,
 }
 
 TemplateInfopicLeftSection.defaultProps = {

--- a/src/templates/homepage/InfopicRightSection.jsx
+++ b/src/templates/homepage/InfopicRightSection.jsx
@@ -1,12 +1,13 @@
 import PropTypes from "prop-types"
-import { forwardRef } from "react"
-import { useQuery } from "react-query"
+import { forwardRef, useState, useEffect } from "react"
+
+import { useGetMediaHook } from "hooks/mediaHooks"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { fetchImageURL } from "utils"
+import { getImagePath } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
@@ -29,14 +30,19 @@ const TemplateInfopicRightSection = (
     e.target.src = "/placeholder_no_image.png"
   }
 
-  const { data: loadedImageURL } = useQuery(
-    `${siteName}/${imageUrl}`,
-    () => fetchImageURL(siteName, decodeURI(imageUrl)),
-    {
-      refetchOnWindowFocus: false,
-      staleTime: Infinity, // Never automatically refetch image unless query is invalidated
+  const [loadedImageURL, setLoadedImageURL] = useState("")
+  const fileName = getImagePath(imageUrl)
+  const { data: mediaData } = useGetMediaHook({
+    siteName,
+    mediaDirectoryName: "images",
+    fileName,
+  })
+
+  useEffect(() => {
+    if (mediaData) {
+      setLoadedImageURL(mediaData.mediaUrl)
     }
-  )
+  }, [mediaData])
 
   return (
     <div ref={ref}>

--- a/src/templates/homepage/InfopicRightSection.jsx
+++ b/src/templates/homepage/InfopicRightSection.jsx
@@ -7,7 +7,7 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { getImagePath } from "utils/images"
+import { getImageDetails } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
@@ -31,10 +31,10 @@ const TemplateInfopicRightSection = (
   }
 
   const [loadedImageURL, setLoadedImageURL] = useState("")
-  const fileName = getImagePath(imageUrl)
+  const { fileName, imageDirectory } = getImageDetails(imageUrl)
   const { data: mediaData } = useGetMediaHook({
     siteName,
-    mediaDirectoryName: "images",
+    mediaDirectoryName: imageDirectory || "images",
     fileName,
   })
 

--- a/src/templates/homepage/InfopicRightSection.jsx
+++ b/src/templates/homepage/InfopicRightSection.jsx
@@ -1,48 +1,25 @@
 import PropTypes from "prop-types"
-import { forwardRef, useState, useEffect } from "react"
+import { forwardRef } from "react"
 
-import { useGetMediaHook } from "hooks/mediaHooks"
+import { useFetchPreviewMedia } from "hooks/useFetchPreviewMedia"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
-
-import { getImageDetails } from "utils/images"
 
 /* eslint
   react/no-array-index-key: 0
  */
 
 const TemplateInfopicRightSection = (
-  {
-    title,
-    subtitle,
-    description,
-    button,
-    sectionIndex,
-    imageUrl,
-    imageAlt,
-    siteName,
-  },
+  { title, subtitle, description, button, sectionIndex, imageUrl, imageAlt },
   ref
 ) => {
   const addDefaultSrc = (e) => {
     e.target.src = "/placeholder_no_image.png"
   }
 
-  const [loadedImageURL, setLoadedImageURL] = useState("")
-  const { fileName, imageDirectory } = getImageDetails(imageUrl)
-  const { data: mediaData } = useGetMediaHook({
-    siteName,
-    mediaDirectoryName: imageDirectory || "images",
-    fileName,
-  })
-
-  useEffect(() => {
-    if (mediaData) {
-      setLoadedImageURL(mediaData.mediaUrl)
-    }
-  }, [mediaData])
+  const loadedImageURL = useFetchPreviewMedia(imageUrl)
 
   return (
     <div ref={ref}>
@@ -269,7 +246,6 @@ TemplateInfopicRightSection.propTypes = {
   imageUrl: PropTypes.string,
   imageAlt: PropTypes.string,
   sectionIndex: PropTypes.number.isRequired,
-  siteName: PropTypes.string.isRequired,
 }
 
 TemplateInfopicRightSection.defaultProps = {

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -2,7 +2,9 @@
  * Util method to retrieve image details from /images folder from the relative file path,
  * e.g. "/images/album%/picture$.jpg" -> { imageDirectory: "images%2Falbum%25", fileName: "picture%24.jpg" }
  */
-export const getImageDetails = (imageLink: string): { fileName: string; imageDirectory: string } => {
+export const getImageDetails = (
+  imageLink: string
+): { fileName: string; imageDirectory: string } => {
   const cleanImagePath = decodeURI(imageLink).replace(/^\//, "")
   const filePathArr = cleanImagePath
     .split("/")

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,0 +1,10 @@
+/**
+ * Util method to retrieve image path from /images folder from the relative file path,
+ * e.g. "/images/album/picture.jpg" -> "album/picture.jpg"
+ */
+export const getImagePath = (imageLink: string) => {
+  const cleanImagePath = decodeURI(imageLink).replace(/^\//, "")
+  const filePathArr = cleanImagePath.split("/")
+  const filePath = filePathArr[filePathArr.length - 1]
+  return filePath
+}

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,6 +1,6 @@
 /**
  * Util method to retrieve image details from /images folder from the relative file path,
- * e.g. "/images/album%/picture$.jpg" -> { imageDirectory: "images%2Falbum%24", fileName: "picture%24.jpg" }
+ * e.g. "/images/album%/picture$.jpg" -> { imageDirectory: "images%2Falbum%25", fileName: "picture%24.jpg" }
  */
 export const getImageDetails = (imageLink: string): { fileName: string; imageDirectory: string } => {
   const cleanImagePath = decodeURI(imageLink).replace(/^\//, "")

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,10 +1,18 @@
 /**
- * Util method to retrieve image path from /images folder from the relative file path,
- * e.g. "/images/album/picture.jpg" -> "album/picture.jpg"
+ * Util method to retrieve image details from /images folder from the relative file path,
+ * e.g. "/images/album%/picture$.jpg" -> { imageDirectory: "images%2Falbum%24", fileName: "picture%24.jpg" }
  */
-export const getImagePath = (imageLink: string) => {
+export const getImageDetails = (imageLink: string) => {
   const cleanImagePath = decodeURI(imageLink).replace(/^\//, "")
-  const filePathArr = cleanImagePath.split("/")
-  const filePath = filePathArr[filePathArr.length - 1]
-  return filePath
+  const filePathArr = cleanImagePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+  const fileName = filePathArr[filePathArr.length - 1]
+  const imageDirectory = filePathArr
+    .slice(0, filePathArr.length - 1)
+    .join("%2F")
+  return {
+    fileName,
+    imageDirectory,
+  }
 }

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -2,7 +2,7 @@
  * Util method to retrieve image details from /images folder from the relative file path,
  * e.g. "/images/album%/picture$.jpg" -> { imageDirectory: "images%2Falbum%24", fileName: "picture%24.jpg" }
  */
-export const getImageDetails = (imageLink: string) => {
+export const getImageDetails = (imageLink: string): { fileName: string; imageDirectory: string } => {
   const cleanImagePath = decodeURI(imageLink).replace(/^\//, "")
   const filePathArr = cleanImagePath
     .split("/")


### PR DESCRIPTION
## Problem

This PR fixes an issue where images on the homepage for private/GGS repos were not showing up as intended. The reason for this issue was the preview components using the outdated `v1` endpoint to fetch images - they have been modified to use the updated hook calling the `v2` endpoint instead, since the media url is handled by our backend in v2 instead of being offloaded to the frontend.

Resolves IS-527

## Test

- [ ] Go to edithomepage for any private repo (e.g. a-test-v4)
- [ ] Verify that images show up on 
  - [ ] Hero banner
  - [ ] Left infopic
  - [ ] Right infopic
- [ ] Verify that nested images work as well (e.g. `/images/album/nested.jpg`)
- [ ] When creating a new infopic section, no error toast should appear