### PR TITLE
fix(header): adjust siteName function params

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -54,7 +54,7 @@ const Header = ({
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { setRedirectToPage } = useRedirectHook()
   const { siteName } = useParams()
-  const { data: stagingUrl, isLoading } = useGetStagingUrl({ siteName })
+  const { data: stagingUrl, isLoading } = useGetStagingUrl(siteName)
   const {
     isOpen: isWarningModalOpen,
     onOpen: onWarningModalOpen,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The siteName param was given as an object to the `useGetStagingUrl` hook, which causing the "Open Staging" button to not work when editing pages.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The params input has been fixed and the "Open Staging" button works now.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit a page
    - [ ] Verify that the "Open Staging" button works and brings you to the correct staging site

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*