### PR TITLE
fix(e2e): utlise new backend endpoint to reset e2e repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,6 @@
         "@typescript-eslint/parser": "^5.55.0",
         "auto-changelog": "^2.4.0",
         "babel-jest": "^29.5.0",
-        "btoa": "^1.2.1",
         "chromatic": "^6.5.6",
         "cypress": "^12.8.0",
         "cypress-pipe": "^2.0.0",
@@ -13548,17 +13547,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "@typescript-eslint/parser": "^5.55.0",
     "auto-changelog": "^2.4.0",
     "babel-jest": "^29.5.0",
-    "btoa": "^1.2.1",
     "chromatic": "^6.5.6",
     "cypress": "^12.8.0",
     "cypress-pipe": "^2.0.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,7 +11,7 @@ const {
 } = process.env
 if (!CYPRESS_COOKIE_NAME || !CYPRESS_COOKIE_VALUE) {
   throw new Error(
-    `E2E tests require env vars CYPRESS_COOKIE_NAME (${CYPRESS_COOKIE_NAME}) and CYPRESS_COOKIE_VALUE (${CYPRESS_COOKIE_VALUE}) to be set.`
+    `E2E tests require env vars CYPRESS_COOKIE_NAME and CYPRESS_COOKIE_VALUE to be set.`
   )
 }
 

--- a/scripts/reset-e2e.js
+++ b/scripts/reset-e2e.js
@@ -1,3 +1,3 @@
-const { resetE2eTestRepo } = require("./build")
+const { resetE2ETestRepositories } = require("./build")
 
-resetE2eTestRepo()
+resetE2ETestRepositories()

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,3 +1,3 @@
-const { runE2eTests } = require("./build")
+const { runE2ETests } = require("./build")
 
-runE2eTests()
+runE2ETests()


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of IS-446.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Resetting e2e test repos now uses a new backend endpoint instead of calling GitHub API directly. This was done in https://github.com/isomerpages/isomercms-backend/pull/950.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Ensure your backend has the new reset repo endpoint
    - [ ] Run `npm run reset-e2e`
    - [ ] Notice that there are now 4 repos being reset

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**REMOVED dev dependencies**:

- `btoa`
