### PR TITLE
fix(editable): hover and focus states for title text

### DIFF
--- a/src/layouts/components/Editable/Editable.tsx
+++ b/src/layouts/components/Editable/Editable.tsx
@@ -368,7 +368,7 @@ const DraggableAccordionItem = ({
               <Flex
                 pt={isNested ? "0.375rem" : "1.88rem"}
                 pb={!isExpanded && !isNested ? "0.88rem" : "0rem"}
-                role="group"
+                data-group
                 _hover={{
                   bgColor: getDraggableAccordionItemStyle({
                     item: "hover-bgColor",
@@ -432,6 +432,9 @@ const DraggableAccordionItem = ({
                         isNested,
                         isInvalid,
                       }),
+                    }}
+                    _groupFocus={{
+                      color: "base.content.strong",
                     }}
                   >
                     {title}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The hover and focus states for the title text in a nested editable accordion was not implemented properly.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The group hover selector is now fixed
- The font colour change for the title text on focus state is now supported

## Before & After Screenshots

https://github.com/isomerpages/isomercms-frontend/assets/27919917/dd8d596f-6b5d-4931-9da1-d3ad45a1c4c8

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Verify that the nested card title font colour changes on hover
    - [ ] Verify that the nested card title font colour changes on focus

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*