### PR TITLE
feat(e2e): run e2e tests in parallel and support notggs repo

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -90,6 +90,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: staging
+    strategy:
+      fail-fast: false
+      matrix:
+        type: ["run-email", "run", "run-notggs"]
     env:
       CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
       CYPRESS_BASEURL: ${{secrets.CYPRESS_BASEURL}}
@@ -137,5 +141,14 @@ jobs:
           echo "COMMIT_INFO_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       - name: Install dependencies
         run: npm ci
-      - name: Run test ci
+      - name: Run E2E tests (e2e test repo)
+        if: ${{ matrix.type == 'run' }}
+        run: npm run test:ci
+      - name: Run E2E tests (email test repo)
+        if: ${{ matrix.type == 'run-email' }}
+        run: npm run test:email-ci
+      - name: Run E2E tests (not GGS test repo)
+        if: ${{ matrix.type == 'run-notggs' }}
+        env:
+          CYPRESS_TEST_REPO_NAME: ${{secrets.CYPRESS_NOTGGS_TEST_REPO_NAME}}
         run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "release": "npm version $npm_config_isomer_update && git push --tags",
     "test": "craco test",
     "test:ci": "node scripts/run-e2e.js run",
+    "test:email-ci": "node scripts/run-e2e.js run-email",
     "test-e2e": "source .env && node scripts/run-e2e.js run",
     "reset-e2e": "source .env && node scripts/reset-e2e.js",
     "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx --ignore-path .gitignore .",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,7 +25,7 @@ const githubHeaders = {
 }
 
 // Cypress test runner
-const emaile2eTests = [
+const emailE2ETests = [
   "collaborators",
   "comments",
   "dashboard",
@@ -47,11 +47,11 @@ let runCypressCommand = baseCypressCommand
 if (cypressCommand === "open") {
   runCypressCommand = `${baseCypressCommand} open`
 } else if (cypressCommand === "run-email") {
-  runCypressCommand = `${baseCypressCommand} run --spec "${emaile2eTests
+  runCypressCommand = `${baseCypressCommand} run --spec "${emailE2ETests
     .map((x) => `cypress/e2e/${x}.spec.ts`)
     .join(",")}" --record --tag "e2e-email-test-repo"`
 } else {
-  runCypressCommand = `${baseCypressCommand} run --spec "**/!(${emaile2eTests.join(
+  runCypressCommand = `${baseCypressCommand} run --spec "**/!(${emailE2ETests.join(
     "|"
   )}).spec.ts" --record --tag "${CYPRESS_TEST_REPO_NAME}"`
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -70,7 +70,7 @@ const resetRepository = async (repository, branchName, userType) => {
     { withCredentials: true }
   )
   console.log(
-    `Successfully reset ${repository} (${branchName}) to ${e2eTestRepositoriesWithHashes[repository]}}`
+    `Successfully reset ${repository} (${branchName}) to ${e2eTestRepositoriesWithHashes[repository]}`
   )
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of IS-446.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The e2e tests now run in parallel using GitHub Actions' job matrix strategy. This is split into 3 jobs:
    - `run-email`: To run email login-specific tests on `e2e-email-test-repo`. This is defined to be `collaborators`, `comments`, `dashboard`, `notifications` and `reviewRequests` and will need to be manually updated when new test specs are created that are specific for email login functionality that requires the `e2e-email-test-repo`.
    - `run`: To run the rest of the test specs (i.e excluding those above) on the GGS-whitelisted `e2e-test-repo`.
    - `run-notggs`: To run the rest of the test specs (i.e excluding those above) on the not-GGS-whitelisted repo `e2e-notggs-test-repo`. Note that this will no longer exist once > 70% of our sites move onto GGS.
- As the jobs now run in parallel, only the relevant repo is reset and not all at once. This is to prevent encountering errors with the repo being locked (since resetting of repos is done via the CMS backend now).
- Unfortunately, it is not possible to group the Cypress test runs into a single run on the dashboard, so I have added tags to indicate which repo the test run is for, for easier identification.

## Screenshots

![Screenshot 2023-09-29 at 1 12 01 PM](https://github.com/isomerpages/isomercms-frontend/assets/27919917/1ae6c2ed-d899-433e-b7b8-f260e772c239)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

This is a GitHub Actions change, so the changes can only be tested after it is merged. Previous tests were done by adding pushes to this branch as a trigger, and the [latest successful run is here](https://github.com/isomerpages/isomercms-frontend/actions/runs/6347177731) (ignore the failing as the builds are failing due to e2e tests itself).

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*