### PR TITLE
chore: remove extra test

### DIFF
--- a/cypress/e2e/collaborators.spec.ts
+++ b/cypress/e2e/collaborators.spec.ts
@@ -85,15 +85,6 @@ describe("collaborators flow", () => {
       // Assert
       cy.contains(DUPLICATE_COLLABORATOR_ERROR_MESSAGE).should("be.visible")
     })
-    it("should not be able to add a collaborator without an isomer account", () => {
-      // Act
-      // NOTE: Initial admin will always be added manually
-      inputCollaborators("gibberish@nonsense.gov.sg")
-      ignoreNotFoundError()
-
-      // Assert
-      cy.contains(NON_EXISTING_USER_ERROR_MESSAGE).should("be.visible")
-    })
     it("should be able to add a collaborator", () => {
       // Arrange
       // NOTE: Mock a login with a collaborator account.


### PR DESCRIPTION
## Problem

This PR removes a test which is no longer relevant after the change in behaviour for adding new collaborators to no longer check for an existing user.
