### PR TITLE
fix(chromatic): attempt to fix chromatic again

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,6 +46,8 @@ Closes [insert issue #]
 - [ ] e2e tests (comment on this PR with the text `!run e2e`)
 - [ ] Smoke tests
 
+!run-chromatic
+
 ## Deploy Notes
 
 <!-- Notes regarding deployment of the contained body of work.  -->

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,16 +3,15 @@ name: "Chromatic"
 
 # Event for the workflow
 on:
-  issue_comment:
-    types: [created, edited]
-
+  pull_request:
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - develop
 
 env:
   # The full comment text to match to trigger this workflow
-  ISOMER_TRIGGER_COMMENT: "!run chromatic"
+  ISOMER_TRIGGER_COMMENT: "!run-chromatic"
   # The slug for the Isomer core team
   ISOMER_CORE_TEAM_SLUG: core
   # Use GitHub Token
@@ -30,25 +29,13 @@ jobs:
     environment: staging
     # Job steps
     steps:
-      # Determine if the PR comment should trigger the Chromatic build
-      - name: Check if user is part of Isomer core team (PR comment)
-        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
-        uses: tspascoal/get-user-teams-membership@v1
-        id: checkUserMember
-        with:
-          username: ${{ github.actor }}
-          team: ${{ env.ISOMER_CORE_TEAM_SLUG }}
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # requires read:org
-
       - name: Check for trigger words (in PR comment)
-        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
         uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
         with:
           trigger: "${{ env.ISOMER_TRIGGER_COMMENT }}"
           prefix_only: "true"
           reaction: "+1"
-
       - name: Checkout repository (pull request)
         if: ${{ github.event_name == 'issue_comment' }}
         uses: actions/checkout@v3
@@ -74,7 +61,6 @@ jobs:
               - 'src/styles/**'
 
       - name: Set environment variable to run Chromatic build
-        if: ${{ (github.event_name == 'push' || (steps.check.outputs.triggered == 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request)) && steps.filter.outputs.frontend == 'true' }}
         run: echo "ISOMER_RUN_CHROMATIC_BUILD=true" >> $GITHUB_ENV
 
       # This extra step is not in the original chromatic workflow.
@@ -90,17 +76,8 @@ jobs:
         if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' }}
         run: npm ci
 
-      - name: Get pull request information (for pull requests)
-        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
-        uses: octokit/request-action@v2.x
-        id: get_pull_request
-        with:
-          route: GET /repos/{repository}/pulls/{pull_number}
-          repository: ${{ github.repository }} # isomerpages/isomercms-frontend
-          pull_number: ${{ github.event.issue.number }}
-
       - name: Save branch name as environment variable (for pull requests)
-        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true' && github.event_name == 'issue_comment' }}
+        if: ${{ env.ISOMER_RUN_CHROMATIC_BUILD == 'true'}}
         run: echo "ISOMER_BRANCH_NAME=${{ fromJSON(steps.get_pull_request.outputs.data).head.ref }}" >> $GITHUB_ENV
 
       - name: Save branch name as environment variable (for push)

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -59,6 +59,8 @@ jobs:
               - 'src/layouts/**'
               - 'src/theme/**'
               - 'src/styles/**'
+              - package.json
+              - package-lock.json
 
       - name: Set environment variable to run Chromatic build
         run: echo "ISOMER_RUN_CHROMATIC_BUILD=true" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

Chromatic is still not working. Attempting to
1. change the default template to include the string 
2. change the trigger to a pr push by uncommenting the line in the PR template (ie. opt in) 



## Solution

I am trying to achieve a state where if pr is opened -> automatically build chromatic. Opt in if you need chromatic. 


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

!run-chromatic

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
