### PR TITLE
chore(login): automatically focus on input field

### DIFF
--- a/src/layouts/Login/components/OtpForm.tsx
+++ b/src/layouts/Login/components/OtpForm.tsx
@@ -64,10 +64,12 @@ export const OtpForm = ({
         </FormLabel>
         <HStack spacing="0.5rem">
           <Input
+            id="otp"
             type="text"
             maxLength={6}
             inputMode="numeric"
             autoComplete="one-time-code"
+            autoFocus
             {...register("otp", {
               pattern: {
                 value: /^[0-9\b]+$/, // \b is a word boundary - link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When logging in via email, the OTP field does not gain auto focus, which requires the user to perform an additional click.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- The OTP input field now gains auto focus after the user presses submit for the email, reducing the need to click the OTP field again.
- Clicking on the form label also directs the user correctly to the OTP input field.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Login via email by typing in your email
    - [ ] Verify that you automatically get focused onto the OTP input field after you press enter/Log in.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*