### PR TITLE
fix(navbar): fix race condition when retrieving second level data

### DIFF
--- a/src/hooks/directoryHooks/useGetSecondLevelFoldersAndPages.ts
+++ b/src/hooks/directoryHooks/useGetSecondLevelFoldersAndPages.ts
@@ -1,4 +1,4 @@
-import { useQueries, UseQueryResult } from "react-query"
+import { useQuery, UseQueryResult } from "react-query"
 
 import { DIR_SECOND_LEVEL_DIRECTORIES_KEY } from "constants/queryKeys"
 
@@ -15,27 +15,42 @@ interface OrderedCollection {
   order: string[]
 }
 
+const getSecondLevelFoldersAndPages = ({
+  siteName,
+  collectionsData = [],
+}: SecondLevelFoldersAndPagesParams) => {
+  return Promise.all(
+    collectionsData
+      .filter<DirectoryData>((item): item is DirectoryData =>
+        isDirectoryData(item)
+      )
+      .map(
+        ({ name }) =>
+          DirectoryService.getCollection({
+            siteName,
+            collectionName: name,
+          })
+            .then((data) => ({
+              collectionName: name,
+              order: data.map(({ name: directoryName }) => directoryName),
+            }))
+            .catch((_) => null) as Promise<OrderedCollection | null>
+      )
+  )
+}
+
 export const useGetSecondLevelFoldersAndPages = ({
   siteName,
   collectionsData = [],
-}: SecondLevelFoldersAndPagesParams): UseQueryResult<OrderedCollection[]>[] => {
-  const directoryQueries = collectionsData
-    .filter<DirectoryData>((item): item is DirectoryData =>
-      isDirectoryData(item)
-    )
-    .map(({ name }) => ({
-      queryKey: [DIR_SECOND_LEVEL_DIRECTORIES_KEY, siteName, name],
-      queryFn: () =>
-        DirectoryService.getCollection({
-          siteName,
-          collectionName: name,
-        }).then((data) => ({
-          collectionName: name,
-          order: data.map(({ name: directoryName }) => directoryName),
-        })),
-    }))
-
-  return useQueries<OrderedCollection[]>(directoryQueries) as UseQueryResult<
-    OrderedCollection[]
-  >[]
+}: SecondLevelFoldersAndPagesParams): UseQueryResult<
+  (OrderedCollection | null)[]
+> => {
+  return useQuery<(OrderedCollection | null)[]>(
+    [DIR_SECOND_LEVEL_DIRECTORIES_KEY, ...collectionsData],
+    () => getSecondLevelFoldersAndPages({ siteName, collectionsData }),
+    {
+      retry: false,
+      cacheTime: 0, // We want to refetch data on every page load because file order may have changed
+    }
+  )
 }

--- a/src/layouts/EditNavBar.jsx
+++ b/src/layouts/EditNavBar.jsx
@@ -202,7 +202,6 @@ const EditNavBar = ({ match }) => {
       : undefined
     const foldersContent = secondLevelData
       ? secondLevelData.reduce((acc, curr) => {
-          // const { data } = curr
           if (!curr) return acc
           const { collectionName, order } = curr
           acc[collectionName] = getNavFolderDropdownFromFolderOrder(order)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Because `secondLevelData` is not part of the `useEffect` hook, it can lead to race conditions if `secondLevelData` is still loading.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Switch from using `useQueries` to a single query with a `Promise.all`, so that we can deterministically ensure that all Promises are completed before it gets returned.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit the navigation bar
    - [ ] Keep refreshing, ensure that the "removed content" modal does not appear

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*