### PR TITLE
fix(herobody): solves empty highlight deafult issue

### DIFF
--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -961,9 +961,9 @@ const EditHomepage = ({ match }) => {
                                 handleHighlightDropdownToggle
                               }
                               initialSectionType={
-                                section.hero.key_highlights
-                                  ? "highlights"
-                                  : "dropdown"
+                                section.hero.dropdown
+                                  ? "dropdown"
+                                  : "highlights"
                               }
                             >
                               {({ currentSelectedOption }) =>

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -960,6 +960,11 @@ const EditHomepage = ({ match }) => {
                               handleHighlightDropdownToggle={
                                 handleHighlightDropdownToggle
                               }
+                              initialSectionType={
+                                section.hero.key_highlights
+                                  ? "highlights"
+                                  : "dropdown"
+                              }
                             >
                               {({ currentSelectedOption }) =>
                                 currentSelectedOption === "dropdown" ? (

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -51,6 +51,7 @@ interface HeroBodyProps extends HeroBodyFormFields {
   children: (props: {
     currentSelectedOption: HeroSectionType
   }) => React.ReactNode
+  initialSectionType: HeroSectionType
 }
 
 export const HeroBody = ({
@@ -62,9 +63,10 @@ export const HeroBody = ({
   handleHighlightDropdownToggle,
   notification,
   children,
+  initialSectionType,
 }: HeroBodyProps) => {
   const [heroSectionType, setHeroSectionType] = useState<HeroSectionType>(
-    "highlights"
+    initialSectionType
   )
   const { onChange } = useEditableContext()
 
@@ -147,7 +149,7 @@ export const HeroBody = ({
                 },
               })
             }}
-            defaultValue="highlights"
+            defaultValue={initialSectionType}
           >
             <HStack spacing="2rem">
               <Radio

--- a/src/layouts/components/Homepage/HeroDropdownSection.tsx
+++ b/src/layouts/components/Homepage/HeroDropdownSection.tsx
@@ -31,7 +31,7 @@ interface HeroDropdownSectionProps extends EditorHeroDropdownSection {
 
 export const HeroDropdownSection = ({
   errors,
-  dropdown,
+  dropdown = { options: [] },
   title,
 }: HeroDropdownSectionProps) => {
   const {


### PR DESCRIPTION
## Problem
Previously we default to `highlights` - however, a bug existed where if you had empty highlights, adding the highlight options would not work **on preview** (because our preview checks using the `!hero.dropdown` property 

## Solution
update `HeroBody` component so that we take an `initialSectionType` so it fits with how preview does the dropdown/highlight

## Tests
- [ ] go to a site
- [ ] delete all highlights and make highlight the selected option
- [ ] click save
- [ ] reload the page
- [ ] click add highlight option
- [ ] a highlight should show on previwe