### PR TITLE
fix(preview): use site colours for headings in preview

### DIFF
--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -126,6 +126,21 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
     `.content h5 { color: ${secondaryColor} !important;}`,
     0
   )
+
+  // EditPage: Blockquotes
+  customStyleSheet.insertRule(
+    `.content blockquote { border-left-color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
+    `.content blockquote > p { color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
+    `.content blockquote > ul { color: ${secondaryColor} !important;}`,
+    0
+  )
+
   customStyleSheet.insertRule(
     `.has-text-secondary { color: ${secondaryColor} !important;}`,
     0

--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -107,6 +107,26 @@ const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
     0
   )
   customStyleSheet.insertRule(
+    `.content h1 { color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
+    `.content h2 { color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
+    `.content h3 { color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
+    `.content h4 { color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
+    `.content h5 { color: ${secondaryColor} !important;}`,
+    0
+  )
+  customStyleSheet.insertRule(
     `.has-text-secondary { color: ${secondaryColor} !important;}`,
     0
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The preview does not show the headings properly in the site colours.

Fixes IS-567.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The site colours CSS rule is now properly injected in the site colour utilities. This rule is taken from the custom.scss files that every repo should be using: https://github.com/isomerpages/site-creation-base/blob/b7b29561760891bdfa5ba7f7d5fb78e9725d53a2/misc/custom.scss#L257-L272

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![Screenshot 2023-11-10 at 09 23 55](https://github.com/isomerpages/isomercms-frontend/assets/27919917/31185f51-ebbc-4c56-88fd-3e3009e31d1b)

**AFTER**:

<!-- [insert screenshot here] -->
![Screenshot 2023-11-10 at 09 24 24](https://github.com/isomerpages/isomercms-frontend/assets/27919917/ca09e55f-8046-41cb-9af0-f166acce92b5)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site with a custom colour set for their secondary colour.
    - [ ] Verify that pages that use headings and quotes now use the secondary colour correctly.
    - [ ] Change the secondary colour of the site
    - [ ] Verify that the same pages using the headings and quotes now use the new secondary colour correctly.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*