### PR TITLE
feat(heroimageonlylayout): add dropdown

### DIFF
--- a/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
@@ -2,7 +2,20 @@ import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
 import { getClassNames } from "templates/utils/stylingUtils"
 
-export const HeroImageOnlyLayout = () => {
+import { EditorHeroDropdownSection } from "types/homepage"
+
+import { HeroDropdown } from "./HeroDropdown"
+
+interface HeroImageOnlyLayoutProps {
+  dropdown?: EditorHeroDropdownSection["dropdown"]
+  dropdownIsActive: boolean
+  toggleDropdown: () => void
+}
+export const HeroImageOnlyLayout = ({
+  dropdown,
+  dropdownIsActive,
+  toggleDropdown,
+}: HeroImageOnlyLayoutProps) => {
   return (
     <div
       className={getClassNames(editorStyles, ["bp-hero-body, with-padding"])}
@@ -21,7 +34,23 @@ export const HeroImageOnlyLayout = () => {
             "ma",
           ])}
         >
-          <div className={getClassNames(editorStyles, ["min-height-mobile"])} />
+          <div
+            className={getClassNames(editorStyles, [
+              "min-height-mobile",
+              "is-flex",
+              "row",
+              "is-vcentered",
+            ])}
+          >
+            {dropdown && (
+              <HeroDropdown
+                title={dropdown.title}
+                options={dropdown.options}
+                isActive={dropdownIsActive}
+                toggleDropdown={toggleDropdown}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
@@ -40,6 +40,7 @@ export const HeroImageOnlyLayout = ({
               "is-flex",
               "row",
               "is-vcentered",
+              "is-centered",
             ])}
           >
             {dropdown && (

--- a/src/templates/homepage/HeroSection/HeroSection.tsx
+++ b/src/templates/homepage/HeroSection/HeroSection.tsx
@@ -151,7 +151,13 @@ export const TemplateHeroSection = forwardRef<
               toggleDropdown={toggleDropdown}
             />
           )}
-          {variant === "image" && <HeroImageOnlyLayout />}
+          {variant === "image" && (
+            <HeroImageOnlyLayout
+              dropdown={hero.dropdown}
+              dropdownIsActive={dropdownIsActive}
+              toggleDropdown={toggleDropdown}
+            />
+          )}
           {variant === "side" && (
             <HeroSideLayout
               {...hero}


### PR DESCRIPTION
## Problem
Currently our image only layout only has support for highlights and not dropdown. This PR adds it in

## Solution
Follow conditionals from template and add the `HeroDropdown` in to `HeroImageOnlyLayout`

## Tests 
- [ ] select image only variant for hero section
- [ ] select dropdown for hero interactions
- [ ] there should be a dropdown in preview
- [ ] update options/title -> preview should also update
- [ ] repeat in diff screen sizes