### PR TITLE
fix(edithomepage): spread properly

### DIFF
--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -964,8 +964,8 @@ const EditHomepage = ({ match }) => {
                               {({ currentSelectedOption }) =>
                                 currentSelectedOption === "dropdown" ? (
                                   <HeroDropdownSection
+                                    {...section.hero}
                                     {...section.hero.dropdown}
-                                    state={section.hero}
                                     errors={{
                                       ...errors,
                                       ...errors.sections[0].hero,

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -978,6 +978,7 @@ const EditHomepage = ({ match }) => {
                                       ...errors.sections[0].hero,
                                     }}
                                     highlights={section.hero.key_highlights}
+                                    {...section.hero}
                                   />
                                 )
                               }

--- a/src/layouts/components/Homepage/HeroDropdownSection.tsx
+++ b/src/layouts/components/Homepage/HeroDropdownSection.tsx
@@ -20,19 +20,18 @@ export interface HeroDropdownFormFields {
   url: string
 }
 
-interface HeroDropdownSectionProps {
+interface HeroDropdownSectionProps extends EditorHeroDropdownSection {
   errors: {
     dropdownElems: HeroDropdownFormFields[]
     title: string
     dropdown: string
   }
-  state: EditorHeroDropdownSection
   title: string
 }
 
 export const HeroDropdownSection = ({
   errors,
-  state,
+  dropdown,
   title,
 }: HeroDropdownSectionProps) => {
   const {
@@ -67,10 +66,10 @@ export const HeroDropdownSection = ({
             <Editable.EmptySection
               title="Options you add will appear here"
               subtitle="Add options to allow users to quickly navigate your site"
-              isEmpty={state.dropdown.options.length === 0}
+              isEmpty={dropdown.options.length === 0}
             >
               <Editable.Section px={0} spacing="0.75rem" py="1.5rem">
-                {state.dropdown.options.map(
+                {dropdown.options.map(
                   (
                     { title: optionTitle, url: optionUrl },
                     dropdownOptionIndex
@@ -145,7 +144,7 @@ export const HeroDropdownSection = ({
         </Editable.Droppable>
       </DragDropContext>
       <Button
-        id={`dropdownelem-${state.dropdown.options.length}-create`}
+        id={`dropdownelem-${dropdown.options.length}-create`}
         onClick={() => onCreate({ target: { id: "dropdownelem" } })}
         variant="outline"
         w="full"


### PR DESCRIPTION
## Problem
Previously the highlight section was missing properties due to a missing spread after rebase (sadge). This led to the input being blank on initial load (edits etc will still work)

## Solution
spread the property of `section.hero`

## Tests
- [ ] on initial load, the button/url should both contain the properties of the button on the preview
- [ ] on save + reload, the new changes should be persisted to the input