### PR TITLE
fix(menubar): remove uuid

### DIFF
--- a/src/layouts/components/Editor/components/MenuBar.tsx
+++ b/src/layouts/components/Editor/components/MenuBar.tsx
@@ -176,7 +176,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       borderTopRadius="0.25rem"
     >
       {items.map((item) => (
-        <Fragment key={uuid()}>
+        <>
           {item.type === "divider" ? (
             <Divider
               orientation="vertical"
@@ -187,7 +187,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
           ) : (
             <MenuItem {...item} />
           )}
-        </Fragment>
+        </>
       ))}
     </HStack>
   )


### PR DESCRIPTION
## Problem
The menu bar was rendering twice, which required 2 clicks to active modals. 

Closes IS-742

## Solution
Removed the `uuid`. This is because on state change (clicking etc), the uuid function fires again, which leads to a new key. This, in turn, causes react to re-render the component, leading to the first click being dropped.