### PR TITLE
feat(announcements): add help overlay

### DIFF
--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -41,7 +41,10 @@ import {
   validateAnnouncementItems,
 } from "utils/validators"
 
-import { HomepageStartEditingImage } from "assets"
+import {
+  HomepageStartEditingImage,
+  HomepageAnnouncementsSampleImage,
+} from "assets"
 import { EditorHomepageFrontmatterSection } from "types/homepage"
 import { DEFAULT_RETRY_MSG } from "utils"
 
@@ -1316,21 +1319,27 @@ const EditHomepage = ({ match }) => {
                         subtitle={INFOBAR_SECTION.subtitle}
                         onClick={() => onClick(INFOBAR_SECTION.id)}
                       />
-                      {/* NOTE: Check if the sections contain any `announcements` 
+                      {/* NOTE: Check if the sections contain any `announcements`
                                 and if it does, prevent creation of another `resources` section
                             */}
                       {showNewLayouts &&
                         !frontMatter.sections.some(
                           ({ announcements }) => !!announcements
                         ) && (
-                          <AddSectionButton.Option
-                            title={ANNOUNCEMENT_BLOCK.title}
-                            subtitle={ANNOUNCEMENT_BLOCK.subtitle}
-                            onClick={() => onClick(ANNOUNCEMENT_BLOCK.id)}
-                          />
+                          <AddSectionButton.HelpOverlay
+                            title="Announcements"
+                            description="Make exciting news from your organisation stand out by adding a list of announcements with dates on your homepage."
+                            image={<HomepageAnnouncementsSampleImage />}
+                          >
+                            <AddSectionButton.Option
+                              title={ANNOUNCEMENT_BLOCK.title}
+                              subtitle={ANNOUNCEMENT_BLOCK.subtitle}
+                              onClick={() => onClick(ANNOUNCEMENT_BLOCK.id)}
+                            />
+                          </AddSectionButton.HelpOverlay>
                         )}
 
-                      {/* NOTE: Check if the sections contain any `resources` 
+                      {/* NOTE: Check if the sections contain any `resources`
                                 and if it does, prevent creation of another `resources` section
                             */}
                       {!frontMatter.sections.some(


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-519.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- A new help overlay has been added for the new announcements block.

## Before & After Screenshots

**AFTER**:

<!-- [insert screenshot here] -->
<img width="744" alt="Screenshot 2023-09-25 at 6 13 17 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/ec1342c7-2cef-4d4d-aff3-b22511fe135a">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Visit any site that can create a new announcements block
    - [ ] Verify that the help overlay appears when hovering over the announcements block when adding a new section

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*