### PR TITLE
fix(media): support replacement of media src with spaces

### DIFF
--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -36,7 +36,7 @@ export const adjustImageSrcs = (
   const $ = cheerio.load(html)
 
   $("img").each((_, element) => {
-    const src = $(element).attr("src")
+    const src = $(element).attr("src")?.replaceAll("%20", " ")
 
     if (src && isLinkInternal(src)) {
       $(element).attr(


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Media sources with spaces do not get replaced and shows not found.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Media srcs with spaces now work

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

Test #1580 but with spaces in the file name and/or album name.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*