### PR TITLE
Fix/homepageAnnouncementScroll

### DIFF
--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -317,6 +317,7 @@ const updateHomepageState = (
         destination.index,
         draggedError
       )
+      console.log(`source index: ${source.index}`)
       const displayBool = displayAnnouncementItems[source.index]
       const newDisplayAnnouncementItems = updatePositions(
         displayAnnouncementItems,

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -38,12 +38,6 @@ const createElement = <T,>(section: T[], elem: T): T[] => {
   })
 }
 
-const createElementFromTop = <T,>(section: T[], elem: T): T[] => {
-  return update(section, {
-    $unshift: [elem],
-  })
-}
-
 const deleteElement = <T,>(section: T[], indexToDelete: number): T[] => {
   return update(section, {
     $splice: [[indexToDelete, 1]],
@@ -443,7 +437,7 @@ export const onCreate = <E,>(
       const announcementBlockSection: AnnouncementsFrontmatterSection = frontMatter
         .sections[announcementsIndex] as AnnouncementsFrontmatterSection
 
-      const announcements = createElementFromTop(
+      const announcements = createElement(
         announcementBlockSection.announcements.announcement_items,
         val as AnnouncementOption
       )
@@ -452,15 +446,12 @@ export const onCreate = <E,>(
         Array(displayAnnouncementItems.length),
         false
       )
-      const newDisplayAnnouncementItems = createElementFromTop(
+      const newDisplayAnnouncementItems = createElement(
         resetDisplaySections,
         true
       )
 
-      const newAnnouncementErrors = createElementFromTop(
-        errors.announcementItems,
-        err
-      )
+      const newAnnouncementErrors = createElement(errors.announcementItems, err)
 
       return updateAnnouncementSection(
         homepageState,

--- a/src/hooks/useDrag.tsx
+++ b/src/hooks/useDrag.tsx
@@ -317,7 +317,6 @@ const updateHomepageState = (
         destination.index,
         draggedError
       )
-      console.log(`source index: ${source.index}`)
       const displayBool = displayAnnouncementItems[source.index]
       const newDisplayAnnouncementItems = updatePositions(
         displayAnnouncementItems,

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -425,7 +425,6 @@ const EditContactUs = ({ match }) => {
   }
 
   const onFieldChange = async (event) => {
-    console.log({ event })
     try {
       const { id, value } = event.target
       const idArray = id.split("-")
@@ -929,12 +928,7 @@ const EditContactUs = ({ match }) => {
             >
               <HStack className={elementStyles.wrapper}>
                 <Editable.Sidebar title="Contact Us">
-                  <Editable.Accordion
-                    onChange={(idx) => {
-                      console.log({ idx })
-                      displayHandler(idx)
-                    }}
-                  >
+                  <Editable.Accordion onChange={displayHandler}>
                     <VStack
                       bg="base.canvas.alt"
                       p="1.5rem"

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -425,6 +425,7 @@ const EditContactUs = ({ match }) => {
   }
 
   const onFieldChange = async (event) => {
+    console.log({ event })
     try {
       const { id, value } = event.target
       const idArray = id.split("-")
@@ -928,7 +929,12 @@ const EditContactUs = ({ match }) => {
             >
               <HStack className={elementStyles.wrapper}>
                 <Editable.Sidebar title="Contact Us">
-                  <Editable.Accordion onChange={displayHandler}>
+                  <Editable.Accordion
+                    onChange={(idx) => {
+                      console.log({ idx })
+                      displayHandler(idx)
+                    }}
+                  >
                     <VStack
                       bg="base.canvas.alt"
                       p="1.5rem"

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -374,6 +374,7 @@ const EditHomepage = ({ match }) => {
   }, [scrollRefs, frontMatter.sections.length])
 
   const onFieldChange = async (event) => {
+    console.log({ event })
     try {
       const { id, value } = event.target
       const idArray = id.split("-")
@@ -743,7 +744,24 @@ const EditHomepage = ({ match }) => {
           )
           // We know this is the case since announcements are added from the top
           const newAnnouncementIndex = 0
+          // const resetAnnouncementSections = _.fill(
+          //   // this is the on create handler, adding one more announcement
+          //   Array(displayAnnouncementItems.length),
+          //   false
+          // )
+          // // open the new announcement that was created
+          // resetAnnouncementSections[newAnnouncementIndex] = true
+          // console.log({ resetAnnouncementSections })
+          // const newDisplayAnnouncements = update(displayAnnouncementItems, {
+          //   $set: resetAnnouncementSections,
+          // })
+
+          console.log(announcementScrollRefs)
           scrollTo(announcementScrollRefs[newAnnouncementIndex])
+          // console.log({ newDisplayAnnouncements })
+          // setDisplayAnnouncementItems(newDisplayAnnouncements)
+          console.log(updatedHomepageState.displayAnnouncementItems)
+
           break
         }
         default:
@@ -941,6 +959,7 @@ const EditHomepage = ({ match }) => {
   }
 
   const displayHandler = async (elemType, index) => {
+    console.log({ elemType, index })
     // NOTE: If index is less than 0,
     // this means that the accordion is being closed.
     // Hence, we don't trigger a scroll.
@@ -1113,7 +1132,11 @@ const EditHomepage = ({ match }) => {
             <HStack className={elementStyles.wrapper}>
               <Editable.Sidebar title="Homepage">
                 <Editable.Accordion
-                  onChange={(idx) => displayHandler("section", idx)}
+                  onChange={(idx) => {
+                    console.log({ idx })
+                    console.log("hhuh")
+                    displayHandler("section", idx)
+                  }}
                 >
                   <VStack
                     bg="base.canvas.alt"
@@ -1278,6 +1301,11 @@ const EditHomepage = ({ match }) => {
                                     errors.sections[sectionIndex]
                                       .announcements && (
                                       <Editable.DraggableAccordionItem
+                                        // onChange={(idx) => {
+                                        //   console.log({ idx })
+                                        //   // console.log("hehe")
+                                        //   displayHandler("announcement", idx)
+                                        // }}
                                         index={sectionIndex}
                                         tag={
                                           <Tag variant="subtle">
@@ -1313,6 +1341,9 @@ const EditHomepage = ({ match }) => {
                                             errors={{
                                               ...errors,
                                             }}
+                                            displayAnnouncementItems={
+                                              displayAnnouncementItems
+                                            }
                                           />
                                         </AnnouncementSection>
                                       </Editable.DraggableAccordionItem>

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -741,8 +741,8 @@ const EditHomepage = ({ match }) => {
               $push: [createRef()],
             })
           )
-          // We know this is the case since announcements are added from the top
-          const newAnnouncementIndex = 0
+          // We know this is the case since announcements are added from the bottom
+          const newAnnouncementIndex = announcementScrollRefs.length - 1
           scrollTo(announcementScrollRefs[newAnnouncementIndex])
           break
         }

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -374,7 +374,6 @@ const EditHomepage = ({ match }) => {
   }, [scrollRefs, frontMatter.sections.length])
 
   const onFieldChange = async (event) => {
-    console.log({ event })
     try {
       const { id, value } = event.target
       const idArray = id.split("-")
@@ -744,24 +743,7 @@ const EditHomepage = ({ match }) => {
           )
           // We know this is the case since announcements are added from the top
           const newAnnouncementIndex = 0
-          // const resetAnnouncementSections = _.fill(
-          //   // this is the on create handler, adding one more announcement
-          //   Array(displayAnnouncementItems.length),
-          //   false
-          // )
-          // // open the new announcement that was created
-          // resetAnnouncementSections[newAnnouncementIndex] = true
-          // console.log({ resetAnnouncementSections })
-          // const newDisplayAnnouncements = update(displayAnnouncementItems, {
-          //   $set: resetAnnouncementSections,
-          // })
-
-          console.log(announcementScrollRefs)
           scrollTo(announcementScrollRefs[newAnnouncementIndex])
-          // console.log({ newDisplayAnnouncements })
-          // setDisplayAnnouncementItems(newDisplayAnnouncements)
-          console.log(updatedHomepageState.displayAnnouncementItems)
-
           break
         }
         default:
@@ -959,7 +941,6 @@ const EditHomepage = ({ match }) => {
   }
 
   const displayHandler = async (elemType, index) => {
-    console.log({ elemType, index })
     // NOTE: If index is less than 0,
     // this means that the accordion is being closed.
     // Hence, we don't trigger a scroll.
@@ -1132,11 +1113,7 @@ const EditHomepage = ({ match }) => {
             <HStack className={elementStyles.wrapper}>
               <Editable.Sidebar title="Homepage">
                 <Editable.Accordion
-                  onChange={(idx) => {
-                    console.log({ idx })
-                    console.log("hhuh")
-                    displayHandler("section", idx)
-                  }}
+                  onChange={(idx) => displayHandler("section", idx)}
                 >
                   <VStack
                     bg="base.canvas.alt"
@@ -1301,11 +1278,6 @@ const EditHomepage = ({ match }) => {
                                     errors.sections[sectionIndex]
                                       .announcements && (
                                       <Editable.DraggableAccordionItem
-                                        // onChange={(idx) => {
-                                        //   console.log({ idx })
-                                        //   // console.log("hehe")
-                                        //   displayHandler("announcement", idx)
-                                        // }}
                                         index={sectionIndex}
                                         tag={
                                           <Tag variant="subtle">
@@ -1341,9 +1313,6 @@ const EditHomepage = ({ match }) => {
                                             errors={{
                                               ...errors,
                                             }}
-                                            displayAnnouncementItems={
-                                              displayAnnouncementItems
-                                            }
                                           />
                                         </AnnouncementSection>
                                       </Editable.DraggableAccordionItem>

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -156,6 +156,8 @@ const EditHomepage = ({ match }) => {
   const { siteName } = match.params
   const [hasLoaded, setHasLoaded] = useState(false)
   const [scrollRefs, setScrollRefs] = useState([])
+  const [announcementScrollRefs, setAnnouncementScrollRefs] = useState([])
+
   const [frontMatter, setFrontMatter] = useState({
     title: "",
     subtitle: "",
@@ -247,6 +249,7 @@ const EditHomepage = ({ match }) => {
         let highlightsErrors = []
         let announcementItemErrors = []
         const scrollRefs = []
+        const announcementScrollRefs = []
         frontMatter.sections.forEach((section) => {
           scrollRefs.push(createRef())
           // If this is the hero section, hide all highlights/dropdownelems by default
@@ -305,6 +308,9 @@ const EditHomepage = ({ match }) => {
               section.announcements.announcement_items,
               () => getErrorValues(getDefaultAnnouncementSection())
             )
+            _.map(section.announcements.announcement_items, () => {
+              announcementScrollRefs.push(createRef())
+            })
             if (!section.announcements.announcement_items) {
               // define an empty array to announcement_items to prevent error
               frontMatter = update(frontMatter, {
@@ -344,6 +350,7 @@ const EditHomepage = ({ match }) => {
         setErrors(errors)
         setHasLoaded(true)
         setScrollRefs(scrollRefs)
+        setAnnouncementScrollRefs(announcementScrollRefs)
       } catch (err) {
         // Set frontMatter to be same to prevent warning message when navigating away
         setFrontMatter(originalFrontMatter)
@@ -557,7 +564,7 @@ const EditHomepage = ({ match }) => {
             sections: newSections,
           })
           setErrors(newErrors)
-          scrollTo(scrollRefs[announcementsIndex])
+          scrollTo(announcementScrollRefs[announcementItemsIndex])
           break
         }
         case "dropdownelem": {
@@ -680,6 +687,12 @@ const EditHomepage = ({ match }) => {
               getErrorValues(getDefaultAnnouncementSection())
             )
             setHomepageState(updatedAnnouncementState)
+            setAnnouncementScrollRefs(
+              update(announcementScrollRefs, {
+                $push: [createRef()],
+              })
+            )
+            setDisplayAnnouncementItems(_.fill(Array(1), false))
           }
           break
         }
@@ -723,6 +736,14 @@ const EditHomepage = ({ match }) => {
             err
           )
           setHomepageState(updatedHomepageState)
+          setAnnouncementScrollRefs(
+            update(announcementScrollRefs, {
+              $push: [createRef()],
+            })
+          )
+          // We know this is the case since announcements are added from the top
+          const newAnnouncementIndex = 0
+          scrollTo(announcementScrollRefs[newAnnouncementIndex])
           break
         }
         default:
@@ -744,6 +765,13 @@ const EditHomepage = ({ match }) => {
         })
 
         setScrollRefs(newScrollRefs)
+      }
+
+      if (elemType === "announcement") {
+        const newAnnouncementScrollRefs = update(announcementScrollRefs, {
+          $splice: [[index, 1]],
+        })
+        setAnnouncementScrollRefs(newAnnouncementScrollRefs)
       }
 
       const newHomepageState = onDelete(homepageState, elemType, index)
@@ -934,9 +962,6 @@ const EditHomepage = ({ match }) => {
           break
         }
         case "announcement": {
-          const announcementsIndex = frontMatter.sections.findIndex((section) =>
-            EditorHomepageFrontmatterSection.isAnnouncements(section)
-          )
           const resetAnnouncementSections = _.fill(
             Array(displayAnnouncementItems.length),
             false
@@ -946,7 +971,7 @@ const EditHomepage = ({ match }) => {
             $set: resetAnnouncementSections,
           })
 
-          scrollTo(scrollRefs[announcementsIndex])
+          scrollTo(announcementScrollRefs[index])
           setDisplayAnnouncementItems(newDisplayAnnouncements)
           break
         }
@@ -1358,6 +1383,7 @@ const EditHomepage = ({ match }) => {
               <HomepagePreview
                 frontMatter={frontMatter}
                 scrollRefs={scrollRefs}
+                announcementScrollRefs={announcementScrollRefs}
               />
             </HStack>
             <Footer>

--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -33,10 +33,12 @@ const isLeftInfoPic = (
 interface HomepagePreviewProps {
   frontMatter: EditorHomepageState["frontMatter"]
   scrollRefs: Ref<unknown>[]
+  announcementScrollRefs: Ref<unknown>[]
 }
 export const HomepagePreview = ({
   frontMatter,
   scrollRefs,
+  announcementScrollRefs,
 }: HomepagePreviewProps) => {
   const [dropdownIsActive, setDropdownIsActive] = useState(false)
 
@@ -175,6 +177,9 @@ export const HomepagePreview = ({
                 subtitle={section.announcements.subtitle}
                 announcementItems={section.announcements.announcement_items}
                 sectionIndex={sectionIndex}
+                announcementScrollRefs={
+                  announcementScrollRefs as Ref<HTMLDivElement>[]
+                }
                 ref={scrollRefs[sectionIndex] as Ref<HTMLDivElement>}
               />
             </>

--- a/src/layouts/EditHomepage/HomepagePreview.tsx
+++ b/src/layouts/EditHomepage/HomepagePreview.tsx
@@ -33,7 +33,7 @@ const isLeftInfoPic = (
 interface HomepagePreviewProps {
   frontMatter: EditorHomepageState["frontMatter"]
   scrollRefs: Ref<unknown>[]
-  announcementScrollRefs: Ref<unknown>[]
+  announcementScrollRefs: Ref<HTMLDivElement>[]
 }
 export const HomepagePreview = ({
   frontMatter,
@@ -177,9 +177,7 @@ export const HomepagePreview = ({
                 subtitle={section.announcements.subtitle}
                 announcementItems={section.announcements.announcement_items}
                 sectionIndex={sectionIndex}
-                announcementScrollRefs={
-                  announcementScrollRefs as Ref<HTMLDivElement>[]
-                }
+                announcementScrollRefs={announcementScrollRefs}
                 ref={scrollRefs[sectionIndex] as Ref<HTMLDivElement>}
               />
             </>

--- a/src/layouts/components/Homepage/AnnouncementBody.tsx
+++ b/src/layouts/components/Homepage/AnnouncementBody.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, FormControl, ExpandedIndex } from "@chakra-ui/react"
+import { Text, Box, FormControl } from "@chakra-ui/react"
 import { DragDropContext } from "@hello-pangea/dnd"
 import {
   FormLabel,
@@ -10,7 +10,6 @@ import {
 } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import moment from "moment"
-import React from "react"
 import { BiPlus } from "react-icons/bi"
 
 import { Editable } from "components/Editable/Editable"
@@ -26,7 +25,6 @@ interface AnnouncementBodyProps {
     announcementItems: AnnouncementError[]
   }
   announcementItems: Partial<AnnouncementOption>[]
-  displayAnnouncementItems: boolean[]
 }
 
 /**
@@ -62,7 +60,6 @@ const toCmsPanelDateFormat = (date?: string) => {
 export const AnnouncementBody = ({
   errors,
   announcementItems = [],
-  displayAnnouncementItems = [],
 }: AnnouncementBodyProps) => {
   const {
     onDragEnd,
@@ -71,15 +68,6 @@ export const AnnouncementBody = ({
     onDelete,
     onDisplay,
   } = useEditableContext()
-  const [openIndex, setOpenIndex] = React.useState<number>(0)
-  console.log(displayAnnouncementItems)
-
-  if (displayAnnouncementItems.length > 0) {
-    const newOpenIndex = displayAnnouncementItems.indexOf(true)
-    if (newOpenIndex !== openIndex) {
-      setOpenIndex(newOpenIndex)
-    }
-  }
   return (
     <Box w="full">
       <DragDropContext onDragEnd={onDragEnd}>
@@ -90,27 +78,7 @@ export const AnnouncementBody = ({
             announcements are shown on the top of the list`}
           </Text>
 
-          <Editable.Accordion
-            defaultIndex={0}
-            index={openIndex}
-            onChange={(idx: ExpandedIndex) => {
-              console.log(idx)
-              if (typeof idx === "number") {
-                // setOpenIndex(idx)
-                onDisplay("announcement", idx)
-              } else if (
-                idx instanceof Array &&
-                idx.length > 0 &&
-                typeof idx[0] === "number"
-              ) {
-                // setOpenIndex(idx[0])
-                onDisplay("announcement", idx[0])
-              } else {
-                // setOpenIndex(-1)
-                onDisplay("announcement", -1)
-              }
-            }}
-          >
+          <Editable.Accordion onChange={() => onDisplay("announcement")}>
             <Editable.EmptySection
               isEmpty={announcementItems.length === 0}
               title="Announcements you add will appear here"
@@ -138,12 +106,7 @@ export const AnnouncementBody = ({
                         )}
                         isNested
                       >
-                        <Editable.Section
-                          onChange={() => {
-                            console.log("changed in here")
-                            onDisplay("announcement", announcementIndex)
-                          }}
-                        >
+                        <Editable.Section>
                           <FormControl
                             isInvalid={
                               !!errors.announcementItems[announcementIndex]

--- a/src/layouts/components/Homepage/AnnouncementBody.tsx
+++ b/src/layouts/components/Homepage/AnnouncementBody.tsx
@@ -78,7 +78,22 @@ export const AnnouncementBody = ({
             announcements are shown on the top of the list`}
           </Text>
 
-          <Editable.Accordion onChange={() => onDisplay("announcement")}>
+          <Editable.Accordion
+            defaultIndex={0}
+            onChange={(idx: ExpandedIndex) => {
+              if (typeof idx === "number") {
+                onDisplay("announcement", idx)
+              } else if (
+                idx instanceof Array &&
+                idx.length > 0 &&
+                typeof idx[0] === "number"
+              ) {
+                onDisplay("announcement", idx[0])
+              } else {
+                onDisplay("announcement", -1)
+              }
+            }}
+          >
             <Editable.EmptySection
               isEmpty={announcementItems.length === 0}
               title="Announcements you add will appear here"

--- a/src/layouts/components/Homepage/AnnouncementBody.tsx
+++ b/src/layouts/components/Homepage/AnnouncementBody.tsx
@@ -84,12 +84,17 @@ export const AnnouncementBody = ({
               if (typeof idx === "number") {
                 onDisplay("announcement", idx)
               } else if (
+                /**
+                 * Should not reach here since we only allow one expanded item
+                 * This is done defensively since Accordion can have multiple expanded items
+                 */
                 idx instanceof Array &&
                 idx.length > 0 &&
                 typeof idx[0] === "number"
               ) {
                 onDisplay("announcement", idx[0])
               } else {
+                // Should not reach here as well, done defensively
                 onDisplay("announcement", -1)
               }
             }}

--- a/src/layouts/components/Homepage/AnnouncementBody.tsx
+++ b/src/layouts/components/Homepage/AnnouncementBody.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, FormControl } from "@chakra-ui/react"
+import { Text, Box, FormControl, ExpandedIndex } from "@chakra-ui/react"
 import { DragDropContext } from "@hello-pangea/dnd"
 import {
   FormLabel,

--- a/src/layouts/components/Homepage/AnnouncementBody.tsx
+++ b/src/layouts/components/Homepage/AnnouncementBody.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, FormControl } from "@chakra-ui/react"
+import { Text, Box, FormControl, ExpandedIndex } from "@chakra-ui/react"
 import { DragDropContext } from "@hello-pangea/dnd"
 import {
   FormLabel,
@@ -10,6 +10,7 @@ import {
 } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import moment from "moment"
+import React from "react"
 import { BiPlus } from "react-icons/bi"
 
 import { Editable } from "components/Editable/Editable"
@@ -25,6 +26,7 @@ interface AnnouncementBodyProps {
     announcementItems: AnnouncementError[]
   }
   announcementItems: Partial<AnnouncementOption>[]
+  displayAnnouncementItems: boolean[]
 }
 
 /**
@@ -60,6 +62,7 @@ const toCmsPanelDateFormat = (date?: string) => {
 export const AnnouncementBody = ({
   errors,
   announcementItems = [],
+  displayAnnouncementItems = [],
 }: AnnouncementBodyProps) => {
   const {
     onDragEnd,
@@ -68,6 +71,15 @@ export const AnnouncementBody = ({
     onDelete,
     onDisplay,
   } = useEditableContext()
+  const [openIndex, setOpenIndex] = React.useState<number>(0)
+  console.log(displayAnnouncementItems)
+
+  if (displayAnnouncementItems.length > 0) {
+    const newOpenIndex = displayAnnouncementItems.indexOf(true)
+    if (newOpenIndex !== openIndex) {
+      setOpenIndex(newOpenIndex)
+    }
+  }
   return (
     <Box w="full">
       <DragDropContext onDragEnd={onDragEnd}>
@@ -78,7 +90,27 @@ export const AnnouncementBody = ({
             announcements are shown on the top of the list`}
           </Text>
 
-          <Editable.Accordion onChange={() => onDisplay("announcement")}>
+          <Editable.Accordion
+            defaultIndex={0}
+            index={openIndex}
+            onChange={(idx: ExpandedIndex) => {
+              console.log(idx)
+              if (typeof idx === "number") {
+                // setOpenIndex(idx)
+                onDisplay("announcement", idx)
+              } else if (
+                idx instanceof Array &&
+                idx.length > 0 &&
+                typeof idx[0] === "number"
+              ) {
+                // setOpenIndex(idx[0])
+                onDisplay("announcement", idx[0])
+              } else {
+                // setOpenIndex(-1)
+                onDisplay("announcement", -1)
+              }
+            }}
+          >
             <Editable.EmptySection
               isEmpty={announcementItems.length === 0}
               title="Announcements you add will appear here"
@@ -106,7 +138,12 @@ export const AnnouncementBody = ({
                         )}
                         isNested
                       >
-                        <Editable.Section>
+                        <Editable.Section
+                          onChange={() => {
+                            console.log("changed in here")
+                            onDisplay("announcement", announcementIndex)
+                          }}
+                        >
                           <FormControl
                             isInvalid={
                               !!errors.announcementItems[announcementIndex]

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -12,13 +12,12 @@ type TemplateAnnouncementsSectionProps = Omit<
 > & {
   announcementItems: AnnouncementsBlockSection["announcement_items"]
   sectionIndex: number
+  announcementScrollRefs: Ref<HTMLDivElement>[]
 }
 
 export const TemplateAnnouncementsSection = forwardRef<
   HTMLDivElement,
-  TemplateAnnouncementsSectionProps & {
-    announcementScrollRefs: Ref<HTMLDivElement>[]
-  }
+  TemplateAnnouncementsSectionProps
 >(
   (
     {

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react"
+import { Ref, forwardRef } from "react"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
 
@@ -16,7 +16,9 @@ type TemplateAnnouncementsSectionProps = Omit<
 
 export const TemplateAnnouncementsSection = forwardRef<
   HTMLDivElement,
-  TemplateAnnouncementsSectionProps
+  TemplateAnnouncementsSectionProps & {
+    announcementScrollRefs: Ref<HTMLDivElement>[]
+  }
 >(
   (
     {
@@ -24,7 +26,10 @@ export const TemplateAnnouncementsSection = forwardRef<
       subtitle,
       announcementItems,
       sectionIndex,
-    }: TemplateAnnouncementsSectionProps,
+      announcementScrollRefs,
+    }: TemplateAnnouncementsSectionProps & {
+      announcementScrollRefs: Ref<HTMLDivElement>[]
+    },
     ref
   ) => {
     return (
@@ -82,7 +87,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                   {announcementItems &&
                     announcementItems.map((announcement, index) => {
                       return (
-                        <>
+                        <div ref={announcementScrollRefs[index]}>
                           <div
                             className={getClassNames(editorStyles, [
                               "row",
@@ -154,7 +159,7 @@ export const TemplateAnnouncementsSection = forwardRef<
                               ])}
                             />
                           )}
-                        </>
+                        </div>
                       )
                     })}
                 </>

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -26,9 +26,7 @@ export const TemplateAnnouncementsSection = forwardRef<
       announcementItems,
       sectionIndex,
       announcementScrollRefs,
-    }: TemplateAnnouncementsSectionProps & {
-      announcementScrollRefs: Ref<HTMLDivElement>[]
-    },
+    }: TemplateAnnouncementsSectionProps,
     ref
   ) => {
     return (


### PR DESCRIPTION
## Problem

There are 2 main pending issues with Announcements. 
1. Announcments pinching up when updating them

https://github.com/isomerpages/isomercms-frontend/assets/42832651/6b9257e8-ecb7-4c0e-b1e3-77392b4831cc

2. Make 2 announcements, open the second announcement. Then, add a new announcement. Now, the opened announcement state is the second one, but since announcements are added from the top, this is a different announcement now.


https://github.com/isomerpages/isomercms-frontend/assets/42832651/d6cd253a-be7f-41e6-ac6c-c8a6798564a0




## Solution

for 1, I added a new array `announcementScrollRefs`. 

Working sol:

https://github.com/isomerpages/isomercms-frontend/assets/42832651/e13fc393-817a-48c4-af09-16b52244adf9

~for 2, i am blocked. I attempted until this [b0fa396](https://github.com/isomerpages/isomercms-frontend/pull/1530/commits/b0fa396498a367b8f67d4a2086a4cac38315ca77), and while it did fix the original error, it was visually buggy. Not sure if there is a more elegant way to fix this~

NOTE: Adding elements from the bottom as a workaround for now. 

https://github.com/isomerpages/isomercms-frontend/assets/42832651/d766126a-b549-486f-8195-1969f5dab53a

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)




