### PR TITLE
Feat/text cards panel

### DIFF
--- a/src/components/Editable/Editable.tsx
+++ b/src/components/Editable/Editable.tsx
@@ -167,6 +167,7 @@ type HomepageDroppableZone =
   | "leftPane"
   | "highlight"
   | "announcement"
+  | `textcardcard-${number}`
 type ContactUsDroppableZone =
   | "locations"
   | "contacts"

--- a/src/components/Editable/Editable.tsx
+++ b/src/components/Editable/Editable.tsx
@@ -167,7 +167,7 @@ type HomepageDroppableZone =
   | "leftPane"
   | "highlight"
   | "announcement"
-  | `textcardcard-${number}`
+  | `textCardItem-${number}`
 type ContactUsDroppableZone =
   | "locations"
   | "contacts"

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -9,12 +9,17 @@ import {
   EditorHeroHighlightsSection,
   EditorHomepageElement,
   EditorHomepageState,
+  EditorTextcardCardsSection,
+  EditorTextcardSection,
   HeroFrontmatterSection,
   PossibleEditorSections,
   EditorHomepageFrontmatterSection,
   AnnouncementsFrontmatterSection,
   AnnouncementOption,
+  TextcardFrontmatterSection,
 } from "types/homepage"
+
+const RADIX_PARSE_INT = 10
 
 const updatePositions = <T,>(
   section: T[],
@@ -44,11 +49,24 @@ const deleteElement = <T,>(section: T[], indexToDelete: number): T[] => {
   })
 }
 
+const updateElement = <T,>(
+  section: T[],
+  elem: T,
+  indexToUpdate: number
+): T[] => {
+  return update(section, {
+    [indexToUpdate]: {
+      $set: elem,
+    },
+  })
+}
+
 const updateEditorSection = (
   homepageState: EditorHomepageState,
   newDisplaySections: unknown[],
   newFrontMatterSection: EditorHomepageState["frontMatter"]["sections"],
-  newSectionErrors: unknown[]
+  newSectionErrors: unknown[],
+  newTextcardErrors: unknown[][]
 ): EditorHomepageState => ({
   ...homepageState,
   displaySections: newDisplaySections,
@@ -56,7 +74,11 @@ const updateEditorSection = (
     ...homepageState.frontMatter,
     sections: newFrontMatterSection,
   },
-  errors: { ...homepageState.errors, sections: newSectionErrors },
+  errors: {
+    ...homepageState.errors,
+    sections: newSectionErrors,
+    textcards: newTextcardErrors,
+  },
 })
 
 const updateAnnouncementSection = (
@@ -125,6 +147,37 @@ const updateHighlightsSection = (
   errors: { ...homepageState.errors, highlights: newHighlightErrors },
 })
 
+const updateTextCardsCardSection = (
+  homepageState: EditorHomepageState,
+  sectionIndex: number,
+  newTextCards: unknown[],
+  newTextCardErrors: unknown[]
+): EditorHomepageState => ({
+  ...homepageState,
+  frontMatter: {
+    ...homepageState.frontMatter,
+    sections: _.set(
+      // NOTE: Deep clone here to avoid mutation
+      _.cloneDeep(homepageState.frontMatter.sections),
+      [sectionIndex, "textcards", "cards"],
+      newTextCards
+    ),
+  },
+  errors: {
+    ...homepageState.errors,
+    textcards: _.set(
+      // NOTE: Deep clone here to avoid mutation
+      _.cloneDeep(homepageState.errors.textcards),
+      [sectionIndex],
+      newTextCardErrors
+    ),
+    // {
+    //   ...homepageState.errors.textcards,
+    //   [sectionIndex]: newTextCardErrors,
+    // },
+  },
+})
+
 type OnDragEndResponseWrapper = (
   state: EditorHomepageState
 ) => (result: DropResult) => EditorHomepageState
@@ -164,7 +217,8 @@ const updateHomepageState = (
   )
     return homepageState
 
-  switch (type) {
+  const typeArray = type.split("-")
+  switch (typeArray[0]) {
     case "editor": {
       const draggedElem = frontMatter.sections[source.index]
       const newSections = updatePositions(
@@ -181,6 +235,14 @@ const updateHomepageState = (
         draggedError
       )
 
+      const draggedTextcardError = errors.textcards[source.index]
+      const newCardErrors = updatePositions(
+        errors.textcards,
+        source.index,
+        destination.index,
+        draggedTextcardError
+      )
+
       const displayBool = displaySections[source.index]
       const newDisplaySections = updatePositions(
         displaySections,
@@ -193,7 +255,8 @@ const updateHomepageState = (
         homepageState,
         newDisplaySections,
         newSections,
-        newSectionErrors
+        newSectionErrors,
+        newCardErrors
       )
     }
     // inner dnd for hero
@@ -327,7 +390,35 @@ const updateHomepageState = (
         announcementsIndex
       )
     }
+    case "textcardcard": {
+      const parentId = parseInt(typeArray[1], RADIX_PARSE_INT)
+      const draggedElem = ((frontMatter.sections[
+        parentId
+      ] as TextcardFrontmatterSection).textcards as EditorTextcardSection)
+        .cards[source.index]
+      const newTextcards = updatePositions(
+        ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
+          .textcards as EditorTextcardSection).cards,
+        source.index,
+        destination.index,
+        draggedElem
+      )
 
+      const draggedError = errors.textcards[parentId][source.index]
+      const newTextcardErrors = updatePositions(
+        errors.textcards[parentId],
+        source.index,
+        destination.index,
+        draggedError
+      )
+
+      return updateTextCardsCardSection(
+        homepageState,
+        parentId,
+        newTextcards,
+        newTextcardErrors
+      )
+    }
     default:
       return homepageState
   }
@@ -339,7 +430,8 @@ export const onCreate = <E,>(
   homepageState: EditorHomepageState,
   elemType: EditorHomepageElement,
   val: PossibleEditorSections,
-  err: E
+  err: E,
+  parentId = 0
 ): EditorHomepageState => {
   const {
     errors,
@@ -358,11 +450,14 @@ export const onCreate = <E,>(
       const resetDisplaySections = _.fill(Array(displaySections.length), false)
       const newDisplaySections = createElement(resetDisplaySections, true)
 
+      const newTextcardErrors = createElement(errors.textcards, [])
+
       return updateEditorSection(
         homepageState,
         newDisplaySections,
         sections as EditorHomepageState["frontMatter"]["sections"],
-        newErrorSections
+        newErrorSections,
+        newTextcardErrors
       )
     }
     case "dropdownelem": {
@@ -461,6 +556,28 @@ export const onCreate = <E,>(
         announcementsIndex
       )
     }
+    case "textcardcard": {
+      if (
+        !_.isEmpty(
+          ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
+            .textcards as EditorTextcardCardsSection).cards
+        )
+      ) {
+        const newTextCards = createElement(
+          ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
+            .textcards as EditorTextcardCardsSection).cards,
+          val
+        )
+        const newTextcardErrors = createElement(errors.textcards[parentId], err)
+        return updateTextCardsCardSection(
+          homepageState,
+          parentId,
+          newTextCards,
+          newTextcardErrors
+        )
+      }
+      return updateTextCardsCardSection(homepageState, parentId, [val], [err])
+    }
     default:
       return homepageState
   }
@@ -469,7 +586,8 @@ export const onCreate = <E,>(
 export const onDelete = (
   homepageState: EditorHomepageState,
   elemType: EditorHomepageElement,
-  indexToDelete: number
+  indexToDelete: number,
+  subindexToDelete = 0
 ): EditorHomepageState => {
   const {
     errors,
@@ -485,12 +603,14 @@ export const onDelete = (
       const sections = deleteElement(frontMatter.sections, indexToDelete)
       const newErrorSections = deleteElement(errors.sections, indexToDelete)
       const newDisplaySections = deleteElement(displaySections, indexToDelete)
+      const newTextcardErrors = deleteElement(errors.textcards, indexToDelete)
 
       return updateEditorSection(
         homepageState,
         newDisplaySections,
         sections,
-        newErrorSections
+        newErrorSections,
+        newTextcardErrors
       )
     }
 
@@ -573,6 +693,23 @@ export const onDelete = (
         newAnnouncementOptions,
         newAnnouncementErrors,
         announcementsIndex
+      )
+    }
+    case "textcardcard": {
+      const newTextCards = deleteElement(
+        ((frontMatter.sections[indexToDelete] as TextcardFrontmatterSection)
+          .textcards as EditorTextcardCardsSection).cards,
+        subindexToDelete
+      )
+      const newTextcardErrors = deleteElement(
+        errors.textcards[indexToDelete],
+        subindexToDelete
+      )
+      return updateTextCardsCardSection(
+        homepageState,
+        indexToDelete,
+        newTextCards,
+        newTextcardErrors
       )
     }
     default:

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -171,10 +171,6 @@ const updateTextCardsCardSection = (
       [sectionIndex],
       newTextCardErrors
     ),
-    // {
-    //   ...homepageState.errors.textcards,
-    //   [sectionIndex]: newTextCardErrors,
-    // },
   },
 })
 

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -388,13 +388,12 @@ const updateHomepageState = (
     }
     case "textcardcard": {
       const parentId = parseInt(typeArray[1], RADIX_PARSE_INT)
-      const draggedElem = ((frontMatter.sections[
+      const textCardsItem = (frontMatter.sections[
         parentId
-      ] as TextcardFrontmatterSection).textcards as EditorTextcardSection)
-        .cards[source.index]
+      ] as TextcardFrontmatterSection).textcards as EditorTextcardSection
+      const draggedElem = textCardsItem.cards[source.index]
       const newTextcards = updatePositions(
-        ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
-          .textcards as EditorTextcardSection).cards,
+        textCardsItem.cards,
         source.index,
         destination.index,
         draggedElem

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -379,7 +379,7 @@ const updateHomepageState = (
         announcementsIndex
       )
     }
