### PR TITLE
feat(homepage): add preview for announcements component

### DIFF
--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
+import { TemplateAnnouncementsSection } from "templates/homepage/AnnouncementsSection"
 import TemplateHeroSection from "templates/homepage/HeroSection"
 import TemplateInfobarSection from "templates/homepage/InfobarSection"
 import TemplateInfopicLeftSection from "templates/homepage/InfopicLeftSection"
@@ -164,6 +165,19 @@ export const HomepagePreview = ({
                   ref={scrollRefs[sectionIndex]}
                 />
               )}
+            </>
+          )}
+          {/* Announcements section */}
+          {EditorHomepageFrontmatterSection.isAnnouncements(section) && (
+            <>
+              <TemplateAnnouncementsSection
+                key={`section-${sectionIndex}`}
+                title={section.announcements.title}
+                subtitle={section.announcements.subtitle}
+                announcementItems={section.announcements.announcement_items}
+                sectionIndex={sectionIndex}
+                ref={scrollRefs[sectionIndex] as Ref<HTMLDivElement>}
+              />
             </>
           )}
         </>

--- a/src/styles/isomer-template/helpers.scss
+++ b/src/styles/isomer-template/helpers.scss
@@ -8,6 +8,7 @@
 */
 
 $spaceamounts: (
+  "auto",
   0,
   1,
   2,
@@ -39,46 +40,70 @@ $spaceamounts: (
   80,
   96
 );
-$sides: (top, bottom, left, right);
+$sides: (
+  "t": "top",
+  "b": "bottom",
+  "l": "left",
+  "r": "right",
+  "x": (
+    "left",
+    "right",
+  ),
+  "y": (
+    "top",
+    "bottom",
+  ),
+  "": (
+    "top",
+    "bottom",
+    "left",
+    "right",
+  ),
+);
 
-@each $space in $spaceamounts {
-  $remSpace: calc(#{$space}rem / 4);
+@each $breakpoint, $minwidth in $breakpoints {
+  @if $minwidth != 0px {
+    @media (min-width: $minwidth) {
+      @each $space in $spaceamounts {
+        $remSpace: if($space == "auto", auto, calc(#{$space}rem / 4));
 
-  @each $side in $sides {
-    .m#{str-slice($side, 0, 1)}-#{$space} {
-      margin-#{$side}: $remSpace;
+        @each $prefix, $positions in $sides {
+          $suffix: #{$prefix};
+          @if $minwidth != 0px {
+            $suffix: #{$prefix}-#{$breakpoint};
+          }
+
+          .m#{$suffix}-#{$space} {
+            @each $position in $positions {
+              margin-#{$position}: $remSpace !important;
+            }
+          }
+
+          .p#{$suffix}-#{$space} {
+            @each $position in $positions {
+              padding-#{$position}: $remSpace !important;
+            }
+          }
+        }
+      }
     }
+  } @else {
+    @each $space in $spaceamounts {
+      $remSpace: if($space == "auto", auto, calc(#{$space}rem / 4));
 
-    .p#{str-slice($side, 0, 1)}-#{$space} {
-      padding-#{$side}: $remSpace;
+      @each $prefix, $positions in $sides {
+        .m#{$prefix}-#{$space} {
+          @each $position in $positions {
+            margin-#{$position}: $remSpace !important;
+          }
+        }
+
+        .p#{$prefix}-#{$space} {
+          @each $position in $positions {
+            padding-#{$position}: $remSpace !important;
+          }
+        }
+      }
     }
-  }
-
-  .mx-#{$space} {
-    margin-left: $remSpace;
-    margin-right: $remSpace;
-  }
-
-  .px-#{$space} {
-    padding-left: $remSpace;
-    padding-right: $remSpace;
-  }
-
-  .my-#{$space} {
-    margin-top: $remSpace;
-    margin-bottom: $remSpace;
-  }
-
-  .py-#{$space} {
-    padding-top: $remSpace;
-    padding-bottom: $remSpace;
-  }
-
-  .m-#{$space} {
-    margin: $remSpace;
-  }
-
-  .p-#{$space} {
-    padding: $remSpace;
   }
 }

