### PR TITLE
fix(styles): introduce site colors as CSS variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "sass": "^1.51.0",
         "sgds-govtech": "^1.3.16",
         "slugify": "^1.6.5",
+        "tinycolor2": "^1.6.0",
         "toml": "^3.0.0",
         "turndown": "^7.1.1",
         "turndown-plugin-gfm": "^1.0.2",
@@ -35650,7 +35651,8 @@
     },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "sass": "^1.51.0",
     "sgds-govtech": "^1.3.16",
     "slugify": "^1.6.5",
+    "tinycolor2": "^1.6.0",
     "toml": "^3.0.0",
     "turndown": "^7.1.1",
     "turndown-plugin-gfm": "^1.0.2",

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -1,4 +1,5 @@
 import axios from "axios"
+import tinycolor from "tinycolor2"
 
 // axios settings
 axios.defaults.withCredentials = true
@@ -31,6 +32,7 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
   styleElement.setAttribute("title", styleTitle)
   document.head.appendChild(styleElement)
 
+  const secondaryColorHover = tinycolor(secondaryColor).lighten(10).toString()
   const customStyleSheet = getStyleSheet(styleTitle)
 
   // breadcrumb - primary color
@@ -128,6 +130,11 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
   )
   customStyleSheet.insertRule(
     `.sgds-icon.bx-chevron-down:before { color: ${secondaryColor} !important;}`,
+    0
+  )
+
+  customStyleSheet.insertRule(
+    `:root { --site-primary-color: ${primaryColor} !important; --site-secondary-color: ${secondaryColor} !important; --site-secondary-color-hover: ${secondaryColorHover} !important;}`,
     0
   )
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The site colours are not available in SCSS as they are only available at runtime. This meant that we cannot make use of CSS classes that needs to change based on the site colours defined by the user.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- This change adds the primary and secondary colours that can be set by the user for the site as CSS variables.
- The secondary colour hover has also been implemented the same way as the template, which is to lighten by 10%.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Visit any site's homepage
    - [ ] See that the `--site-primary-color`, `--site-secondary-color` and `--site-secondary-color-hover` variables are defined in the root element

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `tinycolor2` : Library for performing SCSS's lighten on a provided HEX code