### PR TITLE
feat(homepage): allow user to override changes when there is a conflict

### DIFF
--- a/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
+++ b/src/components/OverwriteChangesModal/OverwriteChangesModal.tsx
@@ -27,8 +27,8 @@ export const OverwriteChangesModal = ({
               edits now, their changes will be lost.
             </Text>
             <Text>
-              We recommend you to make a copy of your changes elsewhere and come
-              back later.
+              We recommend you to make a copy of your changes elsewhere, and
+              come back later to reconcile your changes.
             </Text>
           </VStack>
         </Box>

--- a/src/hooks/homepageHooks/useUpdateHomepageHook.ts
+++ b/src/hooks/homepageHooks/useUpdateHomepageHook.ts
@@ -1,5 +1,10 @@
 import { AxiosError } from "axios"
-import { UseMutationResult, useQueryClient, useMutation } from "react-query"
+import {
+  UseMutationResult,
+  useQueryClient,
+  useMutation,
+  UseMutationOptions,
+} from "react-query"
 
 import { GET_HOMEPAGE_KEY } from "constants/queryKeys"
 
@@ -9,27 +14,41 @@ import { HomepageDto } from "types/homepage"
 import { useSuccessToast, useErrorToast, DEFAULT_RETRY_MSG } from "utils"
 
 export const useUpdateHomepageHook = (
-  siteName: string
+  siteName: string,
+  mutationOptions?: Omit<
+    UseMutationOptions<void, AxiosError<MiddlewareError>, HomepageDto>,
+    "mutationFn" | "mutationKey"
+  >
 ): UseMutationResult<void, AxiosError<MiddlewareError>, HomepageDto> => {
   const queryClient = useQueryClient()
   const successToast = useSuccessToast()
   const errorToast = useErrorToast()
+
   return useMutation(
     (homepageData: HomepageDto) =>
       HomepageService.updateHomepage(siteName, homepageData),
     {
-      onSuccess: () => {
+      ...mutationOptions,
+      onSettled: () => {
         queryClient.invalidateQueries([GET_HOMEPAGE_KEY, siteName])
+      },
+      onSuccess: (data, variables, context) => {
         successToast({
           id: "update-homepage-success",
           description: "Homepage updated successfully",
         })
+        if (mutationOptions?.onSuccess)
+          mutationOptions.onSuccess(data, variables, context)
       },
-      onError: (err: AxiosError) => {
-        errorToast({
-          id: "update-homepage-error",
-          description: `Could not update homepage. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data.error.message}`,
-        })
+      onError: (err, variables, context) => {
+        if (err.response?.status !== 409) {
+          errorToast({
+            id: "update-homepage-error",
+            description: `Could not update homepage. ${DEFAULT_RETRY_MSG}. Error: ${err.response?.data?.message}`,
+          })
+        }
+        if (mutationOptions?.onError)
+          mutationOptions.onError(err, variables, context)
       },
     }
   )

--- a/src/layouts/Settings/components/OverrideWarningModal.tsx
+++ b/src/layouts/Settings/components/OverrideWarningModal.tsx
@@ -34,8 +34,8 @@ export const OverrideWarningModal = ({
               choose to either override their changes, or go back to editing.
             </Text>
             <Text>
-              We recommend you to make a copy of your changes elsewhere and come
-              back later.
+              We recommend you to make a copy of your changes elsewhere, and
+              come back later to reconcile your changes.
             </Text>
           </VStack>
         </Box>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-629.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The homepage now has an override modal to override changes if a 409 Conflict is detected.

## Before & After Screenshots

<!-- [insert screenshot here] -->
<img width="1512" alt="Screenshot 2023-10-16 at 13 43 35" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/d2bca78e-d173-4eb2-87a5-5a28afe898b9">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and open 2 tabs of the Homepage editor
    - [ ] Make a valid change on the first tab and save. Verify that the changes can be saved successfully.
    - [ ] Switch to the second tab and make another change that is not the same as the first one.
    - [ ] Save the changes. Verify that the override modal (screenshot above) appears, and there is no error toast shown behind the warning modal.
    - [ ] Click on "Save my edits anyway", verify that the second set of changes have been saved successfully.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*