### PR TITLE
Fix/is 625 fix scroll to bottom on save

### DIFF
--- a/src/hooks/useAfterFirstLoad.ts
+++ b/src/hooks/useAfterFirstLoad.ts
@@ -5,18 +5,27 @@ import { useState } from "react"
  * e.g. if data is not fully populated at the time of mounting.
  * It wraps a method in a conditional to check that it has been executed once before.
  */
-export const useAfterFirstLoad = (
-  wrappedMethod: (...args: unknown[]) => void
-) => {
+
+export const useAfterFirstLoad = () => {
   const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false)
 
-  const executeAfterFirstLoad = (...args: unknown[]) => {
-    if (isFirstLoadComplete) {
-      wrappedMethod(...args)
-    } else {
-      setIsFirstLoadComplete(true)
+  const afterFirstLoad = (wrappedMethod: (...args: unknown[]) => void) => {
+    const executeAfterFirstLoad = (...args: unknown[]) => {
+      if (isFirstLoadComplete) {
+        wrappedMethod(...args)
+      } else {
+        setIsFirstLoadComplete(true)
+      }
     }
+
+    return executeAfterFirstLoad
   }
 
-  return executeAfterFirstLoad
+  const resetFirstLoad = () => {
+    setIsFirstLoadComplete(false)
+  }
+  return {
+    afterFirstLoad,
+    resetFirstLoad,
+  }
 }

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -394,7 +394,8 @@ const EditHomepage = ({ match }) => {
     loadPageDetails()
   }, [homepageData])
 
-  const delayedScrollTo = useAfterFirstLoad(scrollTo)
+  const { afterFirstLoad, resetFirstLoad } = useAfterFirstLoad()
+  const delayedScrollTo = afterFirstLoad(scrollTo)
 
   useEffect(() => {
     if (scrollRefs.length === 0) return // Page data has not been populated
@@ -1156,6 +1157,7 @@ const EditHomepage = ({ match }) => {
         sha,
       }
 
+      resetFirstLoad()
       await updateHomepageHandler(params)
     } catch (err) {
       errorToast({


### PR DESCRIPTION
## Problem

This PR fixes an issue where the homepage would scroll to the bottom on save. The issue was caused because our scroll behaviour is triggered by a useEffect whenever `scrollRefs` or `frontMatter.sections.length` changes (after the first time), which includes the time when the file is changed. This behaviour is necessary because the scroll ref does not provide the proper position until after the createHandler has been fully resolved.

To resolve this issue, the `useAfterFirstLoad` hook has been extended to provide a reset method as well, and is included in the save handler - this allows the first load behaviour (where the screen does not scroll) to occur again immediately after saving, which prevents the scroll.