### PR TITLE
feat(hero-section): adds dropdown

### DIFF
--- a/src/templates/homepage/HeroSection/HeroCenteredLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroCenteredLayout.tsx
@@ -1,15 +1,10 @@
-// NOTE: jsx-ally is disabled for this file as the output of this
-// should match jekyll output as closely as possible.
-// As jekyll outputs an <a /> tag like so, this behaviour is preserved here.
-/* eslint-disable jsx-a11y/anchor-is-valid */
-
-/* eslint
-  react/no-array-index-key: 0
- */
-
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
+
+import { EditorHeroDropdownSection } from "types/homepage"
+
+import { HeroDropdown } from "./HeroDropdown"
 
 interface HeroButtonProps {
   button?: string
@@ -32,105 +27,13 @@ const HeroButton = ({ button }: HeroButtonProps) => (
   </>
 )
 
-interface HeroDropdownElemProps {
-  title: string
-}
-const HeroDropdownElem = ({ title }: HeroDropdownElemProps) => (
-  <div className={editorStyles["bp-dropdown-item"]}>
-    <h5>{title}</h5>
-  </div>
-)
-
-interface HeroDropdownProps {
-  title: string
-  isActive?: boolean
-  options: { title: string }[]
-  toggleDropdown: () => void
-}
-const HeroDropdown = ({
-  title,
-  options,
-  isActive,
-  toggleDropdown,
-}: HeroDropdownProps) => (
-  <div
-    className={getClassNames(editorStyles, [
-      "bp-dropdown",
-      "margin--top--sm",
-      `${isActive ? "is-active" : null}`,
-    ])}
-  >
-    <div className={editorStyles["bp-dropdown-trigger"]}>
-      <a
-        className={getClassNames(editorStyles, [
-          "bp-button",
-          "bp-dropdown-button",
-          "hero-dropdown",
-          "is-centered",
-        ])}
-        role="button"
-        tabIndex={0}
-        aria-haspopup="true"
-        aria-controls="hero-dropdown-menu"
-        onClick={toggleDropdown}
-        onKeyDown={toggleDropdown}
-      >
-        <span>
-          <b>
-            <p>{title}</p>
-          </b>
-        </span>
-        <span className={getClassNames(editorStyles, ["icon", "is-small"])}>
-          <i
-            className={getClassNames(editorStyles, [
-              "sgds-icon",
-              "sgds-icon-chevron-down",
-              "is-size-4",
-            ])}
-            aria-hidden="true"
-          />
-        </span>
-      </a>
-    </div>
-    <div
-      className={getClassNames(editorStyles, [
-        "bp-dropdown-menu",
-        "has-text-left",
-      ])}
-      id={editorStyles["hero-dropdown-menu"]}
-      role="menu"
-    >
-      <div
-        className={getClassNames(editorStyles, [
-          "bp-dropdown-content",
-          "is-centered",
-        ])}
-      >
-        {options
-          ? options.map((option, index) =>
-              option.title ? (
-                <HeroDropdownElem
-                  key={`dropdown-${index}`}
-                  title={option.title}
-                />
-              ) : null
-            )
-          : null}
-      </div>
-    </div>
-  </div>
-)
-
 interface HeroCenteredLayoutProps {
   hero: {
     background?: string
     title?: string
     subtitle?: string
     button?: string
-    dropdown: {
-      title: string
-      options: { title: string }[]
-    }
+    dropdown: EditorHeroDropdownSection["dropdown"]
   }
   dropdownIsActive: boolean
   toggleDropdown: () => void

--- a/src/templates/homepage/HeroSection/HeroDropdown.tsx
+++ b/src/templates/homepage/HeroSection/HeroDropdown.tsx
@@ -1,0 +1,100 @@
+// NOTE: jsx-ally is disabled for this file as the output of this
+// should match jekyll output as closely as possible.
+// As jekyll outputs an <a /> tag like so, this behaviour is preserved here.
+/* eslint-disable jsx-a11y/anchor-is-valid */
+
+/* eslint
+  react/no-array-index-key: 0
+ */
+import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
+
+import { getClassNames } from "templates/utils/stylingUtils"
+
+interface HeroDropdownElemProps {
+  title: string
+}
+const HeroDropdownElem = ({ title }: HeroDropdownElemProps) => (
+  <div className={editorStyles["bp-dropdown-item"]}>
+    <h5>{title}</h5>
+  </div>
+)
+
+interface HeroDropdownProps {
+  title: string
+  isActive?: boolean
+  options: { title: string }[]
+  toggleDropdown: () => void
+}
+export const HeroDropdown = ({
+  title,
+  options,
+  isActive,
+  toggleDropdown,
+}: HeroDropdownProps) => (
+  <div
+    className={getClassNames(editorStyles, [
+      "bp-dropdown",
+      "margin--top--sm",
+      `${isActive ? "is-active" : null}`,
+    ])}
+  >
+    <div className={editorStyles["bp-dropdown-trigger"]}>
+      <a
+        className={getClassNames(editorStyles, [
+          "bp-button",
+          "bp-dropdown-button",
+          "hero-dropdown",
+          "is-centered",
+        ])}
+        role="button"
+        tabIndex={0}
+        aria-haspopup="true"
+        aria-controls="hero-dropdown-menu"
+        onClick={toggleDropdown}
+        onKeyDown={toggleDropdown}
+      >
+        <span>
+          <b>
+            <p>{title}</p>
+          </b>
+        </span>
+        <span className={getClassNames(editorStyles, ["icon", "is-small"])}>
+          <i
+            className={getClassNames(editorStyles, [
+              "sgds-icon",
+              "sgds-icon-chevron-down",
+              "is-size-4",
+            ])}
+            aria-hidden="true"
+          />
+        </span>
+      </a>
+    </div>
+    <div
+      className={getClassNames(editorStyles, [
+        "bp-dropdown-menu",
+        "has-text-left",
+      ])}
+      id={editorStyles["hero-dropdown-menu"]}
+      role="menu"
+    >
+      <div
+        className={getClassNames(editorStyles, [
+          "bp-dropdown-content",
+          "is-centered",
+        ])}
+      >
+        {options
+          ? options.map((option, index) =>
+              option.title ? (
+                <HeroDropdownElem
+                  key={`dropdown-${index}`}
+                  title={option.title}
+                />
+              ) : null
+            )
+          : null}
+      </div>
+    </div>
+  </div>
+)

--- a/src/templates/homepage/HeroSection/HeroSection.tsx
+++ b/src/templates/homepage/HeroSection/HeroSection.tsx
@@ -16,7 +16,7 @@ import {
   SectionBackgroundColor,
   SectionSize,
 } from "types/hero"
-import { HeroBannerLayouts } from "types/homepage"
+import { EditorHeroDropdownSection, HeroBannerLayouts } from "types/homepage"
 
 import { HeroCenteredLayout } from "./HeroCenteredLayout"
 import { HeroImageOnlyLayout } from "./HeroImageOnlyLayout"
@@ -103,10 +103,7 @@ interface TemplateHeroSectionProps {
     title?: string
     subtitle?: string
     button?: string
-    dropdown: {
-      title: string
-      options: { title: string }[]
-    }
+    dropdown: EditorHeroDropdownSection["dropdown"]
     // eslint-disable-next-line camelcase
     key_highlights: {
       title?: string
@@ -156,7 +153,12 @@ export const TemplateHeroSection = forwardRef<
           )}
           {variant === "image" && <HeroImageOnlyLayout />}
           {variant === "side" && (
-            <HeroSideLayout {...hero} title={hero.title || ""} />
+            <HeroSideLayout
+              {...hero}
+              title={hero.title || ""}
+              dropdownIsActive={dropdownIsActive}
+              toggleDropdown={toggleDropdown}
+            />
           )}
         </section>
         {/* Key highlights */}

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -74,12 +74,20 @@ const HeroInfoboxDesktop = ({
           )}
 
           {dropdown ? (
-            <HeroDropdown
-              title={dropdown.title}
-              options={dropdown.options}
-              isActive={dropdownIsActive}
-              toggleDropdown={toggleDropdown}
-            />
+            <div
+              className={getClassNames(editorStyles, ["is-flex"])}
+              style={{
+                justifyContent: "center",
+                alignContent: "center",
+              }}
+            >
+              <HeroDropdown
+                title={dropdown.title}
+                options={dropdown.options}
+                isActive={dropdownIsActive}
+                toggleDropdown={toggleDropdown}
+              />
+            </div>
           ) : (
             // NOTE: This is to mirror the template structure
             // as closely as possible.

--- a/src/templates/homepage/HeroSection/HeroSideLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroSideLayout.tsx
@@ -8,68 +8,33 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 import { getClassNames } from "templates/utils/stylingUtils"
 
 import { SectionBackgroundColor, SectionSize } from "types/hero"
+import { EditorHeroDropdownSection } from "types/homepage"
+
+import { HeroDropdown } from "./HeroDropdown"
 
 const TRANSLUCENT_GRAY = "#00000080"
 
-interface HeroInfoboxProps {
+interface HeroInfoboxDesktopProps {
+  size: SectionSize
+  backgroundColor: SectionBackgroundColor
   title: string
   subtitle?: string
   url?: string
   button?: string
-}
-const HeroInfobox = ({ title, subtitle, url, button }: HeroInfoboxProps) => {
-  return (
-    <div className={getClassNames(editorStyles, ["py16"])}>
-      <div className={getClassNames(editorStyles, ["mb8"])}>
-        <h1 className={getClassNames(editorStyles, ["hero-title", "mb4"])}>
-          {title && (
-            <>
-              <b className={getClassNames(editorStyles, ["is-hidden-touch"])}>
-                {title}
-              </b>
-              <b className={getClassNames(editorStyles, ["is-hidden-desktop"])}>
-                {title}
-              </b>
-            </>
-          )}
-        </h1>
-
-        {subtitle && (
-          <p
-            className={getClassNames(editorStyles, [
-              "is-hidden-touch",
-              "hero-subtitle",
-            ])}
-          >
-            {subtitle}
-          </p>
-        )}
-
-        {url && button && (
-          <a
-            className={getClassNames(editorStyles, [
-              "bp-button",
-              "is-secondary",
-              "is-uppercase",
-              "search-button",
-            ])}
-          >
-            {button}
-          </a>
-        )}
-      </div>
-    </div>
-  )
-}
-
-interface HeroInfoboxDesktopProps extends HeroInfoboxProps {
-  size: SectionSize
-  backgroundColor: SectionBackgroundColor
+  dropdown?: EditorHeroDropdownSection["dropdown"]
+  dropdownIsActive: boolean
+  toggleDropdown: () => void
 }
 const HeroInfoboxDesktop = ({
   size,
   backgroundColor,
-  ...rest
+  title,
+  subtitle,
+  dropdown,
+  dropdownIsActive,
+  toggleDropdown,
+  url,
+  button,
 }: HeroInfoboxDesktopProps) => {
   return (
     <div
@@ -80,7 +45,61 @@ const HeroInfoboxDesktop = ({
           backgroundColor === "gray" ? TRANSLUCENT_GRAY : backgroundColor,
       }}
     >
-      <HeroInfobox {...rest} />
+      <div className={getClassNames(editorStyles, ["py16"])}>
+        <div className={getClassNames(editorStyles, ["mb8"])}>
+          <h1 className={getClassNames(editorStyles, ["hero-title", "mb4"])}>
+            {title && (
+              <>
+                <b className={getClassNames(editorStyles, ["is-hidden-touch"])}>
+                  {title}
+                </b>
+                <b
+                  className={getClassNames(editorStyles, ["is-hidden-desktop"])}
+                >
+                  {title}
+                </b>
+              </>
+            )}
+          </h1>
+
+          {subtitle && (
+            <p
+              className={getClassNames(editorStyles, [
+                "is-hidden-touch",
+                "hero-subtitle",
+              ])}
+            >
+              {subtitle}
+            </p>
+          )}
+
+          {dropdown ? (
+            <HeroDropdown
+              title={dropdown.title}
+              options={dropdown.options}
+              isActive={dropdownIsActive}
+              toggleDropdown={toggleDropdown}
+            />
+          ) : (
+            // NOTE: This is to mirror the template structure
+            // as closely as possible.
+            url &&
+            button && (
+              <a
+                href="/"
+                className={getClassNames(editorStyles, [
+                  "bp-button",
+                  "is-secondary",
+                  "is-uppercase",
+                  "search-button",
+                ])}
+              >
+                {button}
+              </a>
+            )
+          )}
+        </div>
+      </div>
     </div>
   )
 }
@@ -93,6 +112,9 @@ interface HeroSideLayoutProps {
   subtitle?: string
   title: string
   backgroundColor: SectionBackgroundColor
+  dropdownIsActive: boolean
+  toggleDropdown: () => void
+  dropdown?: EditorHeroDropdownSection["dropdown"]
 }
 export const HeroSideLayout = ({
   alignment = "left",
@@ -102,6 +124,9 @@ export const HeroSideLayout = ({
   subtitle,
   button,
   backgroundColor,
+  dropdownIsActive,
+  toggleDropdown,
+  dropdown,
 }: HeroSideLayoutProps) => {
   return (
     <div className={getClassNames(editorStyles, ["bp-hero-body"])}>
@@ -114,6 +139,9 @@ export const HeroSideLayout = ({
           title={title}
           subtitle={subtitle}
           backgroundColor={backgroundColor}
+          dropdownIsActive={dropdownIsActive}
+          toggleDropdown={toggleDropdown}
+          dropdown={dropdown}
         />
       ) : (
         <div className={getClassNames(editorStyles, ["is-flex", "flex-end"])}>
@@ -124,6 +152,9 @@ export const HeroSideLayout = ({
             title={title}
             subtitle={subtitle}
             backgroundColor={backgroundColor}
+            dropdownIsActive={dropdownIsActive}
+            toggleDropdown={toggleDropdown}
+            dropdown={dropdown}
           />
         </div>
       )}
@@ -164,18 +195,30 @@ export const HeroSideLayout = ({
               </b>
             </h1>
           </div>
-          {url && button && (
-            <a
-              href="/"
-              className={getClassNames(editorStyles, [
-                "bp-button",
-                "is-secondary",
-                "is-uppercase",
-                "search-button",
-              ])}
-            >
-              {button}
-            </a>
+          {dropdown ? (
+            <HeroDropdown
+              title={dropdown.title}
+              options={dropdown.options}
+              isActive={dropdownIsActive}
+              toggleDropdown={toggleDropdown}
+            />
+          ) : (
+            // NOTE: This is to mirror the template structure
+            // as closely as possible.
+            url &&
+            button && (
+              <a
+                href="/"
+                className={getClassNames(editorStyles, [
+                  "bp-button",
+                  "is-secondary",
+                  "is-uppercase",
+                  "search-button",
+                ])}
+              >
+                {button}
+              </a>
+            )
           )}
         </div>
       </div>


### PR DESCRIPTION
## Problem
The existing hero section does not have a dropdown. This adds the preview component for the dropdown in.

## Solution
Copy paste over the dropdown from the template code (with modification so it can be consumed by react)

## Tests 
- [ ] Go to the hero section
- [ ] select the side variant
- [ ] select dropdown 
- [ ] the options there should be preserved, and the preview should be updated
- [ ] change the dropdown options/title
- [ ] the preview should also update accordingly
- [ ] try this in different view ports (technically we don't support)