### PR TITLE
fix(announcements): add validation url

### DIFF
--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -578,6 +578,7 @@ const EditHomepage = ({ match }) => {
             .announcements.announcement_items[announcementItemsIndex].link_url
 
           const isLinkUrlError = isLinkTextFilled && !isLinkUrlFilled
+          const isLinkTextError = !isLinkTextFilled && isLinkUrlFilled
           const isLinkUrlOrTextChanged =
             field === "link_text" || field === "link_url"
           if (isLinkUrlOrTextChanged) {
@@ -585,6 +586,11 @@ const EditHomepage = ({ match }) => {
               announcementItemsIndex
             ].link_url = isLinkUrlError
               ? "Please specify a URL for your link"
+              : ""
+            newErrors.announcementItems[
+              announcementItemsIndex
+            ].link_text = isLinkTextError
+              ? "Please specify text for your link"
               : ""
           }
 


### PR DESCRIPTION
## Problem

UI polish, currently weird that 
non empty text with empty url leads to error
but 
non empty url with empty test leads to NO error

Closes [insert issue #]


## Solution

quick validation
<img width="330" alt="Screenshot 2023-10-02 at 9 53 38 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/016224fb-562e-4587-984f-2e9d87c0fba2">
**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)
