### PR TITLE
fix(announemnt): fix announcemnt bug

### DIFF
--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -564,6 +564,7 @@ const EditHomepage = ({ match }) => {
             sections: newSections,
           })
           setErrors(newErrors)
+          console.log({ announcementScrollRefs })
           scrollTo(announcementScrollRefs[announcementItemsIndex])
           break
         }
@@ -743,6 +744,7 @@ const EditHomepage = ({ match }) => {
           )
           // We know this is the case since announcements are added from the bottom
           const newAnnouncementIndex = announcementScrollRefs.length - 1
+          console.log({ announcementScrollRefs })
           scrollTo(announcementScrollRefs[newAnnouncementIndex])
           break
         }
@@ -758,13 +760,15 @@ const EditHomepage = ({ match }) => {
       const idArray = id.split("-")
       const elemType = idArray[0]
       const index = parseInt(idArray[1], RADIX_PARSE_INT)
-
       if (elemType === "section") {
         const newScrollRefs = update(scrollRefs, {
           $splice: [[index, 1]],
         })
 
         setScrollRefs(newScrollRefs)
+        if (frontMatter.sections[index].announcements) {
+          setAnnouncementScrollRefs([])
+        }
       }
 
       if (elemType === "announcement") {
@@ -970,7 +974,7 @@ const EditHomepage = ({ match }) => {
           const newDisplayAnnouncements = update(displayAnnouncementItems, {
             $set: resetAnnouncementSections,
           })
-
+          console.log({ announcementScrollRefs })
           scrollTo(announcementScrollRefs[index])
           setDisplayAnnouncementItems(newDisplayAnnouncements)
           break

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -564,7 +564,6 @@ const EditHomepage = ({ match }) => {
             sections: newSections,
           })
           setErrors(newErrors)
-          console.log({ announcementScrollRefs })
           scrollTo(announcementScrollRefs[announcementItemsIndex])
           break
         }
@@ -744,7 +743,6 @@ const EditHomepage = ({ match }) => {
           )
           // We know this is the case since announcements are added from the bottom
           const newAnnouncementIndex = announcementScrollRefs.length - 1
-          console.log({ announcementScrollRefs })
           scrollTo(announcementScrollRefs[newAnnouncementIndex])
           break
         }
@@ -974,7 +972,7 @@ const EditHomepage = ({ match }) => {
           const newDisplayAnnouncements = update(displayAnnouncementItems, {
             $set: resetAnnouncementSections,
           })
-          console.log({ announcementScrollRefs })
+
           scrollTo(announcementScrollRefs[index])
           setDisplayAnnouncementItems(newDisplayAnnouncements)
           break


### PR DESCRIPTION
## Problem

when the entire announcemnt block close, the `announcemnetScrollRef` never reset. 

Closes [insert issue #]

## Solution

reset it when the entire announcemnt section is deleted

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

https://github.com/isomerpages/isomercms-frontend/assets/42832651/7ba4eb3e-8ef3-4271-b990-1e9a8f1f2668





## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] CRUD operations on announcemnts (eg like the video above) 


