### PR TITLE
fix(editpage): change query key from object to array

### DIFF
--- a/src/hooks/pageHooks/useGetPageHook.jsx
+++ b/src/hooks/pageHooks/useGetPageHook.jsx
@@ -12,8 +12,10 @@ import { DEFAULT_RETRY_MSG } from "utils"
 export function useGetPageHook(params, queryParams) {
   const { pageService } = useContext(ServicesContext)
   const errorToast = useErrorToast()
+  const { siteName, fileName } = params
+
   return useQuery(
-    [PAGE_CONTENT_KEY, { ...params }],
+    [PAGE_CONTENT_KEY, siteName, fileName],
     () => pageService.get(params),
     {
       ...queryParams,

--- a/src/hooks/pageHooks/useUpdatePageHook.jsx
+++ b/src/hooks/pageHooks/useUpdatePageHook.jsx
@@ -20,6 +20,8 @@ export function useUpdatePageHook(params, queryParams) {
   const { pageService } = useContext(ServicesContext)
   const successToast = useSuccessToast()
   const errorToast = useErrorToast()
+  const { siteName, fileName } = params
+
   return useMutation(
     (body) => {
       const { newFileName, sha, frontMatter, pageBody } = extractPageInfo(body)
@@ -33,7 +35,7 @@ export function useUpdatePageHook(params, queryParams) {
     {
       ...queryParams,
       onSettled: () => {
-        queryClient.invalidateQueries([PAGE_CONTENT_KEY, { ...params }])
+        queryClient.invalidateQueries([PAGE_CONTENT_KEY, siteName, fileName])
       },
       onSuccess: () => {
         if (params.collectionName)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The edit page does not invalidate the correct key for some reason.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The edit page query key has been adjusted to put the site name and file name in the query key directly instead of being nested inside the object. I'm not sure why objects do not work, [when the docs claim that they do](https://tanstack.com/query/v4/docs/react/guides/query-keys#query-keys-are-hashed-deterministically), might be an upstream bug.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit the page.
    - [ ] Save the page, verify that the latest changes will stay on the editor.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*