### PR TITLE
feat(blocks): rollback handler

### DIFF
--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -3,4 +3,5 @@ export const FEATURE_FLAGS = {
   REPO_PRIVATISATION: "repo_privatisation",
   BANNER: "banner",
   NPS_FORM: "nps_form",
+  ENABLED_BLOCKS: "homepage_enabled_blocks",
 } as const

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -2,7 +2,7 @@ export const FEATURE_FLAGS = {
   REPO_PRIVATISATION: "repo_privatisation",
   BANNER: "banner",
   NPS_FORM: "nps_form",
-  ENABLED_BLOCKS: "homepage_enabled_blocks",
+  HOMEPAGE_ENABLED_BLOCKS: "homepage_enabled_blocks",
 } as const
 
 // NOTE: Only have 4 default blocks:

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,7 +1,10 @@
 export const FEATURE_FLAGS = {
-  HOMEPAGE_TEMPLATES: "homepage_new_templates",
   REPO_PRIVATISATION: "repo_privatisation",
   BANNER: "banner",
   NPS_FORM: "nps_form",
   ENABLED_BLOCKS: "homepage_enabled_blocks",
 } as const
+
+// NOTE: Only have 4 default blocks:
+// hero/infobar/infopic/resources
+export const NUM_DEFAULT_HOMEPAGE_BLOCKS = 4

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,4 +1,5 @@
 export enum LOCAL_STORAGE_KEYS {
+  FrontmatterSections = "frontmatter-sections",
   SitesIsPrivate = "sites-is-private",
   Email = "email",
   Announcements = "announcements",

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,5 +1,5 @@
 export enum LOCAL_STORAGE_KEYS {
-  FrontmatterSections = "frontmatter-sections",
+  HomepageFrontmatterSections = "homepage-frontmatter-sections",
   SitesIsPrivate = "sites-is-private",
   Email = "email",
   Announcements = "announcements",

--- a/src/hooks/homepageHooks/index.ts
+++ b/src/hooks/homepageHooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useGetHomepageHook"
 export * from "./useUpdateHomepageHook"
+export * from "./useFrontmatterSections"

--- a/src/hooks/homepageHooks/useFrontmatterSections.ts
+++ b/src/hooks/homepageHooks/useFrontmatterSections.ts
@@ -26,9 +26,9 @@ type UseFrontmatterSectionsReturn = (
 export const useFrontmatterSections = (): UseFrontmatterSectionsReturn => {
   const [storedFrontmatter, setStoredFrontmatter] = useLocalStorage<
     EditorHomepageFrontmatterSection[]
-  >(LOCAL_STORAGE_KEYS.FrontmatterSections, [])
+  >(LOCAL_STORAGE_KEYS.HomepageFrontmatterSections, [])
 
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
     blocks: [],
   })
 
@@ -67,10 +67,12 @@ export const useFrontmatterSections = (): UseFrontmatterSectionsReturn => {
         )
       )
 
-      console.log("===", enabledStoredFrontmatterBlocks, actualBlocks)
-
       return [...actualBlocks, ...enabledStoredFrontmatterBlocks]
     },
+    // NOTE: We are disabling the eslint rule here because
+    // the function referenced in the dependency array
+    // would change on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [blocks]
   )
 }

