### PR TITLE
feat(homepage): add previews for side layout

### DIFF
--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -51,19 +51,19 @@ export interface HeroBodyFormFields {
   background: string
 }
 
-const getIconButtonProps = (color: "black" | "grey" | "white") => {
+const getIconButtonProps = (color: SectionBackgroundColor) => {
   return {
     "aria-label": `${color} background`,
     border: "1px solid",
     borderColor: "border.input.default",
-    bg: color === "grey" ? "base.divider.strong" : color,
+    bg: color === "gray" ? "base.divider.strong" : color,
     colorScheme: color,
     size: "sm",
     isRound: true,
     _focus: {
       boxShadow: "0 0 0 2px var(--chakra-colors-border-action-default)",
     },
-    ...(color === "grey" && {
+    ...(color === "gray" && {
       _hover: {
         bg: "base.divider.strong",
       },
@@ -181,7 +181,7 @@ const HeroSideSectionLayout = ({
   alignment = "left",
 }: HeroSideSectionProps) => {
   const { onChange } = useEditableContext()
-  const onClick = (value: string) =>
+  const onClick = (value: SectionBackgroundColor) =>
     onChange({
       target: {
         id: "section-0-hero-backgroundColor",
@@ -268,7 +268,7 @@ const HeroSideSectionLayout = ({
           </Tooltip>
           <Tooltip label="translucent gray" hasArrow>
             <IconButton
-              {...getIconButtonProps("grey")}
+              {...getIconButtonProps("gray")}
               onClick={() => onClick("gray")}
               icon={<BxGrayTranslucent />}
             />

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -16,6 +16,7 @@ import {
   Input,
   Radio,
   SingleSelect,
+  Tooltip,
 } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { useState } from "react"
@@ -180,6 +181,13 @@ const HeroSideSectionLayout = ({
   alignment = "left",
 }: HeroSideSectionProps) => {
   const { onChange } = useEditableContext()
+  const onClick = (value: string) =>
+    onChange({
+      target: {
+        id: "section-0-hero-backgroundColor",
+        value,
+      },
+    })
 
   return (
     <>
@@ -242,44 +250,29 @@ const HeroSideSectionLayout = ({
       <Box w="100%">
         <Text textStyle="subhead-1">Section background colour</Text>
         <HStack spacing="0.75rem" alignItems="flex-start">
-          <IconButton
-            {...getIconButtonProps("black")}
-            onClick={() =>
-              onChange({
-                target: {
-                  id: "section-0-hero-backgroundColor",
-                  value: "black",
-                },
-              })
-            }
-          >
-            <Icon as={BiInfoCircle} fill="black" fontSize="1rem" />
-          </IconButton>
-          <IconButton
-            {...getIconButtonProps("white")}
-            onClick={() =>
-              onChange({
-                target: {
-                  id: "section-0-hero-backgroundColor",
-                  value: "white",
-                },
-              })
-            }
-          >
-            <Icon as={BiInfoCircle} fill="white" fontSize="1rem" />
-          </IconButton>
-          <IconButton
-            {...getIconButtonProps("grey")}
-            onClick={() =>
-              onChange({
-                target: {
-                  id: "section-0-hero-backgroundColor",
-                  value: "gray",
-                },
-              })
-            }
-            icon={<BxGrayTranslucent />}
-          />
+          <Tooltip label="black" hasArrow>
+            <IconButton
+              {...getIconButtonProps("black")}
+              onClick={() => onClick("black")}
+            >
+              <Icon as={BiInfoCircle} fill="black" fontSize="1rem" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip label="white" hasArrow>
+            <IconButton
+              {...getIconButtonProps("white")}
+              onClick={() => onClick("white")}
+            >
+              <Icon as={BiInfoCircle} fill="white" fontSize="1rem" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip label="translucent gray" hasArrow>
+            <IconButton
+              {...getIconButtonProps("grey")}
+              onClick={() => onClick("gray")}
+              icon={<BxGrayTranslucent />}
+            />
+          </Tooltip>
         </HStack>
       </Box>
     </>

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -134,7 +134,6 @@ const HeroCenteredLayout = ({
 const HeroImageOnlyLayout = ({
   errors,
   background,
-  index,
 }: Omit<HeroCenteredLayoutProps, "subtitle" | "title">) => {
   const { onChange } = useEditableContext()
   return (
@@ -150,7 +149,7 @@ const HeroImageOnlyLayout = ({
         </Box>
         <FormFieldMedia
           value={background}
-          id={`section-${index}-hero-background`}
+          id="section-0-hero-background"
           inlineButtonText="Select"
         />
         <FormError>{errors.background}</FormError>
@@ -169,7 +168,6 @@ interface HeroSideSectionProps extends HeroCenteredLayoutProps {
   } & HeroBodyFormFields
   size: SectionSize
   alignment: SectionAlignment
-  backgroundColor: SectionBackgroundColor
 }
 
 const HeroSideSectionLayout = ({
@@ -178,13 +176,10 @@ const HeroSideSectionLayout = ({
   errors,
   title,
   subtitle,
-  size = "half",
+  size = "50%",
   alignment = "left",
-  backgroundColor = "black",
 }: HeroSideSectionProps) => {
-  const [, setSectionSize] = useState(size)
-  const [, setSectionAlignment] = useState(alignment)
-  const [, setSectionBackgroundColor] = useState(backgroundColor)
+  const { onChange } = useEditableContext()
 
   return (
     <>
@@ -199,16 +194,22 @@ const HeroSideSectionLayout = ({
         <Text textStyle="subhead-1">Section size</Text>
         <Radio.RadioGroup
           onChange={(nextSectionSize) => {
-            setSectionSize(nextSectionSize as SectionSize)
+            onChange({
+              target: {
+                id: "section-0-hero-size",
+                value: nextSectionSize,
+              },
+            })
           }}
-          defaultValue="half"
+          // section-0-hero-background
+          defaultValue={size || "half"}
         >
           <HStack spacing="0.5rem">
-            <Radio value="half" size="xs" w="50%" allowDeselect={false}>
+            <Radio value="50%" size="xs" w="50%" allowDeselect={false}>
               Half (1/2) of banner
             </Radio>
             <Spacer />
-            <Radio value="one-third" size="xs" w="50%" allowDeselect={false}>
+            <Radio value="33%" size="xs" w="50%" allowDeselect={false}>
               Third (1/3) of banner
             </Radio>
           </HStack>
@@ -218,9 +219,14 @@ const HeroSideSectionLayout = ({
         <Text textStyle="subhead-1">Alignment</Text>
         <Radio.RadioGroup
           onChange={(nextSectionAlignment) => {
-            setSectionAlignment(nextSectionAlignment as SectionAlignment)
+            onChange({
+              target: {
+                id: "section-0-hero-alignment",
+                value: nextSectionAlignment,
+              },
+            })
           }}
-          defaultValue="left"
+          defaultValue={alignment || "left"}
         >
           <HStack spacing="0.5rem">
             <Radio value="left" size="xs" w="50%" allowDeselect={false}>
@@ -238,19 +244,40 @@ const HeroSideSectionLayout = ({
         <HStack spacing="0.75rem" alignItems="flex-start">
           <IconButton
             {...getIconButtonProps("black")}
-            onClick={() => setSectionBackgroundColor("black")}
+            onClick={() =>
+              onChange({
+                target: {
+                  id: "section-0-hero-backgroundColor",
+                  value: "black",
+                },
+              })
+            }
           >
             <Icon as={BiInfoCircle} fill="black" fontSize="1rem" />
           </IconButton>
           <IconButton
             {...getIconButtonProps("white")}
-            onClick={() => setSectionBackgroundColor("white")}
+            onClick={() =>
+              onChange({
+                target: {
+                  id: "section-0-hero-backgroundColor",
+                  value: "white",
+                },
+              })
+            }
           >
             <Icon as={BiInfoCircle} fill="white" fontSize="1rem" />
           </IconButton>
           <IconButton
             {...getIconButtonProps("grey")}
-            onClick={() => setSectionBackgroundColor("translucent gray")}
+            onClick={() =>
+              onChange({
+                target: {
+                  id: "section-0-hero-backgroundColor",
+                  value: "gray",
+                },
+              })
+            }
             icon={<BxGrayTranslucent />}
           />
         </HStack>
@@ -317,6 +344,8 @@ interface HeroBodyProps extends HeroBodyFormFields {
   }) => React.ReactNode
   initialSectionType: HeroSectionType
   variant: HeroBannerLayouts
+  size: SectionSize
+  alignment: SectionAlignment
 }
 
 export const HeroBody = ({
@@ -369,14 +398,7 @@ export const HeroBody = ({
             }
 
             if (currentSelectedOption === HERO_LAYOUTS.SIDE_SECTION.value) {
-              return (
-                <HeroSideSectionLayout
-                  {...rest}
-                  size="half"
-                  alignment="left"
-                  backgroundColor="black"
-                />
-              )
+              return <HeroSideSectionLayout {...rest} />
             }
 
             const unmatchedOption: never = currentSelectedOption

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -31,6 +31,11 @@ import { useEditableContext } from "contexts/EditableContext"
 import { Editable } from "layouts/components/Editable"
 
 import { BxGrayTranslucent } from "assets"
+import {
+  SectionSize,
+  SectionAlignment,
+  SectionBackgroundColor,
+} from "types/hero"
 import { HeroBannerLayouts, HighlightOption } from "types/homepage"
 
 import { HeroDropdownFormFields } from "./HeroDropdownSection"
@@ -153,12 +158,6 @@ const HeroImageOnlyLayout = ({
     </Box>
   )
 }
-
-type SectionSize = "half" | "one-third"
-
-type SectionAlignment = "left" | "right"
-
-type SectionBackgroundColor = "black" | "white" | "translucent gray"
 
 interface HeroSideSectionProps extends HeroCenteredLayoutProps {
   background: string

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -181,7 +181,7 @@ const HeroSideSectionLayout = ({
   alignment = "left",
 }: HeroSideSectionProps) => {
   const { onChange } = useEditableContext()
-  const onClick = (value: SectionBackgroundColor) =>
+  const onIconButtonClick = (value: SectionBackgroundColor) =>
     onChange({
       target: {
         id: "section-0-hero-backgroundColor",
@@ -209,8 +209,7 @@ const HeroSideSectionLayout = ({
               },
             })
           }}
-          // section-0-hero-background
-          defaultValue={size || "half"}
+          defaultValue={size}
         >
           <HStack spacing="0.5rem">
             <Radio value="50%" size="xs" w="50%" allowDeselect={false}>
@@ -234,7 +233,7 @@ const HeroSideSectionLayout = ({
               },
             })
           }}
-          defaultValue={alignment || "left"}
+          defaultValue={alignment}
         >
           <HStack spacing="0.5rem">
             <Radio value="left" size="xs" w="50%" allowDeselect={false}>
@@ -253,7 +252,7 @@ const HeroSideSectionLayout = ({
           <Tooltip label="black" hasArrow>
             <IconButton
               {...getIconButtonProps("black")}
-              onClick={() => onClick("black")}
+              onClick={() => onIconButtonClick("black")}
             >
               <Icon as={BiInfoCircle} fill="black" fontSize="1rem" />
             </IconButton>
@@ -261,7 +260,7 @@ const HeroSideSectionLayout = ({
           <Tooltip label="white" hasArrow>
             <IconButton
               {...getIconButtonProps("white")}
-              onClick={() => onClick("white")}
+              onClick={() => onIconButtonClick("white")}
             >
               <Icon as={BiInfoCircle} fill="white" fontSize="1rem" />
             </IconButton>
@@ -269,7 +268,7 @@ const HeroSideSectionLayout = ({
           <Tooltip label="translucent gray" hasArrow>
             <IconButton
               {...getIconButtonProps("gray")}
-              onClick={() => onClick("gray")}
+              onClick={() => onIconButtonClick("gray")}
               icon={<BxGrayTranslucent />}
             />
           </Tooltip>

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -1,4 +1,10 @@
 @charset "UTF-8";
+@use 'templates/components/hero.scss';
+@use "templates/theme/padding.scss";
+@use "templates/theme/text-styles.scss";
+@use "templates/theme/margin.scss";
+@use "templates/theme/layout.scss";
+@use "templates/theme/background.scss";
 
 .bg-media-color-0 {
   background-color: #4b268e;

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -10889,7 +10889,6 @@ a.navbar-link:hover {
 .bp-hero-body {
   flex-grow: 1;
   flex-shrink: 0;
-  padding: 3rem 1.5rem;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/styles/templates/components/hero.scss
+++ b/src/styles/templates/components/hero.scss
@@ -5,3 +5,7 @@
 .gray-overlay {
   background: rgba(0, 0, 0, 0.25);
 }
+
+.with-padding {
+  padding: 3rem 1.5rem;
+}

--- a/src/styles/templates/theme/background.scss
+++ b/src/styles/templates/theme/background.scss
@@ -1,0 +1,3 @@
+.bg-white {
+  background-color: white;
+}

--- a/src/styles/templates/theme/layout.scss
+++ b/src/styles/templates/theme/layout.scss
@@ -1,0 +1,3 @@
+.flex-end {
+  justify-content: flex-end;
+}

--- a/src/styles/templates/theme/margin.scss
+++ b/src/styles/templates/theme/margin.scss
@@ -1,0 +1,7 @@
+.mb4 {
+  margin-bottom: 1rem;
+}
+
+.mb8 {
+  margin-bottom: 2rem;
+}

--- a/src/styles/templates/theme/padding.scss
+++ b/src/styles/templates/theme/padding.scss
@@ -1,0 +1,12 @@
+.p8 {
+  padding: 2rem;
+}
+
+.p16 {
+  padding: 4rem;
+}
+
+.py16 {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}

--- a/src/styles/templates/theme/text-styles.scss
+++ b/src/styles/templates/theme/text-styles.scss
@@ -1,0 +1,17 @@
+.hero-title {
+  font-family: Lato;
+  font-size: 3rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 3.5rem; /* 116.667% */
+  letter-spacing: -1.056px;
+}
+
+.hero-subtitle {
+  font-feature-settings: "clig" off, "liga" off;
+  font-family: Lato;
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 2rem; /* 160% */
+}

--- a/src/templates/homepage/HeroSection/HeroCenteredLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroCenteredLayout.tsx
@@ -142,7 +142,11 @@ export const HeroCenteredLayout = ({
 }: HeroCenteredLayoutProps) => {
   return (
     <div
-      className={getClassNames(editorStyles, ["bp-hero-body", "gray-overlay"])}
+      className={getClassNames(editorStyles, [
+        "bp-hero-body",
+        "gray-overlay",
+        "with-padding",
+      ])}
     >
       <div
         className={getClassNames(editorStyles, [

--- a/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
@@ -4,7 +4,9 @@ import { getClassNames } from "templates/utils/stylingUtils"
 
 export const HeroImageOnlyLayout = () => {
   return (
-    <div className={getClassNames(editorStyles, ["bp-hero-body"])}>
+    <div
+      className={getClassNames(editorStyles, ["bp-hero-body, with-padding"])}
+    >
       <div
         className={getClassNames(editorStyles, [
           "bp-container",

--- a/src/templates/homepage/HeroSection/HeroSection.tsx
+++ b/src/templates/homepage/HeroSection/HeroSection.tsx
@@ -11,7 +11,11 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-import { SectionAlignment, SectionSize } from "types/hero"
+import {
+  SectionAlignment,
+  SectionBackgroundColor,
+  SectionSize,
+} from "types/hero"
 import { HeroBannerLayouts } from "types/homepage"
 
 import { HeroCenteredLayout } from "./HeroCenteredLayout"
@@ -110,6 +114,7 @@ interface TemplateHeroSectionProps {
     }[]
     alignment: SectionAlignment
     size: SectionSize
+    backgroundColor: SectionBackgroundColor
   }
   dropdownIsActive: boolean
   toggleDropdown: () => void

--- a/src/templates/homepage/HeroSection/HeroSection.tsx
+++ b/src/templates/homepage/HeroSection/HeroSection.tsx
@@ -11,10 +11,12 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
+import { SectionAlignment, SectionSize } from "types/hero"
 import { HeroBannerLayouts } from "types/homepage"
 
 import { HeroCenteredLayout } from "./HeroCenteredLayout"
 import { HeroImageOnlyLayout } from "./HeroImageOnlyLayout"
+import { HeroSideLayout } from "./HeroSideLayout"
 
 /* eslint
   react/no-array-index-key: 0
@@ -106,6 +108,8 @@ interface TemplateHeroSectionProps {
       title?: string
       description?: string
     }[]
+    alignment: SectionAlignment
+    size: SectionSize
   }
   dropdownIsActive: boolean
   toggleDropdown: () => void
@@ -138,14 +142,16 @@ export const TemplateHeroSection = forwardRef<
           className={getClassNames(editorStyles, ["bp-hero", "bg-hero"])}
           style={heroStyle}
         >
-          {variant === "center" ? (
+          {variant === "center" && (
             <HeroCenteredLayout
               hero={hero}
               dropdownIsActive={dropdownIsActive}
               toggleDropdown={toggleDropdown}
             />
-          ) : (
-            <HeroImageOnlyLayout />
+          )}
+          {variant === "image" && <HeroImageOnlyLayout />}
+          {variant === "side" && (
+            <HeroSideLayout {...hero} title={hero.title || ""} />
           )}
         </section>
         {/* Key highlights */}

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -1,0 +1,185 @@
+import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
+
+import { getClassNames } from "templates/utils/stylingUtils"
+
+interface HeroInfoboxProps {
+  title: string
+  subtitle?: string
+  url?: string
+  button?: string
+}
+const HeroInfobox = ({ title, subtitle, url, button }: HeroInfoboxProps) => {
+  return (
+    <div className={getClassNames(editorStyles, ["py16"])}>
+      <div className={getClassNames(editorStyles, ["mb8"])}>
+        <h1 className={getClassNames(editorStyles, ["hero-title", "mb4"])}>
+          {title && (
+            <>
+              <b className={getClassNames(editorStyles, ["is-hidden-touch"])}>
+                {title}
+              </b>
+              <b className={getClassNames(editorStyles, ["is-hidden-desktop"])}>
+                {title}
+              </b>
+            </>
+          )}
+        </h1>
+
+        {subtitle && (
+          <p
+            className={getClassNames(editorStyles, [
+              "is-hidden-touch",
+              "hero-subtitle",
+            ])}
+          >
+            {subtitle}
+          </p>
+        )}
+
+        {url && button && (
+          <a
+            href="/"
+            className={getClassNames(editorStyles, [
+              "bp-button",
+              "is-secondary",
+              "is-uppercase",
+              "search-button",
+            ])}
+          >
+            {button}
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface HeroInfoboxDesktopProps extends HeroInfoboxProps {
+  size: "half" | "one-third"
+}
+const HeroInfoboxDesktop = ({ size, ...rest }: HeroInfoboxDesktopProps) => {
+  return (
+    <>
+      {size === "half" ? (
+        <div
+          className={getClassNames(editorStyles, [
+            "bg-white",
+            "p16",
+            "is-hidden-mobile",
+          ])}
+          style={{
+            width: "50%",
+          }}
+        >
+          <HeroInfobox {...rest} />
+        </div>
+      ) : (
+        <div
+          className={getClassNames(editorStyles, [
+            "bg-white",
+            "p16",
+            "is-hidden-mobile",
+          ])}
+          style={{
+            width: "33%",
+          }}
+        >
+          <HeroInfobox {...rest} />
+        </div>
+      )}
+    </>
+  )
+}
+
+interface HeroSideLayoutProps {
+  alignment: "left" | "right"
+  size: "half" | "one-third"
+  url?: string
+  button?: string
+  subtitle?: string
+  title: string
+}
+export const HeroSideLayout = ({
+  alignment = "left",
+  size = "half",
+  url,
+  title,
+  subtitle,
+  button,
+}: HeroSideLayoutProps) => {
+  return (
+    <div className={getClassNames(editorStyles, ["bp-hero-body"])}>
+      {/* desktop view - done using css media queries */}
+      {alignment === "left" ? (
+        <HeroInfoboxDesktop
+          size={size}
+          url={url}
+          button={button}
+          title={title}
+          subtitle={subtitle}
+        />
+      ) : (
+        <div className={getClassNames(editorStyles, ["is-flex", "flex-end"])}>
+          <HeroInfoboxDesktop
+            size={size}
+            url={url}
+            button={button}
+            title={title}
+            subtitle={subtitle}
+          />
+        </div>
+      )}
+
+      {/* mobile view - done using css media queries */}
+      <div
+        className={getClassNames(editorStyles, [
+          "row",
+          "is-vcentered",
+          "is-centered",
+          "is-hidden-tablet",
+        ])}
+        style={{
+          paddingTop: "106px",
+          paddingBottom: "106px",
+          paddingLeft: "84px",
+          paddingRight: "84px",
+        }}
+      >
+        <div
+          className={getClassNames(editorStyles, [
+            "bg-white",
+            "p8",
+            "row",
+            "is-vcentered",
+            "is-centered",
+            "is-flex",
+          ])}
+          style={{
+            flexDirection: "column",
+          }}
+        >
+          <div className={getClassNames(editorStyles, ["mb8"])}>
+            <h1 className={getClassNames(editorStyles, ["hero-title", "mb4"])}>
+              <b className={getClassNames(editorStyles, ["is-hidden-desktop"])}>
+                {title}
+              </b>
+            </h1>
+          </div>
+          {url && button && (
+            <a
+              href="/"
+              className={getClassNames(editorStyles, [
+                "bp-button",
+                "is-secondary",
+                "is-uppercase",
+                "search-button",
+              ])}
+            >
+              {button}
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -1,3 +1,8 @@
+// NOTE: jsx-ally is disabled for this file as the output of this
+// should match jekyll output as closely as possible.
+// As jekyll outputs an <a /> tag like so, this behaviour is preserved here.
+/* eslint-disable jsx-a11y/anchor-is-valid */
+
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
@@ -42,7 +47,6 @@ const HeroInfobox = ({ title, subtitle, url, button }: HeroInfoboxProps) => {
 
         {url && button && (
           <a
-            href="/"
             className={getClassNames(editorStyles, [
               "bp-button",
               "is-secondary",

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -4,6 +4,8 @@ import { getClassNames } from "templates/utils/stylingUtils"
 
 import { SectionBackgroundColor, SectionSize } from "types/hero"
 
+const TRANSLUCENT_GRAY = "#00000080"
+
 interface HeroInfoboxProps {
   title: string
   subtitle?: string
@@ -70,8 +72,8 @@ const HeroInfoboxDesktop = ({
       className={getClassNames(editorStyles, ["p16", "is-hidden-mobile"])}
       style={{
         width: size,
-        backgroundColor: backgroundColor === "white" ? "white" : "black",
-        opacity: backgroundColor === "gray" ? "50%" : "100%",
+        background:
+          backgroundColor === "gray" ? TRANSLUCENT_GRAY : backgroundColor,
       }}
     >
       <HeroInfobox {...rest} />

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -2,6 +2,8 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
+import { SectionBackgroundColor, SectionSize } from "types/hero"
+
 interface HeroInfoboxProps {
   title: string
   subtitle?: string
@@ -55,57 +57,45 @@ const HeroInfobox = ({ title, subtitle, url, button }: HeroInfoboxProps) => {
 }
 
 interface HeroInfoboxDesktopProps extends HeroInfoboxProps {
-  size: "half" | "one-third"
+  size: SectionSize
+  backgroundColor: SectionBackgroundColor
 }
-const HeroInfoboxDesktop = ({ size, ...rest }: HeroInfoboxDesktopProps) => {
+const HeroInfoboxDesktop = ({
+  size,
+  backgroundColor,
+  ...rest
+}: HeroInfoboxDesktopProps) => {
   return (
-    <>
-      {size === "half" ? (
-        <div
-          className={getClassNames(editorStyles, [
-            "bg-white",
-            "p16",
-            "is-hidden-mobile",
-          ])}
-          style={{
-            width: "50%",
-          }}
-        >
-          <HeroInfobox {...rest} />
-        </div>
-      ) : (
-        <div
-          className={getClassNames(editorStyles, [
-            "bg-white",
-            "p16",
-            "is-hidden-mobile",
-          ])}
-          style={{
-            width: "33%",
-          }}
-        >
-          <HeroInfobox {...rest} />
-        </div>
-      )}
-    </>
+    <div
+      className={getClassNames(editorStyles, ["p16", "is-hidden-mobile"])}
+      style={{
+        width: size,
+        backgroundColor: backgroundColor === "white" ? "white" : "black",
+        opacity: backgroundColor === "gray" ? "50%" : "100%",
+      }}
+    >
+      <HeroInfobox {...rest} />
+    </div>
   )
 }
 
 interface HeroSideLayoutProps {
   alignment: "left" | "right"
-  size: "half" | "one-third"
+  size: SectionSize
   url?: string
   button?: string
   subtitle?: string
   title: string
+  backgroundColor: SectionBackgroundColor
 }
 export const HeroSideLayout = ({
   alignment = "left",
-  size = "half",
+  size = "50%",
   url,
   title,
   subtitle,
   button,
+  backgroundColor,
 }: HeroSideLayoutProps) => {
   return (
     <div className={getClassNames(editorStyles, ["bp-hero-body"])}>
@@ -117,6 +107,7 @@ export const HeroSideLayout = ({
           button={button}
           title={title}
           subtitle={subtitle}
+          backgroundColor={backgroundColor}
         />
       ) : (
         <div className={getClassNames(editorStyles, ["is-flex", "flex-end"])}>
@@ -126,6 +117,7 @@ export const HeroSideLayout = ({
             button={button}
             title={title}
             subtitle={subtitle}
+            backgroundColor={backgroundColor}
           />
         </div>
       )}
@@ -147,7 +139,6 @@ export const HeroSideLayout = ({
       >
         <div
           className={getClassNames(editorStyles, [
-            "bg-white",
             "p8",
             "row",
             "is-vcentered",
@@ -156,6 +147,8 @@ export const HeroSideLayout = ({
           ])}
           style={{
             flexDirection: "column",
+            backgroundColor: backgroundColor === "white" ? "white" : "black",
+            opacity: backgroundColor === "gray" ? "50%" : "100%",
           }}
         >
           <div className={getClassNames(editorStyles, ["mb8"])}>

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -149,8 +149,8 @@ export const HeroSideLayout = ({
           ])}
           style={{
             flexDirection: "column",
-            backgroundColor: backgroundColor === "white" ? "white" : "black",
-            opacity: backgroundColor === "gray" ? "50%" : "100%",
+            background:
+              backgroundColor === "gray" ? TRANSLUCENT_GRAY : backgroundColor,
           }}
         >
           <div className={getClassNames(editorStyles, ["mb8"])}>

--- a/src/types/hero.ts
+++ b/src/types/hero.ts
@@ -1,0 +1,5 @@
+export type SectionSize = "half" | "one-third"
+
+export type SectionAlignment = "left" | "right"
+
+export type SectionBackgroundColor = "black" | "white" | "translucent gray"

--- a/src/types/hero.ts
+++ b/src/types/hero.ts
@@ -1,5 +1,5 @@
-export type SectionSize = "half" | "one-third"
+export type SectionSize = "50%" | "33%"
 
 export type SectionAlignment = "left" | "right"
 
-export type SectionBackgroundColor = "black" | "white" | "translucent gray"
+export type SectionBackgroundColor = "black" | "white" | "gray"

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -2,7 +2,7 @@ import type { IterableElement, SetOptional } from "type-fest"
 
 import { HERO_LAYOUTS } from "constants/homepage"
 
-import { SectionAlignment, SectionSize } from "./hero"
+import { SectionAlignment, SectionBackgroundColor, SectionSize } from "./hero"
 
 export type DropdownOption = {
   title: string
@@ -110,6 +110,7 @@ export type HomepageEditorHeroSection = EditorHeroDropdownSection &
     variant: HeroBannerLayouts
     alignment: SectionAlignment
     size: SectionSize
+    backgroundColor: SectionBackgroundColor
   }
 
 export type HeroFrontmatterSection = { hero: HomepageEditorHeroSection }

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -2,6 +2,8 @@ import type { IterableElement, SetOptional } from "type-fest"
 
 import { HERO_LAYOUTS } from "constants/homepage"
 
+import { SectionAlignment, SectionSize } from "./hero"
+
 export type DropdownOption = {
   title: string
   url: string
@@ -104,7 +106,11 @@ export type PossibleEditorSections = IterableElement<
 export type HeroBannerLayouts = typeof HERO_LAYOUTS[keyof typeof HERO_LAYOUTS]["value"]
 
 export type HomepageEditorHeroSection = EditorHeroDropdownSection &
-  EditorHeroHighlightsSection & { variant: HeroBannerLayouts }
+  EditorHeroHighlightsSection & {
+    variant: HeroBannerLayouts
+    alignment: SectionAlignment
+    size: SectionSize
+  }
 
 export type HeroFrontmatterSection = { hero: HomepageEditorHeroSection }
 export type ResourcesFrontmatterSection = { resources: ResourcesSection }


### PR DESCRIPTION
## Problem
Previously, homepage did not have any previews for the hero side layout. This PR adds the previews in.

## Solution
1. add template component from preview
2. add css styling for template component
    - this is a **stop gap** measure cos this PR came out **before** the PR for helpers so i'll have a PR post-merge to update. (easier to do then)

## Screenshots
![Recording 2023-09-20 at 12 23 52](https://github.com/isomerpages/isomercms-frontend/assets/44049504/64b761cb-24b1-424c-a7cf-f0512e8f0ce5)


## Tests 
- [ ] go to homepage
- [ ] select side variant 
- [ ] the preview should update with default options 
- [ ] select the various options 
- [ ] the preview should update correctly
- [ ] update to either highlight/dropdown for hero interaction
- [ ] preview should update correctly