--- a/src/styles/isomer-template/homepage/announcements.scss
+++ b/src/styles/isomer-template/homepage/announcements.scss
@@ -1,0 +1,37 @@
+.announcements-divider {
+  height: 1px;
+  color: #f9f9f9;
+}
+
+.announcements-announcement-title {
+  font-size: 1.625rem;
+  font-weight: 700;
+  line-height: 2rem;
+}
+
+.announcements-announcement-subtitle {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.375rem;
+}
+
+.announcements-announcement-link {
+  text-transform: unset !important;
+  letter-spacing: 0.27px !important;
+}
+
+@media screen and (min-width: 1024px) {
+  .announcements-announcement-row-px-desktop {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+
+  .announcements-announcement-col-px-desktop {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .announcements-announcement-title-mr-desktop {
+    margin-right: 1.5rem;
+  }
+}

--- a/src/styles/isomer-template/homepage/announcements.scss
+++ b/src/styles/isomer-template/homepage/announcements.scss
@@ -16,22 +16,20 @@
 }
 
 .announcements-announcement-link {
-  text-transform: unset !important;
-  letter-spacing: 0.27px !important;
+  color: var(--site-secondary-color);
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  letter-spacing: 0.27px;
+  text-decoration-line: underline;
+  text-transform: capitalize;
+  text-underline-offset: 0.25rem;
 }
 
-@media screen and (min-width: 1024px) {
-  .announcements-announcement-row-px-desktop {
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
-  }
+.announcements-announcement-link:hover {
+  color: var(--site-secondary-color-hover);
+}
 
-  .announcements-announcement-col-px-desktop {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-
-  .announcements-announcement-title-mr-desktop {
-    margin-right: 1.5rem;
-  }
+a[target="_blank"].announcements-announcement-link::after {
+  content: unset;
 }

--- a/src/styles/isomer-template/styles.scss
+++ b/src/styles/isomer-template/styles.scss
@@ -1,5 +1,13 @@
-@charset 'UTF-8';
+// Minimum width before a media query is triggered
+$breakpoints: (
+  "": 0px,
+  sm: 431px,
+  md: 770px,
+  lg: 1024px,
+  xl: 1280px,
+  xxl: 1408px,
+);
 
-@use "helpers";
+@import "helpers";
 
 @use "homepage/announcements";

--- a/src/styles/isomer-template/styles.scss
+++ b/src/styles/isomer-template/styles.scss
@@ -10,4 +10,4 @@ $breakpoints: (
 
 @import "helpers";
 
-@use "homepage/announcements";
+@import "homepage/announcements";

--- a/src/styles/isomer-template/styles.scss
+++ b/src/styles/isomer-template/styles.scss
@@ -1,3 +1,5 @@
 @charset 'UTF-8';
 
 @use "helpers";
+
+@use "homepage/announcements";

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -1,0 +1,170 @@
+import { forwardRef } from "react"
+
+import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
+
+import { getClassNames } from "templates/utils/stylingUtils"
+
+import { AnnouncementsSection } from "types/homepage"
+
+type TemplateAnnouncementsSectionProps = Omit<
+  AnnouncementsSection,
+  "announcement_items"
+> & {
+  announcementItems: AnnouncementsSection["announcement_items"]
+  sectionIndex: number
+}
+
+export const TemplateAnnouncementsSection = forwardRef<
+  HTMLDivElement,
+  TemplateAnnouncementsSectionProps
+>(
+  (
+    {
+      title,
+      subtitle,
+      announcementItems,
+      sectionIndex,
+    }: TemplateAnnouncementsSectionProps,
+    ref
+  ) => {
+    return (
+      <div ref={ref}>
+        <section
+          className={getClassNames(editorStyles, [
+            `bp-section`,
+            sectionIndex % 2 === 1 ? "bg-newssection" : "",
+          ])}
+        >
+          <div
+            className={getClassNames(editorStyles, [
+              "bp-container",
+              "is-fluid",
+            ])}
+          >
+            <div className={editorStyles.row}>
+              <div
+                className={getClassNames(editorStyles, [
+                  "col",
+                  "is-full",
+                  "p-16",
+                ])}
+              >
+                <>
+                  {subtitle && (
+                    <p
+                      className={getClassNames(editorStyles, [
+                        "eyebrow",
+                        "is-uppercase",
+                        "pb-4",
+                        "has-text-centered",
+                      ])}
+                    >
+                      {subtitle}
+                    </p>
+                  )}
+                  {title && (
+                    <h1
+                      className={getClassNames(editorStyles, [
+                        "has-text-secondary",
+                        "pb-4",
+                        "has-text-centered",
+                      ])}
+                    >
+                      <b>{title}</b>
+                    </h1>
+                  )}
+
+                  <hr
+                    className={getClassNames(editorStyles, [
+                      "my-8",
+                      "announcements-divider",
+                    ])}
+                  />
+
+                  {announcementItems &&
+                    announcementItems.map((announcement, index) => {
+                      return (
+                        <>
+                          <div
+                            className={getClassNames(editorStyles, [
+                              "row",
+                              "is-desktop",
+                              "announcements-announcement-row-px-desktop",
+                            ])}
+                          >
+                            <div
+                              className={getClassNames(editorStyles, [
+                                "col",
+                                "is-4-desktop",
+                                "announcements-announcement-col-px-desktop",
+                                "announcements-announcement-title-mr-desktop",
+                              ])}
+                            >
+                              <h3
+                                className={getClassNames(editorStyles, [
+                                  "announcements-announcement-title",
+                                  "mb-4",
+                                ])}
+                              >
+                                <b>{announcement.title}</b>
+                              </h3>
+                              <p
+                                className={
+                                  editorStyles[
+                                    "announcements-announcement-subtitle"
+                                  ]
+                                }
+                              >
+                                {announcement.date}
+                              </p>
+                            </div>
+                            <div
+                              className={getClassNames(editorStyles, [
+                                "col",
+                                "announcements-announcement-col-px-desktop",
+                              ])}
+                            >
+                              <p>{announcement.announcement}</p>
+                              {announcement.link_text && announcement.link_url && (
+                                <div className={editorStyles["mt-4"]}>
+                                  <div
+                                    className={getClassNames(editorStyles, [
+                                      "announcements-announcement-link",
+                                      "bp-sec-button",
+                                    ])}
+                                  >
+                                    <span>{announcement.link_text}</span>
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                          {announcementItems &&
+                          announcementItems.length === index + 1 ? (
+                            <hr
+                              className={getClassNames(editorStyles, [
+                                "mt-8",
+                                "mb-0",
+                                "announcements-divider",
+                              ])}
+                            />
+                          ) : (
+                            <hr
+                              className={getClassNames(editorStyles, [
+                                "my-8",
+                                "announcements-divider",
+                              ])}
+                            />
+                          )}
+                        </>
+                      )
+                    })}
+                </>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    )
+  }
+)

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -33,22 +33,20 @@ export const TemplateAnnouncementsSection = forwardRef<
           className={getClassNames(editorStyles, [
             `bp-section`,
             sectionIndex % 2 === 1 ? "bg-newssection" : "",
+            "px-14",
+            "px-md-24",
+            "py-24",
           ])}
         >
           <div
             className={getClassNames(editorStyles, [
               "bp-container",
               "is-fluid",
+              "m-0",
             ])}
           >
             <div className={editorStyles.row}>
-              <div
-                className={getClassNames(editorStyles, [
-                  "col",
-                  "is-full",
-                  "p-16",
-                ])}
-              >
+              <div className={getClassNames(editorStyles, ["col", "is-full"])}>
                 <>
                   {subtitle && (
                     <p
@@ -89,15 +87,14 @@ export const TemplateAnnouncementsSection = forwardRef<
                             className={getClassNames(editorStyles, [
                               "row",
                               "is-desktop",
-                              "announcements-announcement-row-px-desktop",
                             ])}
                           >
                             <div
                               className={getClassNames(editorStyles, [
                                 "col",
                                 "is-4-desktop",
-                                "announcements-announcement-col-px-desktop",
-                                "announcements-announcement-title-mr-desktop",
+                                "px-lg-6",
+                                "mr-lg-6",
                               ])}
                             >
                               <h3
@@ -121,17 +118,18 @@ export const TemplateAnnouncementsSection = forwardRef<
                             <div
                               className={getClassNames(editorStyles, [
                                 "col",
-                                "announcements-announcement-col-px-desktop",
+                                "px-lg-6",
                               ])}
                             >
                               <p>{announcement.announcement}</p>
                               {announcement.link_text && announcement.link_url && (
                                 <div className={editorStyles["mt-4"]}>
                                   <div
-                                    className={getClassNames(editorStyles, [
-                                      "announcements-announcement-link",
-                                      "bp-sec-button",
-                                    ])}
+                                    className={
+                                      editorStyles[
+                                        "announcements-announcement-link"
+                                      ]
+                                    }
                                   >
                                     <span>{announcement.link_text}</span>
                                   </div>

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -49,7 +49,7 @@ export interface InfopicSection {
   description?: string
   button?: string
   url?: string
-  images?: string
+  image?: string
   alt?: string
 }
 
@@ -57,6 +57,18 @@ export interface ResourcesSection {
   title?: string
   subtitle?: string
   button?: string
+}
+
+export interface AnnouncementsSection {
+  title?: string
+  subtitle?: string
+  announcement_items?: Array<{
+    title?: string
+    date?: string
+    announcement?: string
+    link_text?: string
+    link_url?: string
+  }>
 }
 
 export interface HomepageDto {
@@ -73,6 +85,7 @@ export interface HomepageDto {
         | InfobarSection
         | InfopicSection
         | ResourcesSection
+        | AnnouncementsSection
       )[]
     }
     pageBody?: string
@@ -91,20 +104,18 @@ export type HomepageEditorHeroSection =
   | EditorHeroHighlightsSection
 
 export type HeroFrontmatterSection = { hero: HomepageEditorHeroSection }
-// TODO: add properties here instead of typing as `Record<string, unknown>`
-// we can find them in `HomepagePreview`
-export type ResourcesFrontmatterSection = { resources: Record<string, unknown> }
+export type ResourcesFrontmatterSection = { resources: ResourcesSection }
 
-// TODO: add properties here instead of typing as `Record<string, unknown>`
-// we can find them in `HomepagePreview`
 export type InfopicFrontmatterSection = {
-  infopic: Record<string, unknown>
+  infopic: InfopicSection
 }
 
-// TODO: add properties here instead of typing as `Record<string, unknown>`
-// we can find them in `HomepagePreview`
 export type InfobarFrontmatterSection = {
-  infobar: Record<string, unknown>
+  infobar: InfobarSection
+}
+
+export type AnnouncementsFrontmatterSection = {
+  announcements: AnnouncementsSection
 }
 
 export type EditorHomepageFrontmatterSection =
@@ -112,6 +123,7 @@ export type EditorHomepageFrontmatterSection =
   | ResourcesFrontmatterSection
   | InfopicFrontmatterSection
   | InfobarFrontmatterSection
+  | AnnouncementsFrontmatterSection
 
 export const EditorHomepageFrontmatterSection = {
   isHero: (
@@ -130,6 +142,10 @@ export const EditorHomepageFrontmatterSection = {
     section: EditorHomepageFrontmatterSection
   ): section is InfobarFrontmatterSection =>
     !!(section as InfobarFrontmatterSection).infobar,
+  isAnnouncements: (
+    section: EditorHomepageFrontmatterSection
+  ): section is AnnouncementsFrontmatterSection =>
+    !!(section as AnnouncementsFrontmatterSection).announcements,
 }
 
 export interface EditorHomepageState {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-517.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- The homepage editor now has the ability to preview a new announcements component.

## Before & After Screenshots

<!-- [insert screenshot here] -->
![Screenshot 2023-09-14 at 3 41 04 PM](https://github.com/isomerpages/isomercms-frontend/assets/27919917/f830ed1d-f021-4556-9963-9c9cbdfdb87f)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

No tests are currently available, as the announcements component can only be previewed once the left sidebar is updated to support editing of the new announcements component.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*