### PR TITLE
refactor(text-styles): update to have mobile

### DIFF
--- a/src/styles/isomer-template/theme/_text-styles.scss
+++ b/src/styles/isomer-template/theme/_text-styles.scss
@@ -12,7 +12,7 @@ display-1 {
 }
 
 // 1024 and above
-@media screen and (min-width: map.get($breakpoints, "lg")) {
+@media screen and (min-width: map-get($breakpoints, "lg")) {
   .h1 {
     color: $content-base;
 
@@ -26,7 +26,7 @@ display-1 {
 }
 
 // 1023 and below
-@media screen and (max-width: (map.get($breakpoints, "lg") - 1)) {
+@media screen and (max-width: (map-get($breakpoints, "lg") - 1)) {
   .h1 {
     color: $content-base;
 

--- a/src/styles/isomer-template/theme/_text-styles.scss
+++ b/src/styles/isomer-template/theme/_text-styles.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 display-1 {
   color: $content-base;
 
@@ -9,26 +11,32 @@ display-1 {
   letter-spacing: -1.408px;
 }
 
-.h1 {
-  color: $content-base;
+// 1024 and above
+@media screen and (min-width: map.get($breakpoints, "lg")) {
+  .h1 {
+    color: $content-base;
 
-  font-family: Lato;
-  font-size: 3rem;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 3.5rem; /* 116.667% */
-  letter-spacing: -1.056px;
+    font-family: Lato;
+    font-size: 3rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 3.5rem; /* 116.667% */
+    letter-spacing: -0.066rem;
+  }
 }
 
-.h1-small {
-  color: $content-base;
+// 1023 and below
+@media screen and (max-width: (map.get($breakpoints, "lg") - 1)) {
+  .h1 {
+    color: $content-base;
 
-  font-family: Lato;
-  font-size: 2.75rem;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 3.5rem; /* 116.667% */
-  letter-spacing: -1.056px;
+    font-family: Lato;
+    font-size: 2.75rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 3.5rem; /* 116.667% */
+    letter-spacing: -0.0605rem;
+  }
 }
 
 .h2 {
@@ -146,6 +154,6 @@ display-1 {
   text-decoration-line: underline;
 
   &:hover {
-    color: var(--site-secondary-color-hover)
+    color: var(--site-secondary-color-hover);
   }
 }


### PR DESCRIPTION
## Problem
`h1` has a mobile version for smaller screens; this was previously done as `h1-small` but it should have been automatically shifted to a smaller size.

## Solution
replace `h1-small` with a media query so that it automatically resizes
