### PR TITLE
fix(media): add additional query key to invalidate

### DIFF
--- a/src/hooks/mediaHooks/useDeleteMultipleMediaHook.tsx
+++ b/src/hooks/mediaHooks/useDeleteMultipleMediaHook.tsx
@@ -6,7 +6,10 @@ import {
   useQueryClient,
 } from "react-query"
 
-import { LIST_MEDIA_DIRECTORY_FILES_KEY } from "constants/queryKeys"
+import {
+  GET_ALL_MEDIA_FILES_KEY,
+  LIST_MEDIA_DIRECTORY_FILES_KEY,
+} from "constants/queryKeys"
 
 import { apiService } from "services/ApiService"
 
@@ -68,6 +71,7 @@ export const useDeleteMultipleMediaHook = (
       ...mutationOptions,
       onSettled: (data, error, variables, context) => {
         queryClient.invalidateQueries([LIST_MEDIA_DIRECTORY_FILES_KEY])
+        queryClient.invalidateQueries([GET_ALL_MEDIA_FILES_KEY])
         if (mutationOptions?.onSettled)
           mutationOptions.onSettled(data, error, variables, context)
       },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

After deleting, the list of media files do not get refreshed.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Invalidate the `GET_ALL_MEDIA_FILES_KEY` query key as well.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*