### PR TITLE
chore(announcements): sync changes from template

### DIFF
--- a/src/styles/isomer-template/components/homepage/_announcements.scss
+++ b/src/styles/isomer-template/components/homepage/_announcements.scss
@@ -1,3 +1,9 @@
+.announcements-section {
+  max-width: $container-max-width;
+  flex-direction: column;
+  align-items: center;
+}
+
 .announcements-divider {
   height: 1px;
   color: #f9f9f9;

--- a/src/styles/isomer-template/theme/_breakpoints.scss
+++ b/src/styles/isomer-template/theme/_breakpoints.scss
@@ -7,3 +7,6 @@ $breakpoints: (
   xl: 1280px,
   xxl: 1408px,
 );
+
+// Maximum width of site contents
+$container-max-width: 1280px;

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -40,9 +40,9 @@ export const TemplateAnnouncementsSection = forwardRef<
         >
           <div
             className={getClassNames(editorStyles, [
-              "bp-container",
-              "is-fluid",
-              "m-0",
+              "announcements-section",
+              "mx-auto",
+              "is-flex",
             ])}
           >
             <div className={editorStyles.row}>
@@ -53,7 +53,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                       className={getClassNames(editorStyles, [
                         "eyebrow",
                         "is-uppercase",
-                        "pb-4",
+                        "mb-2",
                         "has-text-centered",
                       ])}
                     >
@@ -64,7 +64,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                     <h1
                       className={getClassNames(editorStyles, [
                         "has-text-secondary",
-                        "pb-4",
+                        "mb-12",
                         "has-text-centered",
                       ])}
                     >
@@ -74,7 +74,8 @@ export const TemplateAnnouncementsSection = forwardRef<
 
                   <hr
                     className={getClassNames(editorStyles, [
-                      "my-8",
+                      "mb-2",
+                      "mt-0",
                       "announcements-divider",
                     ])}
                   />
@@ -87,20 +88,28 @@ export const TemplateAnnouncementsSection = forwardRef<
                             className={getClassNames(editorStyles, [
                               "row",
                               "is-desktop",
+                              "px-0",
+                              "py-6",
+                              "py-lg-0",
+                              "m-0",
                             ])}
                           >
                             <div
                               className={getClassNames(editorStyles, [
                                 "col",
                                 "is-4-desktop",
-                                "px-lg-6",
+                                "p-0",
+                                "p-lg-6",
+                                "mb-6",
+                                "mb-lg-0",
                                 "mr-lg-6",
                               ])}
                             >
                               <h3
                                 className={getClassNames(editorStyles, [
                                   "announcements-announcement-title",
-                                  "mb-4",
+                                  "mb-2",
+                                  "mb-lg-4",
                                 ])}
                               >
                                 <b>{announcement.title}</b>
@@ -118,12 +127,18 @@ export const TemplateAnnouncementsSection = forwardRef<
                             <div
                               className={getClassNames(editorStyles, [
                                 "col",
-                                "px-lg-6",
+                                "p-0",
+                                "p-lg-6",
                               ])}
                             >
                               <p>{announcement.announcement}</p>
                               {announcement.link_text && announcement.link_url && (
-                                <div className={editorStyles["mt-4"]}>
+                                <div
+                                  className={getClassNames(editorStyles, [
+                                    "mt-6",
+                                    "mt-lg-4",
+                                  ])}
+                                >
                                   <div
                                     className={
                                       editorStyles[
@@ -141,7 +156,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                           announcementItems.length === index + 1 ? (
                             <hr
                               className={getClassNames(editorStyles, [
-                                "mt-8",
+                                "mt-2",
                                 "mb-0",
                                 "announcements-divider",
                               ])}
@@ -149,7 +164,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                           ) : (
                             <hr
                               className={getClassNames(editorStyles, [
-                                "my-8",
+                                "my-2",
                                 "announcements-divider",
                               ])}
                             />


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The announcements preview on the frontend and the announcements component on the template has diverged.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Synchronise the changes made to the template:
    - Match padding and margin values to be exactly how it was done in Figma (using margins instead of paddings when Figma used them as such)
    - Centre-align text, so that on text overflow, the text remains centred

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site with the announcements component
    - [ ] Ensure that there are no visible changes on the homepage preview
    - [ ] Ensure that on very small viewports (<= 425px), the announcements component title remains centred

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*