### PR TITLE
fix(chromatic): only do path checking on push

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -62,7 +62,8 @@ jobs:
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
-      - name: Check for changes
+      - name: Check for changes (push)
+        if: ${{ github.event_name == 'push' }}
         uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -74,7 +75,7 @@ jobs:
               - 'src/styles/**'
 
       - name: Set environment variable to run Chromatic build
-        if: ${{ (github.event_name == 'push' || (steps.check.outputs.triggered == 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request)) && steps.filter.outputs.frontend == 'true' }}
+        if: ${{ ((github.event_name == 'push' && steps.filter.outputs.frontend == 'true') || (steps.check.outputs.triggered == 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request)) }}
         run: echo "ISOMER_RUN_CHROMATIC_BUILD=true" >> $GITHUB_ENV
 
       # This extra step is not in the original chromatic workflow.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -73,6 +73,8 @@ jobs:
               - 'src/layouts/**'
               - 'src/theme/**'
               - 'src/styles/**'
+              - 'package.json'
+              - 'package-lock.json'
 
       - name: Set environment variable to run Chromatic build
         if: ${{ ((github.event_name == 'push' && steps.filter.outputs.frontend == 'true') || (steps.check.outputs.triggered == 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request)) }}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Path checking is done for both push and issue_comment currently, which is not ideal since if I do a `!run chromatic`, I really want Chromatic to run, regardless of whether there is a need to. We as humans need to take back control from the system.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Restrict the path changed checking to only push events.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

Minor fix, only testable after merge.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*