### PR TITLE
fix(editable): change drag handle to be on top part only

### DIFF
--- a/src/layouts/components/ContactUs/LocationCard.tsx
+++ b/src/layouts/components/ContactUs/LocationCard.tsx
@@ -133,9 +133,7 @@ export const LocationCard = ({
               isEmpty={frontMatter.operating_hours.length === 0}
             >
               <Editable.Accordion>
-                {/* Note: contentEditable is required to stop drag and drop
-                    from hitting the first level drag and drop */}
-                <VStack p={0} spacing="0.75rem" contentEditable>
+                <VStack p={0} spacing="1.125rem">
                   {frontMatter.operating_hours.map(
                     (operatingHour, operatingHourIndex) => (
                       <Editable.DraggableAccordionItem

--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -319,7 +319,7 @@ const DraggableAccordionItem = ({
           borderRadius={isNested ? "0.375rem" : "0.5rem"}
           {...draggableProvided.draggableProps}
           ref={draggableProvided.innerRef}
-          {...draggableProvided.dragHandleProps}
+          boxShadow="sm"
           position="relative"
         >
           {({ isExpanded }) => (
@@ -379,6 +379,7 @@ const DraggableAccordionItem = ({
                   borderRadius: isNested ? "0.375rem" : "0.5rem",
                 }}
                 bgColor="none"
+                {...draggableProvided.dragHandleProps}
               >
                 {isNested && (
                   <IconButton

--- a/src/layouts/components/NavBar/GroupMenuBody.tsx
+++ b/src/layouts/components/NavBar/GroupMenuBody.tsx
@@ -76,8 +76,7 @@ export const GroupMenuBody = ({
               <Editable.Accordion>
                 <VStack p={0} spacing="1.25rem">
                   {sublinks.map((sublink, sublinkIndex) => (
-                    // Note: contentEditable is required to stop drag and drop from hitting the first level drag and drop
-                    <VStack contentEditable w="100%">
+                    <VStack w="100%">
                       <Editable.DraggableAccordionItem
                         draggableId={`sublink-${index}-${sublinkIndex}-draggable`}
                         index={sublinkIndex}


### PR DESCRIPTION
## Problem
Previously, when we cancelled deletion of a sub-menu, there would be a cursor popping up on the button due to usage of `contentEditable`. 

## Solution
Make only the **top portion** of the accordion teh drag handle. this was preferred over making the icon the drag handle as it preserves existing behaviour on production. 

as users have been trained that the entire card can be dragged, we don't want to break that existing mental model. users are also unlikely to drag the body due to the large # of inputs there and small draggable area, so this is a compromise we're (me + design) is ok with for now. 

**Video**:
**old behaviour w ss**
link [here](https://www.notion.so/opengov/Restyling-feedback-3a4dc84523ff44529e0644ae85b4e0ca?pvs=4#9f212ed8d4e94acfb2253e9d8f2f3572)

**new behaviour**
![Recording 2023-09-06 at 13 26 45](https://github.com/isomerpages/isomercms-frontend/assets/44049504/e7958b54-4690-4a94-b06e-48ecdec96d31)

## Tests
- [ ] go to nav bar
- [ ] add **2** sub menu
- [ ] click on delete sub menu **but cancel the deletion**
- [ ] the delete button should not have a cursor 