### PR TITLE
chore(announcements): sync changes from template

### DIFF
--- a/src/styles/isomer-template/components/homepage/_announcements.scss
+++ b/src/styles/isomer-template/components/homepage/_announcements.scss
@@ -9,33 +9,6 @@
   color: #f9f9f9;
 }
 
-.announcements-announcement-title {
-  font-size: 1.625rem;
-  font-weight: 700;
-  line-height: 2rem;
-}
-
-.announcements-announcement-subtitle {
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.375rem;
-}
-
-.announcements-announcement-link {
-  color: var(--site-secondary-color);
-  font-size: 1.125rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  letter-spacing: 0.27px;
-  text-decoration-line: underline;
-  text-transform: capitalize;
-  text-underline-offset: 0.25rem;
-}
-
-.announcements-announcement-link:hover {
-  color: var(--site-secondary-color-hover);
-}
-
-a[target="_blank"].announcements-announcement-link::after {
+a[target="_blank"].link::after {
   content: unset;
 }

--- a/src/styles/isomer-template/theme/_colors.scss
+++ b/src/styles/isomer-template/theme/_colors.scss
@@ -1,5 +1,5 @@
 $canvas-base: #ffffff;
-$content-base: #000000;
+$content-base: #344054;
 $utility-theme-color: var(--site-primary-color);
 $canvas-inverse: #000000;
 $content-inverse: #ffffff;

--- a/src/styles/isomer-template/theme/_layout.scss
+++ b/src/styles/isomer-template/theme/_layout.scss
@@ -1,3 +1,7 @@
 .flex-end {
   justify-content: flex-end;
 }
+
+.w-100 {
+  width: 100%;
+}

--- a/src/templates/homepage/AnnouncementsSection.tsx
+++ b/src/templates/homepage/AnnouncementsSection.tsx
@@ -47,134 +47,132 @@ export const TemplateAnnouncementsSection = forwardRef<
               "is-flex",
             ])}
           >
-            <div className={editorStyles.row}>
-              <div className={getClassNames(editorStyles, ["col", "is-full"])}>
-                <>
-                  {subtitle && (
-                    <p
-                      className={getClassNames(editorStyles, [
-                        "eyebrow",
-                        "is-uppercase",
-                        "mb-2",
-                        "has-text-centered",
-                      ])}
-                    >
-                      {subtitle}
-                    </p>
-                  )}
-                  {title && (
-                    <h1
-                      className={getClassNames(editorStyles, [
-                        "has-text-secondary",
-                        "mb-12",
-                        "has-text-centered",
-                      ])}
-                    >
-                      <b>{title}</b>
-                    </h1>
-                  )}
+            {subtitle && (
+              <p
+                className={getClassNames(editorStyles, [
+                  "subtitle-2",
+                  "eyebrow",
+                  "is-uppercase",
+                  "mb-2",
+                  "has-text-centered",
+                ])}
+              >
+                {subtitle}
+              </p>
+            )}
+            {title && (
+              <h1
+                className={getClassNames(editorStyles, [
+                  "h1",
+                  "has-text-secondary",
+                  "mb-12",
+                  "has-text-centered",
+                ])}
+              >
+                {title}
+              </h1>
+            )}
 
-                  <hr
-                    className={getClassNames(editorStyles, [
-                      "mb-2",
-                      "mt-0",
-                      "announcements-divider",
-                    ])}
-                  />
+            <div
+              className={getClassNames(editorStyles, ["row", "w-100", "m-0"])}
+            >
+              <div
+                className={getClassNames(editorStyles, [
+                  "col",
+                  "is-full",
+                  "p-0",
+                ])}
+              >
+                <hr
+                  className={getClassNames(editorStyles, [
+                    "mb-2",
+                    "mt-0",
+                    "announcements-divider",
+                  ])}
+                />
 
