### PR TITLE
feat: re-introduce comment-based trigger for Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,27 +2,68 @@
 name: "Chromatic"
 
 # Event for the workflow
-on: push
+on:
+  issue_comment:
+    types: [created, edited]
+
+  push:
+    branches:
+      - develop
 
 env:
+  # The full comment text to match to trigger this workflow
+  ISOMER_TRIGGER_COMMENT: "!run chromatic"
+  # The slug for the Isomer core team
+  ISOMER_CORE_TEAM_SLUG: core
+  # Use GitHub Token
+  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   # Required for the chromatic action
   REACT_APP_BACKEND_URL: "https://cms-api.isomer.gov.sg/v1"
 
 # List of jobs
 jobs:
-  chromatic-deployment:
+  chromatic:
     # Operating System
     runs-on: ubuntu-latest
-    # Only run if the user is not a bot and there are changes
+    # Only run if the user is not a bot
     if: ${{ !endsWith(github.actor , 'bot') }}
     environment: staging
     # Job steps
     steps:
-      - uses: actions/checkout@v3
+      # Determine if the PR comment should trigger the Chromatic build
+      - name: Check if user is part of Isomer core team (PR comment)
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+        uses: tspascoal/get-user-teams-membership@v1
+        id: checkUserMember
+        with:
+          username: ${{ github.actor }}
+          team: ${{ env.ISOMER_CORE_TEAM_SLUG }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # requires read:org
+
+      - name: Check for trigger words (in PR comment)
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+        uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: "${{ env.ISOMER_TRIGGER_COMMENT }}"
+          prefix_only: "true"
+          reaction: "+1"
+
+      - name: Checkout repository (pull request)
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0 # 👈 Required to retrieve git history
+
+      - name: Checkout repository (push)
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
-      - uses: dorny/paths-filter@v2
+      - name: Check for changes
+        uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |
@@ -32,22 +73,43 @@ jobs:
               - 'src/theme/**'
               - 'src/styles/**'
 
+      - name: Set environment variable to run Chromatic build
+        if: ${{ (github.event_name == 'push' || (steps.check.outputs.triggered == 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request)) && steps.filter.outputs.frontend == 'true' }}
+        run: echo "ISOMER_RUN_CHROMATIC_BUILD=true" >> $GITHUB_ENV
+
       # This extra step is not in the original chromatic workflow.
       # This is to pin the version of node (18.x) used.
       - name: Setup Node.js
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
         uses: actions/setup-node@v3
         with:
           node-version: "18.x"
           cache: "npm"
 
       - name: Install dependencies
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
         run: npm ci
 
-        # 👇 Adds Chromatic as a step in the workflow
+      - name: Get pull request information (for pull requests)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
+        uses: octokit/request-action@v2.x
+        id: get_pull_request
+        with:
+          route: GET /repos/{repository}/pulls/{pull_number}
+          repository: ${{ github.repository }} # isomerpages/isomercms-frontend
+          pull_number: ${{ github.event.issue.number }}
+
+      - name: Save branch name as environment variable (for pull requests)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
+        run: echo "ISOMER_BRANCH_NAME=${{ fromJSON(steps.get_pull_request.outputs.data).head.ref }}" >> $GITHUB_ENV
+
+      - name: Save branch name as environment variable (for push)
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'push' }}
+        run: echo "ISOMER_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
         uses: chromaui/action@v1
         # Chromatic GitHub Action options
         with:
@@ -55,3 +117,5 @@ jobs:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          branchName: ${{ env.ISOMER_BRANCH_NAME }}
+          autoAcceptChanges: develop


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Chromatic snapshots are expensive and we should have a way to get a snapshot only when we really need one.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- A second attempt of triggering Chromatic snapshots via a PR comment. Here's what changed from previously:
    - A new `branchName` configuration has been added. This is needed to let Chromatic be aware of where the snapshot is coming from. Without this configuration, Chromatic will pull from the `GITHUB_REF` environment variable, which is always `develop` when [on the `issue_comment` workflow](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment). This causes Chromatic to constantly rebuild the `develop` branch and causing our baselines to always reset.
    - A new `autoAcceptChanges` configuration has been added. This is needed so that the baseline (which should, in theory, be the `develop` branch) is up-to-date, as Chromatic treats the latest accepted ancestor build as the baseline to compare pull request changes against. This is done together with the `push` event to the `develop` branch, which will generate a new Chromatic snapshot that Chromatic will automatically mark as accepted.

**Notes**:

- Changes were tested earlier [on a personal repository](https://github.com/dcshzj/chromatic-explore) and the [Chromatic build history is here](https://www.chromatic.com/builds?appId=64f03673697498ccc5d0b523) (notice the build ancestors for each build).
- However, Chromatic builds work in mysterious ways which is very difficult to test. In the worst case if this does not work, [we can just follow how FormSG does it](https://github.com/opengovsg/FormSG/blob/develop/.github/workflows/chromatic.yml).

**You tell me that you can only test after this is merged, how am I going to review this?**

I hear your concerns. This was what I did to test my hypothesis:

- Visit the [test repository](https://github.com/dcshzj/chromatic-explore) that I created to simulate Chromatic builds and the [Chromatic build history](https://www.chromatic.com/builds?appId=64f03673697498ccc5d0b523).
- Step through the changes made (using the `test-1`, `test-2`, `test-3`, `test-4` and `test-5` branches, along with their associated PRs).
- Step through the Chromatic builds made (including the ones for `develop`).
- Analyse the ancestor build(s) that Chromatic has chosen. The builds chosen should make sense (baseline should be `develop` as much as possible, or the parent commit of the same branch).
- Finally, check that the syntax of the workflow file is correct.

If you are interested, the [full documentation of how Chromatic calculates the ancestor builds is available](https://www.chromatic.com/docs/branching-and-baselines#how-baselines-are-calculated).

## Tests

<!-- What tests should be run to confirm functionality? -->

Developer experience changes, no user-facing changes. Testing can unfortunately only be done once it is merged.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*