### PR TITLE
fix(protected-route): add missing deps

### DIFF
--- a/src/routing/ProtectedRoute.tsx
+++ b/src/routing/ProtectedRoute.tsx
@@ -53,7 +53,16 @@ export const ProtectedRoute = ({
       }
       growthbook.setAttributes(gbAttributes)
     }
-  }, [userId, userType, email, displayedName, contactNumber, currPath])
+  }, [
+    userId,
+    userType,
+    email,
+    displayedName,
+    contactNumber,
+    currPath,
+    growthbook,
+    siteNameFromPath,
+  ])
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Problem
Previously we didn't have a dep in protected route, which might have led to `siteName` not being in growthbook

## Solution
Add to `useEffect`