### PR TITLE
refactor(editpage): abstract out overwrite changes warning modal

### DIFF
--- a/src/components/OverwriteChangesModal/OverwriteChangesModal.stories.tsx
+++ b/src/components/OverwriteChangesModal/OverwriteChangesModal.stories.tsx
@@ -1,0 +1,38 @@
+import { useDisclosure } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import { Meta, StoryFn } from "@storybook/react"
+
+import { useSuccessToast } from "utils/toasts"
+
+import { OverwriteChangesModal } from "./OverwriteChangesModal"
+
+const overwriteChangesModalMeta = {
+  title: "Components/OverwriteChangesModal",
+  component: OverwriteChangesModal,
+} as Meta<typeof OverwriteChangesModal>
+
+const overwriteChangesModalTemplate: StoryFn<
+  typeof OverwriteChangesModal
+> = () => {
+  const props = useDisclosure({ defaultIsOpen: true })
+  const successToast = useSuccessToast()
+  const onProceed = () => {
+    successToast({
+      id: "storybook-overwrite-changes-success",
+      description: "STORYBOOK: Changes have been successfully overwritten",
+    })
+    props.onClose()
+  }
+
+  return (
+    <>
+      <Button onClick={props.onOpen}>Open overwrite changes modal</Button>
+      <OverwriteChangesModal onProceed={onProceed} {...props} />
+    </>
+  )
+}
+
+export const Default = overwriteChangesModalTemplate.bind({})
+Default.args = {}
+
+export default overwriteChangesModalMeta

--- a/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
+++ b/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
@@ -1,0 +1,51 @@
+import { Box, Text, VStack } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+
+import { WarningModal } from "components/WarningModal"
+
+interface OverwriteChangesModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onProceed: () => void
+}
+
+export const OverwriteChangesModal = (
+  props: OverwriteChangesModalProps
+): JSX.Element => {
+  const { isOpen, onClose, onProceed } = props
+
+  return (
+    <WarningModal
+      isOpen={isOpen}
+      onClose={onClose}
+      displayTitle="Override Changes"
+      displayText={
+        <Box>
+          <VStack gap="1.5rem">
+            <Text>
+              A different version of this page has recently been saved by
+              another user. You can choose to either override their changes, or
+              go back to editing.
+            </Text>
+            <Text>
+              We recommend you to make a copy of your changes elsewhere, and
+              come back later to reconcile your changes.
+            </Text>
+          </VStack>
+        </Box>
+      }
+    >
+      <Button
+        variant="clear"
+        colorScheme="secondary"
+        textColor="text.title.alt"
+        onClick={onClose}
+      >
+        Back to Editing
+      </Button>
+      <Button colorScheme="critical" onClick={onProceed}>
+        Override
+      </Button>
+    </WarningModal>
+  )
+}

