### PR TITLE
chore(announcements): add missing padding for item

### DIFF
--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -87,6 +87,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                             className={getClassNames(editorStyles, [
                               "row",
                               "is-desktop",
+                              "px-lg-3",
                             ])}
                           >
                             <div


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The announcements component on the template has an extra padding that is missing in the CMS homepage preview.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The missing padding has been added to the announcements preview component.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Visit a homepage with the announcements preview component.
    - [ ] Verify that the x-axis padding for every announcement item is 24px instead of the previous 12px.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*