### PR TITLE
chore(contactus): fix spacing of error message on general information section

### DIFF
--- a/src/layouts/components/ContactUs/GeneralInfoSection.tsx
+++ b/src/layouts/components/ContactUs/GeneralInfoSection.tsx
@@ -36,7 +36,7 @@ export const GeneralInfoSection = ({
       title="General Information"
       isInvalid={!!errors.agency_name || !!errors.feedback}
     >
-      <Editable.Section spacing="1.25rem" pb="1.25rem">
+      <Editable.Section spacing="1.25rem">
         <FormControl isRequired isInvalid={!!errors.agency_name}>
           <FormLabel>Name of Organisation / Agency</FormLabel>
           <Input
@@ -58,7 +58,9 @@ export const GeneralInfoSection = ({
             onChange={onChange}
           />
           {errors.feedback ? (
-            <FormErrorMessage>{errors.feedback}</FormErrorMessage>
+            <FormErrorMessage mt="0.5rem" mb={0}>
+              {errors.feedback}
+            </FormErrorMessage>
           ) : (
             <Flex flexDir="row" mt="0.75rem">
               <Icon


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The spacing used on the general information section does not match that on Figma.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The spacing is now fixed.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="414" alt="Screenshot 2023-10-04 at 15 58 48" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/326d1b86-4264-4dc9-94ec-0d47ca08d8d4">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="403" alt="Screenshot 2023-10-04 at 15 59 04" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/2b496492-c183-4310-b331-126798e9c8e3">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Go to the contact us page for any site
    - [ ] Make the feedback URL link invalid
    - [ ] Ensure that the spacing between the error message and the bottom edge of the card is smaller (matches the spacing in the screenshot above

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*