### PR TITLE
IS-577: Move site privatisation to growth book

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -19,7 +19,5 @@ export USERNAME=''
 # GitGuardian
 export GITGUARDIAN_API_KEY=""
 
-export REACT_APP_IS_SITE_PRIVATISATION_ACTIVE=false
-
 # GrowthBook
 export REACT_APP_GROWTHBOOK_CLIENT_KEY=xyz

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,5 +1,5 @@
 export const FEATURE_FLAGS = {
   STYLING_REVAMP: "styles",
   HOMEPAGE_TEMPLATES: "homepage_new_templates",
-  REPO_PRIVATISATION: "privatisation_whitelist",
+  REPO_PRIVATISATION: "repo_privatisation",
 } as const

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,4 +1,5 @@
 export const FEATURE_FLAGS = {
   STYLING_REVAMP: "styles",
   HOMEPAGE_TEMPLATES: "homepage_new_templates",
+  REPO_PRIVATISATION: "privatisation_whitelist",
 } as const

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -6,7 +6,6 @@ import { SETTINGS_CONTENT_KEY } from "constants/queryKeys"
 
 import * as SettingsService from "services/SettingsService"
 
-import { PrivatisationWhitelist } from "types/featureFlags"
 import {
   BackendPasswordSettings,
   BackendSiteSettings,
@@ -129,7 +128,7 @@ const extractPassword = (
 export const useGetSettings = (
   siteName: string,
   isEmailLogin?: boolean,
-  repoPrivatisationWhitelist?: PrivatisationWhitelist
+  isPrivatisationAllowed?: boolean
 ): UseQueryResult<SiteSettings> => {
   const shouldGetPrivacyDetails =
     isEmailLogin === undefined ? false : isEmailLogin
@@ -138,7 +137,7 @@ export const useGetSettings = (
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
       const isSitePrivatisationActive =
-        repoPrivatisationWhitelist?.repos.includes(siteName) || false
+        isPrivatisationAllowed === undefined ? false : isPrivatisationAllowed
       let passwordSettings
       if (shouldGetPrivacyDetails && isSitePrivatisationActive) {
         passwordSettings = await SettingsService.getPassword({ siteName })

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -136,8 +136,7 @@ export const useGetSettings = (
     [SETTINGS_CONTENT_KEY, siteName, shouldGetPrivacyDetails],
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
-      const isSitePrivatisationActive =
-        isPrivatisationAllowed ?? false
+      const isSitePrivatisationActive = isPrivatisationAllowed ?? false
       let passwordSettings
       if (shouldGetPrivacyDetails && isSitePrivatisationActive) {
         passwordSettings = await SettingsService.getPassword({ siteName })

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -6,6 +6,7 @@ import { SETTINGS_CONTENT_KEY } from "constants/queryKeys"
 
 import * as SettingsService from "services/SettingsService"
 
+import { PrivatisationWhitelist } from "types/featureFlags"
 import {
   BackendPasswordSettings,
   BackendSiteSettings,
@@ -15,10 +16,6 @@ import {
 } from "types/settings"
 
 import { BE_TO_FE } from "./constants"
-
-const IS_SITE_PRIVATISATION_ACTIVE =
-  process.env.REACT_APP_IS_SITE_PRIVATISATION_ACTIVE &&
-  process.env.REACT_APP_IS_SITE_PRIVATISATION_ACTIVE.toLowerCase() === "true"
 
 const DEFAULT_BE_STATE = {
   title: "",
@@ -131,7 +128,8 @@ const extractPassword = (
 
 export const useGetSettings = (
   siteName: string,
-  isEmailLogin?: boolean
+  isEmailLogin?: boolean,
+  repoPrivatisationWhitelist?: PrivatisationWhitelist
 ): UseQueryResult<SiteSettings> => {
   const shouldGetPrivacyDetails =
     isEmailLogin === undefined ? false : isEmailLogin
@@ -139,9 +137,10 @@ export const useGetSettings = (
     [SETTINGS_CONTENT_KEY, siteName, shouldGetPrivacyDetails],
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
+      const isSitePrivatisationActive =
+        repoPrivatisationWhitelist?.repos.includes(siteName) || false
       let passwordSettings
-      if (shouldGetPrivacyDetails && IS_SITE_PRIVATISATION_ACTIVE) {
-        // TODO: LaunchDarkly to allow specific groups to access this feature first
+      if (shouldGetPrivacyDetails && isSitePrivatisationActive) {
         passwordSettings = await SettingsService.getPassword({ siteName })
       } else {
         passwordSettings = {

--- a/src/hooks/settingsHooks/useGetSettings.ts
+++ b/src/hooks/settingsHooks/useGetSettings.ts
@@ -137,7 +137,7 @@ export const useGetSettings = (
     async () => {
       const siteSettings = await SettingsService.get({ siteName })
       const isSitePrivatisationActive =
-        isPrivatisationAllowed === undefined ? false : isPrivatisationAllowed
+        isPrivatisationAllowed ?? false
       let passwordSettings
       if (shouldGetPrivacyDetails && isSitePrivatisationActive) {
         passwordSettings = await SettingsService.getPassword({ siteName })

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -6,7 +6,7 @@ import {
   StackDivider,
   useDisclosure,
 } from "@chakra-ui/react"
-import { useGrowthBook } from "@growthbook/growthbook-react"
+import { useFeatureIsOn } from "@growthbook/growthbook-react"
 import { Button } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { useEffect, useRef } from "react"
@@ -24,7 +24,7 @@ import { useGetSettings, useUpdateSettings } from "hooks/settingsHooks"
 
 import { useErrorToast, useSuccessToast } from "utils/toasts"
 
-import { FeatureFlags, PrivatisationWhitelist } from "types/featureFlags"
+import { FeatureFlags } from "types/featureFlags"
 import { SiteSettings } from "types/settings"
 import { DEFAULT_RETRY_MSG } from "utils"
 
@@ -41,13 +41,9 @@ import { PrivacySettings } from "./PrivacySettings"
 import { SocialMediaSettings } from "./SocialMediaSettings"
 
 export const Settings = (): JSX.Element => {
-  const growthbook = useGrowthBook<FeatureFlags>()
-  const fallbackWhitelist: PrivatisationWhitelist = { repos: [] }
-  const repoPrivatisationWhitelist =
-    growthbook?.getFeatureValue(
-      FEATURE_FLAGS.REPO_PRIVATISATION,
-      fallbackWhitelist
-    ) || fallbackWhitelist
+  const isPrivatisationAllowed = useFeatureIsOn<FeatureFlags>(
+    FEATURE_FLAGS.REPO_PRIVATISATION
+  )
 
   const { siteName } = useParams<{ siteName: string }>()
   const { userId } = useLoginContext()
@@ -57,7 +53,7 @@ export const Settings = (): JSX.Element => {
     data: settingsData,
     isLoading: isGetSettingsLoading,
     isError: isGetSettingsError,
-  } = useGetSettings(siteName, !isGithubUser, repoPrivatisationWhitelist)
+  } = useGetSettings(siteName, !isGithubUser, isPrivatisationAllowed)
   const errorToast = useErrorToast()
 
   // Trigger an error toast informing the user if settings data could not be fetched

--- a/src/layouts/Settings/Settings.tsx
+++ b/src/layouts/Settings/Settings.tsx
@@ -6,6 +6,7 @@ import {
   StackDivider,
   useDisclosure,
 } from "@chakra-ui/react"
+import { useGrowthBook } from "@growthbook/growthbook-react"
 import { Button } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { useEffect, useRef } from "react"
@@ -14,6 +15,8 @@ import { useParams } from "react-router-dom"
 
 import { Footer } from "components/Footer"
 
+import { FEATURE_FLAGS } from "constants/featureFlags"
+
 import { useDirtyFieldContext } from "contexts/DirtyFieldContext"
 import { useLoginContext } from "contexts/LoginContext"
 
@@ -21,6 +24,7 @@ import { useGetSettings, useUpdateSettings } from "hooks/settingsHooks"
 
 import { useErrorToast, useSuccessToast } from "utils/toasts"
 
+import { FeatureFlags, PrivatisationWhitelist } from "types/featureFlags"
 import { SiteSettings } from "types/settings"
 import { DEFAULT_RETRY_MSG } from "utils"
 
@@ -37,6 +41,14 @@ import { PrivacySettings } from "./PrivacySettings"
 import { SocialMediaSettings } from "./SocialMediaSettings"
 
 export const Settings = (): JSX.Element => {
+  const growthbook = useGrowthBook<FeatureFlags>()
+  const fallbackWhitelist: PrivatisationWhitelist = { repos: [] }
+  const repoPrivatisationWhitelist =
+    growthbook?.getFeatureValue(
+      FEATURE_FLAGS.REPO_PRIVATISATION,
+      fallbackWhitelist
+    ) || fallbackWhitelist
+
   const { siteName } = useParams<{ siteName: string }>()
   const { userId } = useLoginContext()
   // Only github users have userId, and not logged in users have userId as "Unknown user"
@@ -45,7 +57,7 @@ export const Settings = (): JSX.Element => {
     data: settingsData,
     isLoading: isGetSettingsLoading,
     isError: isGetSettingsError,
-  } = useGetSettings(siteName, !isGithubUser)
+  } = useGetSettings(siteName, !isGithubUser, repoPrivatisationWhitelist)
   const errorToast = useErrorToast()
 
   // Trigger an error toast informing the user if settings data could not be fetched

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -1,8 +1,11 @@
 import { FEATURE_FLAGS } from "constants/featureFlags"
 
+export type PrivatisationWhitelist = { repos: string[] }
+
 // Example usage: const gb = useGrowthBook<FeatureFlags>();
 export interface FeatureFlags {
   [FEATURE_FLAGS.STYLING_REVAMP]: boolean
+  [FEATURE_FLAGS.REPO_PRIVATISATION]: PrivatisationWhitelist
 }
 
 export type GBAttributes = {

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -1,11 +1,9 @@
 import { FEATURE_FLAGS } from "constants/featureFlags"
 
-export type PrivatisationWhitelist = { repos: string[] }
-
 // Example usage: const gb = useGrowthBook<FeatureFlags>();
 export interface FeatureFlags {
   [FEATURE_FLAGS.STYLING_REVAMP]: boolean
-  [FEATURE_FLAGS.REPO_PRIVATISATION]: PrivatisationWhitelist
+  [FEATURE_FLAGS.REPO_PRIVATISATION]: boolean
 }
 
 export type GBAttributes = {


### PR DESCRIPTION
## Problem

Site privatisation is feature-flagged via env var now with just a boolean. We want to move this to growthbook and to allow site-level whitelist.

Closes IS-577

## Solution

Moved to growthbook with new feature flag and json response of all the whitelisted sites for repo privatisation feature.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

## Tests

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests
    - [ ] On growthbook, whitelist your test-repo for the `dev` stage only or if on staging, for `staging` only
    - [ ] On CMS, visit site settings and ensure you see the Privacy Settings option

## Deploy Notes

**Removed environment variables**:

- `REACT_APP_IS_SITE_PRIVATISATION_ACTIVE` : removed in favour of new feature flag on GB