-    case "textcardcard": {
+    case "textCardItem": {
       const parentId = parseInt(typeArray[1], RADIX_PARSE_INT)
       const textCardsItem = (frontMatter.sections[
         parentId
@@ -544,7 +544,7 @@ export const onCreate = <E,>(
         announcementsIndex
       )
     }
-    case "textcardcard": {
+    case "textCardItem": {
       if (
         !_.isEmpty(
           ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
@@ -683,7 +683,7 @@ export const onDelete = (
         announcementsIndex
       )
     }
-    case "textcardcard": {
+    case "textCardItem": {
       const newTextCards = deleteElement(
         ((frontMatter.sections[indexToDelete] as TextcardFrontmatterSection)
           .textcards as EditorTextcardCardsSection).cards,

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -49,18 +49,6 @@ const deleteElement = <T,>(section: T[], indexToDelete: number): T[] => {
   })
 }
 
-const updateElement = <T,>(
-  section: T[],
-  elem: T,
-  indexToUpdate: number
-): T[] => {
-  return update(section, {
-    [indexToUpdate]: {
-      $set: elem,
-    },
-  })
-}
-
 const updateEditorSection = (
   homepageState: EditorHomepageState,
   newDisplaySections: unknown[],

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -9,7 +9,7 @@ import {
   EditorHeroHighlightsSection,
   EditorHomepageElement,
   EditorHomepageState,
-  EditorTextcardCardsSection,
+  EditortextCardItemsSection,
   EditorTextcardSection,
   HeroFrontmatterSection,
   PossibleEditorSections,
@@ -178,6 +178,38 @@ export const useDrag: OnDragEndResponseWrapper = (
   return updateHomepageState(result, homepageState)
 }
 
+type UpdateHomepageType =
+  | "editor"
+  | "dropdownelem"
+  | "highlight"
+  | "announcement"
+  | `textCardItem-${number}`
+
+const isUpdateHomepageType = (
+  value: unknown
+): value is UpdateHomepageType | EditorHomepageElement => {
+  if (typeof value === "string" && value.startsWith("textCardItem-")) {
+    const valArr = value.split("-")
+    const possibleCardIndex = valArr[1]
+    return (
+      valArr.length === 2 &&
+      !!possibleCardIndex &&
+      !Number.isNaN(Number(possibleCardIndex))
+    )
+  }
+  if (typeof value === "string") {
+    return (
+      value === "editor" ||
+      value === "dropdownelem" ||
+      value === "highlight" ||
+      value === "announcement" ||
+      value === "section"
+    )
+  }
+
+  return false
+}
+
 // NOTE: We mutate by addr in some places
 // maybe we just do a deep copy?
 // and point it to a store next time,
@@ -205,211 +237,209 @@ const updateHomepageState = (
     destination.index === source.index
   )
     return homepageState
+  if (!isUpdateHomepageType(type)) return homepageState
 
-  const typeArray = type.split("-")
-  switch (typeArray[0]) {
-    case "editor": {
-      const draggedElem = frontMatter.sections[source.index]
-      const newSections = updatePositions(
-        frontMatter.sections,
-        source.index,
-        destination.index,
-        draggedElem
-      )
-      const draggedError = errors.sections[source.index]
-      const newSectionErrors = updatePositions(
-        errors.sections,
-        source.index,
-        destination.index,
-        draggedError
-      )
+  if (type === "editor") {
+    const draggedElem = frontMatter.sections[source.index]
+    const newSections = updatePositions(
+      frontMatter.sections,
+      source.index,
+      destination.index,
+      draggedElem
+    )
+    const draggedError = errors.sections[source.index]
+    const newSectionErrors = updatePositions(
+      errors.sections,
+      source.index,
+      destination.index,
+      draggedError
+    )
 
-      const draggedTextcardError = errors.textcards[source.index]
-      const newCardErrors = updatePositions(
-        errors.textcards,
-        source.index,
-        destination.index,
-        draggedTextcardError
-      )
+    const draggedTextcardError = errors.textcards[source.index]
+    const newCardErrors = updatePositions(
+      errors.textcards,
+      source.index,
+      destination.index,
+      draggedTextcardError
+    )
 
-      const displayBool = displaySections[source.index]
-      const newDisplaySections = updatePositions(
-        displaySections,
-        source.index,
-        destination.index,
-        displayBool
-      )
+    const displayBool = displaySections[source.index]
+    const newDisplaySections = updatePositions(
+      displaySections,
+      source.index,
+      destination.index,
+      displayBool
+    )
 
-      return updateEditorSection(
-        homepageState,
-        newDisplaySections,
-        newSections,
-        newSectionErrors,
-        newCardErrors
-      )
+    return updateEditorSection(
+      homepageState,
+      newDisplaySections,
+      newSections,
+      newSectionErrors,
+      newCardErrors
+    )
+  }
+  // inner dnd for hero
+  // passed in via droppableId
+  if (type === "dropdownelem") {
+    // TODO: type check to avoid casting
+    const draggedElem = ((frontMatter.sections[0] as HeroFrontmatterSection)
+      .hero as EditorHeroDropdownSection).dropdown.options[source.index]
+    const newDropdownOptions = updatePositions(
+      ((frontMatter.sections[0] as HeroFrontmatterSection)
+        .hero as EditorHeroDropdownSection).dropdown.options,
+      source.index,
+      destination.index,
+      draggedElem
+    )
+
+    const draggedError = errors.dropdownElems[source.index]
+    const newDropdownErrors = updatePositions(
+      errors.dropdownElems,
+      source.index,
+      destination.index,
+      draggedError
+    )
+    const displayBool = displayDropdownElems[source.index]
+    const newDisplayDropdownElems = updatePositions(
+      displayDropdownElems,
+      source.index,
+      destination.index,
+      displayBool
+    )
+
+    return {
+      ...homepageState,
+      displayDropdownElems: newDisplayDropdownElems,
+      frontMatter: {
+        ...frontMatter,
+        sections: _.set(
+          frontMatter.sections,
+          ["0", "hero", "dropdown", "options"],
+          newDropdownOptions
+        ),
+      },
+      errors: { ...errors, dropdownElems: newDropdownErrors },
     }
-    // inner dnd for hero
-    // passed in via droppableId
-    case "dropdownelem": {
-      // TODO: type check to avoid casting
-      const draggedElem = ((frontMatter.sections[0] as HeroFrontmatterSection)
-        .hero as EditorHeroDropdownSection).dropdown.options[source.index]
-      const newDropdownOptions = updatePositions(
-        ((frontMatter.sections[0] as HeroFrontmatterSection)
-          .hero as EditorHeroDropdownSection).dropdown.options,
-        source.index,
-        destination.index,
-        draggedElem
-      )
+  }
+  if (type === "highlight") {
+    // TODO: type check to avoid casting
+    const draggedElem = ((frontMatter.sections[0] as HeroFrontmatterSection)
+      .hero as EditorHeroHighlightsSection).key_highlights[source.index]
+    const newHighlightOptions = updatePositions(
+      ((frontMatter.sections[0] as HeroFrontmatterSection)
+        .hero as EditorHeroHighlightsSection).key_highlights,
+      source.index,
+      destination.index,
+      draggedElem
+    )
 
-      const draggedError = errors.dropdownElems[source.index]
-      const newDropdownErrors = updatePositions(
-        errors.dropdownElems,
-        source.index,
-        destination.index,
-        draggedError
-      )
-      const displayBool = displayDropdownElems[source.index]
-      const newDisplayDropdownElems = updatePositions(
-        displayDropdownElems,
-        source.index,
-        destination.index,
-        displayBool
-      )
+    const draggedError = errors.highlights[source.index]
+    const newHighlightErrors = updatePositions(
+      errors.highlights,
+      source.index,
+      destination.index,
+      draggedError
+    )
 
-      return {
-        ...homepageState,
-        displayDropdownElems: newDisplayDropdownElems,
-        frontMatter: {
-          ...frontMatter,
-          sections: _.set(
-            frontMatter.sections,
-            ["0", "hero", "dropdown", "options"],
-            newDropdownOptions
-          ),
-        },
-        errors: { ...errors, dropdownElems: newDropdownErrors },
-      }
-    }
-    case "highlight": {
-      // TODO: type check to avoid casting
-      const draggedElem = ((frontMatter.sections[0] as HeroFrontmatterSection)
-        .hero as EditorHeroHighlightsSection).key_highlights[source.index]
-      const newHighlightOptions = updatePositions(
-        ((frontMatter.sections[0] as HeroFrontmatterSection)
-          .hero as EditorHeroHighlightsSection).key_highlights,
-        source.index,
-        destination.index,
-        draggedElem
-      )
-
-      const draggedError = errors.highlights[source.index]
-      const newHighlightErrors = updatePositions(
-        errors.highlights,
-        source.index,
-        destination.index,
-        draggedError
-      )
-
-      const displayBool = displayHighlights[source.index]
-      const newDisplayHighlights = updatePositions(
-        displayHighlights,
-        source.index,
-        destination.index,
-        displayBool
-      )
-      return updateHighlightsSection(
-        homepageState,
-        newDisplayHighlights,
-        newHighlightOptions,
-        newHighlightErrors
-      )
-    }
-    case "announcement": {
-      const doesAnnouncementKeyExist = !_.isEmpty(
-        frontMatter.sections.find((section) =>
-          EditorHomepageFrontmatterSection.isAnnouncements(section)
-        )
-      )
-      if (!doesAnnouncementKeyExist) {
-        // should not reach here, but defensively return the original state
-        return homepageState
-      }
-
-      const announcementsIndex = frontMatter.sections.findIndex((section) =>
+    const displayBool = displayHighlights[source.index]
+    const newDisplayHighlights = updatePositions(
+      displayHighlights,
+      source.index,
+      destination.index,
+      displayBool
+    )
+    return updateHighlightsSection(
+      homepageState,
+      newDisplayHighlights,
+      newHighlightOptions,
+      newHighlightErrors
+    )
+  }
+  if (type === "announcement") {
+    const doesAnnouncementKeyExist = !_.isEmpty(
+      frontMatter.sections.find((section) =>
         EditorHomepageFrontmatterSection.isAnnouncements(section)
       )
-      const draggedElem = (frontMatter.sections[
+    )
+    if (!doesAnnouncementKeyExist) {
+      // should not reach here, but defensively return the original state
+      return homepageState
+    }
+
+    const announcementsIndex = frontMatter.sections.findIndex((section) =>
+      EditorHomepageFrontmatterSection.isAnnouncements(section)
+    )
+    const draggedElem = (frontMatter.sections[
+      announcementsIndex
+      // safe to assert as check is done above
+    ] as AnnouncementsFrontmatterSection).announcements.announcement_items[
+      source.index
+    ]
+
+    const newAnnouncementsOptions = updatePositions(
+      (frontMatter.sections[
         announcementsIndex
         // safe to assert as check is done above
-      ] as AnnouncementsFrontmatterSection).announcements.announcement_items[
-        source.index
-      ]
+      ] as AnnouncementsFrontmatterSection).announcements.announcement_items,
+      source.index,
+      destination.index,
+      draggedElem
+    )
 
-      const newAnnouncementsOptions = updatePositions(
-        (frontMatter.sections[
-          announcementsIndex
-          // safe to assert as check is done above
-        ] as AnnouncementsFrontmatterSection).announcements.announcement_items,
-        source.index,
-        destination.index,
-        draggedElem
-      )
+    const draggedError = errors.announcementItems[source.index]
+    const newAnnouncementErrors = updatePositions(
+      errors.announcementItems,
+      source.index,
+      destination.index,
+      draggedError
+    )
+    const displayBool = displayAnnouncementItems[source.index]
+    const newDisplayAnnouncementItems = updatePositions(
+      displayAnnouncementItems,
+      source.index,
+      destination.index,
+      displayBool
+    )
 
-      const draggedError = errors.announcementItems[source.index]
-      const newAnnouncementErrors = updatePositions(
-        errors.announcementItems,
-        source.index,
-        destination.index,
-        draggedError
-      )
-      const displayBool = displayAnnouncementItems[source.index]
-      const newDisplayAnnouncementItems = updatePositions(
-        displayAnnouncementItems,
-        source.index,
-        destination.index,
-        displayBool
-      )
-
-      return updateAnnouncementSection(
-        homepageState,
-        newDisplayAnnouncementItems,
-        newAnnouncementsOptions,
-        newAnnouncementErrors,
-        announcementsIndex
-      )
-    }
-    case "textCardItem": {
-      const parentId = parseInt(typeArray[1], RADIX_PARSE_INT)
-      const textCardsItem = (frontMatter.sections[
-        parentId
-      ] as TextcardFrontmatterSection).textcards as EditorTextcardSection
-      const draggedElem = textCardsItem.cards[source.index]
-      const newTextcards = updatePositions(
-        textCardsItem.cards,
-        source.index,
-        destination.index,
-        draggedElem
-      )
-
-      const draggedError = errors.textcards[parentId][source.index]
-      const newTextcardErrors = updatePositions(
-        errors.textcards[parentId],
-        source.index,
-        destination.index,
-        draggedError
-      )
-
-      return updateTextCardsCardSection(
-        homepageState,
-        parentId,
-        newTextcards,
-        newTextcardErrors
-      )
-    }
-    default:
-      return homepageState
+    return updateAnnouncementSection(
+      homepageState,
+      newDisplayAnnouncementItems,
+      newAnnouncementsOptions,
+      newAnnouncementErrors,
+      announcementsIndex
+    )
   }
+  if (type.startsWith("textCardItem")) {
+    // We've validated that type can only be such that the second item is a number
+    const parentId = parseInt(type.split("-")[1], RADIX_PARSE_INT)
+    const textCardsItem = (frontMatter.sections[
+      parentId
+    ] as TextcardFrontmatterSection).textcards as EditorTextcardSection
+    const draggedElem = textCardsItem.cards[source.index]
+    const newTextcards = updatePositions(
+      textCardsItem.cards,
+      source.index,
+      destination.index,
+      draggedElem
+    )
+
+    const draggedError = errors.textcards[parentId][source.index]
+    const newTextcardErrors = updatePositions(
+      errors.textcards[parentId],
+      source.index,
+      destination.index,
+      draggedError
+    )
+
+    return updateTextCardsCardSection(
+      homepageState,
+      parentId,
+      newTextcards,
+      newTextcardErrors
+    )
+  }
+  return homepageState
 }
 
 // NOTE: Handles only placement,
@@ -418,8 +448,7 @@ export const onCreate = <E,>(
   homepageState: EditorHomepageState,
   elemType: EditorHomepageElement,
   val: PossibleEditorSections,
-  err: E,
-  parentId = 0
+  err: E
 ): EditorHomepageState => {
   const {
     errors,
@@ -430,212 +459,69 @@ export const onCreate = <E,>(
     displayAnnouncementItems,
   } = homepageState
 
-  switch (elemType) {
-    case "section": {
-      const sections = createElement(frontMatter.sections, val)
-      const newErrorSections = createElement(errors.sections, err)
+  if (!isUpdateHomepageType(elemType)) return homepageState
 
-      const resetDisplaySections = _.fill(Array(displaySections.length), false)
-      const newDisplaySections = createElement(resetDisplaySections, true)
+  if (elemType === "section") {
+    const sections = createElement(frontMatter.sections, val)
+    const newErrorSections = createElement(errors.sections, err)
 
-      const newTextcardErrors = createElement(errors.textcards, [])
+    const resetDisplaySections = _.fill(Array(displaySections.length), false)
+    const newDisplaySections = createElement(resetDisplaySections, true)
 
-      return updateEditorSection(
-        homepageState,
-        newDisplaySections,
-        sections as EditorHomepageState["frontMatter"]["sections"],
-        newErrorSections,
-        newTextcardErrors
-      )
-    }
-    case "dropdownelem": {
-      const newDropdownOptions = createElement(
-        ((frontMatter.sections[0] as HeroFrontmatterSection)
-          .hero as EditorHeroDropdownSection).dropdown.options,
-        val
-      )
-      const newDropdownErrors = createElement(errors.dropdownElems, err)
-      const resetDisplayDropdownElems = _.fill(
-        Array(displayDropdownElems.length),
-        false
-      )
-      const newDisplayDropdownElems = createElement(
-        resetDisplayDropdownElems,
-        true
-      )
+    const newTextcardErrors = createElement(errors.textcards, [])
 
-      return updateDropdownSection(
-        homepageState,
-        newDisplayDropdownElems,
-        newDropdownOptions,
-        newDropdownErrors
-      )
-    }
-    case "highlight": {
-      // If key highlights section exists
-      if (
-        !_.isEmpty(
-          ((frontMatter.sections[0] as HeroFrontmatterSection)
-            .hero as EditorHeroHighlightsSection).key_highlights
-        )
-      ) {
-        const newHighlightOptions = createElement(
-          ((frontMatter.sections[0] as HeroFrontmatterSection)
-            .hero as EditorHeroHighlightsSection).key_highlights,
-          val
-        )
-
-        const newHighlightErrors = createElement(errors.highlights, err)
-
-        const resetDisplayHighlights = _.fill(
-          Array(displayHighlights.length),
-          false
-        )
-        const newDisplayHighlights = createElement(resetDisplayHighlights, true)
-
-        return updateHighlightsSection(
-          homepageState,
-          newDisplayHighlights,
-          newHighlightOptions,
-          newHighlightErrors
-        )
-      }
-
-      return updateHighlightsSection(homepageState, [true], [val], [err])
-    }
-    case "announcement": {
-      const announcementKeyExist = !_.isEmpty(
-        frontMatter.sections.find((section) =>
-          EditorHomepageFrontmatterSection.isAnnouncements(section)
-        )
-      )
-      if (!announcementKeyExist) {
-        // should not reach here, but defensively return the original state
-        return homepageState
-      }
-
-      const announcementsIndex = frontMatter.sections.findIndex((section) =>
-        EditorHomepageFrontmatterSection.isAnnouncements(section)
-      )
-      const announcementBlockSection: AnnouncementsFrontmatterSection = frontMatter
-        .sections[announcementsIndex] as AnnouncementsFrontmatterSection
-
-      const announcements = createElement(
-        announcementBlockSection.announcements.announcement_items,
-        val as AnnouncementOption
-      )
-
-      const resetDisplaySections = _.fill(
-        Array(displayAnnouncementItems.length),
-        false
-      )
-      const newDisplayAnnouncementItems = createElement(
-        resetDisplaySections,
-        true
-      )
-
-      const newAnnouncementErrors = createElement(errors.announcementItems, err)
-
-      return updateAnnouncementSection(
-        homepageState,
-        newDisplayAnnouncementItems,
-        announcements,
-        newAnnouncementErrors,
-        announcementsIndex
-      )
-    }
-    case "textCardItem": {
-      if (
-        !_.isEmpty(
-          ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
-            .textcards as EditorTextcardCardsSection).cards
-        )
-      ) {
-        const newTextCards = createElement(
-          ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
-            .textcards as EditorTextcardCardsSection).cards,
-          val
-        )
-        const newTextcardErrors = createElement(errors.textcards[parentId], err)
-        return updateTextCardsCardSection(
-          homepageState,
-          parentId,
-          newTextCards,
-          newTextcardErrors
-        )
-      }
-      return updateTextCardsCardSection(homepageState, parentId, [val], [err])
-    }
-    default:
-      return homepageState
+    return updateEditorSection(
+      homepageState,
+      newDisplaySections,
+      sections as EditorHomepageState["frontMatter"]["sections"],
+      newErrorSections,
+      newTextcardErrors
+    )
   }
-}
+  if (elemType === "dropdownelem") {
+    const newDropdownOptions = createElement(
+      ((frontMatter.sections[0] as HeroFrontmatterSection)
+        .hero as EditorHeroDropdownSection).dropdown.options,
+      val
+    )
+    const newDropdownErrors = createElement(errors.dropdownElems, err)
+    const resetDisplayDropdownElems = _.fill(
+      Array(displayDropdownElems.length),
+      false
+    )
+    const newDisplayDropdownElems = createElement(
+      resetDisplayDropdownElems,
+      true
+    )
 
-export const onDelete = (
-  homepageState: EditorHomepageState,
-  elemType: EditorHomepageElement,
-  indexToDelete: number,
-  subindexToDelete = 0
-): EditorHomepageState => {
-  const {
-    errors,
-    frontMatter,
-    displaySections,
-    displayDropdownElems,
-    displayHighlights,
-    displayAnnouncementItems,
-  } = homepageState
-
-  switch (elemType) {
-    case "section": {
-      const sections = deleteElement(frontMatter.sections, indexToDelete)
-      const newErrorSections = deleteElement(errors.sections, indexToDelete)
-      const newDisplaySections = deleteElement(displaySections, indexToDelete)
-      const newTextcardErrors = deleteElement(errors.textcards, indexToDelete)
-
-      return updateEditorSection(
-        homepageState,
-        newDisplaySections,
-        sections,
-        newErrorSections,
-        newTextcardErrors
-      )
-    }
-
-    case "dropdownelem": {
-      const newDropdownOptions = deleteElement(
+    return updateDropdownSection(
+      homepageState,
+      newDisplayDropdownElems,
+      newDropdownOptions,
+      newDropdownErrors
+    )
+  }
+  if (elemType === "highlight") {
+    // If key highlights section exists
+    if (
+      !_.isEmpty(
         ((frontMatter.sections[0] as HeroFrontmatterSection)
-          .hero as EditorHeroDropdownSection).dropdown.options,
-        indexToDelete
+          .hero as EditorHeroHighlightsSection).key_highlights
       )
-      const newDropdownErrors = deleteElement(
-        errors.dropdownElems,
-        indexToDelete
-      )
-      const newDisplayDropdownElems = deleteElement(
-        displayDropdownElems,
-        indexToDelete
-      )
-
-      return updateDropdownSection(
-        homepageState,
-        newDisplayDropdownElems,
-        newDropdownOptions,
-        newDropdownErrors
-      )
-    }
-    case "highlight": {
-      const newHighlightOptions = deleteElement(
+    ) {
+      const newHighlightOptions = createElement(
         ((frontMatter.sections[0] as HeroFrontmatterSection)
           .hero as EditorHeroHighlightsSection).key_highlights,
-        indexToDelete
+        val
       )
-      const newHighlightErrors = deleteElement(errors.highlights, indexToDelete)
 
-      const newDisplayHighlights = deleteElement(
-        displayHighlights,
-        indexToDelete
+      const newHighlightErrors = createElement(errors.highlights, err)
+
+      const resetDisplayHighlights = _.fill(
+        Array(displayHighlights.length),
+        false
       )
+      const newDisplayHighlights = createElement(resetDisplayHighlights, true)
 
       return updateHighlightsSection(
         homepageState,
@@ -644,63 +530,200 @@ export const onDelete = (
         newHighlightErrors
       )
     }
-    case "announcement": {
-      const announcementKeyExist = !_.isEmpty(
-        frontMatter.sections.find((section) =>
-          EditorHomepageFrontmatterSection.isAnnouncements(section)
-        )
-      )
-      if (!announcementKeyExist) {
-        // should not reach here, but defensively return the original state
-        return homepageState
-      }
 
-      const announcementsIndex = frontMatter.sections.findIndex((section) =>
+    return updateHighlightsSection(homepageState, [true], [val], [err])
+  }
+  if (elemType === "announcement") {
+    const announcementKeyExist = !_.isEmpty(
+      frontMatter.sections.find((section) =>
         EditorHomepageFrontmatterSection.isAnnouncements(section)
       )
-      const announcementsSection: AnnouncementsFrontmatterSection = frontMatter
-        .sections[announcementsIndex] as AnnouncementsFrontmatterSection
-
-      const newAnnouncementOptions = deleteElement(
-        announcementsSection.announcements.announcement_items,
-        indexToDelete
-      )
-      const newAnnouncementErrors = deleteElement(
-        errors.announcementItems,
-        indexToDelete
-      )
-
-      const newDisplayAnnouncements = deleteElement(
-        displayAnnouncementItems,
-        indexToDelete
-      )
-
-      return updateAnnouncementSection(
-        homepageState,
-        newDisplayAnnouncements,
-        newAnnouncementOptions,
-        newAnnouncementErrors,
-        announcementsIndex
-      )
+    )
+    if (!announcementKeyExist) {
+      // should not reach here, but defensively return the original state
+      return homepageState
     }
-    case "textCardItem": {
-      const newTextCards = deleteElement(
-        ((frontMatter.sections[indexToDelete] as TextcardFrontmatterSection)
-          .textcards as EditorTextcardCardsSection).cards,
-        subindexToDelete
-      )
-      const newTextcardErrors = deleteElement(
-        errors.textcards[indexToDelete],
-        subindexToDelete
-      )
+
+    const announcementsIndex = frontMatter.sections.findIndex((section) =>
+      EditorHomepageFrontmatterSection.isAnnouncements(section)
+    )
+    const announcementBlockSection: AnnouncementsFrontmatterSection = frontMatter
+      .sections[announcementsIndex] as AnnouncementsFrontmatterSection
+
+    const announcements = createElement(
+      announcementBlockSection.announcements.announcement_items,
+      val as AnnouncementOption
+    )
+
+    const resetDisplaySections = _.fill(
+      Array(displayAnnouncementItems.length),
+      false
+    )
+    const newDisplayAnnouncementItems = createElement(
+      resetDisplaySections,
+      true
+    )
+
+    const newAnnouncementErrors = createElement(errors.announcementItems, err)
+
+    return updateAnnouncementSection(
+      homepageState,
+      newDisplayAnnouncementItems,
+      announcements,
+      newAnnouncementErrors,
+      announcementsIndex
+    )
+  }
+  if (elemType.startsWith("textCardItem")) {
+    // We've validated that type can only be such that the second item is a number
+    const parentId = parseInt(elemType.split("-")[1], RADIX_PARSE_INT)
+    const sectionInfo = (frontMatter.sections[
+      parentId
+    ] as TextcardFrontmatterSection).textcards as EditortextCardItemsSection
+    if (!_.isEmpty(sectionInfo.cards)) {
+      const newTextCards = createElement(sectionInfo.cards, val)
+      const newTextcardErrors = createElement(errors.textcards[parentId], err)
       return updateTextCardsCardSection(
         homepageState,
-        indexToDelete,
+        parentId,
         newTextCards,
         newTextcardErrors
       )
     }
-    default:
-      return homepageState
+    const newState = updateTextCardsCardSection(
+      homepageState,
+      parentId,
+      [val],
+      [err]
+    )
+    return newState
   }
+  return homepageState
+}
+
+export const onDelete = (
+  homepageState: EditorHomepageState,
+  elemType: EditorHomepageElement,
+  indexToDelete: number
+): EditorHomepageState => {
+  const {
+    errors,
+    frontMatter,
+    displaySections,
+    displayDropdownElems,
+    displayHighlights,
+    displayAnnouncementItems,
+  } = homepageState
+
+  if (!isUpdateHomepageType(elemType)) return homepageState
+  if (elemType === "section") {
+    const sections = deleteElement(frontMatter.sections, indexToDelete)
+    const newErrorSections = deleteElement(errors.sections, indexToDelete)
+    const newDisplaySections = deleteElement(displaySections, indexToDelete)
+    const newTextcardErrors = deleteElement(errors.textcards, indexToDelete)
+
+    return updateEditorSection(
+      homepageState,
+      newDisplaySections,
+      sections,
+      newErrorSections,
+      newTextcardErrors
+    )
+  }
+
+  if (elemType === "dropdownelem") {
+    const newDropdownOptions = deleteElement(
+      ((frontMatter.sections[0] as HeroFrontmatterSection)
+        .hero as EditorHeroDropdownSection).dropdown.options,
+      indexToDelete
+    )
+    const newDropdownErrors = deleteElement(errors.dropdownElems, indexToDelete)
+    const newDisplayDropdownElems = deleteElement(
+      displayDropdownElems,
+      indexToDelete
+    )
+
+    return updateDropdownSection(
+      homepageState,
+      newDisplayDropdownElems,
+      newDropdownOptions,
+      newDropdownErrors
+    )
+  }
+  if (elemType === "highlight") {
+    const newHighlightOptions = deleteElement(
+      ((frontMatter.sections[0] as HeroFrontmatterSection)
+        .hero as EditorHeroHighlightsSection).key_highlights,
+      indexToDelete
+    )
+    const newHighlightErrors = deleteElement(errors.highlights, indexToDelete)
+
+    const newDisplayHighlights = deleteElement(displayHighlights, indexToDelete)
+
+    return updateHighlightsSection(
+      homepageState,
+      newDisplayHighlights,
+      newHighlightOptions,
+      newHighlightErrors
+    )
+  }
+  if (elemType === "announcement") {
+    const announcementKeyExist = !_.isEmpty(
+      frontMatter.sections.find((section) =>
+        EditorHomepageFrontmatterSection.isAnnouncements(section)
+      )
+    )
+    if (!announcementKeyExist) {
+      // should not reach here, but defensively return the original state
+      return homepageState
+    }
+
+    const announcementsIndex = frontMatter.sections.findIndex((section) =>
+      EditorHomepageFrontmatterSection.isAnnouncements(section)
+    )
+    const announcementsSection: AnnouncementsFrontmatterSection = frontMatter
+      .sections[announcementsIndex] as AnnouncementsFrontmatterSection
+
+    const newAnnouncementOptions = deleteElement(
+      announcementsSection.announcements.announcement_items,
+      indexToDelete
+    )
+    const newAnnouncementErrors = deleteElement(
+      errors.announcementItems,
+      indexToDelete
+    )
+
+    const newDisplayAnnouncements = deleteElement(
+      displayAnnouncementItems,
+      indexToDelete
+    )
+
+    return updateAnnouncementSection(
+      homepageState,
+      newDisplayAnnouncements,
+      newAnnouncementOptions,
+      newAnnouncementErrors,
+      announcementsIndex
+    )
+  }
+  if (elemType.startsWith("textCardItem")) {
+    // We've validated that type can only be such that the second item is a number
+    const parentId = parseInt(elemType.split("-")[1], RADIX_PARSE_INT)
+    const newTextCards = deleteElement(
+      ((frontMatter.sections[parentId] as TextcardFrontmatterSection)
+        .textcards as EditortextCardItemsSection).cards,
+      indexToDelete
+    )
+    const newTextcardErrors = deleteElement(
+      errors.textcards[parentId],
+      indexToDelete
+    )
+    return updateTextCardsCardSection(
+      homepageState,
+      parentId,
+      newTextCards,
+      newTextcardErrors
+    )
+  }
+  return homepageState
 }

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -140,27 +140,32 @@ const updateTextCardsCardSection = (
   sectionIndex: number,
   newTextCards: unknown[],
   newTextCardErrors: unknown[]
-): EditorHomepageState => ({
-  ...homepageState,
-  frontMatter: {
-    ...homepageState.frontMatter,
-    sections: _.set(
-      // NOTE: Deep clone here to avoid mutation
-      _.cloneDeep(homepageState.frontMatter.sections),
-      [sectionIndex, "textcards", "cards"],
-      newTextCards
-    ),
-  },
-  errors: {
-    ...homepageState.errors,
-    textcards: _.set(
-      // NOTE: Deep clone here to avoid mutation
-      _.cloneDeep(homepageState.errors.textcards),
-      [sectionIndex],
-      newTextCardErrors
-    ),
-  },
-})
+): EditorHomepageState => {
+  // Needs to be done separately - lodash's set seems to be buggy when handling arrays of objects
+  const modifiedSection = _.set(
+    _.cloneDeep(homepageState.frontMatter.sections[sectionIndex]),
+    ["textcards", "cards"],
+    newTextCards
+  )
+  const newSections = _.cloneDeep(homepageState.frontMatter.sections)
+  newSections[sectionIndex] = modifiedSection
+  return {
+    ...homepageState,
+    frontMatter: {
+      ...homepageState.frontMatter,
+      sections: newSections,
+    },
+    errors: {
+      ...homepageState.errors,
+      textcards: _.set(
+        // NOTE: Deep clone here to avoid mutation
+        _.cloneDeep(homepageState.errors.textcards),
+        [sectionIndex],
+        newTextCardErrors
+      ),
+    },
+  }
+}
 
 type OnDragEndResponseWrapper = (
   state: EditorHomepageState

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -113,7 +113,9 @@ const getHasErrors = (errors) => {
   const hasHighlightErrors = getHasError(errors.highlights)
   const hasDropdownElemErrors = getHasError(errors.dropdownElems)
   const hasAnnouncementErrors = getHasError(errors.announcementItems)
-  const hasTextcardCardErrors = getHasError(errors.textcards)
+  const hasTextcardCardErrors = _.some(errors.textcards, (section) =>
+    getHasError(section)
+  )
 
   return (
     hasSectionErrors ||

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -114,7 +114,7 @@ const getHasErrors = (errors) => {
   const hasHighlightErrors = getHasError(errors.highlights)
   const hasDropdownElemErrors = getHasError(errors.dropdownElems)
   const hasAnnouncementErrors = getHasError(errors.announcementItems)
-  const hasTextcardCardErrors = _.some(errors.textcards, (section) =>
+  const hastextCardItemErrors = _.some(errors.textcards, (section) =>
     getHasError(section)
   )
 
@@ -123,7 +123,7 @@ const getHasErrors = (errors) => {
     hasHighlightErrors ||
     hasDropdownElemErrors ||
     hasAnnouncementErrors ||
-    hasTextcardCardErrors
+    hastextCardItemErrors
   )
 }
 
@@ -826,10 +826,9 @@ const EditHomepage = ({ match }) => {
           const err = getErrorValues(TEXTCARDS_ITEM_SECTION)
           const updatedHomepageState = onCreate(
             homepageState,
-            elemType,
+            `${elemType}-${parentId}`,
             val,
-            err,
-            parentId
+            err
           )
 
           setHomepageState(updatedHomepageState)
@@ -866,8 +865,7 @@ const EditHomepage = ({ match }) => {
 
         const newHomepageState = onDelete(
           homepageState,
-          elemType,
-          index,
+          `${elemType}-${index}`,
           childIndex
         )
         setHomepageState(newHomepageState)

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -262,7 +262,7 @@ const EditHomepage = ({ match }) => {
         let dropdownElemsErrors = []
         let highlightsErrors = []
         let announcementItemErrors = []
-        const textcardCardErrors = []
+        const textCardItemErrors = []
         const scrollRefs = []
         const announcementScrollRefs = []
         frontMatter.sections.forEach((section) => {
@@ -349,11 +349,11 @@ const EditHomepage = ({ match }) => {
             })
             const { cards } = section.textcards
             // Fill in dropdown elem errors array
-            textcardCardErrors.push(
+            textCardItemErrors.push(
               _.map(cards, () => getErrorValues(TEXTCARDS_ITEM_SECTION))
             )
           } else {
-            textcardCardErrors.push([])
+            textCardItemErrors.push([])
           }
 
           // Minimize all sections by default
@@ -366,7 +366,7 @@ const EditHomepage = ({ match }) => {
           highlights: highlightsErrors,
           dropdownElems: dropdownElemsErrors,
           announcementItems: announcementItemErrors,
-          textcards: textcardCardErrors,
+          textcards: textCardItemErrors,
         }
 
         setFrontMatter(frontMatter)
@@ -640,7 +640,7 @@ const EditHomepage = ({ match }) => {
           scrollTo(scrollRefs[0])
           break
         }
-        case "textcardcard": {
+        case "textCardItem": {
           // The field that changed is a text card element
           const { sections } = frontMatter
 
@@ -819,7 +819,7 @@ const EditHomepage = ({ match }) => {
           scrollTo(announcementScrollRefs[newAnnouncementIndex])
           break
         }
-        case "textcardcard": {
+        case "textCardItem": {
           const parentId = parseInt(idArray[1], RADIX_PARSE_INT)
           const val = TEXTCARDS_ITEM_SECTION
           const err = getErrorValues(TEXTCARDS_ITEM_SECTION)
@@ -860,7 +860,7 @@ const EditHomepage = ({ match }) => {
         })
         setAnnouncementScrollRefs(newAnnouncementScrollRefs)
       }
-      if (elemType === "textcardcard") {
+      if (elemType === "textCardItem") {
         const childIndex = parseInt(idArray[2], RADIX_PARSE_INT)
 
         const newHomepageState = onDelete(

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -47,6 +47,7 @@ import {
 import {
   HomepageStartEditingImage,
   HomepageAnnouncementsSampleImage,
+  HomepageTextCardsSampleImage,
 } from "assets"
 import { EditorHomepageFrontmatterSection } from "types/homepage"
 import { DEFAULT_RETRY_MSG } from "utils"
@@ -1478,6 +1479,18 @@ const EditHomepage = ({ match }) => {
                         subtitle={INFOBAR_SECTION.subtitle}
                         onClick={() => onClick(INFOBAR_SECTION.id)}
                       />
+                      {/* NOTE: Check if the sections contain any `resources`
+                                and if it does, prevent creation of another `resources` section
+                            */}
+                      {!frontMatter.sections.some(
+                        ({ resources }) => !!resources
+                      ) && (
+                        <AddSectionButton.Option
+                          title={RESOURCES_SECTION.title}
+                          subtitle={RESOURCES_SECTION.subtitle}
+                          onClick={() => onClick(RESOURCES_SECTION.id)}
+                        />
+                      )}
                       {/* NOTE: Check if the sections contain any `announcements`
                                 and if it does, prevent creation of another `resources` section
                             */}
@@ -1497,24 +1510,19 @@ const EditHomepage = ({ match }) => {
                             />
                           </AddSectionButton.HelpOverlay>
                         )}
-
-                      {/* NOTE: Check if the sections contain any `resources`
-                                and if it does, prevent creation of another `resources` section
-                            */}
-                      {!frontMatter.sections.some(
-                        ({ resources }) => !!resources
-                      ) && (
-                        <AddSectionButton.Option
-                          title={RESOURCES_SECTION.title}
-                          subtitle={RESOURCES_SECTION.subtitle}
-                          onClick={() => onClick(RESOURCES_SECTION.id)}
-                        />
+                      {showNewLayouts && (
+                        <AddSectionButton.HelpOverlay
+                          title="Text cards"
+                          description="Add clickable cards with bite-sized information to your homepage. You can link any page or external URL, such as blog posts, articles, and more."
+                          image={<HomepageTextCardsSampleImage />}
+                        >
+                          <AddSectionButton.Option
+                            title={TEXTCARDS_BLOCK_SECTION.title}
+                            subtitle={TEXTCARDS_BLOCK_SECTION.subtitle}
+                            onClick={() => onClick(TEXTCARDS_BLOCK_SECTION.id)}
+                          />
+                        </AddSectionButton.HelpOverlay>
                       )}
-                      <AddSectionButton.Option
-                        title={TEXTCARDS_BLOCK_SECTION.title}
-                        subtitle={TEXTCARDS_BLOCK_SECTION.subtitle}
-                        onClick={() => onClick(TEXTCARDS_BLOCK_SECTION.id)}
-                      />
                     </AddSectionButton.List>
                   </AddSectionButton>
                 </Box>

--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -10,6 +10,7 @@ import TemplateInfobarSection from "templates/homepage/InfobarSection"
 import TemplateInfopicLeftSection from "templates/homepage/InfopicLeftSection"
 import TemplateInfopicRightSection from "templates/homepage/InfopicRightSection"
 import TemplateResourcesSection from "templates/homepage/ResourcesSection"
+import TemplateTextCardsSection from "templates/homepage/TextCardsSection"
 import { getClassNames } from "templates/utils/stylingUtils"
 
 import {
@@ -182,17 +183,17 @@ export const HomepagePreview = ({
               />
             </>
           )}
-          {/* Textcard section placeholder */}
+          {/* Textcard section */}
           {EditorHomepageFrontmatterSection.isTextcard(section) && (
             <>
-              <TemplateInfobarSection
+              <TemplateTextCardsSection
                 key={`section-${sectionIndex}`}
                 title={section.textcards.title}
                 subtitle={section.textcards.subtitle}
                 description={section.textcards.description}
-                button=""
+                cards={section.textcards.cards}
                 sectionIndex={sectionIndex}
-                ref={scrollRefs[sectionIndex]}
+                ref={scrollRefs[sectionIndex] as Ref<HTMLDivElement>}
               />
             </>
           )}

--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -182,6 +182,20 @@ export const HomepagePreview = ({
               />
             </>
           )}
+          {/* Textcard section placeholder */}
+          {EditorHomepageFrontmatterSection.isTextcard(section) && (
+            <>
+              <TemplateInfobarSection
+                key={`section-${sectionIndex}`}
+                title={section.textcards.title}
+                subtitle={section.textcards.subtitle}
+                description={section.textcards.description}
+                button=""
+                sectionIndex={sectionIndex}
+                ref={scrollRefs[sectionIndex]}
+              />
+            </>
+          )}
         </>
       ))}
     </div>

--- a/src/layouts/EditHomepage/constants.ts
+++ b/src/layouts/EditHomepage/constants.ts
@@ -72,3 +72,17 @@ export const DROPDOWN_SECTION = {
   title: "Hero Dropdown Title",
   options: [],
 } as const
+
+export const TEXTCARDS_BLOCK_SECTION = {
+  title: "Text Cards",
+  subtitle: "Add informational text",
+  id: "textcards",
+  description: "Text card description",
+} as const
+
+export const TEXTCARDS_ITEM_SECTION = {
+  title: "Card",
+  description: "Card description",
+  linktext: "Learn more",
+  url: "", // No default value so that no broken link is created
+} as const

--- a/src/layouts/components/Homepage/TextCardsBody.tsx
+++ b/src/layouts/components/Homepage/TextCardsBody.tsx
@@ -1,0 +1,214 @@
+import { FormControl, VStack, Text } from "@chakra-ui/react"
+import { DragDropContext } from "@hello-pangea/dnd"
+import {
+  Button,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+} from "@opengovsg/design-system-react"
+import _ from "lodash"
+
+import { useEditableContext } from "contexts/EditableContext"
+
+import { Editable } from "../Editable"
+import { AddSectionButton } from "../Editable/AddSectionButton"
+
+interface TextCardFormFields {
+  title: string
+  description?: string
+  linktext: string
+  url: string
+}
+
+interface TextCardsSectionFormFields {
+  title: string
+  subtitle?: string
+  description?: string
+  cards: TextCardFormFields[]
+}
+
+interface TextCardsSectionProps extends TextCardsSectionFormFields {
+  index: number
+  errors: Omit<TextCardsSectionFormFields, "cards">
+  cardErrors: TextCardFormFields[]
+}
+
+export const TextCardsSectionBody = ({
+  title,
+  subtitle,
+  description,
+  cards = [],
+  index,
+  errors,
+  cardErrors = [],
+}: TextCardsSectionProps) => {
+  console.log(cards)
+  const { onChange, onDelete, onDragEnd, onCreate } = useEditableContext()
+
+  return (
+    // NOTE: Setting negative margin so that the gap is correct.
+    // This is because there is inbuilt padding onto the `AccordionPanels`.
+    <Editable.Section mt="-0.5rem">
+      <FormControl isInvalid={!!errors.subtitle}>
+        <FormLabel>Subtitle</FormLabel>
+        <Input
+          placeholder="This subtitle appears above the title"
+          id={`section-${index}-textcards-subtitle`}
+          value={subtitle}
+          onChange={onChange}
+        />
+        <FormErrorMessage>{errors.subtitle}</FormErrorMessage>
+      </FormControl>
+      <FormControl isRequired isInvalid={!!errors.title}>
+        <FormLabel>Title</FormLabel>
+        <Input
+          placeholder="Your title goes here"
+          id={`section-${index}-textcards-title`}
+          value={title}
+          onChange={onChange}
+        />
+        <FormErrorMessage>{errors.title}</FormErrorMessage>
+      </FormControl>
+      <FormControl isInvalid={!!errors.description}>
+        <FormLabel>Description</FormLabel>
+        <Input
+          placeholder="This description appears below your title. We recommend keeping it as short and succinct as possible."
+          id={`section-${index}-textcards-description`}
+          value={description}
+          onChange={onChange}
+        />
+        <FormErrorMessage>{errors.description}</FormErrorMessage>
+      </FormControl>
+      <FormControl isRequired pt="0.5rem">
+        <FormLabel mb="0.5rem" textStyle="h6">
+          Cards
+        </FormLabel>
+        <Text textStyle="body-2" mb="1.5rem">
+          Cards are displayed side by side on a desktop screens
+        </Text>
+        <DragDropContext onDragEnd={onDragEnd}>
+          <Editable.Droppable width="100%" editableId={`textcardcard-${index}`}>
+            <Editable.EmptySection
+              title="Add a card to get started"
+              subtitle="You must add at least 1 card to this block"
+              isEmpty={cards.length === 0}
+            >
+              <Editable.Accordion>
+                <VStack p={0} spacing="0.75rem">
+                  {cards.map((card, cardIndex) => (
+                    <Editable.DraggableAccordionItem
+                      draggableId={`textcardcard-${index}-${cardIndex}-draggable`}
+                      index={cardIndex}
+                      title={card.title}
+                      isInvalid={_.some(cardErrors[cardIndex])}
+                      isNested
+                    >
+                      <Editable.Section mt="-0.5rem">
+                        <FormControl
+                          isRequired
+                          isInvalid={!!cardErrors[cardIndex].title}
+                        >
+                          <FormLabel>Title</FormLabel>
+                          <Input
+                            placeholder="This is a title for the card"
+                            id={`textcardcard-${index}-${cardIndex}-title`}
+                            value={card.title}
+                            onChange={onChange}
+                          />
+                          <FormErrorMessage>
+                            {cardErrors[cardIndex].title}
+                          </FormErrorMessage>
+                        </FormControl>
+                        <FormControl
+                          isRequired
+                          isInvalid={!!cardErrors[cardIndex].description}
+                        >
+                          <FormLabel>Description</FormLabel>
+                          <Input
+                            placeholder="This is a description for the card. We recommend keeping it short and succinct."
+                            id={`textcardcard-${index}-${cardIndex}-description`}
+                            value={card.description}
+                            onChange={onChange}
+                          />
+                          <FormErrorMessage>
+                            {cardErrors[cardIndex].description}
+                          </FormErrorMessage>
+                        </FormControl>
+                        <FormControl
+                          isRequired
+                          isInvalid={!!cardErrors[cardIndex].linktext}
+                        >
+                          <FormLabel>Link text</FormLabel>
+                          <Input
+                            placeholder="Learn more"
+                            id={`textcardcard-${index}-${cardIndex}-linktext`}
+                            value={card.linktext}
+                            onChange={onChange}
+                          />
+                          <FormErrorMessage>
+                            {cardErrors[cardIndex].linktext}
+                          </FormErrorMessage>
+                        </FormControl>
+                        <FormControl
+                          isRequired
+                          isInvalid={!!cardErrors[cardIndex].url}
+                        >
+                          <FormLabel>Link URL</FormLabel>
+                          <Input
+                            placeholder="Enter a /page-url or link for this menu item"
+                            id={`textcardcard-${index}-${cardIndex}-url`}
+                            value={card.url}
+                            onChange={onChange}
+                          />
+                          <FormErrorMessage>
+                            {cardErrors[cardIndex].url}
+                          </FormErrorMessage>
+                        </FormControl>
+                        <Button
+                          id={`textcardcard-${index}-${cardIndex}`}
+                          onClick={() =>
+                            onDelete(
+                              `textcardcard-${index}-${cardIndex}`,
+                              "Card"
+                            )
+                          }
+                          alignSelf="center"
+                          variant="clear"
+                          colorScheme="critical"
+                        >
+                          Delete card
+                        </Button>
+                      </Editable.Section>
+                    </Editable.DraggableAccordionItem>
+                  ))}
+                </VStack>
+              </Editable.Accordion>
+            </Editable.EmptySection>
+          </Editable.Droppable>
+        </DragDropContext>
+      </FormControl>
+      <AddSectionButton
+        w="100%"
+        pt="0.5rem"
+        buttonText="Add card"
+        onClick={() => {
+          onCreate({
+            target: {
+              id: `textcardcard-${index}`,
+            },
+          })
+        }}
+      />
+      <Button
+        id={`section-${index}`}
+        onClick={() => onDelete(`section-${index}`, "Text Cards Section")}
+        alignSelf="center"
+        variant="clear"
+        colorScheme="critical"
+        mt="1rem"
+      >
+        Delete cards
+      </Button>
+    </Editable.Section>
+  )
+}

--- a/src/layouts/components/Homepage/TextCardsBody.tsx
+++ b/src/layouts/components/Homepage/TextCardsBody.tsx
@@ -7,12 +7,13 @@ import {
   Input,
 } from "@opengovsg/design-system-react"
 import _ from "lodash"
+import { BiPlus } from "react-icons/bi"
 
 import { useEditableContext } from "contexts/EditableContext"
 
 import { Editable } from "../Editable"
-import { AddSectionButton } from "../Editable/AddSectionButton"
 
+const NUM_MAX_CARDS = 4
 interface TextCardFormFields {
   title: string
   description?: string
@@ -42,7 +43,6 @@ export const TextCardsSectionBody = ({
   errors,
   cardErrors = [],
 }: TextCardsSectionProps) => {
-  console.log(cards)
   const { onChange, onDelete, onDragEnd, onCreate } = useEditableContext()
 
   return (
@@ -187,10 +187,13 @@ export const TextCardsSectionBody = ({
           </Editable.Droppable>
         </DragDropContext>
       </FormControl>
-      <AddSectionButton
-        w="100%"
+      <Button
+        id={`textcardcard-${index}-create`}
+        variant="outline"
+        w="full"
         pt="0.5rem"
-        buttonText="Add card"
+        leftIcon={<BiPlus fontSize="1.5rem" />}
+        isDisabled={cards.length >= NUM_MAX_CARDS}
         onClick={() => {
           onCreate({
             target: {
@@ -198,7 +201,9 @@ export const TextCardsSectionBody = ({
             },
           })
         }}
-      />
+      >
+        Add card
+      </Button>
       <Button
         id={`section-${index}`}
         onClick={() => onDelete(`section-${index}`, "Text Cards Section")}

--- a/src/layouts/components/Homepage/TextCardsBody.tsx
+++ b/src/layouts/components/Homepage/TextCardsBody.tsx
@@ -9,9 +9,9 @@ import {
 import _ from "lodash"
 import { BiPlus } from "react-icons/bi"
 
-import { useEditableContext } from "contexts/EditableContext"
+import { Editable } from "components/Editable"
 
-import { Editable } from "../Editable"
+import { useEditableContext } from "contexts/EditableContext"
 
 const NUM_MAX_CARDS = 4
 interface TextCardFormFields {

--- a/src/layouts/components/Homepage/TextCardsBody.tsx
+++ b/src/layouts/components/Homepage/TextCardsBody.tsx
@@ -87,7 +87,7 @@ export const TextCardsSectionBody = ({
           Cards are displayed side by side on a desktop screens
         </Text>
         <DragDropContext onDragEnd={onDragEnd}>
-          <Editable.Droppable width="100%" editableId={`textcardcard-${index}`}>
+          <Editable.Droppable width="100%" editableId={`textCardItem-${index}`}>
             <Editable.EmptySection
               title="Add a card to get started"
               subtitle="You must add at least 1 card to this block"
@@ -97,7 +97,7 @@ export const TextCardsSectionBody = ({
                 <VStack p={0} spacing="0.75rem">
                   {cards.map((card, cardIndex) => (
                     <Editable.DraggableAccordionItem
-                      draggableId={`textcardcard-${index}-${cardIndex}-draggable`}
+                      draggableId={`textCardItem-${index}-${cardIndex}-draggable`}
                       index={cardIndex}
                       title={card.title}
                       isInvalid={_.some(cardErrors[cardIndex])}
@@ -111,7 +111,7 @@ export const TextCardsSectionBody = ({
                           <FormLabel>Title</FormLabel>
                           <Input
                             placeholder="This is a title for the card"
-                            id={`textcardcard-${index}-${cardIndex}-title`}
+                            id={`textCardItem-${index}-${cardIndex}-title`}
                             value={card.title}
                             onChange={onChange}
                           />
@@ -126,7 +126,7 @@ export const TextCardsSectionBody = ({
                           <FormLabel>Description</FormLabel>
                           <Input
                             placeholder="This is a description for the card. We recommend keeping it short and succinct."
-                            id={`textcardcard-${index}-${cardIndex}-description`}
+                            id={`textCardItem-${index}-${cardIndex}-description`}
                             value={card.description}
                             onChange={onChange}
                           />
@@ -141,7 +141,7 @@ export const TextCardsSectionBody = ({
                           <FormLabel>Link text</FormLabel>
                           <Input
                             placeholder="Learn more"
-                            id={`textcardcard-${index}-${cardIndex}-linktext`}
+                            id={`textCardItem-${index}-${cardIndex}-linktext`}
                             value={card.linktext}
                             onChange={onChange}
                           />
@@ -156,7 +156,7 @@ export const TextCardsSectionBody = ({
                           <FormLabel>Link URL</FormLabel>
                           <Input
                             placeholder="Enter a /page-url or link for this menu item"
-                            id={`textcardcard-${index}-${cardIndex}-url`}
+                            id={`textCardItem-${index}-${cardIndex}-url`}
                             value={card.url}
                             onChange={onChange}
                           />
@@ -165,10 +165,10 @@ export const TextCardsSectionBody = ({
                           </FormErrorMessage>
                         </FormControl>
                         <Button
-                          id={`textcardcard-${index}-${cardIndex}`}
+                          id={`textCardItem-${index}-${cardIndex}`}
                           onClick={() =>
                             onDelete(
-                              `textcardcard-${index}-${cardIndex}`,
+                              `textCardItem-${index}-${cardIndex}`,
                               "Card"
                             )
                           }
@@ -188,7 +188,7 @@ export const TextCardsSectionBody = ({
         </DragDropContext>
       </FormControl>
       <Button
-        id={`textcardcard-${index}-create`}
+        id={`textCardItem-${index}-create`}
         variant="outline"
         w="full"
         pt="0.5rem"
@@ -197,7 +197,7 @@ export const TextCardsSectionBody = ({
         onClick={() => {
           onCreate({
             target: {
-              id: `textcardcard-${index}`,
+              id: `textCardItem-${index}`,
             },
           })
         }}

--- a/src/styles/isomer-template/components/homepage/_index.scss
+++ b/src/styles/isomer-template/components/homepage/_index.scss
@@ -1,2 +1,3 @@
 @import "./announcements.scss";
 @import "./hero.scss";
+@import "./text-cards.scss";

--- a/src/styles/isomer-template/components/homepage/_text-cards.scss
+++ b/src/styles/isomer-template/components/homepage/_text-cards.scss
@@ -1,0 +1,62 @@
+.textcards-section {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+
+  @media screen and (min-width: 1408px) {
+    max-width: 1440px;
+    margin: auto;
+  }
+}
+
+.textcards-card-section {
+  justify-content: center;
+  align-items: flex-start;
+  gap: 2rem;
+  width: 100%;
+  flex-wrap: wrap;
+  flex-direction: column;
+
+  @media screen and (min-width: 770px) {
+    flex-direction: row;
+  }
+
+  .textcards-card-body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    flex: 1 0 0;
+    align-self: stretch;
+    color: #484848;
+
+    border-radius: 4px;
+    border: 1px solid $stroke-default;
+    background: var(--white, #FFF);
+    box-shadow: 0px 0px 10px 0px rgba(191, 191, 191, 0.50);
+
+    @media screen and (min-width: 770px) {
+      max-width: 50%;
+    }
+
+    @media screen and (min-width: 1280px) {
+      max-width: 40%;
+    }
+
+    @media screen and (min-width: 770px) and (max-width: 1279px) {
+      flex: 0 0 calc(50% - 24px);
+    }
+
+    &:hover {
+      background-color: $interaction-hover;
+      cursor: pointer;
+      > .link {
+        color: var(--site-secondary-color-hover);
+      }
+    }
+
+    .textcards-card-description {
+      flex-grow: 1;
+    }
+  }
+}

--- a/src/styles/isomer-template/shared.scss
+++ b/src/styles/isomer-template/shared.scss
@@ -1,0 +1,4 @@
+@charset 'UTF-8';
+
+$stroke-default-color: #D0D5DD;
+$interaction-hover-color: #F9F9F9;

--- a/src/styles/isomer-template/theme/_text-styles.scss
+++ b/src/styles/isomer-template/theme/_text-styles.scss
@@ -1,8 +1,30 @@
+display-1 {
+  color: $content-base;
+
+  font-family: Lato;
+  font-size: 4rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 5rem; /* 125% */
+  letter-spacing: -1.408px;
+}
+
 .h1 {
   color: $content-base;
 
   font-family: Lato;
   font-size: 3rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 3.5rem; /* 116.667% */
+  letter-spacing: -1.056px;
+}
+
+.h1-small {
+  color: $content-base;
+
+  font-family: Lato;
+  font-size: 2.75rem;
   font-style: normal;
   font-weight: 700;
   line-height: 3.5rem; /* 116.667% */
@@ -96,7 +118,7 @@
 }
 
 .button-text {
-  color: $utility-theme-color;
+  color: var(--site-secondary-color);
   text-align: center;
   font-feature-settings: "clig" off, "liga" off;
 
@@ -110,7 +132,7 @@
 }
 
 .link {
-  color: $utility-theme-color;
+  color: var(--site-secondary-color);
   font-variant-numeric: lining-nums tabular-nums;
   font-feature-settings: "clig" off, "liga" off;
 
@@ -122,4 +144,8 @@
   line-height: 1.5rem; /* 133.333% */
   letter-spacing: 0.01688rem;
   text-decoration-line: underline;
+
+  &:hover {
+    color: var(--site-secondary-color-hover)
+  }
 }

--- a/src/templates/homepage/TextCardsSection.tsx
+++ b/src/templates/homepage/TextCardsSection.tsx
@@ -1,0 +1,97 @@
+import { ForwardedRef, forwardRef, RefObject } from "react"
+
+import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
+
+import { getClassNames } from "templates/utils/stylingUtils"
+
+import { TextcardsSection } from "types/homepage"
+
+interface TemplateTextCardsSectionProps extends TextcardsSection {
+  sectionIndex: number
+}
+
+const TemplateTextCardsSection = forwardRef<
+  HTMLDivElement,
+  TemplateTextCardsSectionProps
+>(
+  (
+    {
+      title,
+      subtitle,
+      description,
+      cards,
+      sectionIndex,
+    }: TemplateTextCardsSectionProps,
+    ref: ForwardedRef<HTMLDivElement>
+  ) => {
+    return (
+      <section
+        className={getClassNames(editorStyles, [
+          "px-8",
+          "px-sm-16",
+          "px-md-24",
+          "py-24",
+          sectionIndex % 2 === 1 ? "bg-newssection" : "",
+        ])}
+        ref={ref}
+      >
+        <div
+          className={getClassNames(editorStyles, [
+            "textcards-section",
+            "is-flex",
+          ])}
+        >
+          <p className={getClassNames(editorStyles, ["subtitle-2", "pb-4"])}>
+            {subtitle}
+          </p>
+          <h1 className="h1 has-text-secondary has-text-centered pb-4">
+            {title}
+          </h1>
+          <p
+            className={getClassNames(editorStyles, [
+              "body-1",
+              "has-text-centered",
+              "pb-12",
+            ])}
+          >
+            {description}
+          </p>
+          <div
+            className={getClassNames(editorStyles, [
+              "textcards-card-section",
+              "has-text-left",
+              "is-flex",
+            ])}
+          >
+            {!!cards &&
+              cards.map((card) => (
+                <>
+                  <a
+                    className={getClassNames(editorStyles, [
+                      "textcards-card-body",
+                      "is-flex",
+                      "p-6",
+                    ])}
+                    href="{{ card.url }}"
+                  >
+                    <h3 className={editorStyles.h3}>{card.title}</h3>
+                    <p
+                      className={getClassNames(editorStyles, [
+                        "body-1",
+                        "textcards-card-description",
+                      ])}
+                    >
+                      {card.description}
+                    </p>
+                    <p className={editorStyles.link}>{card.linktext}</p>
+                  </a>
+                </>
+              ))}
+          </div>
+        </div>
+      </section>
+    )
+  }
+)
+
+export default TemplateTextCardsSection

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -78,6 +78,19 @@ export interface AnnouncementsBlockSection {
   subtitle?: string
   announcement_items: AnnouncementOption[]
 }
+export interface TextcardsCard {
+  title: string
+  description?: string
+  linktext: string
+  url: string
+}
+
+export interface TextcardsSection {
+  title: string
+  subtitle?: string
+  description?: string
+  cards: TextcardsCard[]
+}
 
 export interface HomepageDto {
   content: {
@@ -94,6 +107,7 @@ export interface HomepageDto {
         | InfopicSection
         | ResourcesSection
         | AnnouncementsBlockSection
+        | TextcardsSection
       )[]
     }
     pageBody?: string
@@ -106,6 +120,7 @@ export type EditorHomepageElement =
   | "dropdownelem"
   | "highlight"
   | "announcement"
+  | `textcardcard`
 export type PossibleEditorSections = IterableElement<
   | EditorHomepageState["frontMatter"]["sections"]
   | EditorHeroDropdownSection["dropdown"]["options"]
@@ -136,12 +151,27 @@ export type AnnouncementsFrontmatterSection = {
   announcements: AnnouncementsBlockSection
 }
 
+export interface EditorTextcardCardsSection {
+  cards: []
+}
+
+export interface EditorTextcardSection extends EditorTextcardCardsSection {
+  title: string
+  subtitle: string
+  description: string
+}
+
+export type TextcardFrontmatterSection = {
+  textcards: EditorTextcardSection
+}
+
 export type EditorHomepageFrontmatterSection =
   | HeroFrontmatterSection
   | ResourcesFrontmatterSection
   | InfopicFrontmatterSection
   | InfobarFrontmatterSection
   | AnnouncementsFrontmatterSection
+  | TextcardFrontmatterSection
 
 export const EditorHomepageFrontmatterSection = {
   isHero: (
@@ -164,6 +194,10 @@ export const EditorHomepageFrontmatterSection = {
     section: EditorHomepageFrontmatterSection
   ): section is AnnouncementsFrontmatterSection =>
     !!(section as AnnouncementsFrontmatterSection).announcements,
+  isTextcard: (
+    section: EditorHomepageFrontmatterSection
+  ): section is TextcardFrontmatterSection =>
+    !!(section as TextcardFrontmatterSection).textcards,
 }
 
 export interface EditorHomepageState {
@@ -175,6 +209,7 @@ export interface EditorHomepageState {
     dropdownElems: unknown[]
     highlights: unknown[]
     announcementItems: unknown[]
+    textcards: unknown[][]
   }
   displaySections: unknown[]
   displayDropdownElems: unknown[]

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -78,7 +78,7 @@ export interface AnnouncementsBlockSection {
   subtitle?: string
   announcement_items: AnnouncementOption[]
 }
-export interface TextcardsCard {
+export interface TextCardItem {
   title: string
   description?: string
   linktext: string
@@ -89,7 +89,7 @@ export interface TextcardsSection {
   title: string
   subtitle?: string
   description?: string
-  cards: TextcardsCard[]
+  cards: TextCardItem[]
 }
 
 export interface HomepageDto {
@@ -120,7 +120,7 @@ export type EditorHomepageElement =
   | "dropdownelem"
   | "highlight"
   | "announcement"
-  | `textcardcard`
+  | `textCardItem`
 export type PossibleEditorSections = IterableElement<
   | EditorHomepageState["frontMatter"]["sections"]
   | EditorHeroDropdownSection["dropdown"]["options"]

--- a/src/types/homepage.ts
+++ b/src/types/homepage.ts
@@ -120,7 +120,7 @@ export type EditorHomepageElement =
   | "dropdownelem"
   | "highlight"
   | "announcement"
-  | `textCardItem`
+  | `textCardItem-${number}`
 export type PossibleEditorSections = IterableElement<
   | EditorHomepageState["frontMatter"]["sections"]
   | EditorHeroDropdownSection["dropdown"]["options"]
@@ -151,11 +151,11 @@ export type AnnouncementsFrontmatterSection = {
   announcements: AnnouncementsBlockSection
 }
 
-export interface EditorTextcardCardsSection {
+export interface EditortextCardItemsSection {
   cards: []
 }
 
-export interface EditorTextcardSection extends EditorTextcardCardsSection {
+export interface EditorTextcardSection extends EditortextCardItemsSection {
   title: string
   subtitle: string
   description: string

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -124,6 +124,18 @@ const ANNOUNCEMENT_TITLE_MAX_LENGTH = 100
 const ANNOUNCEMENT_DESCRIPTION_MIN_LENGTH = 0
 const ANNOUNCEMENT_DESCRIPTION_MAX_LENGTH = 300
 const ANNOUNCEMENT_LINK_TEXT_URL_MAX_LENGTH = 50
+// Text cards
+const TEXTCARDS_BLOCK_TITLE_MIN_LENGTH = 0
+const TEXTCARDS_BLOCK_TITLE_MAX_LENGTH = 50
+const TEXTCARDS_BLOCK_SUBTITLE_MAX_LENGTH = 30
+const TEXTCARDS_BLOCK_DESCRIPTION_MAX_LENGTH = 200
+
+const TEXTCARDS_CARD_TITLE_MIN_LENGTH = 0
+const TEXTCARDS_CARD_TITLE_MAX_LENGTH = 50
+const TEXTCARDS_CARD_DESCRIPTION_MAX_LENGTH = 80
+const TEXTCARDS_CARD_LINKTEXT_MIN_LENGTH = 0
+const TEXTCARDS_CARD_LINKTEXT_MAX_LENGTH = 50
+const TEXTCARDS_CARD_URL_MIN_LENGTH = 0
 
 // Contact Us Editor
 // ===============
@@ -597,6 +609,89 @@ const validateAnnouncementsSection = (
   return newSectionError
 }
 
+const validateTextcardsSection = (sectionError, sectionType, field, value) => {
+  const newSectionError = sectionError
+  let errorMessage = ""
+  switch (field) {
+    case "title": {
+      // Title is too short
+      if (value.length <= TEXTCARDS_CARD_TITLE_MIN_LENGTH) {
+        errorMessage = `Title should be longer than ${TEXTCARDS_BLOCK_TITLE_MIN_LENGTH} characters.`
+      }
+      // Title is too long
+      if (value.length >= TEXTCARDS_CARD_TITLE_MAX_LENGTH) {
+        errorMessage = `Title should be shorter than ${TEXTCARDS_BLOCK_TITLE_MAX_LENGTH} characters.`
+      }
+      break
+    }
+    case "subtitle": {
+      // Subtitle is too long
+      if (value.length >= TEXTCARDS_BLOCK_SUBTITLE_MAX_LENGTH) {
+        errorMessage = `Subtitle should be shorter than ${TEXTCARDS_BLOCK_SUBTITLE_MAX_LENGTH} characters.`
+      }
+      break
+    }
+    case "description": {
+      // Button text is too long
+      if (value.length >= TEXTCARDS_BLOCK_DESCRIPTION_MAX_LENGTH) {
+        errorMessage = `Button text should be shorter than ${TEXTCARDS_BLOCK_DESCRIPTION_MAX_LENGTH} characters.`
+      }
+      break
+    }
+    default:
+      break
+  }
+  newSectionError[sectionType][field] = errorMessage
+  return newSectionError
+}
+
+const validateTextcard = (cardError, field, value) => {
+  const newHighlightError = cardError
+  let errorMessage = ""
+  switch (field) {
+    case "title": {
+      // Title is too short
+      if (value.length <= TEXTCARDS_CARD_TITLE_MIN_LENGTH) {
+        errorMessage = `The title should be longer than ${TEXTCARDS_CARD_TITLE_MIN_LENGTH} characters.`
+      }
+      // Title is too long
+      if (value.length >= TEXTCARDS_CARD_TITLE_MAX_LENGTH) {
+        errorMessage = `The title should be shorter than ${TEXTCARDS_CARD_TITLE_MAX_LENGTH} characters.`
+      }
+      break
+    }
+    case "description": {
+      // Description is too long
+      if (value.length >= TEXTCARDS_CARD_DESCRIPTION_MAX_LENGTH) {
+        errorMessage = `The description should be shorter than ${TEXTCARDS_CARD_DESCRIPTION_MAX_LENGTH} characters.`
+      }
+      break
+    }
+    case "linktext": {
+      // Link text is too short
+      if (value.length <= TEXTCARDS_CARD_LINKTEXT_MIN_LENGTH) {
+        errorMessage = `The description should be longer than ${TEXTCARDS_CARD_LINKTEXT_MIN_LENGTH} characters.`
+      }
+      // Link text is too long
+      if (value.length >= TEXTCARDS_CARD_LINKTEXT_MAX_LENGTH) {
+        errorMessage = `The description should be shorter than ${TEXTCARDS_CARD_LINKTEXT_MAX_LENGTH} characters.`
+      }
+      break
+    }
+    case "url": {
+      // Url is too short
+      if (value.length <= TEXTCARDS_CARD_URL_MIN_LENGTH) {
+        errorMessage = `The description should be longer than ${TEXTCARDS_CARD_URL_MIN_LENGTH} characters.`
+      }
+      break
+    }
+    default:
+      break
+  }
+  newHighlightError[field] = errorMessage
+  return newHighlightError
+}
+
 const validateSections = (sectionError, sectionType, field, value) => {
   let newSectionError = sectionError
   switch (sectionType) {
@@ -638,6 +733,15 @@ const validateSections = (sectionError, sectionType, field, value) => {
     }
     case "announcements": {
       newSectionError = validateAnnouncementsSection(
+        sectionError,
+        sectionType,
+        field,
+        value
+      )
+      break
+    }
+    case "textcards": {
+      newSectionError = validateTextcardsSection(
         sectionError,
         sectionType,
         field,
@@ -1071,6 +1175,7 @@ export {
   validateHighlights,
   validateAnnouncementItems,
   validateDropdownElems,
+  validateTextcard,
   validateSections,
   validatePageSettings,
   validateResourceSettings,


### PR DESCRIPTION
This PR introduces the text cards panel to our homepage editor. Resolves IS-454.


https://github.com/isomerpages/isomercms-frontend/assets/22111124/2a1859ba-9350-4b5f-904a-663e8a504bd3

### Tests

- [ ] Go into edit homepage
- [ ] Click on add new section -> text cards
- [ ] New text card section should be editable
- [ ] Errors should cause section to have error bar when minimized
- [ ] Should be able to add a new card to this section
- [ ] Should have a maximum of 4 cards in this section, after which add card button becomes disabled
- [ ] Cards should be draggable
- [ ] Errors in card section show up when card is minimized, and also when section is minimized
- [ ] Errors should block saving
- [ ] On save, changes should persist after refresh

### Known limitations

- On initial creation of a new text card section, no cards are created by default - desired behaviour is for 3 to be created.