### PR TITLE
fix(navbar): ensure all queries are loaded first

### DIFF
--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -181,14 +181,15 @@ const EditNavBar = ({ match }) => {
           deslugifyDirectory(resource.name)
         )
       : undefined
-    const foldersContent = secondLevelData
-      ? secondLevelData.reduce((acc, curr) => {
-          const { data } = curr
-          const { collectionName, order } = data
-          acc[collectionName] = getNavFolderDropdownFromFolderOrder(order)
-          return acc
-        }, {})
-      : {}
+    const foldersContent =
+      secondLevelData && secondLevelData.every(({ isLoading }) => !isLoading)
+        ? secondLevelData.reduce((acc, curr) => {
+            const { data } = curr
+            const { collectionName, order } = data
+            acc[collectionName] = getNavFolderDropdownFromFolderOrder(order)
+            return acc
+          }, {})
+        : {}
 
     // Add booleans for displaying links and sublinks
     const { links: initialLinks } = content


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some queries from `useQueries` get returned even though they are still loading, causing the `data` attribute to be undefined.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- All the queries returned are checked to ensure that they are fully loaded before further processing is performed.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests

Test with #1592 and ensure that the navbar has a folder group.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*