### PR TITLE
fix(contactus): allow location section to be empty but not contact information

### DIFF
--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -807,7 +807,8 @@ const EditContactUs = ({ match }) => {
       if (!filteredFrontMatter.contacts.length) {
         errorToast({
           id: "contact-information-required-error",
-          description: "Contact information is required.",
+          description:
+            "You must add at least one contact information to your Contact Us page.",
         })
         return
       }

--- a/src/layouts/EditContactUs.jsx
+++ b/src/layouts/EditContactUs.jsx
@@ -803,9 +803,16 @@ const EditContactUs = ({ match }) => {
       filteredFrontMatter.locations = newLocations
       filteredFrontMatter.feedback = frontMatter.feedback || ""
 
+      // Contact information is required
+      if (!filteredFrontMatter.contacts.length) {
+        errorToast({
+          id: "contact-information-required-error",
+          description: "Contact information is required.",
+        })
+        return
+      }
+
       // If array is empty, delete the object
-      if (!filteredFrontMatter.contacts.length)
-        delete filteredFrontMatter.contacts
       if (!filteredFrontMatter.locations.length)
         delete filteredFrontMatter.locations
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-471.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The location section of the contact us frontmatter is now optional, so an error toast is shown when the contact information section is empty.
- Corresponding backend change: https://github.com/isomerpages/isomercms-backend/pull/957

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="1510" alt="Screenshot 2023-10-05 at 16 36 54" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/34910807-78aa-4212-bf64-47bcea771758">


**AFTER**:

<!-- [insert screenshot here] -->
![image](https://github.com/isomerpages/isomercms-frontend/assets/27919917/f42dc09b-cc4d-4869-ba39-d192406b6ffd)


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to the contact us page of any site.
    - [ ] Remove all items in the contact information section.
    - [ ] Try to save. Verify that the error toast appears and that there are no requests sent to the backend (i.e. the page isn't saved)

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*