### PR TITLE
feat(ff): add feature flag for editpage

### DIFF
--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -132,7 +132,7 @@ const MarkdownEditor = ({ siteName, onChange, value, isLoading }) => {
       />
       <div
         className={`${editorStyles.pageEditorSidebar} ${
-          isLoading ? editorStyles.pageEditorSidebarLoading : null
+          isLoading ? editorStyles.pageEditorSidebarLoading : ""
         }`}
       >
         <StatusIcon />

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -3,6 +3,7 @@ export const FEATURE_FLAGS = {
   BANNER: "banner",
   NPS_FORM: "nps_form",
   HOMEPAGE_ENABLED_BLOCKS: "homepage_enabled_blocks",
+  TIPTAP_EDITOR: "is-tiptap-enabled",
 } as const
 
 // NOTE: Only have 4 default blocks:

--- a/src/layouts/EditPage/EditPageLayout.tsx
+++ b/src/layouts/EditPage/EditPageLayout.tsx
@@ -22,7 +22,7 @@ interface EditPageLayoutProps {
 
 export const EditPageLayout = ({
   getPageBody,
-  variant,
+  variant = "markdown",
   children,
 }: PropsWithChildren<EditPageLayoutProps>) => {
   const params = useParams<{ siteName: string }>()
@@ -67,7 +67,7 @@ export const EditPageLayout = ({
           isEditPage
           params={decodedParams}
         />
-        <Flex flexDir="row" w="100%" h="100%">
+        <Flex flexDir="row" w="100%" h="100%" alignItems="flex-start">
           {/* Editor */}
           {children}
         </Flex>

--- a/src/layouts/EditPage/EditPageLayout.tsx
+++ b/src/layouts/EditPage/EditPageLayout.tsx
@@ -1,21 +1,36 @@
-import { Flex, Spacer, Button, useDisclosure } from "@chakra-ui/react"
+import {
+  Flex,
+  Spacer,
+  Button,
+  useDisclosure,
+  Box,
+  Code,
+  Text,
+} from "@chakra-ui/react"
 import { AxiosError } from "axios"
-import { PropsWithChildren, useEffect } from "react"
+import DOMPurify from "dompurify"
+import _ from "lodash"
+import { marked } from "marked"
+import { PropsWithChildren, useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
 import { Footer } from "components/Footer"
 import { Greyscale } from "components/Greyscale"
 import Header from "components/Header"
 import { OverwriteChangesModal } from "components/OverwriteChangesModal"
+import { WarningModal } from "components/WarningModal"
 
+import { useGetMultipleMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook, useUpdatePageHook } from "hooks/pageHooks"
-import { useGetSiteColorsHook } from "hooks/settingsHooks"
+import { useCspHook, useGetSiteColorsHook } from "hooks/settingsHooks"
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { PageVariant } from "types/pages"
 import { createPageStyleSheet, getDecodedParams } from "utils"
+
+import { sanitiseRawHtml, updateHtmlWithMediaData } from "./utils"
 
 interface EditPageLayoutProps {
   getEditorContent: () => string
@@ -29,12 +44,14 @@ export const EditPageLayout = ({
 }: PropsWithChildren<EditPageLayoutProps>) => {
   const params = useParams<{ siteName: string }>()
   const decodedParams = getDecodedParams(params)
+  const [mediaSrcs, setMediaSrcs] = useState(new Set(""))
+
   const {
     isOpen: isOverwriteOpen,
     onOpen: onOverwriteOpen,
     onClose: onOverwriteClose,
   } = useDisclosure()
-
+  const { data: csp } = useCspHook()
   const {
     mutateAsync: updatePageHandler,
     isLoading: isSavingPage,
@@ -52,8 +69,37 @@ export const EditPageLayout = ({
     onError: () => setRedirectToNotFound(siteName),
   })
   const { data: siteColorsData } = useGetSiteColorsHook(params)
+  const { data: mediaData } = useGetMultipleMediaHook({
+    siteName,
+    mediaSrcs,
+  })
+  const [isContentViolation, setIsContentViolation] = useState(false)
+  const [isXSSViolation, setIsXSSViolation] = useState(false)
+  const {
+    isOpen: isXSSWarningModalOpen,
+    onOpen: onXSSWarningModalOpen,
+    onClose: onXSSWarningModalClose,
+  } = useDisclosure()
 
   const isWriteDisabled = isWriteActionsDisabled(siteName)
+  const editorContent = getEditorContent()
+
+  useEffect(() => {
+    if (!csp || _.isEmpty(csp) || !editorContent) return
+
+    const isLegacyPage = variant === "markdown" || !variant
+    const html = isLegacyPage ? marked.parse(editorContent) : editorContent
+    const { sanitisedHtml } = sanitiseRawHtml(csp, html)
+
+    const {
+      html: processedChunk,
+      isXssViolation,
+      isContentViolation: isCspViolation,
+    } = updateHtmlWithMediaData(mediaSrcs, sanitisedHtml, mediaData)
+
+    setIsXSSViolation(isXssViolation)
+    setIsContentViolation(isCspViolation)
+  }, [mediaData, csp, mediaSrcs, onXSSWarningModalOpen, editorContent, variant])
 
   useEffect(() => {
     if (siteColorsData)
@@ -90,6 +136,51 @@ export const EditPageLayout = ({
         }}
       />
 
+      <WarningModal
+        isOpen={isXSSViolation && isXSSWarningModalOpen}
+        onClose={onXSSWarningModalClose}
+        displayTitle="Warning"
+        // DOMPurify removed object format taken from https://github.com/cure53/DOMPurify/blob/dd63379e6354f66d4689bb80b30cb43a6d8727c2/src/purify.js
+        displayText={
+          <Box>
+            <Text>
+              There is unauthorised JS detected in the following snippet
+              {DOMPurify.removed.length > 1 ? "s" : ""}:
+            </Text>
+            {DOMPurify.removed.map((elem, i) => (
+              <>
+                <br />
+                <Code>{i + 1}</Code>:
+                <Code>
+                  {elem.attribute?.nodeName || elem.element?.outerHTML || elem}
+                </Code>
+              </>
+            ))}
+            <br />
+            <br />
+            Before saving, the editor input will be automatically sanitised to
+            prevent security vulnerabilities.
+            <br />
+            <br />
+            To save the sanitised editor input, press Acknowledge. To return to
+            the editor without sanitising, press Cancel.
+          </Box>
+        }
+      >
+        <Button colorScheme="critical" onClick={onXSSWarningModalClose}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            setIsXSSViolation(false)
+            onSave()
+            onXSSWarningModalClose()
+          }}
+        >
+          Acknowledge
+        </Button>
+      </WarningModal>
+
       <Greyscale isActive={isWriteDisabled}>
         <Flex flexDir="column" h="full">
           <Header
@@ -106,7 +197,17 @@ export const EditPageLayout = ({
           </Flex>
           <Spacer />
           <Footer>
-            <Button onClick={onSave} isLoading={isSavingPage}>
+            <Button
+              onClick={() => {
+                if (isXSSViolation) onXSSWarningModalOpen()
+                else onSave()
+              }}
+              // TODO: Add an alert/modal
+              // to warn the user when they violate our csp
+              // so they know why + can take action to remedy
+              isDisabled={isContentViolation}
+              isLoading={isSavingPage}
+            >
               Save
             </Button>
           </Footer>

--- a/src/layouts/EditPage/EditPageLayout.tsx
+++ b/src/layouts/EditPage/EditPageLayout.tsx
@@ -1,10 +1,12 @@
-import { Flex, Spacer, Button } from "@chakra-ui/react"
+import { Flex, Spacer, Button, useDisclosure } from "@chakra-ui/react"
+import { AxiosError } from "axios"
 import { PropsWithChildren, useEffect } from "react"
 import { useParams } from "react-router-dom"
 
 import { Footer } from "components/Footer"
 import { Greyscale } from "components/Greyscale"
 import Header from "components/Header"
+import { OverwriteChangesModal } from "components/OverwriteChangesModal"
 
 import { useGetPageHook, useUpdatePageHook } from "hooks/pageHooks"
 import { useGetSiteColorsHook } from "hooks/settingsHooks"
@@ -16,31 +18,36 @@ import { PageVariant } from "types/pages"
 import { createPageStyleSheet, getDecodedParams } from "utils"
 
 interface EditPageLayoutProps {
-  getPageBody: () => string
+  getEditorContent: () => string
   variant: PageVariant
 }
 
 export const EditPageLayout = ({
-  getPageBody,
+  getEditorContent,
   variant = "markdown",
   children,
 }: PropsWithChildren<EditPageLayoutProps>) => {
   const params = useParams<{ siteName: string }>()
   const decodedParams = getDecodedParams(params)
   const {
+    isOpen: isOverwriteOpen,
+    onOpen: onOverwriteOpen,
+    onClose: onOverwriteClose,
+  } = useDisclosure()
+
+  const {
     mutateAsync: updatePageHandler,
     isLoading: isSavingPage,
   } = useUpdatePageHook(params, {
-    // NOTE: Not deleting this as this is important enough
-    // to leave here so that we avoid regression.
-    // onError: (err) => {
-    //   if (err.response.status === 409) onOverwriteOpen()
-    // },
+    onError: (err: AxiosError) => {
+      if (err.response?.status === 409) onOverwriteOpen()
+    },
   })
 
   const { siteName } = decodedParams
 
   const { setRedirectToNotFound } = useRedirectHook()
+  // TODO: Add loading state for page
   const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
     onError: () => setRedirectToNotFound(siteName),
   })
@@ -57,41 +64,54 @@ export const EditPageLayout = ({
       )
   }, [siteColorsData, siteName])
 
+  const onSave = () => {
+    updatePageHandler(({
+      pageData: {
+        frontMatter: {
+          ...(pageData?.content?.frontMatter || {}),
+          variant,
+        },
+        pageBody: getEditorContent(),
+        sha: pageData.sha,
+      },
+      // NOTE: We require the cast here as the original hook is written in js.
+      // because of this, the return handler has types as `unknown`
+    } as unknown) as void)
+  }
+
   return (
-    <Greyscale isActive={isWriteDisabled}>
-      <Flex flexDir="column" h="full">
-        <Header
-          title={pageData?.content?.frontMatter?.title || ""}
-          // TODO: Add this check back in dynamically
-          shouldAllowEditPageBackNav
-          isEditPage
-          params={decodedParams}
-        />
-        <Flex flexDir="row" w="100%" h="100%" alignItems="flex-start">
-          {/* Editor */}
-          {children}
+    <>
+      <OverwriteChangesModal
+        isOpen={isOverwriteOpen}
+        onClose={onOverwriteClose}
+        onProceed={() => {
+          onSave()
+          onOverwriteClose()
+        }}
+      />
+
+      <Greyscale isActive={isWriteDisabled}>
+        <Flex flexDir="column" h="full">
+          <Header
+            title={pageData?.content?.frontMatter?.title || ""}
+            shouldAllowEditPageBackNav={
+              getEditorContent() === pageData?.content?.pageBody?.trim()
+            }
+            isEditPage
+            params={decodedParams}
+          />
+          <Flex flexDir="row" w="100%" h="100%" alignItems="flex-start">
+            {/* Editor */}
+            {children}
+          </Flex>
+          <Spacer />
+          <Footer>
+            <Button onClick={onSave} isLoading={isSavingPage}>
+              Save
+            </Button>
+          </Footer>
         </Flex>
-        <Spacer />
-        <Footer>
-          <Button
-            onClick={() => {
-              updatePageHandler(({
-                pageData: {
-                  frontMatter: {
-                    ...(pageData?.content?.frontMatter || {}),
-                    variant,
-                  },
-                  pageBody: getPageBody(),
-                  sha: pageData.sha,
-                },
-              } as unknown) as void)
-            }}
-            isLoading={isSavingPage}
-          >
-            Save
-          </Button>
-        </Footer>
-      </Flex>
-    </Greyscale>
+      </Greyscale>
+    </>
   )
 }

--- a/src/layouts/EditPage/EditPageLayout.tsx
+++ b/src/layouts/EditPage/EditPageLayout.tsx
@@ -34,11 +34,13 @@ import { sanitiseRawHtml, updateHtmlWithMediaData } from "./utils"
 
 interface EditPageLayoutProps {
   getEditorContent: () => string
+  setEditorContent: (content: string) => void
   variant: PageVariant
 }
 
 export const EditPageLayout = ({
   getEditorContent,
+  setEditorContent,
   variant = "markdown",
   children,
 }: PropsWithChildren<EditPageLayoutProps>) => {
@@ -56,6 +58,13 @@ export const EditPageLayout = ({
     mutateAsync: updatePageHandler,
     isLoading: isSavingPage,
   } = useUpdatePageHook(params, {
+    onSuccess: (data: {
+      content: {
+        pageBody: string
+      }
+    }) => {
+      setEditorContent(data?.content?.pageBody)
+    },
     onError: (err: AxiosError) => {
       if (err.response?.status === 409) onOverwriteOpen()
     },

--- a/src/layouts/EditPage/FeatureFlaggedEditPage.tsx
+++ b/src/layouts/EditPage/FeatureFlaggedEditPage.tsx
@@ -1,0 +1,20 @@
+import { useFeatureIsOn } from "@growthbook/growthbook-react"
+
+import LegacyEditPage from "layouts/LegacyEditPage"
+
+import { EditPage } from "./EditPage"
+
+interface FeatureFlaggedEditPageProps {
+  match: {
+    params: Record<string, unknown>
+    decodedParams: Record<string, unknown>
+  }
+}
+export const FeatureFlaggedEditPage = ({
+  match,
+}: FeatureFlaggedEditPageProps) => {
+  // NOTE: flag so that it shows up in the UI
+  // only if `is-tiptap-enabled`
+  const isNewEditorEnabled = useFeatureIsOn("is-tiptap-enabled")
+  return isNewEditorEnabled ? <EditPage /> : <LegacyEditPage match={match} />
+}

--- a/src/layouts/EditPage/MarkdownEditPage.tsx
+++ b/src/layouts/EditPage/MarkdownEditPage.tsx
@@ -41,43 +41,6 @@ import { EditPageLayout } from "./EditPageLayout"
 // axios settings
 axios.defaults.withCredentials = true
 
-DOMPurify.setConfig({
-  ADD_TAGS: ["iframe", "#comment", "script"],
-  ADD_ATTR: [
-    "allow",
-    "allowfullscreen",
-    "frameborder",
-    "scrolling",
-    "marginheight",
-    "marginwidth",
-    "target",
-    "async",
-  ],
-  // required in case <script> tag appears as the first line of the markdown
-  FORCE_BODY: true,
-})
-DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-  // Allow script tags if it has a src attribute
-  // Script sources are handled by our CSP sanitiser
-  if (
-    data.tagName === "script" &&
-    !(node.hasAttribute("src") && node.innerHTML === "")
-  ) {
-    // Adapted from https://github.com/cure53/DOMPurify/blob/e0970d88053c1c564b6ccd633b4af7e7d9a10375/src/purify.js#L719-L736
-    DOMPurify.removed.push({ element: node })
-    try {
-      node.parentNode?.removeChild(node)
-    } catch (e) {
-      try {
-        // eslint-disable-next-line no-param-reassign
-        node.outerHTML = ""
-      } catch (ex) {
-        node.remove()
-      }
-    }
-  }
-})
-
 interface MarkdownPageProps {
   togglePreview: () => void
 }
@@ -156,7 +119,7 @@ export const MarkdownEditPage = ({ togglePreview }: MarkdownPageProps) => {
   }, [mediaData, editorValue])
 
   return (
-    <EditPageLayout getPageBody={() => editorValue} variant="markdown">
+    <EditPageLayout variant="markdown" getEditorContent={() => editorValue}>
       <Box maxW="50%" p="1.25rem">
         <Flex flexDir="row" bg="gray.100" p="1.38rem" mb="1.38rem">
           <Flex flexDir="column" alignContent="flex-start" mr="1rem">

--- a/src/layouts/EditPage/MarkdownEditPage.tsx
+++ b/src/layouts/EditPage/MarkdownEditPage.tsx
@@ -119,7 +119,11 @@ export const MarkdownEditPage = ({ togglePreview }: MarkdownPageProps) => {
   }, [mediaData, editorValue])
 
   return (
-    <EditPageLayout variant="markdown" getEditorContent={() => editorValue}>
+    <EditPageLayout
+      variant="markdown"
+      getEditorContent={() => editorValue}
+      setEditorContent={(content: string) => setEditorValue(content)}
+    >
       <Box maxW="50%" p="1.25rem">
         <Flex flexDir="row" bg="gray.100" p="1.38rem" mb="1.38rem">
           <Flex flexDir="column" alignContent="flex-start" mr="1rem">

--- a/src/layouts/EditPage/TiptapEditPage.tsx
+++ b/src/layouts/EditPage/TiptapEditPage.tsx
@@ -50,7 +50,13 @@ export const TiptapEditPage = ({
   ])
 
   return (
-    <EditPageLayout getEditorContent={() => editor.getHTML()} variant="tiptap">
+    <EditPageLayout
+      setEditorContent={(content) => {
+        editor.commands.setContent(content)
+      }}
+      getEditorContent={() => editor.getHTML()}
+      variant="tiptap"
+    >
       {/* Editor */}
       <Editor />
       {/* Preview */}

--- a/src/layouts/EditPage/TiptapEditPage.tsx
+++ b/src/layouts/EditPage/TiptapEditPage.tsx
@@ -50,7 +50,7 @@ export const TiptapEditPage = ({
   ])
 
   return (
-    <EditPageLayout getPageBody={() => editor.getHTML()} variant="tiptap">
+    <EditPageLayout getEditorContent={() => editor.getHTML()} variant="tiptap">
       {/* Editor */}
       <Editor />
       {/* Preview */}

--- a/src/layouts/EditPage/index.tsx
+++ b/src/layouts/EditPage/index.tsx
@@ -1,1 +1,1 @@
-export { EditPage } from "./EditPage"
+export { FeatureFlaggedEditPage as EditPage } from "./FeatureFlaggedEditPage"

--- a/src/layouts/EditPage/utils.ts
+++ b/src/layouts/EditPage/utils.ts
@@ -1,0 +1,87 @@
+import parse from "content-security-policy-parser"
+import DOMPurify from "dompurify"
+
+import checkCSP from "utils/cspUtils"
+
+import { MediaData } from "types/directory"
+import { adjustImageSrcs } from "utils"
+
+DOMPurify.setConfig({
+  ADD_TAGS: ["iframe", "#comment", "script"],
+  ADD_ATTR: [
+    "allow",
+    "allowfullscreen",
+    "frameborder",
+    "scrolling",
+    "marginheight",
+    "marginwidth",
+    "target",
+    "async",
+  ],
+  // required in case <script> tag appears as the first line of the markdown
+  FORCE_BODY: true,
+})
+DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+  // Allow script tags if it has a src attribute
+  // Script sources are handled by our CSP sanitiser
+  if (
+    data.tagName === "script" &&
+    !(node.hasAttribute("src") && node.innerHTML === "")
+  ) {
+    // Adapted from https://github.com/cure53/DOMPurify/blob/e0970d88053c1c564b6ccd633b4af7e7d9a10375/src/purify.js#L719-L736
+    DOMPurify.removed.push({ element: node })
+    try {
+      node.parentNode?.removeChild(node)
+    } catch (e) {
+      try {
+        // eslint-disable-next-line no-param-reassign
+        node.outerHTML = ""
+      } catch (ex) {
+        node.remove()
+      }
+    }
+  }
+})
+
+// NOTE: Force callers to go through this
+// so that we cannot inject arbitrary HTML
+export const sanitiseRawHtml = (
+  csp: ReturnType<typeof parse>,
+  html: string
+): { sanitisedHtml: TrustedHTML; isCspViolation: boolean } => {
+  const { sanitisedHtml: CSPSanitisedHtml, isCspViolation } = checkCSP(
+    csp,
+    html
+  )
+
+  const sanitisedHtml = DOMPurify.sanitize(CSPSanitisedHtml, {
+    RETURN_TRUSTED_TYPE: true,
+  })
+
+  return {
+    sanitisedHtml,
+    isCspViolation,
+  }
+}
+
+// TODO: maintain trusted html guarantee
+export const updateHtmlWithMediaData = (
+  mediaSources: Set<string>,
+  sanitisedHtml: TrustedHTML,
+  mediaData: MediaData[] = []
+): { html: string; isXssViolation: boolean; isContentViolation: boolean } => {
+  const processedChunk = adjustImageSrcs(sanitisedHtml.toString(), mediaData)
+
+  // Using FORCE_BODY adds a fake <remove></remove>
+  DOMPurify.removed = DOMPurify.removed.filter(
+    (el) => el.element?.tagName !== "REMOVE"
+  )
+
+  return {
+    isXssViolation: DOMPurify.removed.length > 0,
+    isContentViolation: mediaSources.size > 0,
+    // TODO: Check if adjusting the src
+    // violates sanitization guarantees
+    html: processedChunk,
+  }
+}

--- a/src/layouts/LegacyEditPage.jsx
+++ b/src/layouts/LegacyEditPage.jsx
@@ -1,7 +1,5 @@
-import { useDisclosure, Text, Box, Code } from "@chakra-ui/react"
-import { Button } from "@opengovsg/design-system-react"
+import { useDisclosure, Box } from "@chakra-ui/react"
 import axios from "axios"
-import DOMPurify from "dompurify"
 import _ from "lodash"
 import { marked } from "marked"
 import PropTypes from "prop-types"
@@ -9,61 +7,20 @@ import { useEffect, useState } from "react"
 
 import MarkdownEditor from "components/pages/MarkdownEditor"
 import PagePreview from "components/pages/PagePreview"
-import { WarningModal } from "components/WarningModal"
 
 import { useGetMultipleMediaHook } from "hooks/mediaHooks"
-import { useGetPageHook, useUpdatePageHook } from "hooks/pageHooks"
-import { useCspHook, useGetSiteColorsHook } from "hooks/settingsHooks"
+import { useGetPageHook } from "hooks/pageHooks"
+import { useCspHook } from "hooks/settingsHooks"
 import useRedirectHook from "hooks/useRedirectHook"
 
-// Isomer utils
-import checkCSP from "utils/cspUtils"
-import { createPageStyleSheet } from "utils/siteColorUtils"
-
-import { getMediaSrcsFromHtml, adjustImageSrcs } from "utils"
+import { getMediaSrcsFromHtml } from "utils"
 
 import "easymde/dist/easymde.min.css"
 import { EditPageLayout } from "./EditPage/EditPageLayout"
+import { sanitiseRawHtml, updateHtmlWithMediaData } from "./EditPage/utils"
 
 // axios settings
 axios.defaults.withCredentials = true
-
-DOMPurify.setConfig({
-  ADD_TAGS: ["iframe", "#comment", "script"],
-  ADD_ATTR: [
-    "allow",
-    "allowfullscreen",
-    "frameborder",
-    "scrolling",
-    "marginheight",
-    "marginwidth",
-    "target",
-    "async",
-  ],
-  // required in case <script> tag appears as the first line of the markdown
-  FORCE_BODY: true,
-})
-DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-  // Allow script tags if it has a src attribute
-  // Script sources are handled by our CSP sanitiser
-  if (
-    data.tagName === "script" &&
-    !(node.hasAttribute("src") && node.innerHTML === "")
-  ) {
-    // Adapted from https://github.com/cure53/DOMPurify/blob/e0970d88053c1c564b6ccd633b4af7e7d9a10375/src/purify.js#L719-L736
-    DOMPurify.removed.push({ element: node })
-    try {
-      node.parentNode.removeChild(node)
-    } catch (e) {
-      try {
-        // eslint-disable-next-line no-param-reassign
-        node.outerHTML = ""
-      } catch (ex) {
-        node.remove()
-      }
-    }
-  }
-})
 
 const EditPage = ({ match }) => {
   const { params, decodedParams } = match
@@ -74,77 +31,28 @@ const EditPage = ({ match }) => {
   const [htmlChunk, setHtmlChunk] = useState("")
 
   // TODO: Migrate the below 4 to the new `EditPageLayout`
-  const [currSha, setCurrSha] = useState("")
+  const [, setCurrSha] = useState("")
   const [hasChanges, setHasChanges] = useState(false)
   const [, setIsContentViolation] = useState(false)
-  const [isXSSViolation, setIsXSSViolation] = useState(false)
+  const [, setIsXSSViolation] = useState(false)
 
-  const {
-    isOpen: isXSSWarningModalOpen,
-    onClose: onXSSWarningModalClose,
-  } = useDisclosure()
-
-  const { onOpen: onOverwriteOpen } = useDisclosure()
+  const { onOpen: onXSSWarningModalOpen } = useDisclosure()
 
   const { setRedirectToNotFound } = useRedirectHook()
 
   const { data: pageData, isLoading: isLoadingPage } = useGetPageHook(params, {
     onError: () => setRedirectToNotFound(siteName),
   })
-  const { mutateAsync: updatePageHandler } = useUpdatePageHook(params, {
-    onError: (err) => {
-      if (err.response.status === 409) onOverwriteOpen()
-    },
-    onSuccess: () => setHasChanges(false),
-  })
 
   const { data: csp } = useCspHook()
-  const { data: siteColorsData } = useGetSiteColorsHook(params)
   const { data: mediaData } = useGetMultipleMediaHook({
     siteName,
     mediaSrcs,
   })
 
-  const updateMediaSrcs = () => {
-    if (!csp || _.isEmpty(csp) || !editorValue) return
-    const html = marked.parse(editorValue)
-    const { sanitisedHtml: CSPSanitisedHtml } = checkCSP(csp, html)
-    const DOMCSPSanitisedHtml = DOMPurify.sanitize(CSPSanitisedHtml)
-    setMediaSrcs(getMediaSrcsFromHtml(DOMCSPSanitisedHtml))
-  }
-
-  const updateHtmlWithMediaData = () => {
-    if (!csp || _.isEmpty(csp) || !editorValue) return
-    const html = marked.parse(editorValue)
-    const {
-      isCspViolation: checkedIsCspViolation,
-      sanitisedHtml: CSPSanitisedHtml,
-    } = checkCSP(csp, html)
-    const DOMCSPSanitisedHtml = DOMPurify.sanitize(CSPSanitisedHtml)
-    const processedChunk = adjustImageSrcs(DOMCSPSanitisedHtml, mediaData || [])
-
-    // Using FORCE_BODY adds a fake <remove></remove>
-    DOMPurify.removed = DOMPurify.removed.filter(
-      (el) => el.element?.tagName !== "REMOVE"
-    )
-
-    setIsXSSViolation(DOMPurify.removed.length > 0)
-    setIsContentViolation(checkedIsCspViolation)
-    setHtmlChunk(processedChunk)
-  }
-
   /** ******************************** */
   /*     useEffects to load data     */
   /** ******************************** */
-
-  useEffect(() => {
-    if (siteColorsData)
-      createPageStyleSheet(
-        siteName,
-        siteColorsData.primaryColor,
-        siteColorsData.secondaryColor
-      )
-  }, [siteColorsData, siteName])
 
   useEffect(() => {
     if (pageData && !hasChanges) {
@@ -158,70 +66,33 @@ const EditPage = ({ match }) => {
       setHasChanges(pageData.content.pageBody.trim() !== editorValue)
   }, [pageData, editorValue])
 
+  // TODO: We need to migrate this over to `EditPageLayout`
   useEffect(() => {
-    updateMediaSrcs()
+    if (!csp || _.isEmpty(csp) || !editorValue) return
+    const html = marked.parse(editorValue)
+
+    const { sanitisedHtml: DOMCSPSanitisedHtml } = sanitiseRawHtml(csp, html)
+    setMediaSrcs(getMediaSrcsFromHtml(DOMCSPSanitisedHtml))
   }, [csp, editorValue])
 
   useEffect(() => {
-    updateHtmlWithMediaData()
-  }, [mediaData, editorValue])
+    if (!csp || _.isEmpty(csp) || !editorValue) return
+    const html = marked.parse(editorValue)
+    const { sanitisedHtml } = sanitiseRawHtml(csp, html)
+
+    const {
+      html: processedChunk,
+      isXssViolation,
+      isContentViolation,
+    } = updateHtmlWithMediaData(mediaSrcs, sanitisedHtml, mediaData)
+
+    setIsXSSViolation(isXssViolation)
+    setIsContentViolation(isContentViolation)
+    setHtmlChunk(processedChunk)
+  }, [mediaData, editorValue, csp, mediaSrcs, onXSSWarningModalOpen])
 
   return (
     <EditPageLayout getEditorContent={() => editorValue}>
-      {/* XSS violation warning modal */}
-      <WarningModal
-        isOpen={isXSSViolation && isXSSWarningModalOpen}
-        onClose={onXSSWarningModalClose}
-        displayTitle="Warning"
-        // DOMPurify removed object format taken from https://github.com/cure53/DOMPurify/blob/dd63379e6354f66d4689bb80b30cb43a6d8727c2/src/purify.js
-        displayText={
-          <Box>
-            <Text>
-              There is unauthorised JS detected in the following snippet
-              {DOMPurify.removed.length > 1 ? "s" : ""}:
-            </Text>
-            {DOMPurify.removed.map((elem, i) => (
-              <>
-                <br />
-                <Code>{i + 1}</Code>:
-                <Code>
-                  {elem.attribute?.nodeName || elem.element?.outerHTML || elem}
-                </Code>
-              </>
-            ))}
-            <br />
-            <br />
-            Before saving, the editor input will be automatically sanitised to
-            prevent security vulnerabilities.
-            <br />
-            <br />
-            To save the sanitised editor input, press Acknowledge. To return to
-            the editor without sanitising, press Cancel.`
-          </Box>
-        }
-      >
-        <Button colorScheme="critical" onClick={onXSSWarningModalClose}>
-          Cancel
-        </Button>
-        <Button
-          onClick={() => {
-            const sanitizedEditorValue = DOMPurify.sanitize(editorValue)
-            setEditorValue(sanitizedEditorValue)
-            setIsXSSViolation(false)
-            updatePageHandler({
-              pageData: {
-                frontMatter: pageData.content.frontMatter,
-                sha: currSha,
-                pageBody: sanitizedEditorValue,
-              },
-            })
-            onXSSWarningModalClose()
-          }}
-        >
-          Acknowledge
-        </Button>
-      </WarningModal>
-
       {/* Editor */}
       <Box w="50%" p="1.25rem" maxH="100%" overflowY="scroll">
         <MarkdownEditor

--- a/src/services/PageService.jsx
+++ b/src/services/PageService.jsx
@@ -60,7 +60,7 @@ export class PageService {
       newFileName,
       sha,
     }
-    await this.apiClient.post(this.getPageEndpoint(apiParams), body)
+    return this.apiClient.post(this.getPageEndpoint(apiParams), body)
   }
 
   async get(apiParams) {

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -9,6 +9,7 @@ export interface FeatureFlags {
   }
   [FEATURE_FLAGS.NPS_FORM]: boolean
   [FEATURE_FLAGS.HOMEPAGE_ENABLED_BLOCKS]: string[]
+  [FEATURE_FLAGS.TIPTAP_EDITOR]: boolean
 }
 
 export type GBAttributes = {


### PR DESCRIPTION
## Problem
Our current new RTE has no feature flag. In addition, the new modals are not added. This PR adds them back.

## Solution
1. Add feature flag
2. Shift stuff (the checks) out into utils
3. add checks into layout
4. reuse layout on legacy + new pages.

## Tests
- [ ] make a change
- [ ] exit
- [ ] shuold have warning modal
- [ ] refresh page
- [ ] change something on github and save
- [ ] attempt to save
- [ ] should have override warning
- [ ] add a script tag (**legacy page only**) 
- [ ] should have xss warning
- [ ] refresh page
- [ ] exit
- [ ] should have no warning (can't remember if this is true at present for this PR) 