--- a/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
+++ b/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
@@ -18,33 +18,27 @@ export const OverwriteChangesModal = ({
     <WarningModal
       isOpen={isOpen}
       onClose={onClose}
-      displayTitle="Override Changes"
+      displayTitle="Do you want to override recent changes?"
       displayText={
         <Box>
           <VStack gap="1.5rem">
             <Text>
-              A different version of this page has recently been saved by
-              another user. You can choose to either override their changes, or
-              go back to editing.
+              Another user edited and saved this page recently. If you save your
+              edits now, their changes will be lost.
             </Text>
             <Text>
-              We recommend you to make a copy of your changes elsewhere, and
-              come back later to reconcile your changes.
+              We recommend you to make a copy of your changes elsewhere and come
+              back later.
             </Text>
           </VStack>
         </Box>
       }
     >
-      <Button
-        variant="clear"
-        colorScheme="secondary"
-        textColor="text.title.alt"
-        onClick={onClose}
-      >
-        Back to Editing
+      <Button variant="clear" colorScheme="critical" onClick={onProceed}>
+        Save my edits anyway
       </Button>
-      <Button colorScheme="critical" onClick={onProceed}>
-        Override
+      <Button colorScheme="main" onClick={onClose}>
+        Back to editing
       </Button>
     </WarningModal>
   )

--- a/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
+++ b/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
@@ -9,11 +9,11 @@ interface OverwriteChangesModalProps {
   onProceed: () => void
 }
 
-export const OverwriteChangesModal = (
-  props: OverwriteChangesModalProps
-): JSX.Element => {
-  const { isOpen, onClose, onProceed } = props
-
+export const OverwriteChangesModal = ({
+  isOpen,
+  onClose,
+  onProceed,
+}: OverwriteChangesModalProps): JSX.Element => {
   return (
     <WarningModal
       isOpen={isOpen}

--- a/src/components/OverwriteChangesModal/index.ts
+++ b/src/components/OverwriteChangesModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./OverwriteChangesModal"

--- a/src/layouts/EditPage.jsx
+++ b/src/layouts/EditPage.jsx
@@ -17,6 +17,7 @@ import { useEffect, useState } from "react"
 import { Footer } from "components/Footer"
 import { Greyscale } from "components/Greyscale"
 import Header from "components/Header"
+import { OverwriteChangesModal } from "components/OverwriteChangesModal"
 import MarkdownEditor from "components/pages/MarkdownEditor"
 import PagePreview from "components/pages/PagePreview"
 import { WarningModal } from "components/WarningModal"
@@ -179,6 +180,7 @@ const EditPage = ({ match }) => {
       />
       <Greyscale isActive={isWriteDisabled}>
         <HStack className={elementStyles.wrapper}>
+          {/* XSS violation warning modal */}
           <WarningModal
             isOpen={isXSSViolation && isXSSWarningModalOpen}
             onClose={onXSSWarningModalClose}
@@ -233,48 +235,23 @@ const EditPage = ({ match }) => {
               Acknowledge
             </Button>
           </WarningModal>
-          <WarningModal
+
+          {/* Override changes warning modal */}
+          <OverwriteChangesModal
             isOpen={isOverwriteOpen}
             onClose={onOverwriteClose}
-            displayTitle="Override Changes"
-            displayText={
-              <Box>
-                <Text>
-                  A different version of this page has recently been saved by
-                  another user. You can choose to either override their changes,
-                  or go back to editing.
-                </Text>
-                <br />
-                <Text>
-                  We recommend you to make a copy of your changes elsewhere, and
-                  come back later to reconcile your changes.
-                </Text>
-              </Box>
-            }
-          >
-            <Button
-              variant="clear"
-              colorScheme="secondary"
-              onClick={onOverwriteClose}
-            >
-              Back to Editing
-            </Button>
-            <Button
-              colorScheme="critical"
-              onClick={() => {
-                onOverwriteClose()
-                updatePageHandler({
-                  pageData: {
-                    frontMatter: pageData.content.frontMatter,
-                    sha: pageData.sha,
-                    pageBody: editorValue,
-                  },
-                })
-              }}
-            >
-              Override
-            </Button>
-          </WarningModal>
+            onProceed={() => {
+              onOverwriteClose()
+              updatePageHandler({
+                pageData: {
+                  frontMatter: pageData.content.frontMatter,
+                  sha: pageData.sha,
+                  pageBody: editorValue,
+                },
+              })
+            }}
+          />
+
           {/* Editor */}
           <MarkdownEditor
             siteName={siteName}
@@ -282,6 +259,7 @@ const EditPage = ({ match }) => {
             value={editorValue}
             isLoading={isLoadingPage}
           />
+
           {/* Preview */}
           <PagePreview
             pageParams={decodedParams}

--- a/src/layouts/Settings/components/OverrideWarningModal.tsx
+++ b/src/layouts/Settings/components/OverrideWarningModal.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@chakra-ui/react"
+import { Box, Text, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 
 import { WarningModal } from "components/WarningModal"
@@ -25,26 +25,24 @@ export const OverrideWarningModal = ({
       // and the user still chose to proceed (this only occurs when there is a diff)
       isOpen={isOpen}
       onClose={onClose}
-      displayTitle="Override Changes"
+      displayTitle="Do you want to override recent changes?"
       displayText={
-        <Text>
-          Your site settings have recently been changed by another user. You can
-          choose to either override their changes, or go back to editing.
-          {/*
-           * NOTE: We have 2 line breaks here because we want a line spacing between the 2 <paragraphs.
-           * Only have 1 br would cause the second paragraph to begin on a new line but without the line spacing.
-           */}
-          <br />
-          <br />
-          We recommend you to make a copy of your changes elsewhere, and come
-          back later to reconcile your changes.
-        </Text>
+        <Box>
+          <VStack gap="1.5rem">
+            <Text>
+              Another user edited and saved your site settings recently. You can
+              choose to either override their changes, or go back to editing.
+            </Text>
+            <Text>
+              We recommend you to make a copy of your changes elsewhere and come
+              back later.
+            </Text>
+          </VStack>
+        </Box>
       }
     >
-      <Button variant="outline" onClick={onClose}>
-        Back to editing
-      </Button>
       <Button
+        variant="clear"
         colorScheme="critical"
         type="submit"
         isLoading={isLoading}
@@ -53,7 +51,10 @@ export const OverrideWarningModal = ({
           onClose()
         }}
       >
-        Override
+        Save my edits anyway
+      </Button>
+      <Button colorScheme="main" onClick={onClose}>
+        Back to editing
       </Button>
     </WarningModal>
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of ticket 629 (intentionally not linking since JIRA will think the task is done).

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- The overwrite changes warning modal that used to be present in EditPage has now been abstracted out into its own component. This is to allow other editing pages to be able to use the same override modal.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Go to any site
    - [ ] Open the page editor for a single page on two tabs (both tabs editing the same page)
    - [ ] Make changes and save on the first tab, ensure that the page has saved successfully
    - [ ] Make changes on the second tab and save, verify that the override changes warning modal appears as intended
    - [ ] Click on Override, verify that the changes are indeed overwritten on the repository

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*