### PR TITLE
Chore/replace text styles

### DIFF
--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -66,10 +66,6 @@ h6 {
   letter-spacing: 0 !important;
 }
 
-i {
-  color: $isomer-blue;
-}
-
 .disabledIcon {
   color: $isomer-grey;
 }

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12653,6 +12653,10 @@ html.has-navbar-fixed-top-widescreen {
   cursor: zoom-out;
 }
 
+.remove-after:after {
+  content: "" !important
+}
+
 .bg-primary {
   background-color: #6031b6;
 }

--- a/src/styles/isomer-template/theme/_layout.scss
+++ b/src/styles/isomer-template/theme/_layout.scss
@@ -6,6 +6,10 @@
   justify-content: flex-start;
 }
 
+.flex-center {
+  justify-content: center;
+}
+
 .w-100 {
   width: 100%;
 }
@@ -16,5 +20,4 @@
 
 .is-vh-centered {
   align-items: center;
-  justify-content: center;
 }

--- a/src/styles/isomer-template/theme/_text-styles.scss
+++ b/src/styles/isomer-template/theme/_text-styles.scss
@@ -111,7 +111,7 @@ display-1 {
 }
 
 .link-button {
-  color: $utility-theme-color;
+  color: var(--site-secondary-color);
   text-align: center;
   font-feature-settings: "clig" off, "liga" off;
 
@@ -121,8 +121,15 @@ display-1 {
   font-style: normal;
   font-weight: 600;
   line-height: 2rem; /* 177.778% */
-  text-decoration-line: underline;
   text-transform: uppercase;
+
+  &:hover {
+    color: var(--site-secondary-color-hover);
+  }
+
+  .link-button-text {
+    text-decoration-line: underline;
+  }
 }
 
 .button-text {

--- a/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
+++ b/src/templates/homepage/HeroSection/HeroImageOnlyLayout.tsx
@@ -38,6 +38,7 @@ export const HeroImageOnlyLayout = ({
               "is-flex",
               "is-full-width",
               "is-vh-centered",
+              "flex-center",
             ])}
           >
             {dropdown?.title ? (

--- a/src/templates/homepage/InfobarSection.jsx
+++ b/src/templates/homepage/InfobarSection.jsx
@@ -86,7 +86,7 @@ const TemplateInfobarSection = (
                 "remove-after",
                 "is-flex",
                 "is-vh-centered",
-                "flex-center-button",
+                "flex-center",
               ])}
             >
               <span

--- a/src/templates/homepage/InfobarSection.jsx
+++ b/src/templates/homepage/InfobarSection.jsx
@@ -36,8 +36,7 @@ const TemplateInfobarSection = (
               <p
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
-                  "eyebrow",
-                  "is-uppercase",
+                  "subtitle-2",
                 ])}
               >
                 {subtitle}
@@ -49,13 +48,18 @@ const TemplateInfobarSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
                 <b>{title}</b>
               </h1>
             ) : null}
             {/* Description */}
-            {description ? <p>{description}</p> : null}
+            {description ? (
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
+            ) : null}
           </div>
         </div>
       </div>
@@ -76,18 +80,29 @@ const TemplateInfobarSection = (
               "is-one-third",
             ])}
           >
-            <div className={getClassNames(editorStyles, ["bp-sec-button"])}>
-              <div>
-                <span>{button}</span>
-                <i
-                  className={getClassNames(editorStyles, [
-                    "sgds-icon",
-                    "sgds-icon-arrow-right",
-                    "is-size-4",
-                  ])}
-                  aria-hidden="true"
-                />
-              </div>
+            <div
+              className={getClassNames(editorStyles, [
+                "link-button",
+                "remove-after",
+                "is-flex",
+                "is-vh-centered",
+                "flex-center-button",
+              ])}
+            >
+              <span
+                className={getClassNames(editorStyles, ["link-button-text"])}
+              >
+                {button}
+              </span>
+              <i
+                className={getClassNames(editorStyles, [
+                  "sgds-icon",
+                  "sgds-icon-arrow-right",
+                  "is-size-4",
+                  "ml-3",
+                ])}
+                aria-hidden="true"
+              />
             </div>
           </div>
         </div>

--- a/src/templates/homepage/InfopicLeftSection.jsx
+++ b/src/templates/homepage/InfopicLeftSection.jsx
@@ -48,8 +48,7 @@ const TemplateInfopicLeftSection = (
               <p
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
-                  "eyebrow",
-                  "is-uppercase",
+                  "subtitle-2",
                 ])}
               >
                 {subtitle}
