### PR TITLE
feat: load UI optimistically for reads but not writes

### DIFF
--- a/src/components/DirectoryCreationModal/DirectoryCreationModal.jsx
+++ b/src/components/DirectoryCreationModal/DirectoryCreationModal.jsx
@@ -17,6 +17,7 @@ import adminStyles from "styles/isomer-cms/pages/Admin.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 
 import { getDirectoryCreationType } from "utils/directoryUtils"
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { pageFileNameToTitle } from "utils"
 
@@ -40,6 +41,7 @@ export const DirectoryCreationModal = ({
   } = params
 
   const [isSelectingPages, setIsSelectingPages] = useState(false)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const existingTitlesArray = dirsData.map((item) => item.name)
 
@@ -157,7 +159,10 @@ export const DirectoryCreationModal = ({
               <LoadingButton onClick={onClose} variant="outline">
                 Cancel
               </LoadingButton>
-              <LoadingButton onClick={methods.handleSubmit(onSubmit)}>
+              <LoadingButton
+                onClick={methods.handleSubmit(onSubmit)}
+                isDisabled={isWriteDisabled}
+              >
                 {fields.length === 0 ? "Skip" : "Done"}
               </LoadingButton>
             </Footer>

--- a/src/components/DirectorySettingsModal/DirectorySettingsModal.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsModal.jsx
@@ -14,6 +14,7 @@ import { LoadingButton } from "components/LoadingButton"
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
 import { getDirectorySettingsType } from "utils/directoryUtils"
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import {
   deslugifyDirectory,
@@ -56,7 +57,13 @@ export const DirectorySettingsModal = ({
   onProceed,
   onClose,
 }) => {
-  const { subCollectionName, resourceRoomName, mediaDirectoryName } = params
+  const {
+    siteName,
+    subCollectionName,
+    resourceRoomName,
+    mediaDirectoryName,
+  } = params
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
   const existingDirectoryName = mediaDirectoryName
     ? getMediaDirectoryName(mediaDirectoryName, { start: -1, splitOn: "/" })
     : params[getLastItemType(params)]
@@ -123,7 +130,7 @@ export const DirectorySettingsModal = ({
           >
             <LoadingButton
               onClick={handleSubmit(onSubmit)}
-              isDisabled={!_.isEmpty(errors)}
+              isDisabled={isWriteDisabled || !_.isEmpty(errors)}
             >
               {isCreate ? "Next" : "Save"}
             </LoadingButton>

--- a/src/components/MediaMoveModal/MediaMoveModal.jsx
+++ b/src/components/MediaMoveModal/MediaMoveModal.jsx
@@ -11,12 +11,16 @@ import { useGetMediaFolders } from "hooks/directoryHooks"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { pageFileNameToTitle, getMediaDirectoryName } from "utils"
 
 export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
+  const { siteName } = params
   const [moveQuery, setMoveQuery] = useState(_.omit(queryParams, "fileName"))
   const [moveTo, setMoveTo] = useState(params)
   const { data: dirData } = useGetMediaFolders(moveQuery)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const MenuItems = () => {
     if (dirData && dirData.length)
@@ -136,6 +140,7 @@ export const MediaMoveModal = ({ queryParams, params, onProceed, onClose }) => {
                   items: [{ name: params.fileName, type: "file" }],
                 })
               }
+              isDisabled={isWriteDisabled}
             >
               Move Here
             </LoadingButton>

--- a/src/components/MediaSettingsModal/MediaSettingsModal.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsModal.jsx
@@ -17,6 +17,8 @@ import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 import mediaStyles from "styles/isomer-cms/pages/Media.module.scss"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { getLastItemType, getFileExt, getFileName } from "utils"
 
 import { MediaSettingsSchema } from "./MediaSettingsSchema"
@@ -44,12 +46,13 @@ export const MediaSettingsModal = ({
   onClose,
   toggleUploadInput,
 }) => {
-  const { mediaRoom, fileName } = params
+  const { siteName, mediaRoom, fileName } = params
   const existingTitlesArray =
     mediasData &&
     mediasData
       .filter((item) => item.name !== params[getLastItemType(params)])
       .map((item) => item.name)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const {
     register,
@@ -168,9 +171,10 @@ export const MediaSettingsModal = ({
             <Flex w="100%" dir="row" justifyContent="flex-end" p={1}>
               <LoadingButton
                 isDisabled={
-                  !fileName
+                  isWriteDisabled ||
+                  (!fileName
                     ? !_.isEmpty(errors) || !watch("content")
-                    : !_.isEmpty(errors) || !mediaData?.sha
+                    : !_.isEmpty(errors) || !mediaData?.sha)
                 }
                 onClick={handleSubmit((data) => onSubmit(data))}
               >

--- a/src/components/PageMoveModal/PageMoveModal.jsx
+++ b/src/components/PageMoveModal/PageMoveModal.jsx
@@ -10,12 +10,17 @@ import { useGetDirectoryHook } from "hooks/directoryHooks"
 
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { pageFileNameToTitle, getLastItemType, getNextItemType } from "utils"
+
 // eslint-disable-next-line import/prefer-default-export
 export const PageMoveModal = ({ queryParams, params, onProceed, onClose }) => {
+  const { siteName } = params
   const [moveQuery, setMoveQuery] = useState(_.omit(queryParams, "fileName"))
   const [moveTo, setMoveTo] = useState(params)
   const { data: dirData } = useGetDirectoryHook(moveQuery)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const nextItemType = getNextItemType(moveQuery)
   const lastItemType = getLastItemType(moveQuery)
@@ -128,7 +133,8 @@ export const PageMoveModal = ({ queryParams, params, onProceed, onClose }) => {
                 })
               }
               isDisabled={
-                moveTo.resourceRoomName && !moveTo.resourceCategoryName
+                isWriteDisabled ||
+                (moveTo.resourceRoomName && !moveTo.resourceCategoryName)
               }
             >
               Move Here

--- a/src/components/PageSettingsModal/PageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.tsx
@@ -33,6 +33,8 @@ import {
 import FormFieldMedia from "components/FormFieldMedia"
 import { LoadingButton } from "components/LoadingButton"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { getDefaultFrontMatter, pageFileNameToTitle } from "utils"
 
 import { PageSettingsSchema } from "./PageSettingsSchema"
@@ -86,13 +88,14 @@ export const PageSettingsModal = ({
   siteUrl,
   onClose,
 }: PageSettingsModalParams) => {
-  const { fileName } = params
+  const { siteName, fileName } = params
 
   const existingTitlesArray = pagesData
     .filter((page) => page.name !== fileName)
     .map((page) => pageFileNameToTitle(page.name))
 
   const defaultFrontMatter = getDefaultFrontMatter(params, existingTitlesArray)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const {
     register,
@@ -242,9 +245,10 @@ export const PageSettingsModal = ({
           <LoadingButton
             onClick={handleSubmit(onSubmit)}
             isDisabled={
-              !fileName
+              isWriteDisabled ||
+              (!fileName
                 ? !_.isEmpty(errors)
-                : !_.isEmpty(errors) || !pageData?.sha
+                : !_.isEmpty(errors) || !pageData?.sha)
             }
           >
             Save

--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -39,6 +39,8 @@ import {
 import FormFieldMedia from "components/FormFieldMedia"
 import { LoadingButton } from "components/LoadingButton"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { pageFileNameToTitle } from "utils"
 
 import { PageSettingsSchema } from "./PageSettingsSchema"
@@ -129,7 +131,7 @@ export const ResourcePageSettingsModal = ({
   siteUrl,
   onClose,
 }: ResourcePageSettingsModalParams): JSX.Element => {
-  const { fileName, resourceRoomName, resourceCategoryName } = params
+  const { siteName, fileName, resourceRoomName, resourceCategoryName } = params
 
   const existingTitlesArray = pagesData
     .filter((page: ResourcePageParams) => page.name !== fileName)
@@ -142,6 +144,7 @@ export const ResourcePageSettingsModal = ({
     resourceCategoryName,
     existingTitlesArray
   )
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const {
     register,
@@ -430,9 +433,10 @@ export const ResourcePageSettingsModal = ({
           <LoadingButton
             onClick={handleSubmit(onSubmit)}
             isDisabled={
-              !fileName
+              isWriteDisabled ||
+              (!fileName
                 ? !_.isEmpty(errors)
-                : !_.isEmpty(errors) || !pageData?.sha
+                : !_.isEmpty(errors) || !pageData?.sha)
             }
           >
             Save

--- a/src/components/folders/ReorderingModal.jsx
+++ b/src/components/folders/ReorderingModal.jsx
@@ -14,11 +14,14 @@ import elementStyles from "styles/isomer-cms/Elements.module.scss"
 import adminStyles from "styles/isomer-cms/pages/Admin.module.scss"
 import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { deslugifyDirectory } from "utils"
 
 const ReorderingModal = ({ params, dirData, onProceed, onClose }) => {
-  const { collectionName, subCollectionName } = params
+  const { siteName, collectionName, subCollectionName } = params
   const [dirOrder, setDirOrder] = useState([])
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   useEffect(() => {
     if (dirData) setDirOrder(dirData)
@@ -131,6 +134,7 @@ const ReorderingModal = ({ params, dirData, onProceed, onClose }) => {
                   items: dirOrder,
                 })
               }
+              isDisabled={isWriteDisabled}
             >
               Save
             </LoadingButton>

--- a/src/hooks/siteDashboardHooks/useGetReviewRequests.ts
+++ b/src/hooks/siteDashboardHooks/useGetReviewRequests.ts
@@ -11,8 +11,11 @@ import type { SiteDashboardReviewRequest } from "types/siteDashboard"
 
 export const useGetReviewRequests = (
   siteName: string
-): UseQueryResult<SiteDashboardReviewRequest[], AxiosError<ErrorDto>> => {
-  return useQuery<SiteDashboardReviewRequest[], AxiosError<ErrorDto>>(
+): UseQueryResult<
+  SiteDashboardReviewRequest[] | null,
+  AxiosError<ErrorDto>
+> => {
+  return useQuery<SiteDashboardReviewRequest[] | null, AxiosError<ErrorDto>>(
     [SITE_DASHBOARD_REVIEW_REQUEST_KEY, siteName],
     () => SiteDashboardService.getReviewRequests(siteName),
     {

--- a/src/layouts/Folders/Folders.tsx
+++ b/src/layouts/Folders/Folders.tsx
@@ -15,6 +15,7 @@ import {
   Link as RouterLink,
 } from "react-router-dom"
 
+import { Greyscale } from "components/Greyscale"
 import {
   MenuDropdownButton,
   MenuDropdownItem,
@@ -34,6 +35,7 @@ import {
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 import { getDecodedParams } from "utils/decoding"
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { FolderUrlParams } from "types/folders"
 import { isDirData } from "types/utils"
@@ -47,7 +49,7 @@ import { FolderBreadcrumbs, FolderCard, PageCard } from "./components"
 export const Folders = (): JSX.Element => {
   const { params } = useRouteMatch<FolderUrlParams>()
   const decodedParams = getDecodedParams({ ...params })
-  const { collectionName, subCollectionName } = decodedParams
+  const { siteName, collectionName, subCollectionName } = decodedParams
   // NOTE: As isomer does not support recursively nested folders,
   // the depth of folder creation is 1 (parent -> child).
   // Hence, at the subfolder, folder creation is disabled.
@@ -60,6 +62,7 @@ export const Folders = (): JSX.Element => {
     isLoading: isLoadingDirectory,
   } = useGetFoldersAndPages(params)
   const hasDirContent = dirData && dirData.length
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   return (
     <>
@@ -79,59 +82,63 @@ export const Folders = (): JSX.Element => {
           <Box w="100%">
             <SectionHeader label="Order of items">
               <ButtonGroup variant="outline" spacing="1rem">
-                <Button
-                  as={RouterLink}
-                  to={`${url}/rearrange`}
-                  iconSpacing="0.5rem"
-                  leftIcon={
-                    <Icon as={BiSort} fontSize="1.5rem" fill="icon.default" />
-                  }
-                >
-                  Reorder items
-                </Button>
-                {canCreateFolder ? (
-                  <MenuDropdownButton
-                    variant="outline"
-                    mainButtonText="Create page"
+                <Greyscale isActive={isWriteDisabled}>
+                  <Button
                     as={RouterLink}
-                    to={`${url}/createPage`}
+                    to={`${url}/rearrange`}
+                    iconSpacing="0.5rem"
+                    leftIcon={
+                      <Icon as={BiSort} fontSize="1.5rem" fill="icon.default" />
+                    }
                   >
-                    <MenuDropdownItem
+                    Reorder items
+                  </Button>
+                </Greyscale>
+                <Greyscale isActive={isWriteDisabled}>
+                  {canCreateFolder ? (
+                    <MenuDropdownButton
+                      variant="outline"
+                      mainButtonText="Create page"
                       as={RouterLink}
                       to={`${url}/createPage`}
-                      icon={
-                        <Icon
-                          as={BiFileBlank}
-                          fontSize="1.25rem"
-                          fill="icon.alt"
-                        />
-                      }
                     >
-                      <Text textStyle="body-1" fill="text.body">
-                        Create page
-                      </Text>
-                    </MenuDropdownItem>
-                    <MenuDropdownItem
-                      as={RouterLink}
-                      to={`${url}/createDirectory`}
-                      icon={
-                        <Icon
-                          as={BiFolder}
-                          fontSize="1.25rem"
-                          fill="icon.alt"
-                        />
-                      }
-                    >
-                      <Text textStyle="body-1" fill="text.body">
-                        Create subfolder
-                      </Text>
-                    </MenuDropdownItem>
-                  </MenuDropdownButton>
-                ) : (
-                  <CreateButton as={RouterLink} to={`${url}/createPage`}>
-                    Create page
-                  </CreateButton>
-                )}
+                      <MenuDropdownItem
+                        as={RouterLink}
+                        to={`${url}/createPage`}
+                        icon={
+                          <Icon
+                            as={BiFileBlank}
+                            fontSize="1.25rem"
+                            fill="icon.alt"
+                          />
+                        }
+                      >
+                        <Text textStyle="body-1" fill="text.body">
+                          Create page
+                        </Text>
+                      </MenuDropdownItem>
+                      <MenuDropdownItem
+                        as={RouterLink}
+                        to={`${url}/createDirectory`}
+                        icon={
+                          <Icon
+                            as={BiFolder}
+                            fontSize="1.25rem"
+                            fill="icon.alt"
+                          />
+                        }
+                      >
+                        <Text textStyle="body-1" fill="text.body">
+                          Create subfolder
+                        </Text>
+                      </MenuDropdownItem>
+                    </MenuDropdownButton>
+                  ) : (
+                    <CreateButton as={RouterLink} to={`${url}/createPage`}>
+                      Create page
+                    </CreateButton>
+                  )}
+                </Greyscale>
               </ButtonGroup>
             </SectionHeader>
           </Box>

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -4,6 +4,8 @@ import _ from "lodash"
 import { BiBulb, BiUpload } from "react-icons/bi"
 import { Link, Switch, useRouteMatch, useHistory } from "react-router-dom"
 
+import { Greyscale } from "components/Greyscale"
+
 import { useGetMediaFolders } from "hooks/directoryHooks"
 
 import { DeleteWarningScreen } from "layouts/screens/DeleteWarningScreen"
@@ -14,6 +16,8 @@ import { MediaSettingsScreen } from "layouts/screens/MediaSettingsScreen"
 import { MoveScreen } from "layouts/screens/MoveScreen"
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
+
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { isDirData, isMediaData } from "types/utils"
 
@@ -66,7 +70,7 @@ export const Media = (): JSX.Element => {
     mediaRoom: "files" | "images"
     mediaDirectoryName: string
   }>()
-  const { mediaRoom: mediaType } = params
+  const { siteName, mediaRoom: mediaType } = params
   const { data: mediasData, isLoading } = useGetMediaFolders(params)
   const {
     singularMediaLabel,
@@ -74,6 +78,7 @@ export const Media = (): JSX.Element => {
     singularDirectoryLabel,
     pluralDirectoryLabel,
   } = getMediaLabels(mediaType)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   return (
     <>
@@ -88,9 +93,11 @@ export const Media = (): JSX.Element => {
         </Section>
         <Section>
           <SectionHeader label={_.upperFirst(pluralDirectoryLabel)}>
-            <CreateButton as={Link} to={`${url}/createDirectory`}>
-              {`Create ${singularDirectoryLabel}`}
-            </CreateButton>
+            <Greyscale isActive={isWriteDisabled}>
+              <CreateButton as={Link} to={`${url}/createDirectory`}>
+                {`Create ${singularDirectoryLabel}`}
+              </CreateButton>
+            </Greyscale>
           </SectionHeader>
           <Skeleton
             w="100%"
@@ -107,14 +114,16 @@ export const Media = (): JSX.Element => {
         <Section>
           <Box w="100%">
             <SectionHeader label={`Ungrouped ${pluralMediaLabel}`}>
-              <Button
-                as={Link}
-                to={`${url}/createMedia`}
-                leftIcon={<BiUpload fontSize="1.5rem" />}
-                variant="outline"
-              >
-                {`Upload ${singularMediaLabel}`}
-              </Button>
+              <Greyscale isActive={isWriteDisabled}>
+                <Button
+                  as={Link}
+                  to={`${url}/createMedia`}
+                  leftIcon={<BiUpload fontSize="1.5rem" />}
+                  variant="outline"
+                >
+                  {`Upload ${singularMediaLabel}`}
+                </Button>
+              </Greyscale>
             </SectionHeader>
             <SectionCaption label="PRO TIP: " icon={BiBulb}>
               Upload {pluralMediaLabel} here to link to them in pages and

--- a/src/layouts/ResourceCategory/ResourceCategory.tsx
+++ b/src/layouts/ResourceCategory/ResourceCategory.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router-dom"
 
 import { EmptyArea } from "components/EmptyArea"
+import { Greyscale } from "components/Greyscale"
 
 import { useGetResourceCategory } from "hooks/directoryHooks"
 
@@ -28,6 +29,8 @@ import {
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
 // Import utils
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { ResourceCategoryRouteParams } from "types/resources"
 import { deslugifyDirectory } from "utils"
 
@@ -35,11 +38,12 @@ import { ResourceCard, ResourceCategoryBreadcrumb } from "./components"
 
 export const ResourceCategory = (): JSX.Element => {
   const { params } = useRouteMatch<ResourceCategoryRouteParams>()
-  const { resourceCategoryName } = params
+  const { siteName, resourceCategoryName } = params
   const { path, url } = useRouteMatch()
   const history = useHistory()
 
   const { data: pagesData, isLoading } = useGetResourceCategory(params)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
   const arePagesEmpty = !pagesData?.length
   return (
     <>
@@ -53,16 +57,18 @@ export const ResourceCategory = (): JSX.Element => {
           </Box>
         </Section>
         <Section>
-          {/* 
-              There is no loading state for this as '!arePagesEmpty' will only evaluate to 
+          {/*
+              There is no loading state for this as '!arePagesEmpty' will only evaluate to
               true after we have received data from the API call.
            */}
           {!arePagesEmpty && (
             <Box w="full">
               <SectionHeader label="Resource Pages">
-                <CreateButton as={RouterLink} to={`${url}/createPage`}>
-                  Create resource
-                </CreateButton>
+                <Greyscale isActive={isWriteDisabled}>
+                  <CreateButton as={RouterLink} to={`${url}/createPage`}>
+                    Create resource
+                  </CreateButton>
+                </Greyscale>
               </SectionHeader>
               <SectionCaption icon={BiBulb} label="NOTE: ">
                 Resources are automatically ordered by latest date.
@@ -77,28 +83,34 @@ export const ResourceCategory = (): JSX.Element => {
             <EmptyArea
               isItemEmpty={arePagesEmpty}
               actionButton={
-                <Button
-                  as={RouterLink}
-                  to={`${url}/createPage`}
-                  leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
-                >
-                  Create resource
-                </Button>
+                <Greyscale isActive={isWriteDisabled}>
+                  <Button
+                    as={RouterLink}
+                    to={`${url}/createPage`}
+                    leftIcon={
+                      <Icon as={BiPlus} fontSize="1.5rem" fill="white" />
+                    }
+                  >
+                    Create resource
+                  </Button>
+                </Greyscale>
               }
               subText="Create a resource page to get started."
-            />
-
-            <SimpleGrid columns={3} spacing="1.5rem">
-              {/* NOTE: need to use multiline cards */}
-              {(pagesData || []).map(({ name, title, date, resourceType }) => (
-                <ResourceCard
-                  name={name}
-                  title={title}
-                  date={date}
-                  resourceType={resourceType}
-                />
-              ))}
-            </SimpleGrid>
+            >
+              <SimpleGrid columns={3} spacing="1.5rem">
+                {/* NOTE: need to use multiline cards */}
+                {(pagesData || []).map(
+                  ({ name, title, date, resourceType }) => (
+                    <ResourceCard
+                      name={name}
+                      title={title}
+                      date={date}
+                      resourceType={resourceType}
+                    />
+                  )
+                )}
+              </SimpleGrid>
+            </EmptyArea>
           </Skeleton>
         </Section>
       </SiteEditLayout>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -34,6 +34,7 @@ import {
 
 import { ContextMenu } from "components/ContextMenu"
 import { EmptyArea } from "components/EmptyArea"
+import { Greyscale } from "components/Greyscale"
 
 import {
   useCreateDirectory,
@@ -56,6 +57,7 @@ import {
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 import { useErrorToast, useSuccessToast } from "utils/toasts"
 
 import { DirectoryData, DirectoryInfoProps } from "types/directory"
@@ -255,6 +257,7 @@ const ResourceRoomContent = ({
     isError: isUpdateResourceRoomNameError,
     isSuccess: isUpdateResourceRoomNameSuccess,
   } = useUpdateResourceRoomName(siteName, resourceRoomName)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
   const errorToast = useErrorToast()
   const successToast = useSuccessToast()
 
@@ -310,9 +313,11 @@ const ResourceRoomContent = ({
           {directoryData.length !== 0 && (
             <Box w="full">
               <SectionHeader label="Resource Categories">
-                <CreateButton as={RouterLink} to={`${url}/createDirectory`}>
-                  Create category
-                </CreateButton>
+                <Greyscale isActive={isWriteDisabled}>
+                  <CreateButton as={RouterLink} to={`${url}/createDirectory`}>
+                    Create category
+                  </CreateButton>
+                </Greyscale>
               </SectionHeader>
               <SectionCaption icon={BiBulb} label="PRO TIP: ">
                 Categories impact navigation on your site. Organise your
@@ -324,13 +329,17 @@ const ResourceRoomContent = ({
             <EmptyArea
               isItemEmpty={!directoryData?.length}
               actionButton={
-                <Button
-                  as={RouterLink}
-                  to={`${url}/createDirectory`}
-                  leftIcon={<Icon as={BiPlus} fontSize="1.5rem" fill="white" />}
-                >
-                  Create category
-                </Button>
+                <Greyscale isActive={isWriteDisabled}>
+                  <Button
+                    as={RouterLink}
+                    to={`${url}/createDirectory`}
+                    leftIcon={
+                      <Icon as={BiPlus} fontSize="1.5rem" fill="white" />
+                    }
+                  >
+                    Create category
+                  </Button>
+                </Greyscale>
               }
               subText="Create a resource category to get started."
             >
@@ -383,6 +392,7 @@ const ResourceRoomContent = ({
                 <Button
                   type="submit"
                   isLoading={isUpdateResourceRoomNameLoading}
+                  isDisabled={isWriteDisabled}
                 >
                   Save
                 </Button>

--- a/src/layouts/Workspace/Workspace.tsx
+++ b/src/layouts/Workspace/Workspace.tsx
@@ -4,6 +4,7 @@ import { BiFolder, BiFileBlank } from "react-icons/bi"
 import { Switch, useRouteMatch, useHistory, Link } from "react-router-dom"
 
 import { EmptyArea } from "components/EmptyArea"
+import { Greyscale } from "components/Greyscale"
 import {
   MenuDropdownButton,
   MenuDropdownItem,
@@ -28,6 +29,8 @@ import {
 } from "layouts/screens"
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
+
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { FeatureTourHandler } from "features/FeatureTour/FeatureTour"
 import { WORKSPACE_FEATURE_STEPS } from "features/FeatureTour/FeatureTourSequence"
@@ -54,6 +57,7 @@ const WorkspacePage = (): JSX.Element => {
     siteName,
   })
   const { data: _pagesData } = useGetWorkspacePages(siteName)
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const pagesData = _pagesData || []
   const dirsData = (_dirsAndPagesData || []).filter(isDirData)
@@ -91,44 +95,52 @@ const WorkspacePage = (): JSX.Element => {
           <EmptyArea
             isItemEmpty={isFoldersEmpty && isPagesEmpty}
             actionButton={
-              <MenuDropdownButton
-                variant="outline"
-                mainButtonText="Create page"
-                as={Link}
-                to={`${url}/createPage`}
-              >
-                <MenuDropdownItem
+              <Greyscale isActive={isWriteDisabled}>
+                <MenuDropdownButton
+                  variant="outline"
+                  mainButtonText="Create page"
                   as={Link}
                   to={`${url}/createPage`}
-                  icon={
-                    <Icon as={BiFileBlank} fontSize="1.25rem" fill="icon.alt" />
-                  }
                 >
-                  <Text textStyle="body-1" fill="text.body">
-                    Create page
-                  </Text>
-                </MenuDropdownItem>
-                <MenuDropdownItem
-                  as={Link}
-                  to={`${url}/createDirectory`}
-                  icon={
-                    <Icon as={BiFolder} fontSize="1.25rem" fill="icon.alt" />
-                  }
-                >
-                  <Text textStyle="body-1" fill="text.body">
-                    Create folder
-                  </Text>
-                </MenuDropdownItem>
-              </MenuDropdownButton>
+                  <MenuDropdownItem
+                    as={Link}
+                    to={`${url}/createPage`}
+                    icon={
+                      <Icon
+                        as={BiFileBlank}
+                        fontSize="1.25rem"
+                        fill="icon.alt"
+                      />
+                    }
+                  >
+                    <Text textStyle="body-1" fill="text.body">
+                      Create page
+                    </Text>
+                  </MenuDropdownItem>
+                  <MenuDropdownItem
+                    as={Link}
+                    to={`${url}/createDirectory`}
+                    icon={
+                      <Icon as={BiFolder} fontSize="1.25rem" fill="icon.alt" />
+                    }
+                  >
+                    <Text textStyle="body-1" fill="text.body">
+                      Create folder
+                    </Text>
+                  </MenuDropdownItem>
+                </MenuDropdownButton>
+              </Greyscale>
             }
           >
             <SiteViewContent>
               <EmptyArea
                 isItemEmpty={isFoldersEmpty}
                 actionButton={
-                  <CreateButton as={Link} to={`${url}/createDirectory`}>
-                    Create folder
-                  </CreateButton>
+                  <Greyscale isActive={isWriteDisabled}>
+                    <CreateButton as={Link} to={`${url}/createDirectory`}>
+                      Create folder
+                    </CreateButton>
+                  </Greyscale>
                 }
               >
                 <WorkspaceFolders
@@ -141,12 +153,18 @@ const WorkspacePage = (): JSX.Element => {
               <EmptyArea
                 isItemEmpty={isPagesEmpty}
                 actionButton={
-                  <CreateButton as={Link} to={`${url}/createPage`}>
-                    Create page
-                  </CreateButton>
+                  <Greyscale isActive={isWriteDisabled}>
+                    <CreateButton as={Link} to={`${url}/createPage`}>
+                      Create page
+                    </CreateButton>
+                  </Greyscale>
                 }
               >
-                <UngroupedPages pagesData={pagesData} url={url} />
+                <UngroupedPages
+                  siteName={siteName}
+                  pagesData={pagesData}
+                  url={url}
+                />
               </EmptyArea>
             </SiteViewContent>
           </EmptyArea>

--- a/src/layouts/Workspace/components/UngroupedPages.tsx
+++ b/src/layouts/Workspace/components/UngroupedPages.tsx
@@ -2,6 +2,10 @@ import { SimpleGrid, Box, Skeleton } from "@chakra-ui/react"
 import { BiInfoCircle } from "react-icons/bi"
 import { Link } from "react-router-dom"
 
+import { Greyscale } from "components/Greyscale"
+
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { PageData } from "types/directory"
 
 import {
@@ -14,21 +18,27 @@ import {
 import { PageCard } from "."
 
 export interface UngroupedPagesProps {
+  siteName: string
   pagesData: PageData[]
   url: string
 }
 
 export const UngroupedPages = ({
+  siteName,
   pagesData,
   url,
 }: UngroupedPagesProps): JSX.Element => {
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
+
   return (
     <Section>
       <Box w="100%">
         <SectionHeader label="Ungrouped Pages">
-          <CreateButton as={Link} to={`${url}/createPage`}>
-            Create page
-          </CreateButton>
+          <Greyscale isActive={isWriteDisabled}>
+            <CreateButton as={Link} to={`${url}/createPage`}>
+              Create page
+            </CreateButton>
+          </Greyscale>
         </SectionHeader>
         <SectionCaption label="NOTE: " icon={BiInfoCircle}>
           These pages aren&apos;t in folders, but can be added as items to your

--- a/src/layouts/Workspace/components/WorkspaceFolder.tsx
+++ b/src/layouts/Workspace/components/WorkspaceFolder.tsx
@@ -2,6 +2,10 @@ import { SimpleGrid, Box, Skeleton } from "@chakra-ui/react"
 import { BiBulb } from "react-icons/bi"
 import { Link } from "react-router-dom"
 
+import { Greyscale } from "components/Greyscale"
+
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { DirectoryData, PageData } from "types/directory"
 
 import {
@@ -28,13 +32,17 @@ export const WorkspaceFolders = ({
   url,
   dirsData,
 }: WorkspaceFoldersProps): JSX.Element => {
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
+
   return (
     <Section>
       <Box w="100%">
         <SectionHeader label="Folders">
-          <CreateButton as={Link} to={`${url}/createDirectory`}>
-            Create folder
-          </CreateButton>
+          <Greyscale isActive={isWriteDisabled}>
+            <CreateButton as={Link} to={`${url}/createDirectory`}>
+              Create folder
+            </CreateButton>
+          </Greyscale>
         </SectionHeader>
         <SectionCaption label="PRO TIP: " icon={BiBulb}>
           You can link folders to your navigation bar.

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -32,6 +32,8 @@ import { useGetReviewRequests } from "hooks/siteDashboardHooks"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import { NavImage } from "assets"
 
 export const SiteEditHeader = (): JSX.Element => {
@@ -53,22 +55,9 @@ export const SiteEditHeader = (): JSX.Element => {
   // NOTE: Even if we have an unknown user, we assume that it is github
   // and avoid showing new features.
   const isGithubUser = !!userId
-  const {
-    data: reviewRequests,
-    isLoading: isReviewRequestsLoading,
-  } = useGetReviewRequests(siteName)
   const history = useHistory()
 
-  // Note: if PR is in APPROVED status, it will auto-redirect to dashboard as no edits should happen
-  // But have added here to be explicit of the status checks
-  const openReviewRequests = reviewRequests
-    ? reviewRequests.filter(
-        (request) => request.status === "OPEN" || request.status === "APPROVED"
-      )
-    : []
-
-  const shouldDisableReviewRequestButton =
-    isReviewRequestsLoading || openReviewRequests.length > 0
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   const onBackButtonClick = () => {
     const redirPath = isGithubUser ? "/sites" : `/sites/${siteName}/dashboard`
@@ -128,7 +117,7 @@ export const SiteEditHeader = (): JSX.Element => {
               id="isomer-workspace-feature-tour-step-1"
               leftIcon={<Icon as={BiCheckCircle} fontSize="1.25rem" />}
               onClick={onReviewRequestModalOpen}
-              isDisabled={shouldDisableReviewRequestButton}
+              isDisabled={isWriteDisabled}
             >
               Request a Review
             </Button>

--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -9,6 +9,8 @@ import { useDeleteDirectoryHook } from "hooks/directoryHooks"
 import { useGetMediaHook, useDeleteMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook, useDeletePageHook } from "hooks/pageHooks"
 
+import { isWriteActionsDisabled } from "utils/reviewRequests"
+
 import {
   getLastItemType,
   getMediaDirectoryName,
@@ -17,13 +19,14 @@ import {
 
 export const DeleteWarningScreen = ({ match, onClose }) => {
   const { params, decodedParams } = match
-  const { fileName, mediaRoom } = params
+  const { siteName, fileName, mediaRoom } = params
   const deleteItemName = params.mediaDirectoryName
     ? getMediaDirectoryName(params.mediaDirectoryName, { start: -1 })
     : pageFileNameToTitle(
         decodedParams[getLastItemType(decodedParams)],
         !!(params.resourceRoomName && params.fileName)
       )
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   if (fileName) {
     const { data: fileData } = mediaRoom
@@ -50,6 +53,7 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
         <LoadingButton
           colorScheme="critical"
           onClick={() => deleteHandler({ sha: fileData.sha })}
+          isDisabled={isWriteDisabled}
         >
           Yes, delete
         </LoadingButton>
@@ -73,7 +77,11 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
       <Button variant="clear" colorScheme="secondary" onClick={onClose}>
         Cancel
       </Button>
-      <LoadingButton colorScheme="critical" onClick={deleteHandler}>
+      <LoadingButton
+        colorScheme="critical"
+        onClick={deleteHandler}
+        isDisabled={isWriteDisabled}
+      >
         Yes, delete
       </LoadingButton>
     </WarningModal>

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -79,9 +79,7 @@ export const RouteSelector = () => {
             "/sites/:siteName/folders/:collectionName",
           ]}
         >
-          <ApprovedReviewRedirect>
-            <Folders />
-          </ApprovedReviewRedirect>
+          <Folders />
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps
@@ -95,9 +93,7 @@ export const RouteSelector = () => {
             "/sites/:siteName/media/:mediaRoom/mediaDirectory/:mediaDirectoryName",
           ]}
         >
-          <ApprovedReviewRedirect>
-            <Media />
-          </ApprovedReviewRedirect>
+          <Media />
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps path="/sites/:siteName/dashboard">
@@ -119,9 +115,7 @@ export const RouteSelector = () => {
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps path="/sites/:siteName/workspace">
-          <ApprovedReviewRedirect>
-            <Workspace />
-          </ApprovedReviewRedirect>
+          <Workspace />
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps
@@ -135,9 +129,7 @@ export const RouteSelector = () => {
         />
 
         <ProtectedRouteWithProps path="/sites/:siteName/resourceRoom/:resourceRoomName/resourceCategory/:resourceCategoryName">
-          <ApprovedReviewRedirect>
-            <ResourceCategory />
-          </ApprovedReviewRedirect>
+          <ResourceCategory />
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps
@@ -146,9 +138,7 @@ export const RouteSelector = () => {
             "/sites/:siteName/resourceRoom",
           ]}
         >
-          <ApprovedReviewRedirect>
-            <ResourceRoom />
-          </ApprovedReviewRedirect>
+          <ResourceRoom />
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps path="/sites/:siteName/settings">

--- a/src/services/SiteDashboardService.ts
+++ b/src/services/SiteDashboardService.ts
@@ -23,11 +23,19 @@ export const getSiteInfo = async (
 
 export const getReviewRequests = async (
   siteName: string
-): Promise<SiteDashboardReviewRequest[]> => {
+): Promise<SiteDashboardReviewRequest[] | null> => {
   const endpoint = `/sites/${siteName}/review/summary`
   return apiService
-    .get<{ reviews: SiteDashboardReviewRequest[] }>(endpoint)
-    .then(({ data }) => data.reviews)
+    .get<{ reviews: SiteDashboardReviewRequest[] } | { message: string }>(
+      endpoint
+    )
+    .then(({ data }) => {
+      if ("reviews" in data) {
+        return data.reviews
+      }
+      // Site is not migrated
+      return null
+    })
 }
 
 export const getCollaboratorsStatistics = async (

--- a/src/types/collaborators.ts
+++ b/src/types/collaborators.ts
@@ -1,4 +1,4 @@
-export type SiteMemberRole = "CONTRIBUTOR" | "ADMIN"
+export type SiteMemberRole = "CONTRIBUTOR" | "ADMIN" | "ISOMERADMIN"
 
 export interface CollaboratorDto {
   id: string

--- a/src/utils/reviewRequests.ts
+++ b/src/utils/reviewRequests.ts
@@ -1,0 +1,15 @@
+import { useGetReviewRequests } from "hooks/siteDashboardHooks"
+
+export const isWriteActionsDisabled = (siteName: string) => {
+  const { data: reviewRequests, isLoading, isError } = useGetReviewRequests(
+    siteName
+  )
+
+  // Note: if PR is in APPROVED status, it will auto-redirect to dashboard as no edits should happen
+  // But have added here to be explicit of the status checks
+  const isReviewRequestPending = reviewRequests?.some(
+    (request) => request.status === "OPEN" || request.status === "APPROVED"
+  )
+
+  return isLoading || isError || isReviewRequestPending
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-639.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The UI is now loaded more optimistically while the review request information is being loaded in the background. This is done using the following approach:
    - The blunt method of putting everything in Greyscale has been removed, except for pages that are specifically for writes (i.e. EditPage, EditHomepage, etc)
    - For pages that do reads/listing, the buttons that specifically perform write actions are now disabled until we determine it is safe for the user to make changes

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="1512" alt="Screenshot 2023-10-11 at 11 57 32" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/cfd6c552-0865-40a6-bb56-6e10cd377da7">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="1512" alt="Screenshot 2023-10-11 at 11 56 54" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/8ab2af2a-c583-41c4-9252-8c95752e51f9">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [x] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site that you are not a collaborator of (but you are a super admin)
    - [ ] Verify that you are able to navigate around the workspace and other site-related pages, but write-action buttons are disabled.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*