--- a/src/hooks/homepageHooks/useFrontmatterSections.ts
+++ b/src/hooks/homepageHooks/useFrontmatterSections.ts
@@ -1,0 +1,66 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import _ from "lodash"
+
+import { FEATURE_FLAGS } from "constants/featureFlags"
+import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
+
+import { useLocalStorage } from "hooks/useLocalStorage"
+
+import { EditorHomepageFrontmatterSection } from "types/homepage"
+
+const getIsFeatureEnabled = (
+  section: EditorHomepageFrontmatterSection,
+  enabledBlocks: string[]
+) => {
+  const blockKeys = _.keys(section)
+  // NOTE: If the block keys is not in the list of
+  // allowed blocks, then it has been rolled back.
+  return _.intersection(blockKeys, enabledBlocks).length > 0
+}
+
+export const useFrontmatterSections = (
+  baseFrontmatterSections: EditorHomepageFrontmatterSection[]
+): EditorHomepageFrontmatterSection[] => {
+  const [storedFrontmatter, setStoredFrontmatter] = useLocalStorage<
+    EditorHomepageFrontmatterSection[]
+  >(LOCAL_STORAGE_KEYS.FrontmatterSections, [])
+
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+    blocks: [],
+  })
+
+  const actualBlocks = baseFrontmatterSections.filter((section) =>
+    getIsFeatureEnabled(section, blocks)
+  )
+
+  // NOTE: First, check if there are blocks that are on our sections
+  // that are NOT enabled.
+  // These blocks have been rolled back and should be
+  // saved to local storage to avoid data loss.
+  const rolledBackBlocks = _.cloneDeep(
+    baseFrontmatterSections.filter(
+      (section) => !getIsFeatureEnabled(section, blocks)
+    )
+  )
+
+  const enabledStoredFrontmatterBlocks = storedFrontmatter.filter((section) => {
+    return getIsFeatureEnabled(section, blocks)
+  })
+
+  const remainingStoredFrontmatterBlocks = storedFrontmatter.filter(
+    (section) => {
+      return !getIsFeatureEnabled(section, blocks)
+    }
+  )
+
+  const updatedFrontmatter = [
+    ...actualBlocks,
+    ...enabledStoredFrontmatterBlocks,
+  ]
+  setStoredFrontmatter([
+    ...rolledBackBlocks,
+    ...remainingStoredFrontmatterBlocks,
+  ])
+
+  return updatedFrontmatter
+}

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -28,7 +28,7 @@ import { FEATURE_FLAGS } from "constants/featureFlags"
 // Import hooks
 import { EditableContextProvider } from "contexts/EditableContext"
 
-import { useGetHomepageHook } from "hooks/homepageHooks"
+import { useFrontmatterSections, useGetHomepageHook } from "hooks/homepageHooks"
 import { useUpdateHomepageHook } from "hooks/homepageHooks/useUpdateHomepageHook"
 import { useAfterFirstLoad } from "hooks/useAfterFirstLoad"
 import useSiteColorsHook from "hooks/useSiteColorsHook"