@@ -58,29 +57,43 @@ const TemplateInfopicLeftSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
-              <p>{description}</p>
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
               <div
                 className={getClassNames(editorStyles, [
-                  "bp-sec-button",
-                  "margin--top padding--bottom",
+                  "py-4",
+                  "link-button",
+                  "remove-after",
+                  "is-flex",
+                  "flex-start",
+                  "is-vh-centered",
                 ])}
               >
                 {button ? (
-                  <div>
-                    <span>{button}</span>
+                  <>
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "link-button-text",
+                      ])}
+                    >
+                      {button}
+                    </span>
                     <i
                       className={getClassNames(editorStyles, [
                         "sgds-icon",
                         "sgds-icon-arrow-right",
                         "is-size-4",
+                        "ml-3",
                       ])}
                       aria-hidden="true"
                     />
-                  </div>
+                  </>
                 ) : null}
               </div>
             </div>
@@ -104,8 +117,7 @@ const TemplateInfopicLeftSection = (
               <p
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
-                  "eyebrow",
-                  "is-uppercase",
+                  "subtitle-2",
                 ])}
               >
                 {subtitle}
@@ -114,30 +126,43 @@ const TemplateInfopicLeftSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
-              <p>{description}</p>
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
               <div
                 className={getClassNames(editorStyles, [
-                  "bp-sec-button",
-                  "margin--top",
-                  "padding--bottom",
+                  "py-4",
+                  "link-button",
+                  "remove-after",
+                  "is-flex",
+                  "flex-start",
+                  "is-vh-centered",
                 ])}
               >
                 {button ? (
-                  <div>
-                    <span>{button}</span>
+                  <>
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "link-button-text",
+                      ])}
+                    >
+                      {button}
+                    </span>
                     <i
                       className={getClassNames(editorStyles, [
                         "sgds-icon",
                         "sgds-icon-arrow-right",
                         "is-size-4",
+                        "ml-3",
                       ])}
                       aria-hidden="true"
                     />
-                  </div>
+                  </>
                 ) : null}
               </div>
             </div>
@@ -178,8 +203,7 @@ const TemplateInfopicLeftSection = (
               <p
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
-                  "eyebrow",
-                  "is-uppercase",
+                  "subtitle-2",
                 ])}
               >
                 {subtitle}
@@ -188,30 +212,43 @@ const TemplateInfopicLeftSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
-              <p>{description}</p>
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
               <div
                 className={getClassNames(editorStyles, [
-                  "margin--top",
-                  "padding--bottom",
-                  "bp-sec-button",
+                  "py-4",
+                  "link-button",
+                  "remove-after",
+                  "is-flex",
+                  "flex-start",
+                  "is-vh-centered",
                 ])}
               >
                 {button ? (
-                  <div>
-                    <span>{button}</span>
+                  <>
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "link-button-text",
+                      ])}
+                    >
+                      {button}
+                    </span>
                     <i
                       className={getClassNames(editorStyles, [
                         "sgds-icon",
                         "sgds-icon-arrow-right",
                         "is-size-4",
+                        "ml-3",
                       ])}
                       aria-hidden="true"
                     />
-                  </div>
+                  </>
                 ) : null}
               </div>
             </div>

--- a/src/templates/homepage/InfopicRightSection.jsx
+++ b/src/templates/homepage/InfopicRightSection.jsx
@@ -58,26 +58,39 @@ const TemplateInfopicRightSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
-              <p>{description}</p>
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
               <div
                 className={getClassNames(editorStyles, [
-                  "bp-sec-button",
-                  "margin--top",
-                  "padding--bottom",
+                  "py-4",
+                  "link-button",
+                  "remove-after",
+                  "is-flex",
+                  "flex-start",
+                  "is-vh-centered",
                 ])}
               >
                 {button ? (
                   <div>
-                    <span>{button}</span>
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "link-button-text",
+                      ])}
+                    >
+                      {button}
+                    </span>
                     <i
                       className={getClassNames(editorStyles, [
                         "sgds-icon",
                         "sgds-icon-arrow-right",
                         "is-size-4",
+                        "ml-3",
                       ])}
                       aria-hidden="true"
                     />
@@ -119,8 +132,7 @@ const TemplateInfopicRightSection = (
               <p
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
-                  "eyebrow",
-                  "is-uppercase",
+                  "subtitle-2",
                 ])}
               >
                 {subtitle}
