### PR TITLE
IS-685 enhance delete images

### DIFF
--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -29,7 +29,6 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
         !!(params.resourceRoomName && params.fileName)
       )
 
-  console.log(`match`, match)
   const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   if (fileName) {

--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -80,24 +80,37 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
     onSuccess: () => onClose(),
   })
 
+  const mediaType =
+    mediaRoom === "images"
+      ? { dirType: "album", resourceType: "image" }
+      : { dirType: "folder", resourceType: "file" }
+
   return (
     <WarningModal
       isOpen={!!deleteItemName} // Modal is always present for delete screens
       onClose={onClose}
-      displayTitle={`Delete ${deleteItemName}`}
+      displayTitle={`Delete ${deleteItemName}?`}
       displayText={
-        <Text>Are you sure you want to delete {deleteItemName}?</Text>
+        <Text>
+          Are you sure you want to delete this {mediaType.dirType} and all its
+          child {mediaType.dirType}s and {mediaType.resourceType}s? If you used
+          its child contents on any page, site visitors may see a broken{" "}
+          {mediaType.resourceType}. This cannot be undone.
+        </Text>
       }
     >
+      <Checkbox onChange={(e) => setIsDeleteChecked(e.target.checked)}>
+        Yes, delete this {mediaType.dirType} and all its contents
+      </Checkbox>
       <Button variant="clear" colorScheme="secondary" onClick={onClose}>
         Cancel
       </Button>
       <LoadingButton
         colorScheme="critical"
         onClick={deleteHandler}
-        isDisabled={isWriteDisabled}
+        isDisabled={isWriteDisabled || !isDeleteChecked}
       >
-        Yes, delete
+        Delete {mediaType.dirType}
       </LoadingButton>
     </WarningModal>
   )

--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -1,6 +1,7 @@
 import { Text } from "@chakra-ui/react"
-import { Button } from "@opengovsg/design-system-react"
+import { Button, Checkbox } from "@opengovsg/design-system-react"
 import PropTypes from "prop-types"
+import { useState } from "react"
 
 import { LoadingButton } from "components/LoadingButton"
 import { WarningModal } from "components/WarningModal"
@@ -18,6 +19,7 @@ import {
 } from "utils"
 
 export const DeleteWarningScreen = ({ match, onClose }) => {
+  const [isDeleteChecked, setIsDeleteChecked] = useState(false)
   const { params, decodedParams } = match
   const { siteName, fileName, mediaRoom } = params
   const deleteItemName = params.mediaDirectoryName
@@ -57,13 +59,16 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
           </Text>
         }
       >
+        <Checkbox onChange={(e) => setIsDeleteChecked(e.target.checked)}>
+          Yes, delete {mediaType}
+        </Checkbox>
         <Button variant="clear" colorScheme="secondary" onClick={onClose}>
           Cancel
         </Button>
         <LoadingButton
           colorScheme="critical"
           onClick={() => deleteHandler({ sha: fileData.sha })}
-          isDisabled={isWriteDisabled}
+          isDisabled={isWriteDisabled || !isDeleteChecked}
         >
           Delete {mediaType}
         </LoadingButton>

--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -26,6 +26,8 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
         decodedParams[getLastItemType(decodedParams)],
         !!(params.resourceRoomName && params.fileName)
       )
+
+  console.log(`match`, match)
   const isWriteDisabled = isWriteActionsDisabled(siteName)
 
   if (fileName) {
@@ -40,12 +42,20 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
           onSuccess: () => onClose(),
         })
 
+    const mediaType = mediaRoom === "images" ? "image" : "file"
+
     return (
       <WarningModal
         isOpen={!!fileData}
         onClose={onClose}
-        displayTitle={`Delete ${fileName}`}
-        displayText={<Text>Are you sure you want to delete {fileName}?</Text>}
+        displayTitle={`Delete ${fileName}?`}
+        displayText={
+          <Text>
+            Are you sure you want to delete this {mediaType}? If you used this{" "}
+            {mediaType} on any page, site visitors may see a broken {mediaType}.
+            This cannot be undone.
+          </Text>
+        }
       >
         <Button variant="clear" colorScheme="secondary" onClick={onClose}>
           Cancel
@@ -55,7 +65,7 @@ export const DeleteWarningScreen = ({ match, onClose }) => {
           onClick={() => deleteHandler({ sha: fileData.sha })}
           isDisabled={isWriteDisabled}
         >
-          Yes, delete
+          Delete {mediaType}
         </LoadingButton>
       </WarningModal>
     )


### PR DESCRIPTION
## Problem

Enhance current delete modal for images (also for files, resource categories and pages)

Closes IS-685

## Solution

Enhance delete modal as per this UI

![Screenshot 2023-10-31 at 11 33 58 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/eea291cb-d9e3-4ef8-8a73-09d2617eb821)


**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
![Screenshot 2023-10-31 at 11 34 19 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/80feb8d8-6ad6-4e00-b5c7-438390bb4f7f)


**AFTER**:
![Screenshot 2023-10-31 at 11 30 30 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/ff5dee30-f985-4a53-a514-8a918ca83bdf)
![Screenshot 2023-10-31 at 11 30 10 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/88abd4ff-8a19-4c51-982a-b81a460ee507)
![Screenshot 2023-10-31 at 11 29 56 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/0e9d391a-caa4-4ffc-8dc9-ef8c9a5f3fd1)
![Screenshot 2023-10-31 at 11 29 46 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/892b4702-dd71-4508-a786-c8bfa4305c39)
![Screenshot 2023-10-31 at 11 29 39 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/a80810b1-e3be-4045-b6d1-1a9c4ae6119d)
![Screenshot 2023-10-31 at 11 29 34 AM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/296bc25d-9b34-4e80-a282-db4ab1205d47)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [X] e2e tests (comment on this PR with the text `!run e2e`)
- [X] Smoke tests
    - [ ] Refer to above AFTER screenshots. Visit the respective pages - Workspace, resource room, files, images and ensure that both deleting of a single resource (e.g. a file) or an directory (e.g. an album) pops up the above modal

