### PR TITLE
feat/stagingBuildStatus/addRefreshBehaviour

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,12 @@
-import { Box, Flex, Icon, Text, HStack, useDisclosure } from "@chakra-ui/react"
+import {
+  Box,
+  Flex,
+  Icon,
+  Text,
+  HStack,
+  useDisclosure,
+  Skeleton,
+} from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import axios from "axios"
 import PropTypes from "prop-types"
@@ -7,6 +15,7 @@ import { useParams } from "react-router-dom"
 
 import { ButtonLink } from "components/ButtonLink"
 import { NotificationMenu } from "components/Header/NotificationMenu"
+import { StatusBadge } from "components/Header/StatusBadge"
 import { ViewStagingSiteModal } from "components/ViewStagingSiteModal"
 import { WarningModal } from "components/WarningModal"
 
@@ -16,6 +25,7 @@ import {
   useGetReviewRequests,
   useGetStagingUrl,
 } from "hooks/siteDashboardHooks"
+import { useGetStagingStatus } from "hooks/useGetStagingStatus"
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
@@ -78,6 +88,10 @@ const Header = ({
     if (isEditPage && !shouldAllowEditPageBackNav) onWarningModalOpen()
     else toggleBackNav()
   }
+  const {
+    data: getStagingStatusData,
+    isLoading: isGetStagingStatusLoading,
+  } = useGetStagingStatus(siteName)
 
   return (
     <>
@@ -125,6 +139,9 @@ const Header = ({
           </Flex>
         ) : null}
         <HStack flex={1} justifyContent="flex-end">
+          <Skeleton isLoaded={!isGetStagingStatusLoading}>
+            {getStagingStatusData && <StatusBadge {...getStagingStatusData} />}
+          </Skeleton>
           <NotificationMenu />
           <Button
             onClick={onOpen}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -139,7 +139,7 @@ const Header = ({
           </Flex>
         ) : null}
         <HStack flex={1} justifyContent="flex-end">
-          <Skeleton isLoaded={!isGetStagingStatusLoading}>
+          <Skeleton isLoaded={!isGetStagingStatusLoading} mr="0.75rem">
             {getStagingStatusData && <StatusBadge {...getStagingStatusData} />}
           </Skeleton>
           <NotificationMenu />

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -89,9 +89,7 @@ BuildingStagingSite.parameters = {
     handlers: [
       ...handlers,
       buildGetStagingBuildStatusData({
-        commit: "123",
         status: "PENDING",
-        timeLastSaved: Date.now() - 5 * 60 * 1000,
       }),
     ],
   },
@@ -103,9 +101,7 @@ SuccessStagingBuild.parameters = {
     handlers: [
       ...handlers,
       buildGetStagingBuildStatusData({
-        commit: "123",
         status: "READY",
-        timeLastSaved: Date.now() - 60 * 60 * 1000,
       }),
     ],
   },
@@ -117,9 +113,7 @@ ErrorStagingBuild.parameters = {
     handlers: [
       ...handlers,
       buildGetStagingBuildStatusData({
-        commit: "123",
         status: "ERROR",
-        timeLastSaved: Date.now() - 1 * 60 * 1000,
       }),
     ],
   },

--- a/src/components/Header/StatusBadge.tsx
+++ b/src/components/Header/StatusBadge.tsx
@@ -16,44 +16,20 @@ import { buildStatus } from "types/stagingBuildStatus"
 
 interface StatusBadgeProps {
   status: buildStatus
-  timeLastSaved: number
 }
 
 interface StagingPopoverContentProps {
   status: buildStatus
-  timeLastSavedInMin: number
 }
 
-const getTimeSavedInMins = (timeLastSaved: number): number => {
-  const timeLastSavedInMin = Math.floor(
-    (Date.now() - timeLastSaved) / 1000 / 60
-  )
-
-  return timeLastSavedInMin
-}
-
-const StagingPopoverContent = ({
-  status,
-  timeLastSavedInMin,
-}: StagingPopoverContentProps) => {
+const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
   let headingText = ""
   let bodyText = ""
   let Icon = (props: IconBaseProps) => <BiLoader {...props} />
-  let timeText
-  if (timeLastSavedInMin < 60) {
-    timeText = `${timeLastSavedInMin} minute${
-      timeLastSavedInMin === 1 ? "" : "s"
-    } ago`
-  } else if (timeLastSavedInMin < 60 * 60) {
-    const hours = Math.floor(timeLastSavedInMin / 60)
-    timeText = `${hours} hour${hours === 1 ? "" : "s"} ago`
-  } else {
-    const days = Math.floor(timeLastSavedInMin / 60 / 24)
-    timeText = `${days} day${days === 1 ? "" : "s"} ago`
-  }
+
   switch (status) {
     case "READY":
-      headingText = `All saved edits from ${timeText} are on staging`
+      headingText = `All saved edits are on staging`
       bodyText = "Click on 'Open staging' to take a look."
 
       Icon = (props: IconBaseProps) => (
@@ -62,7 +38,7 @@ const StagingPopoverContent = ({
 
       break
     case "PENDING":
-      headingText = `Site building since last save ${timeText}`
+      headingText = `Site building since last save `
       bodyText = "We'll let you know when the staging site is ready."
       Icon = (props: IconBaseProps) => (
         <BiLoader {...props} style={{ animation: "spin 2s linear infinite" }} />
@@ -70,7 +46,7 @@ const StagingPopoverContent = ({
       break
     case "ERROR":
       headingText =
-        "We had some trouble updating the staging site since your latest save. "
+        "We had some trouble updating the staging site since the latest save. "
       bodyText =
         "Don't worry, your production site isn't affected. Try saving your page again. If the issue persists, please contact Isomer Support."
       Icon = (props: IconBaseProps) => <BiError {...props} />
@@ -92,11 +68,7 @@ const StagingPopoverContent = ({
   )
 }
 
-export const StatusBadge = ({
-  status,
-  timeLastSaved,
-}: StatusBadgeProps): JSX.Element => {
-  const timeLastSavedInMin = getTimeSavedInMins(timeLastSaved ?? Date.now())
+export const StatusBadge = ({ status }: StatusBadgeProps): JSX.Element => {
   let displayText = ""
   let colourScheme = ""
   let dotColor = "#505660"
@@ -121,24 +93,21 @@ export const StatusBadge = ({
   }
 
   return (
-    <Box position="relative">
-      <Popover trigger="hover">
-        <PopoverTrigger>
-          <Badge colorScheme={colourScheme} variant="subtle" cursor="default">
-            <GoDotFill size="1rem" color={dotColor} />
-            <Text ml="0.5rem" mr="0.5rem">
-              {displayText}
-            </Text>
-            <BsFillQuestionCircleFill color="#454953" />
-          </Badge>
-        </PopoverTrigger>
-        <PopoverContent width="26.25rem" height="auto" mt="2rem">
-          <StagingPopoverContent
-            status={status}
-            timeLastSavedInMin={timeLastSavedInMin}
-          />
+    <Popover trigger="hover">
+      <PopoverTrigger>
+        <Badge colorScheme={colourScheme} variant="subtle" cursor="default">
+          <GoDotFill size="1rem" color={dotColor} />
+          <Text ml="0.5rem" mr="0.5rem">
+            {displayText}
+          </Text>
+          <BsFillQuestionCircleFill color="#454953" />
+        </Badge>
+      </PopoverTrigger>
+      <Box position="relative">
+        <PopoverContent width="26.25rem" height="auto">
+          <StagingPopoverContent status={status} />
         </PopoverContent>
-      </Popover>
-    </Box>
+      </Box>
+    </Popover>
   )
 }

--- a/src/components/Header/StatusBadge.tsx
+++ b/src/components/Header/StatusBadge.tsx
@@ -12,19 +12,20 @@ import { BsFillQuestionCircleFill } from "react-icons/bs"
 import { GoDotFill } from "react-icons/go"
 import { IconBaseProps } from "react-icons/lib"
 
-import { buildStatus } from "types/stagingBuildStatus"
+import { BuildStatus } from "types/stagingBuildStatus"
 
 interface StatusBadgeProps {
-  status: buildStatus
+  status: BuildStatus
 }
 
 interface StagingPopoverContentProps {
-  status: buildStatus
+  status: BuildStatus
 }
 
 const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
   let headingText = ""
   let bodyText = ""
+
   let Icon = (props: IconBaseProps) => <BiLoader {...props} />
 
   switch (status) {
@@ -38,8 +39,9 @@ const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
 
       break
     case "PENDING":
-      headingText = `Site building since last save `
-      bodyText = "We'll let you know when the staging site is ready."
+      headingText = `Staging site is building`
+      bodyText =
+        "We detected a change in your site. We'll let you know when the staging site is ready."
       Icon = (props: IconBaseProps) => (
         <BiLoader {...props} style={{ animation: "spin 2s linear infinite" }} />
       )
@@ -48,12 +50,14 @@ const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
       headingText =
         "We had some trouble updating the staging site since the latest save. "
       bodyText =
-        "Don't worry, your production site isn't affected. Try saving your page again. If the issue persists, please contact Isomer Support."
+        "Don't worry, your production site isn't affected. Try saving your page again. If the issue persists, please contact support@isomer.gov.sg."
+
       Icon = (props: IconBaseProps) => <BiError {...props} />
       break
     default:
       break
   }
+
   return (
     <HStack align="start" spacing="0.75rem" m="0.75rem">
       <Box width="1.6rem" height="1.6rem" p="0.05rem">
@@ -62,7 +66,10 @@ const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
 
       <Box alignItems="left">
         <Text textStyle="subhead-2">{headingText}</Text>
-        <Text textStyle="body-2">{bodyText}</Text>
+
+        <Text textStyle="body-2" mt="0.25rem">
+          {bodyText}
+        </Text>
       </Box>
     </HStack>
   )
@@ -95,9 +102,14 @@ export const StatusBadge = ({ status }: StatusBadgeProps): JSX.Element => {
   return (
     <Popover trigger="hover">
       <PopoverTrigger>
-        <Badge colorScheme={colourScheme} variant="subtle" cursor="default">
+        <Badge
+          colorScheme={colourScheme}
+          variant="subtle"
+          cursor="default"
+          borderRadius="3.125rem"
+        >
           <GoDotFill size="1rem" color={dotColor} />
-          <Text ml="0.5rem" mr="0.5rem">
+          <Text ml="0.25rem" mr="0.5rem">
             {displayText}
           </Text>
           <BsFillQuestionCircleFill color="#454953" />

--- a/src/hooks/useGetStagingStatus.ts
+++ b/src/hooks/useGetStagingStatus.ts
@@ -14,7 +14,8 @@ export const useGetStagingStatus = (
     () => getStagingBuildStatus({ siteName }),
     {
       retry: false,
-      refetchInterval: 1000 * 30, // 30 sec
+      // todo: ideally should invalidate on save, now got time lag
+      refetchInterval: 1000 * 10, // 10 sec for quicker feedback when user press save
     }
   )
 }

--- a/src/hooks/useGetStagingStatus.ts
+++ b/src/hooks/useGetStagingStatus.ts
@@ -14,6 +14,7 @@ export const useGetStagingStatus = (
     () => getStagingBuildStatus({ siteName }),
     {
       retry: false,
+      refetchInterval: 1000 * 30, // 30 sec
     }
   )
 }

--- a/src/hooks/useGetStagingStatus.ts
+++ b/src/hooks/useGetStagingStatus.ts
@@ -14,8 +14,7 @@ export const useGetStagingStatus = (
     () => getStagingBuildStatus({ siteName }),
     {
       retry: false,
-      // todo: ideally should invalidate on save, now got time lag
-      refetchInterval: 1000 * 10, // 10 sec for quicker feedback when user press save
+      refetchInterval: 1000 * 5, // 5 sec for quicker feedback when user press save
     }
   )
 }

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -92,7 +92,7 @@ export const SiteEditHeader = (): JSX.Element => {
         </HStack>
         <Spacer />
         <HStack>
-          <Skeleton isLoaded={!isGetStagingStatusLoading}>
+          <Skeleton isLoaded={!isGetStagingStatusLoading} mr="0.75rem">
             {getStagingStatusData && <StatusBadge {...getStagingStatusData} />}
           </Skeleton>
           <NotificationMenu />

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -6,6 +6,7 @@ import {
   HStack,
   LinkBox,
   LinkOverlay,
+  Skeleton,
 } from "@chakra-ui/react"
 import { IconButton } from "@opengovsg/design-system-react"
 import { BiArrowBack } from "react-icons/bi"
@@ -13,16 +14,23 @@ import { Link as RouterLink, useLocation, useParams } from "react-router-dom"
 
 import { AvatarMenu } from "components/Header/AvatarMenu"
 import { NotificationMenu } from "components/Header/NotificationMenu"
+import { StatusBadge } from "components/Header/StatusBadge"
 
 import { ISOMER_GUIDE_LINK } from "constants/config"
 
 import { useLoginContext } from "contexts/LoginContext"
+
+import { useGetStagingStatus } from "hooks/useGetStagingStatus"
 
 export const SiteViewHeader = (): JSX.Element => {
   const { displayedName } = useLoginContext()
   const { pathname } = useLocation()
   const isAtSiteDashboard = pathname.endsWith("dashboard")
   const { siteName } = useParams<{ siteName: string }>()
+  const {
+    data: getStagingStatusData,
+    isLoading: isGetStagingStatusLoading,
+  } = useGetStagingStatus(siteName)
   return (
     <Flex
       py="0.625rem"
@@ -50,6 +58,9 @@ export const SiteViewHeader = (): JSX.Element => {
       </HStack>
       <Spacer />
       <HStack>
+        <Skeleton isLoaded={!isGetStagingStatusLoading}>
+          {getStagingStatusData && <StatusBadge {...getStagingStatusData} />}
+        </Skeleton>
         <LinkBox position="relative">
           <LinkOverlay href={ISOMER_GUIDE_LINK} isExternal>
             <Text

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -58,7 +58,7 @@ export const SiteViewHeader = (): JSX.Element => {
       </HStack>
       <Spacer />
       <HStack>
-        <Skeleton isLoaded={!isGetStagingStatusLoading}>
+        <Skeleton isLoaded={!isGetStagingStatusLoading} mr="0.75rem">
           {getStagingStatusData && <StatusBadge {...getStagingStatusData} />}
         </Skeleton>
         <LinkBox position="relative">

--- a/src/types/stagingBuildStatus.ts
+++ b/src/types/stagingBuildStatus.ts
@@ -1,5 +1,4 @@
 export const statusStates = {
-  unSaved: "UNSAVED",
   pending: "PENDING",
   ready: "READY",
   error: "ERROR",
@@ -7,7 +6,5 @@ export const statusStates = {
 export type buildStatus = typeof statusStates[keyof typeof statusStates]
 
 export interface StagingBuildStatus {
-  commit: string
   status: buildStatus
-  timeLastSaved: number
 }

--- a/src/types/stagingBuildStatus.ts
+++ b/src/types/stagingBuildStatus.ts
@@ -1,10 +1,10 @@
-export const statusStates = {
+export const StatusStates = {
   pending: "PENDING",
   ready: "READY",
   error: "ERROR",
 } as const
-export type buildStatus = typeof statusStates[keyof typeof statusStates]
+export type BuildStatus = typeof StatusStates[keyof typeof StatusStates]
 
 export interface StagingBuildStatus {
-  status: buildStatus
+  status: BuildStatus
 }


### PR DESCRIPTION
## Problem

Originally wanted to save the person's last save and be more accurate with that specific user, but this would lead to 
1. saving the user's last save time in local storage
2. ^ depending on whether user is using quickie, this will have an impact on the time to actually save in the cms
3. ^ would mean that FE would now be aware if site is quickie whitelisted (not a biggie, but just increases complexity) 

Opting to just use the latest amplify build as a sot instead  

Closes [insert issue #]

## Solution

Note that if a site does not have a record in the db (ie its netlify, this feature will not be shown) 


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to a site
- [ ] See that the site status is ready
- [ ] Make a change in a page arbitrary ungrouped page
- [ ] notice that the banner shows pending 
- [ ] do the above two for homepage, + 1 resource page

