### PR TITLE
fix(media): adjust query key to load image in preview on upload

### DIFF
--- a/src/hooks/mediaHooks/useGetMultipleMediaHook.tsx
+++ b/src/hooks/mediaHooks/useGetMultipleMediaHook.tsx
@@ -40,7 +40,7 @@ export const useGetMultipleMediaHook = (
   queryOptions?: Omit<UseQueryOptions<MediaData[]>, "queryFn" | "queryKey">
 ): UseQueryResult<MediaData[]> => {
   return useQuery<MediaData[]>(
-    [MEDIA_MULTIPLE_CONTENT_KEY, params],
+    [MEDIA_MULTIPLE_CONTENT_KEY, ...params.mediaSrcs],
     () => getMultipleMedia(params),
     {
       ...queryOptions,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Image preview does not load newly uploaded images correctly.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Adjust query key to load media that were just uploaded.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit a page
    - [ ] Upload a new image using the editor and add the newly uploaded image to the page
    - [ ] Verify that the newly uploaded image will load after a while without any additional keystrokes/actions

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*