### PR TITLE
Fix/is 470 edit page upload image modal

### DIFF
--- a/cypress/e2e/editPage.spec.ts
+++ b/cypress/e2e/editPage.spec.ts
@@ -146,8 +146,6 @@ describe("editPage.spec", () => {
         .click()
         .wait(Interceptors.POST)
 
-      cy.contains(":button", "Select").click()
-
       cy.get("#altText").clear().type("Hello World")
       cy.contains(":button", "Save").click()
 
@@ -164,8 +162,6 @@ describe("editPage.spec", () => {
         .contains(/^Upload$/)
         .click()
         .wait(Interceptors.POST)
-
-      cy.contains(":button", "Select").click()
 
       cy.get("#altText").clear().type("Hello World")
       cy.contains(":button", "Save").click()

--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -124,7 +124,6 @@ export const MediaSettingsModal = ({
     }
 
     if (mediaRoom === "images") {
-      console.log(`Displaying`, watch("mediaUrl"))
       return (
         <div className={mediaStyles.editImagePreview}>
           <img

--- a/src/components/media/MediaCard.jsx
+++ b/src/components/media/MediaCard.jsx
@@ -19,7 +19,13 @@ import useRedirectHook from "hooks/useRedirectHook"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 import mediaStyles from "styles/isomer-cms/pages/Media.module.scss"
 
-const MediaCard = ({ type, media, onClick, showSettings = true }) => {
+const MediaCard = ({
+  type,
+  media,
+  onClick,
+  isSelected,
+  showSettings = true,
+}) => {
   const { name, mediaUrl } = media
   const encodedName = encodeURIComponent(name)
   const borderColour = useToken("colors", "primary.500")
@@ -46,9 +52,7 @@ const MediaCard = ({ type, media, onClick, showSettings = true }) => {
               `${url}/editMediaSettings/${encodeURIComponent(name)}`
             )
         }}
-        _focus={{
-          outline: `2px solid ${borderColour}`,
-        }}
+        outline={isSelected ? `2px solid ${borderColour}` : ""}
         textStyle="body-1"
         textAlign="left"
         w="100%"

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -42,7 +42,7 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
 
   const onMediaSelect = (media) => {
     if (methods.watch("selectedMedia")?.name === media.name) {
-      methods.setValue("selectedMedia", "")
+      methods.setValue("selectedMedia", undefined)
       methods.setValue("selectedMediaPath", "")
     } else {
       methods.setValue(

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -66,7 +66,7 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
           onProceed={async ({ data }) => {
             await createHandler({ data })
             onMediaSelect({ ...data, mediaUrl: data.content })
-            setMediaMode("select")
+            setMediaMode("details")
           }}
           onClose={onClose}
         />

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -42,7 +42,7 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
 
   const onMediaSelect = (media) => {
     if (methods.watch("selectedMedia")?.name === media.name) {
-      methods.setValue("selectedMedia", {})
+      methods.setValue("selectedMedia", "")
       methods.setValue("selectedMediaPath", "")
     } else {
       methods.setValue(


### PR DESCRIPTION
## Problem

This PR fixes IS-470, as well as several other media modal related issues. Previously, the issue was that uploaded images were not showing up properly in the modal which also asked users to specify alt text. This was actually due to a combination of factors:

- After an image was successfully uploaded, users were brought back to the select page, with the image already selected - but this was not indicated to users in any way, so users would normally click into the image they wanted again
- Clicking on the image in this screen actually deselects the image, but the proceed button was bugged to not get disabled in this case, and the item appears selected due to faulty display css
- The image selected now has missing data in some places, which prevents the preview from working

To fix these issues, this PR makes the following changes:

- The image upload modal immediately transitions to the modal asking for alt text to insert - this is to prevent users from having to go back through their list of images to find and select the image
- The deselect behaviour has been fixed
- The outline css has been tweaked to be active for the selected item, and not on focus.

Fixed behaviour:
https://github.com/isomerpages/isomercms-frontend/assets/22111124/db49e816-fe50-46c8-9980-69ff5ea4e778