@@ -276,6 +276,8 @@ const EditHomepage = ({ match }) => {
     JSON.stringify(originalFrontMatter) !== JSON.stringify(frontMatter)
 
   const errorToast = useErrorToast()
+
+  const featureFlaggedSections = useFrontmatterSections(frontMatter.sections)
 
   // TODO: Tidy up these `useEffects` and figure out what they do
   // TODO: Shift this into react query + custom hook
@@ -1477,7 +1479,7 @@ const EditHomepage = ({ match }) => {
                             }
                           >
                             <VStack p={0} spacing="1.5rem">
-                              {frontMatter.sections.map(
+                              {featureFlaggedSections.map(
                                 (section, sectionIndex) => (
                                   <>
                                     {section.resources && (

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -327,7 +327,6 @@ const EditHomepage = ({ match }) => {
         const sections = computeFrontmatter(frontMatter.sections)
 
         sections.forEach((section) => {
-          console.log(section)
           scrollRefs.push(createRef())
           // If this is the hero section, hide all highlights/dropdownelems by default
           if (section.hero) {
@@ -1333,7 +1332,7 @@ const EditHomepage = ({ match }) => {
       },
     })
   }
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
     blocks: [],
   })
   return (

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -192,6 +192,7 @@ const EditHomepage = ({ match }) => {
   const [hasLoaded, setHasLoaded] = useState(false)
   const [scrollRefs, setScrollRefs] = useState([])
   const [announcementScrollRefs, setAnnouncementScrollRefs] = useState([])
+  const computeFrontmatter = useFrontmatterSections()
 
   const [frontMatter, setFrontMatter] = useState({
     title: "",
@@ -265,7 +266,10 @@ const EditHomepage = ({ match }) => {
     displayAnnouncementItems,
   }) => {
     setDisplaySections(displaySections)
-    setFrontMatter(frontMatter)
+    setFrontMatter({
+      ...frontMatter,
+      sections: computeFrontmatter(frontMatter.sections),
+    })
     setErrors(errors)
     setDisplayDropdownElems(displayDropdownElems)
     setDisplayHighlights(displayHighlights)
@@ -276,8 +280,6 @@ const EditHomepage = ({ match }) => {
     JSON.stringify(originalFrontMatter) !== JSON.stringify(frontMatter)
 
   const errorToast = useErrorToast()
-
-  const featureFlaggedSections = useFrontmatterSections(frontMatter.sections)
 
   // TODO: Tidy up these `useEffects` and figure out what they do
   // TODO: Shift this into react query + custom hook
@@ -318,7 +320,10 @@ const EditHomepage = ({ match }) => {
         const scrollRefs = []
         const announcementScrollRefs = []
 
-        frontMatter.sections.forEach((section) => {
+        const sections = computeFrontmatter(frontMatter.sections)
+
+        sections.forEach((section) => {
+          console.log(section)
           scrollRefs.push(createRef())
           // If this is the hero section, hide all highlights/dropdownelems by default
           if (section.hero) {
@@ -436,7 +441,10 @@ const EditHomepage = ({ match }) => {
           textcards: textCardItemErrors,
           infocols: infocolInfoboxErrors,
         }
-        setFrontMatter(frontMatter)
+        setFrontMatter({
+          ...frontMatter,
+          sections,
+        })
         setOriginalFrontMatter(_.cloneDeep(frontMatter))
         setSha(sha)
         setDisplaySections(displaySections)
@@ -1479,7 +1487,7 @@ const EditHomepage = ({ match }) => {
                             }
                           >
                             <VStack p={0} spacing="1.5rem">
-                              {featureFlaggedSections.map(
+                              {frontMatter.sections.map(
                                 (section, sectionIndex) => (
                                   <>
                                     {section.resources && (

--- a/src/layouts/EditHomepage/EditHomepage.jsx
+++ b/src/layouts/EditHomepage/EditHomepage.jsx
@@ -7,7 +7,7 @@ import {
   VStack,
   Divider,
 } from "@chakra-ui/react"
-import { useFeatureIsOn } from "@growthbook/growthbook-react"
+import { useFeatureValue } from "@growthbook/growthbook-react"
 import { DragDropContext } from "@hello-pangea/dnd"
 import { Button, Tag } from "@opengovsg/design-system-react"
 import update from "immutability-helper"
@@ -90,6 +90,10 @@ import { getErrorValues } from "./utils"
 /* eslint-disable react/no-array-index-key */
 
 const RADIX_PARSE_INT = 10
+
+const ANNOUNCEMENTS_FEATURE_KEY = "announcements"
+const TEXT_CARDS_FEATURE_KEY = "textcards"
+const INFOCOLS_FEATURE_KEY = "infocols"
 
 // NOTE: `scrollIntoView` does not work when called synchronously
 // to avoid this problem, we do a `setTimeout` to wrap it.
@@ -1329,8 +1333,9 @@ const EditHomepage = ({ match }) => {
       },
     })
   }
-
-  const showNewLayouts = useFeatureIsOn(FEATURE_FLAGS.HOMEPAGE_TEMPLATES)
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+    blocks: [],
+  })
   return (
     <>
       {/* Section deletion warning modal */}
@@ -1561,8 +1566,7 @@ const EditHomepage = ({ match }) => {
                                       </Editable.DraggableAccordionItem>
                                     )}
 
-                                    {showNewLayouts &&
-                                      section.announcements &&
+                                    {section.announcements &&
                                       /**
                                        * Somehow, the errors are undefined for 2 renders, not sure
                                        * of the core reason. To avoid the CMS panel from crashing,
@@ -1732,7 +1736,7 @@ const EditHomepage = ({ match }) => {
                         {/* NOTE: Check if the sections contain any `announcements`
                                 and if it does, prevent creation of another `resources` section
                             */}
-                        {showNewLayouts &&
+                        {blocks.includes(ANNOUNCEMENTS_FEATURE_KEY) &&
                           !frontMatter.sections.some(
                             ({ announcements }) => !!announcements
                           ) && (
@@ -1748,7 +1752,7 @@ const EditHomepage = ({ match }) => {
                               />
                             </AddSectionButton.HelpOverlay>
                           )}
-                        {showNewLayouts && (
+                        {blocks.includes(TEXT_CARDS_FEATURE_KEY) && (
                           <AddSectionButton.HelpOverlay
                             title="Text cards"
                             description="Add clickable cards with bite-sized information to your homepage. You can link any page or external URL, such as blog posts, articles, and more."
@@ -1763,7 +1767,7 @@ const EditHomepage = ({ match }) => {
                             />
                           </AddSectionButton.HelpOverlay>
                         )}
-                        {showNewLayouts && (
+                        {blocks.includes(INFOCOLS_FEATURE_KEY) && (
                           <AddSectionButton.HelpOverlay
                             title="Info-columns"
                             description="Add bite-sized snippets of text in a multi-column layout. These texts aren’t clickable. Perfect for showing informative text that describes your organisation."

--- a/src/layouts/EditHomepage/utils.ts
+++ b/src/layouts/EditHomepage/utils.ts
@@ -1,7 +1,13 @@
 import _ from "lodash"
 
+import { NUM_DEFAULT_HOMEPAGE_BLOCKS } from "constants/featureFlags"
+
 export const getErrorValues = (
   obj: Record<string, string>
 ): Record<string, string> => {
   return _.mapValues(obj, () => "")
+}
+
+export const getShouldShowNewLayouts = (blocks: unknown[]) => {
+  return blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
 }

--- a/src/layouts/Sites.tsx
+++ b/src/layouts/Sites.tsx
@@ -16,10 +16,7 @@ import { Link } from "react-router-dom"
 
 import { AllSitesHeader } from "components/Header/AllSitesHeader"
 
-import {
-  FEATURE_FLAGS,
-  NUM_DEFAULT_HOMEPAGE_BLOCKS,
-} from "constants/featureFlags"
+import { FEATURE_FLAGS } from "constants/featureFlags"
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
 import { useLoginContext } from "contexts/LoginContext"

--- a/src/layouts/Sites.tsx
+++ b/src/layouts/Sites.tsx
@@ -37,6 +37,8 @@ import { AnnouncementModal } from "features/AnnouncementModal/AnnouncementModal"
 import { SiteData } from "types/sites"
 import { UserTypes } from "types/user"
 
+import { getShouldShowNewLayouts } from "./EditHomepage/utils"
+
 const SitePreviewImage = ({ imageUrl }: { imageUrl?: string }) => {
   return (
     <Image
@@ -166,10 +168,10 @@ export const Sites = (): JSX.Element => {
     )
   }, [siteRequestData])
 
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
     blocks: [],
   })
-  const showNewLayouts = blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
+  const showNewLayouts = getShouldShowNewLayouts(blocks)
   const isGithubUser = userType === UserTypes.Github
   /**
    * Currently the announcement modal takes in all the keyboard events,

--- a/src/layouts/Sites.tsx
+++ b/src/layouts/Sites.tsx
@@ -8,7 +8,7 @@ import {
   Flex,
   Image,
 } from "@chakra-ui/react"
-import { useFeatureIsOn } from "@growthbook/growthbook-react"
+import { useFeatureValue } from "@growthbook/growthbook-react"
 import { Infobox } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { useEffect, useState } from "react"
@@ -16,7 +16,10 @@ import { Link } from "react-router-dom"
 
 import { AllSitesHeader } from "components/Header/AllSitesHeader"
 
-import { FEATURE_FLAGS } from "constants/featureFlags"
+import {
+  FEATURE_FLAGS,
+  NUM_DEFAULT_HOMEPAGE_BLOCKS,
+} from "constants/featureFlags"
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
 import { useLoginContext } from "contexts/LoginContext"
@@ -163,7 +166,10 @@ export const Sites = (): JSX.Element => {
     )
   }, [siteRequestData])
 
-  const showNewLayouts = useFeatureIsOn(FEATURE_FLAGS.HOMEPAGE_TEMPLATES)
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+    blocks: [],
+  })
+  const showNewLayouts = blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
   const isGithubUser = userType === UserTypes.Github
   /**
    * Currently the announcement modal takes in all the keyboard events,

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -34,8 +34,6 @@ import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
 import { useEditableContext } from "contexts/EditableContext"
 
-import { getShouldShowNewLayouts } from "layouts/EditHomepage/utils"
-
 import { BxGrayTranslucent } from "assets"
 import { FeatureTourHandler } from "features/FeatureTour/FeatureTour"
 import { HERO_OPTIONS_FEATURE_STEPS } from "features/FeatureTour/FeatureTourSequence"
@@ -46,6 +44,7 @@ import {
 } from "types/hero"
 import { HeroBannerLayouts, HighlightOption } from "types/homepage"
 
+import { HOMEPAGE_BLOCKS } from "./constants"
 import { HeroDropdownFormFields } from "./HeroDropdownSection"
 
 type HeroHighlightSectionFormFields = HighlightOption
@@ -297,10 +296,13 @@ const HeroLayoutForm = ({
   children,
 }: HeroLayoutFormProps): JSX.Element => {
   const { onChange } = useEditableContext()
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
-    blocks: [],
-  })
-  const showNewLayouts = getShouldShowNewLayouts(blocks)
+  const { blocks } = useFeatureValue<{ blocks: string[] }>(
+    FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS,
+    {
+      blocks: [],
+    }
+  )
+  const showNewLayouts = blocks.includes(HOMEPAGE_BLOCKS.HERO)
 
   // We only want to show the feature tour when the
   // DOM elements are in view. Else, the feature tour
@@ -395,10 +397,13 @@ export const HeroBody = ({
     initialSectionType
   )
   const { onChange } = useEditableContext()
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
-    blocks: [],
-  })
-  const showNewLayouts = getShouldShowNewLayouts(blocks)
+  const { blocks } = useFeatureValue<{ blocks: string[] }>(
+    FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS,
+    {
+      blocks: [],
+    }
+  )
+  const showNewLayouts = blocks.includes(HOMEPAGE_BLOCKS.HERO)
 
   return (
     <>

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -9,7 +9,7 @@ import {
   HStack,
   Spacer,
 } from "@chakra-ui/react"
-import { useFeatureIsOn } from "@growthbook/growthbook-react"
+import { useFeatureValue } from "@growthbook/growthbook-react"
 import {
   FormErrorMessage,
   FormLabel,
@@ -28,7 +28,10 @@ import { Editable } from "components/Editable"
 import { FormContext, FormError, FormTitle } from "components/Form"
 import FormFieldMedia from "components/FormFieldMedia"
 
-import { FEATURE_FLAGS } from "constants/featureFlags"
+import {
+  FEATURE_FLAGS,
+  NUM_DEFAULT_HOMEPAGE_BLOCKS,
+} from "constants/featureFlags"
 import { HERO_LAYOUTS } from "constants/homepage"
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
@@ -295,7 +298,10 @@ const HeroLayoutForm = ({
   children,
 }: HeroLayoutFormProps): JSX.Element => {
   const { onChange } = useEditableContext()
-  const showNewLayouts = useFeatureIsOn(FEATURE_FLAGS.HOMEPAGE_TEMPLATES)
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+    blocks: [],
+  })
+  const showNewLayouts = blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
 
   // We only want to show the feature tour when the
   // DOM elements are in view. Else, the feature tour
@@ -390,7 +396,10 @@ export const HeroBody = ({
     initialSectionType
   )
   const { onChange } = useEditableContext()
-  const showNewLayouts = useFeatureIsOn(FEATURE_FLAGS.HOMEPAGE_TEMPLATES)
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+    blocks: [],
+  })
+  const showNewLayouts = blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
 
   return (
     <>

--- a/src/layouts/components/Homepage/HeroBody.tsx
+++ b/src/layouts/components/Homepage/HeroBody.tsx
@@ -28,14 +28,13 @@ import { Editable } from "components/Editable"
 import { FormContext, FormError, FormTitle } from "components/Form"
 import FormFieldMedia from "components/FormFieldMedia"
 
-import {
-  FEATURE_FLAGS,
-  NUM_DEFAULT_HOMEPAGE_BLOCKS,
-} from "constants/featureFlags"
+import { FEATURE_FLAGS } from "constants/featureFlags"
 import { HERO_LAYOUTS } from "constants/homepage"
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
 import { useEditableContext } from "contexts/EditableContext"
+
+import { getShouldShowNewLayouts } from "layouts/EditHomepage/utils"
 
 import { BxGrayTranslucent } from "assets"
 import { FeatureTourHandler } from "features/FeatureTour/FeatureTour"
@@ -298,10 +297,10 @@ const HeroLayoutForm = ({
   children,
 }: HeroLayoutFormProps): JSX.Element => {
   const { onChange } = useEditableContext()
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
     blocks: [],
   })
-  const showNewLayouts = blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
+  const showNewLayouts = getShouldShowNewLayouts(blocks)
 
   // We only want to show the feature tour when the
   // DOM elements are in view. Else, the feature tour
@@ -396,10 +395,10 @@ export const HeroBody = ({
     initialSectionType
   )
   const { onChange } = useEditableContext()
-  const { blocks } = useFeatureValue(FEATURE_FLAGS.ENABLED_BLOCKS, {
+  const { blocks } = useFeatureValue(FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS, {
     blocks: [],
   })
-  const showNewLayouts = blocks.length > NUM_DEFAULT_HOMEPAGE_BLOCKS
+  const showNewLayouts = getShouldShowNewLayouts(blocks)
 
   return (
     <>

--- a/src/layouts/components/Homepage/constants.ts
+++ b/src/layouts/components/Homepage/constants.ts
@@ -1,0 +1,3 @@
+export const HOMEPAGE_BLOCKS = {
+  HERO: "hero",
+}

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -8,7 +8,7 @@ export interface FeatureFlags {
     message: string
   }
   [FEATURE_FLAGS.NPS_FORM]: boolean
-  [FEATURE_FLAGS.ENABLED_BLOCKS]: string[]
+  [FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS]: string[]
 }
 
 export type GBAttributes = {

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -8,6 +8,7 @@ export interface FeatureFlags {
     message: string
   }
   [FEATURE_FLAGS.NPS_FORM]: boolean
+  [FEATURE_FLAGS.ENABLED_BLOCKS]: string[]
 }
 
 export type GBAttributes = {


### PR DESCRIPTION
## Problem
We have no way of rolling back blocks at present, which means that we are unable to undo changes safely. 

## Solution
Add a hook that sanitises the frontmatter if the given blocks are not inside the whitelist. This is done through: 
1. checking if the current blocks provided by frontmatter are permitted by our whitelist (and storing it inside `localStorage`) 
2. checking if existing blocks in `localStorage` are now permitted and merging with ^ 
3. presenting this back to the user. 

## Notes
added **all** blocks to feature flag, not just new blocks. lets us rollback as required. also, `Hero` doesn't rollback the variants but the block as a whole :monkas: maybe not ideal but the alternative is quite abit of work and doesn't add that much value too

## Tests
- [ ] go to `a-test-v4` on staging
- [ ] go to homepage
- [ ] make sure all the blocks are present/can be added
- [ ] go to growthbook and disable some of the flags
- [ ] go back to the cms and reload
- [ ] the unflagged blocks should now be gone
- [ ] check `localStorage` (dev console -> application) 
- [ ] blocks should be there
- [ ] undo the changes to growthbook
- [ ] reload
- [ ] blocks should be present 