### PR TITLE
fix(edithomepage): spread correct property

### DIFF
--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -964,7 +964,7 @@ const EditHomepage = ({ match }) => {
                               {({ currentSelectedOption }) =>
                                 currentSelectedOption === "dropdown" ? (
                                   <HeroDropdownSection
-                                    {...section.hero}
+                                    {...section.hero.dropdown}
                                     state={section.hero}
                                     errors={errors}
                                   />


### PR DESCRIPTION
## Problem
Previously, the dropdown title could not be edited properly

Closes IS-547

## Solution
spread the correct property

## Tests
- [ ] go to homepage
- [ ] select dropdown
- [ ] try to chnage the title
- [ ] it should succeed
![Recording 2023-09-06 at 13 01 22](https://github.com/isomerpages/isomercms-frontend/assets/44049504/a8961bef-4a7a-433f-8537-8eb1a0112a48)
