### PR TITLE
feat: allow Isomer admins to edit on email-login

### DIFF
--- a/src/components/CollaboratorModal/components/MainSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/MainSubmodal.tsx
@@ -35,7 +35,7 @@ import * as CollaboratorHooks from "hooks/collaboratorHooks"
 
 import { Collaborator } from "types/collaborators"
 import { MiddlewareError } from "types/error"
-import { DEFAULT_RETRY_MSG, useSuccessToast } from "utils"
+import { DEFAULT_RETRY_MSG, isAdminUser, useSuccessToast } from "utils"
 
 import { ACK_REQUIRED_ERROR_MESSAGE } from "../constants"
 
@@ -162,7 +162,7 @@ export const MainSubmodal = ({
     addCollaboratorError?.response?.data.error
   )
   const showAckModal = errorMessage === ACK_REQUIRED_ERROR_MESSAGE
-  const isDisabled = role !== "ADMIN"
+  const isDisabled = !isAdminUser(role)
 
   const collaboratorFormMethods = useForm({
     mode: "onTouched",

--- a/src/routing/ApprovedReviewRedirect.tsx
+++ b/src/routing/ApprovedReviewRedirect.tsx
@@ -1,11 +1,8 @@
 import { PropsWithChildren, useEffect } from "react"
 import { Redirect, RedirectProps, useParams } from "react-router-dom"
 
-import { Greyscale } from "components/Greyscale"
-
 import { useLoginContext } from "contexts/LoginContext"
 
-import { useGetCollaboratorRoleHook } from "hooks/collaboratorHooks"
 import { useGetReviewRequests } from "hooks/siteDashboardHooks"
 
 import { getAxiosErrorMessage } from "utils/axios"

--- a/src/types/collaborators.ts
+++ b/src/types/collaborators.ts
@@ -1,4 +1,4 @@
-export type SiteMemberRole = "CONTRIBUTOR" | "ADMIN"
+export type SiteMemberRole = "CONTRIBUTOR" | "ADMIN" | "ISOMERADMIN"
 
 export interface CollaboratorDto {
   id: string

--- a/src/utils/collaborators.ts
+++ b/src/utils/collaborators.ts
@@ -1,0 +1,5 @@
+import { SiteMemberRole } from "types/collaborators"
+
+export const isAdminUser = (role?: SiteMemberRole): boolean => {
+  return role === "ADMIN" || role === "ISOMERADMIN"
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./collaborators"
 export * from "./colours"
 export * from "./date"
 export * from "./decoding"

--- a/src/utils/siteLaunchUtils.ts
+++ b/src/utils/siteLaunchUtils.ts
@@ -2,6 +2,8 @@ import { WHITELISTED_REPOS } from "constants/siteLaunch"
 
 import { SiteMemberRole } from "types/collaborators"
 
+import { isAdminUser } from "./collaborators"
+
 const isRepoWhitelistedForSiteLaunch = (siteName: string): boolean => {
   // The name of our sites for our storybooks is "storybook".
   // Therefore, to allow the storybook to use the site launch feature, we need to
@@ -10,10 +12,6 @@ const isRepoWhitelistedForSiteLaunch = (siteName: string): boolean => {
     return true
   }
   return WHITELISTED_REPOS ? WHITELISTED_REPOS.includes(siteName) : false
-}
-
-const isAdminUser = (role?: SiteMemberRole): boolean => {
-  return role === `ADMIN`
 }
 
 export const isSiteLaunchEnabled = (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-654.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- A new collaborator role `ISOMERADMIN` has been added to identify users in the IsomerAdmins table. This additional role allows Isomer admins to have access to sites and act as if they are an admin of that particular site. Review in conjunction with https://github.com/isomerpages/isomercms-backend/pull/982.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [x] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] As email-login user with Isomer Admin access
        - [ ] Navigate to any site that you are not a collaborator of
        - [ ] Verify that you can make changes to the site
        - [ ] Verify that you can make changes to the list of collaborators from the site dashboard
        - [ ] Navigate to any site that you are a collaborator of
        - [ ] Verify that you can still make changes to the site like before
        - [ ] Verify that you can still make changes to the list of collaborators from the site dashboard like before
    - [ ] As email-login admin user without Isomer Admin access
        - [ ] Navigate to any site that you are a collaborator of
        - [ ] Verify that you can still make changes to the site like before
        - [ ] Verify that you can still make changes to the list of collaborators from the site dashboard like before
        - [ ] Attempt to navigate to any site that you are not a collaborator of (by changing the URL directly)
        - [ ] Verify that you are still not able to access the site or view the list of collaborators
    - [ ] As email-login contributor user
        - [ ] Navigate to any site that you are a collaborator of
        - [ ] Verify that you can still make changes to the site like before
        - [ ] Verify that you are able to view the list of collaborators for that site
        - [ ] Attempt to navigate to any site that you are not a collaborator of (by changing the URL directly)
        - [ ] Verify that you are still not able to access the site or view the list of collaborators
    - [ ] As GitHub-login user with Isomer Admin access
        - [ ] Navigate to any site that is already migrated (i.e. has an entry in the sites table)
        - [ ] Verify that you are not able to make changes to the site
        - [ ] Navigate to any site that is not yet migrated (i.e. does not have an entry in the sites table)
        - [ ] Verify that you can still make changes to the site like before
    - [ ] As GitHub-login user without Isomer Admin access
        - [ ] Navigate to any site that is already migrated (i.e. has an entry in the sites table) and you have access to
        - [ ] Verify that you are not able to make changes to the site
        - [ ] Navigate to any site that is not yet migrated (i.e. does not have an entry in the sites table) and you have access to
        - [ ] Verify that you can still make changes to the site like before
        - [ ] Attempt to navigate to any site that you do not have access to (by changing the URL directly)
        - [ ] Verify that you are still not able to access the site

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*