### PR TITLE
feat(herobody): add first pass of layout

### DIFF
--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -152,7 +152,7 @@ type SectionAlignment = "left" | "right"
 
 type SectionBackgroundColor = "black" | "white" | "translucent gray"
 
-interface HeroSideSectionProps {
+interface HeroSideSectionProps extends HeroCenteredLayoutProps {
   background: string
   index: number
   errors: {
@@ -169,35 +169,25 @@ const HeroSideSectionLayout = ({
   background,
   index,
   errors,
+  title,
+  subtitle,
   size = "half",
   alignment = "left",
   backgroundColor = "black",
 }: HeroSideSectionProps) => {
-  const { onChange } = useEditableContext()
   const [, setSectionSize] = useState(size)
   const [, setSectionAlignment] = useState(alignment)
   const [, setSectionBackgroundColor] = useState(backgroundColor)
 
   return (
     <>
-      <Box w="100%">
-        {/* TODO: migrate this to design system components */}
-        <FormContext
-          hasError={!!errors.background}
-          onFieldChange={onChange}
-          isRequired
-        >
-          <Box mb="0.5rem">
-            <FormTitle>Hero background image</FormTitle>
-          </Box>
-          <FormFieldMedia
-            value={background}
-            id={`section-${index}-hero-background`}
-            inlineButtonText="Select"
-          />
-          <FormError>{errors.background}</FormError>
-        </FormContext>
-      </Box>
+      <HeroCenteredLayout
+        index={index}
+        background={background}
+        errors={errors}
+        title={title}
+        subtitle={subtitle}
+      />
       <Box>
         <Text textStyle="subhead-1">Section size</Text>
         <Radio.RadioGroup

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -57,6 +57,21 @@ const HERO_LAYOUTS = {
   },
 } as const
 
+const getIconButtonProps = (color: "black" | "grey" | "white") => {
+  return {
+    "aria-label": `${color} background`,
+    border: "1px solid",
+    borderColor: "border.input.default",
+    bg: color,
+    colorScheme: color,
+    size: "sm",
+    isRound: true,
+    _focus: {
+      boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
+    },
+  }
+}
+
 interface HeroCenteredLayoutProps extends HeroBodyFormFields {
   index: number
   errors: {
@@ -230,46 +245,19 @@ const HeroSideSectionLayout = ({
         <Text textStyle="subhead-1">Section background colour</Text>
         <HStack spacing="0.75rem" alignItems="flex-start">
           <IconButton
-            aria-label="black background"
-            border="1px solid"
-            borderColor="border.input.default"
-            bg="black"
-            colorScheme="black"
-            isRound
-            size="sm"
+            {...getIconButtonProps("black")}
             onClick={() => setSectionBackgroundColor("black")}
-            _focus={{
-              boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
-            }}
           >
             <Icon as={BiInfoCircle} fill="black" fontSize="1rem" />
           </IconButton>
           <IconButton
-            border="1px solid"
-            borderColor="border.input.default"
-            bg="white"
-            colorScheme="white"
-            isRound
-            size="sm"
-            aria-label="white background"
-            _focus={{
-              boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
-            }}
+            {...getIconButtonProps("white")}
             onClick={() => setSectionBackgroundColor("white")}
           >
             <Icon as={BiInfoCircle} fill="white" fontSize="1rem" />
           </IconButton>
           <IconButton
-            border="1px solid"
-            borderColor="border.input.default"
-            aria-label="gray background"
-            bg="gray"
-            colorScheme="grey"
-            isRound
-            size="sm"
-            _focus={{
-              boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
-            }}
+            {...getIconButtonProps("grey")}
             onClick={() => setSectionBackgroundColor("translucent gray")}
           />
         </HStack>

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -292,7 +292,8 @@ const HeroLayoutForm = ({ children }: HeroLayoutFormProps): JSX.Element => {
   )
 
   return (
-    <>
+    <VStack spacing="1rem" align="flex-start" w="100%">
+      <Text textStyle="h5">Customise layout</Text>
       <FormControl isRequired>
         <FormLabel textStyle="subhead-1">Layout</FormLabel>
         <SingleSelect
@@ -307,7 +308,7 @@ const HeroLayoutForm = ({ children }: HeroLayoutFormProps): JSX.Element => {
       <VStack spacing="1rem" w="100%">
         {children({ currentSelectedOption: currentLayout })}
       </VStack>
-    </>
+    </VStack>
   )
 }
 
@@ -395,8 +396,11 @@ export const HeroBody = ({
       <Divider my="1.5rem" />
       <Editable.Section spacing="0.75rem">
         <Box w="100%">
-          <Text textStyle="h5" mb="1rem">
-            Customise Layout
+          <Text textStyle="h5" mb="0.75rem">
+            Hero Interactions
+          </Text>
+          <Text textStyle="subhead-2" mb="0.25rem">
+            Content type
           </Text>
           <Radio.RadioGroup
             onChange={(nextSectionType: HeroSectionType) => {

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -5,14 +5,19 @@ import {
   Text,
   Box,
   Divider,
+  VStack,
   HStack,
+  Spacer,
 } from "@chakra-ui/react"
 import {
   FormErrorMessage,
   FormLabel,
+  IconButton,
   Input,
   Radio,
+  SingleSelect,
 } from "@opengovsg/design-system-react"
+import _ from "lodash"
 import { useState } from "react"
 import { BiInfoCircle } from "react-icons/bi"
 
@@ -37,6 +42,285 @@ export interface HeroBodyFormFields {
   background: string
 }
 
+const HERO_LAYOUTS = {
+  CENTERED: {
+    value: "center",
+    label: "Centre-aligned text",
+  },
+  IMAGE_ONLY: {
+    value: "image",
+    label: "Image only",
+  },
+  SIDE_SECTION: {
+    value: "side",
+    label: "Side section",
+  },
+} as const
+
+interface HeroCenteredLayoutProps extends HeroBodyFormFields {
+  index: number
+  errors: {
+    title: string
+    subtitle: string
+    background: string
+  } & HeroBodyFormFields
+}
+
+const HeroCenteredLayout = ({
+  title,
+  subtitle,
+  background,
+  index,
+  errors,
+}: HeroCenteredLayoutProps) => {
+  const { onChange } = useEditableContext()
+  return (
+    <>
+      <FormControl isRequired isInvalid={!!errors.title}>
+        <FormLabel>Hero title</FormLabel>
+        <Input
+          placeholder="Hero title"
+          id={`section-${index}-hero-title`}
+          value={title}
+          onChange={onChange}
+        />
+        <FormErrorMessage>{errors.title}</FormErrorMessage>
+      </FormControl>
+      <FormControl isRequired isInvalid={!!errors.subtitle}>
+        <FormLabel>Hero subtitle</FormLabel>
+        <Input
+          placeholder="Hero subtitle"
+          id={`section-${index}-hero-subtitle`}
+          value={subtitle}
+          onChange={onChange}
+        />
+        <FormErrorMessage>{errors.subtitle}</FormErrorMessage>
+      </FormControl>
+      <Box w="100%">
+        {/* TODO: migrate this to design system components */}
+        <FormContext
+          hasError={!!errors.background}
+          onFieldChange={onChange}
+          isRequired
+        >
+          <Box mb="0.5rem">
+            <FormTitle>Hero background image</FormTitle>
+          </Box>
+          <FormFieldMedia
+            value={background}
+            id={`section-${index}-hero-background`}
+            inlineButtonText="Select"
+          />
+          <FormError>{errors.background}</FormError>
+        </FormContext>
+      </Box>
+    </>
+  )
+}
+
+const HeroImageOnlyLayout = ({
+  errors,
+  background,
+  index,
+}: Omit<HeroCenteredLayoutProps, "subtitle" | "title">) => {
+  const { onChange } = useEditableContext()
+  return (
+    <Box w="100%">
+      {/* TODO: migrate this to design system components */}
+      <FormContext
+        hasError={!!errors.background}
+        onFieldChange={onChange}
+        isRequired
+      >
+        <Box mb="0.5rem">
+          <FormTitle>Hero background image</FormTitle>
+        </Box>
+        <FormFieldMedia
+          value={background}
+          id={`section-${index}-hero-background`}
+          inlineButtonText="Select"
+        />
+        <FormError>{errors.background}</FormError>
+      </FormContext>
+    </Box>
+  )
+}
+
+type SectionSize = "half" | "one-third"
+
+type SectionAlignment = "left" | "right"
+
+type SectionBackgroundColor = "black" | "white" | "translucent gray"
+
+interface HeroSideSectionProps {
+  background: string
+  index: number
+  errors: {
+    title: string
+    subtitle: string
+    background: string
+  } & HeroBodyFormFields
+  size: SectionSize
+  alignment: SectionAlignment
+  backgroundColor: SectionBackgroundColor
+}
+
+const HeroSideSectionLayout = ({
+  background,
+  index,
+  errors,
+  size = "half",
+  alignment = "left",
+  backgroundColor = "black",
+}: HeroSideSectionProps) => {
+  const { onChange } = useEditableContext()
+  const [, setSectionSize] = useState(size)
+  const [, setSectionAlignment] = useState(alignment)
+  const [, setSectionBackgroundColor] = useState(backgroundColor)
+
+  return (
+    <>
+      <Box w="100%">
+        {/* TODO: migrate this to design system components */}
+        <FormContext
+          hasError={!!errors.background}
+          onFieldChange={onChange}
+          isRequired
+        >
+          <Box mb="0.5rem">
+            <FormTitle>Hero background image</FormTitle>
+          </Box>
+          <FormFieldMedia
+            value={background}
+            id={`section-${index}-hero-background`}
+            inlineButtonText="Select"
+          />
+          <FormError>{errors.background}</FormError>
+        </FormContext>
+      </Box>
+      <Box>
+        <Text textStyle="subhead-1">Section size</Text>
+        <Radio.RadioGroup
+          onChange={(nextSectionSize) => {
+            setSectionSize(nextSectionSize as SectionSize)
+          }}
+          defaultValue="half"
+        >
+          <HStack spacing="0.5rem">
+            <Radio value="half" size="xs" w="50%" allowDeselect={false}>
+              Half (1/2) of banner
+            </Radio>
+            <Spacer />
+            <Radio value="one-third" size="xs" w="50%" allowDeselect={false}>
+              Third (1/3) of banner
+            </Radio>
+          </HStack>
+        </Radio.RadioGroup>
+      </Box>
+      <Box w="100%">
+        <Text textStyle="subhead-1">Alignment</Text>
+        <Radio.RadioGroup
+          onChange={(nextSectionAlignment) => {
+            setSectionAlignment(nextSectionAlignment as SectionAlignment)
+          }}
+          defaultValue="left"
+        >
+          <HStack spacing="0.5rem">
+            <Radio value="left" size="xs" w="50%" allowDeselect={false}>
+              Left
+            </Radio>
+            <Spacer />
+            <Radio value="right" size="xs" w="50%" allowDeselect={false}>
+              Right
+            </Radio>
+          </HStack>
+        </Radio.RadioGroup>
+      </Box>
+      <Box w="100%">
+        <Text textStyle="subhead-1">Section background colour</Text>
+        <HStack spacing="0.75rem" alignItems="flex-start">
+          <IconButton
+            aria-label="black background"
+            border="1px solid"
+            borderColor="border.input.default"
+            bg="black"
+            colorScheme="black"
+            isRound
+            size="sm"
+            onClick={() => setSectionBackgroundColor("black")}
+            _focus={{
+              boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
+            }}
+          >
+            <Icon as={BiInfoCircle} fill="black" fontSize="1rem" />
+          </IconButton>
+          <IconButton
+            border="1px solid"
+            borderColor="border.input.default"
+            bg="white"
+            colorScheme="white"
+            isRound
+            size="sm"
+            aria-label="white background"
+            _focus={{
+              boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
+            }}
+            onClick={() => setSectionBackgroundColor("white")}
+          >
+            <Icon as={BiInfoCircle} fill="white" fontSize="1rem" />
+          </IconButton>
+          <IconButton
+            border="1px solid"
+            borderColor="border.input.default"
+            aria-label="gray background"
+            bg="gray"
+            colorScheme="grey"
+            isRound
+            size="sm"
+            _focus={{
+              boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
+            }}
+            onClick={() => setSectionBackgroundColor("translucent gray")}
+          />
+        </HStack>
+      </Box>
+    </>
+  )
+}
+
+type HeroBannerLayouts = typeof HERO_LAYOUTS[keyof typeof HERO_LAYOUTS]["value"]
+
+interface HeroLayoutFormProps {
+  children: (props: {
+    currentSelectedOption: HeroBannerLayouts
+  }) => React.ReactNode
+}
+
+const HeroLayoutForm = ({ children }: HeroLayoutFormProps): JSX.Element => {
+  const [currentLayout, setCurrentLayout] = useState<HeroBannerLayouts>(
+    HERO_LAYOUTS.CENTERED.value
+  )
+
+  return (
+    <>
+      <FormControl isRequired>
+        <FormLabel textStyle="subhead-1">Layout</FormLabel>
+        <SingleSelect
+          isClearable={false}
+          name="hero layout options"
+          value={currentLayout}
+          items={_.values(HERO_LAYOUTS)}
+          // NOTE: Safe cast - the possible values are given by `HERO_LAYOUTS`
+          onChange={(val) => setCurrentLayout(val as HeroBannerLayouts)}
+        />
+      </FormControl>
+      <VStack spacing="1rem" w="100%">
+        {children({ currentSelectedOption: currentLayout })}
+      </VStack>
+    </>
+  )
+}
+
 interface HeroBodyProps extends HeroBodyFormFields {
   index: number
   errors: {
@@ -55,15 +339,11 @@ interface HeroBodyProps extends HeroBodyFormFields {
 }
 
 export const HeroBody = ({
-  title,
-  subtitle,
-  background,
-  index,
-  errors,
   handleHighlightDropdownToggle,
   notification,
   children,
   initialSectionType,
+  ...rest
 }: HeroBodyProps) => {
   const [heroSectionType, setHeroSectionType] = useState<HeroSectionType>(
     initialSectionType
@@ -95,48 +375,36 @@ export const HeroBody = ({
             </Text>
           </Flex>
         </FormControl>
-        <FormControl isRequired isInvalid={!!errors.title}>
-          <FormLabel>Hero title</FormLabel>
-          <Input
-            placeholder="Hero title"
-            id={`section-${index}-hero-title`}
-            value={title}
-            onChange={onChange}
-          />
-          <FormErrorMessage>{errors.title}</FormErrorMessage>
-        </FormControl>
-        <FormControl isRequired isInvalid={!!errors.subtitle}>
-          <FormLabel>Hero subtitle</FormLabel>
-          <Input
-            placeholder="Hero subtitle"
-            id={`section-${index}-hero-subtitle`}
-            value={subtitle}
-            onChange={onChange}
-          />
-          <FormErrorMessage>{errors.subtitle}</FormErrorMessage>
-        </FormControl>
-        <Box w="100%">
-          {/* TODO: migrate this to design system components */}
-          <FormContext
-            hasError={!!errors.background}
-            onFieldChange={onChange}
-            isRequired
-          >
-            <Box mb="0.75rem">
-              <FormTitle>Hero background image</FormTitle>
-            </Box>
-            <FormFieldMedia
-              value={background}
-              id={`section-${index}-hero-background`}
-              inlineButtonText="Select"
-            />
-            <FormError>{errors.background}</FormError>
-          </FormContext>
-        </Box>
+        <Divider my="0.25rem" />
+        <HeroLayoutForm>
+          {({ currentSelectedOption }) => {
+            if (currentSelectedOption === HERO_LAYOUTS.CENTERED.value) {
+              return <HeroCenteredLayout {...rest} />
+            }
+
+            if (currentSelectedOption === HERO_LAYOUTS.IMAGE_ONLY.value) {
+              return <HeroImageOnlyLayout {...rest} />
+            }
+
+            if (currentSelectedOption === HERO_LAYOUTS.SIDE_SECTION.value) {
+              return (
+                <HeroSideSectionLayout
+                  {...rest}
+                  size="half"
+                  alignment="left"
+                  backgroundColor="black"
+                />
+              )
+            }
+
+            const unmatchedOption: never = currentSelectedOption
+            throw new Error(`Unmatched option for layout: ${unmatchedOption}`)
+          }}
+        </HeroLayoutForm>
       </Editable.Section>
       <Divider my="1.5rem" />
       <Editable.Section spacing="0.75rem">
-        <Box>
+        <Box w="100%">
           <Text textStyle="h5" mb="1rem">
             Customise Layout
           </Text>
@@ -151,21 +419,11 @@ export const HeroBody = ({
             }}
             defaultValue={initialSectionType}
           >
-            <HStack spacing="2rem">
-              <Radio
-                value="highlights"
-                size="xs"
-                w="fit-content"
-                allowDeselect={false}
-              >
+            <HStack spacing="1rem" w="100%">
+              <Radio value="highlights" size="xs" w="50%" allowDeselect={false}>
                 Button + Highlights
               </Radio>
-              <Radio
-                value="dropdown"
-                size="xs"
-                w="fit-content"
-                allowDeselect={false}
-              >
+              <Radio value="dropdown" size="xs" w="50%" allowDeselect={false}>
                 Dropdown
               </Radio>
             </HStack>


### PR DESCRIPTION
## Problem
we need to add new layout options for hero banner

## Solution
- Add panels on the hero section first
- changed hero body so that it contains the new options now


## Screenshots
![Recording 2023-09-08 at 14 39 45](https://github.com/isomerpages/isomercms-frontend/assets/44049504/f5f9f978-79b0-4dab-8b5a-27d800683407)

## Tests
- [ ] go to homepage
- [ ] click on the hero section
- [ ] select the various new layouts
- [ ] the panel should reflect the new options
- [ ] the **preview should not work**