### PR TITLE
chore(contactus): styling fixes based on design feedback

### DIFF
--- a/src/layouts/components/ContactUs/ContactCard.tsx
+++ b/src/layouts/components/ContactUs/ContactCard.tsx
@@ -122,7 +122,7 @@ export const ContactCard = ({
   return (
     <Editable.DraggableAccordionItem
       index={index}
-      title={frontMatter.title || "New Contact Information"}
+      title={frontMatter.title || "New contact information"}
       draggableId={`contacts-${index}`}
       isInvalid={getHasErrors(errors)}
     >

--- a/src/layouts/components/ContactUs/GeneralInfoSection.tsx
+++ b/src/layouts/components/ContactUs/GeneralInfoSection.tsx
@@ -36,7 +36,7 @@ export const GeneralInfoSection = ({
       title="General Information"
       isInvalid={!!errors.agency_name || !!errors.feedback}
     >
-      <Editable.Section spacing="1.25rem">
+      <Editable.Section spacing="1.25rem" pb="1.25rem">
         <FormControl isRequired isInvalid={!!errors.agency_name}>
           <FormLabel>Name of Organisation / Agency</FormLabel>
           <Input
@@ -69,8 +69,8 @@ export const GeneralInfoSection = ({
               />
               <Text textStyle="caption-2" color="base.content.medium">
                 <Text as="span">
-                  This is optional and appears at the bottom of your screen. If
-                  you don&apos;t have a feedback form, you can use
+                  This is optional and appears at the bottom of your Contact Us
+                  page. If you don&apos;t have a feedback form, you can use
                 </Text>
                 <Text as="span" fontWeight="bold">
                   {" "}

--- a/src/layouts/components/ContactUs/LocationCard.tsx
+++ b/src/layouts/components/ContactUs/LocationCard.tsx
@@ -53,7 +53,7 @@ export const LocationCard = ({
   return (
     <Editable.DraggableAccordionItem
       index={index}
-      title={frontMatter.title || "New Location"}
+      title={frontMatter.title || "New location"}
       draggableId={`locations-${index}`}
       isInvalid={getHasErrors(errors)}
     >
@@ -227,7 +227,7 @@ export const LocationCard = ({
                             colorScheme="critical"
                             mt="0.5rem"
                           >
-                            Remove operating hours
+                            Delete operating hours
                           </Button>
                         </Editable.Section>
                       </Editable.DraggableAccordionItem>
@@ -240,6 +240,7 @@ export const LocationCard = ({
         </DragDropContext>
 
         <AddSectionButton
+          mt="0.5rem"
           w="100%"
           id={`locations-${index}-add_operating_hours`}
           buttonText="Add operating hours"

--- a/src/layouts/components/ContactUs/LocationCard.tsx
+++ b/src/layouts/components/ContactUs/LocationCard.tsx
@@ -7,7 +7,6 @@ import {
   Input,
 } from "@opengovsg/design-system-react"
 import _ from "lodash"
-import { ChangeEvent } from "react"
 import { BiInfoCircle } from "react-icons/bi"
 
 import { useEditableContext } from "contexts/EditableContext"

--- a/src/layouts/components/Editable/AddSectionButton.tsx
+++ b/src/layouts/components/Editable/AddSectionButton.tsx
@@ -20,6 +20,7 @@ export const AddSectionButton = ({
             isStretch
             isOpen={isOpen}
             rightIcon={undefined}
+            size="lg"
             {...rest}
           >
             <HStack spacing="0.5rem" justify="center">

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -71,7 +71,13 @@ export const EmptySection = ({
       justifyContent="center"
     >
       {image}
-      <Text>{title}</Text>
+      <Text
+        textColor="base.content.strong"
+        textAlign="center"
+        lineHeight="1.75rem"
+      >
+        {title}
+      </Text>
       <Text
         textStyle="caption-2"
         textColor="base.content.medium"
@@ -97,7 +103,6 @@ const EditableSidebar = ({
       bg="base.canvas.alt"
       width="450px"
       overflowY="scroll"
-      pb="100px"
       // NOTE: We reserve 80px **each** for
       // both the header and the footer
       h="calc(100vh - 160px - 1rem)"
@@ -217,7 +222,7 @@ const EditableAccordionItem = ({
           {/* NOTE: Check with design on styling.
         See if entire section is button (ie, whole component hover styling)
       */}
-          <AccordionButton px="1.5rem" py="3rem">
+          <AccordionButton px="1.5rem" py="2.125rem">
             <Flex flex="1" flexDir="column">
               <Text textStyle="h6" textAlign="left" mt="0.25rem" noOfLines={1}>
                 {title}

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -72,9 +72,9 @@ export const EmptySection = ({
     >
       {image}
       <Text
+        textStyle="subhead-1"
         textColor="base.content.strong"
         textAlign="center"
-        lineHeight="1.75rem"
       >
         {title}
       </Text>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-538.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Some padding and copy changes were made based on the feedback obtained from @sehyunidaaa.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] When creating a new location and contact information card, the default card title should no longer be in titlecase
    - [ ] The bottom padding of the general information section should now be larger
    - [ ] The guiding information underneath the feedback form URL input box should be updated
    - [ ] "Remove operating hours" should be updated to say "Delete operating hours"
    - [ ] There should be more space between the "Add operating hours" and the last operating hours card
    - [ ] The Add section button should now be slightly bigger
    - [ ] The title text in an empty section should now be centre-aligned when the title text spills over to two lines
    - [ ] The extra spacing when scrolling the sidebar all the way to the bottom should now be removed
    - [ ] The size of the accordion of a non-draggable card should now be smaller
    - [ ] The title text of the empty section placeholder now uses `subhead-1` text styling

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*