@@ -129,30 +141,43 @@ const TemplateInfopicRightSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
-              <p>{description}</p>
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
               <div
                 className={getClassNames(editorStyles, [
-                  "bp-sec-button",
-                  "margin--top",
-                  "padding--bottom",
+                  "py-4",
+                  "link-button",
+                  "remove-after",
+                  "is-flex",
+                  "flex-start",
+                  "is-vh-centered",
                 ])}
               >
                 {button ? (
-                  <div>
-                    <span>{button}</span>
+                  <>
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "link-button-text",
+                      ])}
+                    >
+                      {button}
+                    </span>
                     <i
                       className={getClassNames(editorStyles, [
                         "sgds-icon",
                         "sgds-icon-arrow-right",
                         "is-size-4",
+                        "ml-3",
                       ])}
                       aria-hidden="true"
                     />
-                  </div>
+                  </>
                 ) : null}
               </div>
             </div>
@@ -202,30 +227,43 @@ const TemplateInfopicRightSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
-              <p>{description}</p>
+              <p className={getClassNames(editorStyles, ["body-1"])}>
+                {description}
+              </p>
               <div
                 className={getClassNames(editorStyles, [
-                  "bp-sec-button",
-                  "margin--top",
-                  "padding--bottom",
+                  "py-4",
+                  "link-button",
+                  "remove-after",
+                  "is-flex",
+                  "flex-start",
+                  "is-vh-centered",
                 ])}
               >
                 {button ? (
-                  <div>
-                    <span>{button}</span>
+                  <>
+                    <span
+                      className={getClassNames(editorStyles, [
+                        "link-button-text",
+                      ])}
+                    >
+                      {button}
+                    </span>
                     <i
                       className={getClassNames(editorStyles, [
                         "sgds-icon",
                         "sgds-icon-arrow-right",
                         "is-size-4",
+                        "ml-3",
                       ])}
                       aria-hidden="true"
                     />
-                  </div>
+                  </>
                 ) : null}
               </div>
             </div>

--- a/src/templates/homepage/ResourcesSection.jsx
+++ b/src/templates/homepage/ResourcesSection.jsx
@@ -79,8 +79,7 @@ const TemplateResourceSection = (
               <p
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
-                  "eyebrow",
-                  "is-uppercase",
+                  "subtitle-2",
                 ])}
               >
                 {subtitle}
@@ -92,9 +91,10 @@ const TemplateResourceSection = (
                 className={getClassNames(editorStyles, [
                   "padding--bottom",
                   "has-text-secondary",
+                  "h1",
                 ])}
               >
-                <b>{title}</b>
+                {title}
               </h1>
             ) : null}
           </div>
@@ -137,24 +137,30 @@ const TemplateResourceSection = (
               "is-one-third",
             ])}
           >
-            <div className={getClassNames(editorStyles, ["bp-sec-button"])}>
-              <div
-                className={getClassNames(editorStyles, [
-                  "d-flex",
-                  "align-items-center",
-                  "justify-content-center",
-                ])}
+            <div
+              className={getClassNames(editorStyles, [
+                "py-4",
+                "link-button",
+                "remove-after",
+                "is-flex",
+                "flex-center",
+                "is-vh-centered",
+              ])}
+            >
+              <span
+                className={getClassNames(editorStyles, ["link-button-text"])}
               >
-                <span>{button || "MORE"}</span>
-                <i
-                  className={getClassNames(editorStyles, [
-                    "sgds-icon",
-                    "sgds-icon-arrow-right",
-                    "is-size-4",
-                  ])}
-                  aria-hidden="true"
-                />
-              </div>
+                {button || "MORE"}
+              </span>
+              <i
+                className={getClassNames(editorStyles, [
+                  "sgds-icon",
+                  "sgds-icon-arrow-right",
+                  "is-size-4",
+                  "ml-3",
+                ])}
+                aria-hidden="true"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR modifies our existing text styles in the preview for infobar, infopic, and resources sections to replicate those in our template. To be reviewed in conjunction with PR [#341](https://github.com/isomerpages/isomerpages-template/pull/341) on the isomerpages-template repo.

Before:
<img width="1251" alt="Screenshot 2023-10-16 at 10 11 41 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/22111124/b97ec68f-5892-4d0c-9725-8ce03b709fe5">


After:
<img width="1244" alt="Screenshot 2023-10-16 at 10 10 26 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/22111124/5a9c043f-bd83-4a24-9169-81771567f7d8">

Tests:

- [ ] Check that infobox, infopic, resources styles for title, subtitle, description, links match existing styles - can reference newer components like text cards
- [ ] New text styles should match styles seen on staging site