-                  {announcementItems &&
-                    announcementItems.map((announcement, index) => {
-                      return (
-                        <div ref={announcementScrollRefs[index]}>
+                {announcementItems &&
+                  announcementItems.map((announcement, index) => {
+                    return (
+                      <div ref={announcementScrollRefs[index]}>
+                        <div
+                          className={getClassNames(editorStyles, [
+                            "row",
+                            "is-desktop",
+                            "px-0",
+                            "py-6",
+                            "py-lg-0",
+                            "m-0",
+                          ])}
+                        >
                           <div
                             className={getClassNames(editorStyles, [
-                              "row",
-                              "is-desktop",
-                              "px-0",
-                              "py-6",
-                              "py-lg-0",
-                              "m-0",
+                              "col",
+                              "is-4-desktop",
+                              "p-0",
+                              "p-lg-6",
+                              "mb-6",
+                              "mb-lg-0",
+                              "mr-lg-6",
                             ])}
                           >
-                            <div
+                            <h3
                               className={getClassNames(editorStyles, [
-                                "col",
-                                "is-4-desktop",
-                                "p-0",
-                                "p-lg-6",
-                                "mb-6",
-                                "mb-lg-0",
-                                "mr-lg-6",
+                                "h3",
+                                "mb-2",
+                                "mb-lg-4",
                               ])}
                             >
-                              <h3
+                              {announcement.title}
+                            </h3>
+                            <p className={editorStyles["subtitle-1"]}>
+                              {announcement.date}
+                            </p>
+                          </div>
+                          <div
+                            className={getClassNames(editorStyles, [
+                              "col",
+                              "p-0",
+                              "p-lg-6",
+                            ])}
+                          >
+                            <p className={editorStyles["body-1"]}>
+                              {announcement.announcement}
+                            </p>
+                            {announcement.link_text && announcement.link_url && (
+                              <div
                                 className={getClassNames(editorStyles, [
-                                  "announcements-announcement-title",
-                                  "mb-2",
-                                  "mb-lg-4",
+                                  "mt-6",
+                                  "mt-lg-4",
                                 ])}
                               >
-                                <b>{announcement.title}</b>
-                              </h3>
-                              <p
-                                className={
-                                  editorStyles[
-                                    "announcements-announcement-subtitle"
-                                  ]
-                                }
-                              >
-                                {announcement.date}
-                              </p>
-                            </div>
-                            <div
-                              className={getClassNames(editorStyles, [
-                                "col",
-                                "p-0",
-                                "p-lg-6",
-                              ])}
-                            >
-                              <p>{announcement.announcement}</p>
-                              {announcement.link_text && announcement.link_url && (
-                                <div
-                                  className={getClassNames(editorStyles, [
-                                    "mt-6",
-                                    "mt-lg-4",
-                                  ])}
-                                >
-                                  <div
-                                    className={
-                                      editorStyles[
-                                        "announcements-announcement-link"
-                                      ]
-                                    }
-                                  >
-                                    <span>{announcement.link_text}</span>
-                                  </div>
+                                <div className={editorStyles.link}>
+                                  <span>{announcement.link_text}</span>
                                 </div>
-                              )}
-                            </div>
+                              </div>
+                            )}
                           </div>
-                          {announcementItems &&
-                          announcementItems.length === index + 1 ? (
-                            <hr
-                              className={getClassNames(editorStyles, [
-                                "mt-2",
-                                "mb-0",
-                                "announcements-divider",
-                              ])}
-                            />
-                          ) : (
-                            <hr
-                              className={getClassNames(editorStyles, [
-                                "my-2",
-                                "announcements-divider",
-                              ])}
-                            />
-                          )}
                         </div>
-                      )
-                    })}
-                </>
+                        {announcementItems &&
+                        announcementItems.length === index + 1 ? (
+                          <hr
+                            className={getClassNames(editorStyles, [
+                              "mt-2",
+                              "mb-0",
+                              "announcements-divider",
+                            ])}
+                          />
+                        ) : (
+                          <hr
+                            className={getClassNames(editorStyles, [
+                              "my-2",
+                              "announcements-divider",
+                            ])}
+                          />
+                        )}
+                      </div>
+                    )
+                  })}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There are changes to the template that have not been synced to the CMS frontend: https://github.com/isomerpages/isomerpages-template/pull/323

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Changes to the announcements component preview are now synced with the changes made on the template.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![Screenshot 2023-09-29 at 1 25 45 PM](https://github.com/isomerpages/isomercms-frontend/assets/27919917/69862b46-7feb-4972-8863-eaeb004c5eb7)

**AFTER**:

<!-- [insert screenshot here] -->
![Screenshot 2023-09-29 at 1 26 10 PM](https://github.com/isomerpages/isomercms-frontend/assets/27919917/73a1d911-b232-4321-96f2-253027ea0c7d)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site's homepage that can use the new template components
    - [ ] Add a new announcements block
    - [ ] Verify that the size of the block is now the entire width (AFTER screenshot) instead of being compressed (BEFORE screenshot)

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*