### PR TITLE
feat(media): allow create album with selected media

### DIFF
--- a/src/components/Attachment/AttachmentDropzone.tsx
+++ b/src/components/Attachment/AttachmentDropzone.tsx
@@ -27,7 +27,7 @@ export const AttachmentDropzone = ({
           <Text>
             <Button variant="link" isDisabled={inputProps.disabled}>
               Choose files
-            </Button>
+            </Button>{" "}
             or drag and drop here
           </Text>
           <Text textStyle="caption-1">

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
@@ -1,0 +1,97 @@
+import { useDisclosure } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import type { Meta, StoryFn } from "@storybook/react"
+import { MemoryRouter, Route } from "react-router-dom"
+
+import { getMediaLabels } from "utils/media"
+
+import {
+  MOCK_MEDIA_ITEM_FIVE,
+  MOCK_MEDIA_ITEM_FOUR,
+  MOCK_MEDIA_ITEM_ONE,
+  MOCK_MEDIA_ITEM_THREE,
+  MOCK_MEDIA_ITEM_TWO,
+} from "mocks/constants"
+import { useSuccessToast } from "utils"
+
+import { CreateMediaFolderModal } from "./CreateMediaFolderModal"
+
+const createMediaFolderModalMeta = {
+  title: "Components/Create Media Folder Modal",
+  component: CreateMediaFolderModal,
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter
+          initialEntries={[
+            "/sites/storybook/media/images/mediaDirectory/images",
+          ]}
+        >
+          <Route path="/sites/:siteName/media/:mediaRoom/mediaDirectory/:mediaDirectoryName">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      )
+    },
+  ],
+} as Meta<typeof CreateMediaFolderModal>
+
+const createMediaFolderModalTemplate: StoryFn<
+  typeof CreateMediaFolderModal
+> = ({ originalSelectedMedia }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure({ defaultIsOpen: true })
+  const successToast = useSuccessToast()
+  const onProceed = async (result: any) => {
+    console.log(result)
+    successToast({
+      id: "storybook-create-media-folder-success",
+      description: "STORYBOOK: Media folder has been successfully created",
+    })
+    onClose()
+  }
+
+  return (
+    <>
+      <Button onClick={onOpen}>Open create media folder modal</Button>
+      <CreateMediaFolderModal
+        originalSelectedMedia={originalSelectedMedia}
+        mediaLabels={getMediaLabels("images")}
+        subDirectories={{ directories: [] }}
+        mediaData={[
+          MOCK_MEDIA_ITEM_ONE,
+          MOCK_MEDIA_ITEM_TWO,
+          MOCK_MEDIA_ITEM_THREE,
+          MOCK_MEDIA_ITEM_FOUR,
+          MOCK_MEDIA_ITEM_FIVE,
+        ]}
+        isWriteDisabled={false}
+        isOpen={isOpen}
+        isLoading={false}
+        onClose={onClose}
+        onProceed={onProceed}
+      />
+    </>
+  )
+}
+
+export const Default = createMediaFolderModalTemplate.bind({})
+Default.args = {
+  originalSelectedMedia: [],
+}
+
+export const OneSelected = createMediaFolderModalTemplate.bind({})
+OneSelected.args = {
+  originalSelectedMedia: [
+    { filePath: "/images/hero-banner.png", size: 1234, sha: "sha1234" },
+  ],
+}
+
+export const MultipleSelected = createMediaFolderModalTemplate.bind({})
+MultipleSelected.args = {
+  originalSelectedMedia: [
+    { filePath: "/images/hero-banner.png", size: 1234, sha: "sha1234" },
+    { filePath: "/images/hero-banner2.png", size: 2345, sha: "sha1234" },
+  ],
+}
+
+export default createMediaFolderModalMeta

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
@@ -5,13 +5,9 @@ import { MemoryRouter, Route } from "react-router-dom"
 
 import { getMediaLabels } from "utils/media"
 
-import {
-  MOCK_MEDIA_ITEM_FIVE,
-  MOCK_MEDIA_ITEM_FOUR,
-  MOCK_MEDIA_ITEM_ONE,
-  MOCK_MEDIA_ITEM_THREE,
-  MOCK_MEDIA_ITEM_TWO,
-} from "mocks/constants"
+import { MOCK_MEDIA_ITEM_DATA, MOCK_MEDIA_ITEM_ONE } from "mocks/constants"
+import { handlers } from "mocks/handlers"
+import { buildMediaFileData, buildMediaFolderFilesData } from "mocks/utils"
 import { useSuccessToast } from "utils"
 
 import { CreateMediaFolderModal } from "./CreateMediaFolderModal"
@@ -58,9 +54,7 @@ const createMediaFolderModalTemplate: StoryFn<
         mediaLabels={getMediaLabels("images")}
         mediaType="images"
         subDirectories={{ directories: [] }}
-        siteName="storybook"
         mediaDirectoryName="images"
-        isWriteDisabled={false}
         isOpen={isOpen}
         isLoading={false}
         onClose={onClose}
@@ -73,6 +67,15 @@ const createMediaFolderModalTemplate: StoryFn<
 export const Default = createMediaFolderModalTemplate.bind({})
 Default.args = {
   originalSelectedMedia: [],
+}
+Default.parameters = {
+  msw: {
+    handlers: [
+      ...handlers,
+      buildMediaFolderFilesData(MOCK_MEDIA_ITEM_DATA),
+      buildMediaFileData(MOCK_MEDIA_ITEM_ONE),
+    ],
+  },
 }
 
 export const OneSelected = createMediaFolderModalTemplate.bind({})

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
@@ -58,13 +58,8 @@ const createMediaFolderModalTemplate: StoryFn<
         mediaLabels={getMediaLabels("images")}
         mediaType="images"
         subDirectories={{ directories: [] }}
-        mediaData={[
-          MOCK_MEDIA_ITEM_ONE,
-          MOCK_MEDIA_ITEM_TWO,
-          MOCK_MEDIA_ITEM_THREE,
-          MOCK_MEDIA_ITEM_FOUR,
-          MOCK_MEDIA_ITEM_FIVE,
-        ]}
+        siteName="storybook"
+        mediaDirectoryName="images"
         isWriteDisabled={false}
         isOpen={isOpen}
         isLoading={false}

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.stories.tsx
@@ -56,6 +56,7 @@ const createMediaFolderModalTemplate: StoryFn<
       <CreateMediaFolderModal
         originalSelectedMedia={originalSelectedMedia}
         mediaLabels={getMediaLabels("images")}
+        mediaType="images"
         subDirectories={{ directories: [] }}
         mediaData={[
           MOCK_MEDIA_ITEM_ONE,

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -27,6 +27,7 @@ import _ from "lodash"
 import { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { UseMutateAsyncFunction } from "react-query"
+import { useRouteMatch } from "react-router-dom"
 
 import { DirectorySettingsSchema } from "components/DirectorySettingsModal"
 import { ImagePreviewCard } from "components/ImagePreviewCard"
@@ -40,6 +41,7 @@ import { usePaginate } from "hooks/usePaginate"
 import { FilePreviewCard } from "layouts/Media/components"
 
 import { getSelectedMediaDto } from "utils/media"
+import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { GetMediaSubdirectoriesDto, MediaData } from "types/directory"
 import { MiddlewareError } from "types/error"
@@ -55,9 +57,7 @@ interface CreateMediaFolderModalProps {
   mediaLabels: MediaLabels
   mediaType: MediaFolderTypes
   subDirectories: GetMediaSubdirectoriesDto | undefined
-  siteName: string
   mediaDirectoryName: string
-  isWriteDisabled: boolean | undefined
   isOpen: boolean
   isLoading: boolean
   onClose: () => void
@@ -100,15 +100,18 @@ export const CreateMediaFolderModal = ({
   mediaLabels,
   mediaType,
   subDirectories,
-  siteName,
   mediaDirectoryName,
-  isWriteDisabled,
   isOpen,
   isLoading,
   onClose,
   onProceed,
 }: CreateMediaFolderModalProps): JSX.Element => {
+  const { params } = useRouteMatch<{
+    siteName: string
+  }>()
+  const { siteName } = params
   const [curPage, setCurPage] = usePaginate()
+  const isWriteDisabled = isWriteActionsDisabled(siteName)
   const {
     singularMediaLabel,
     pluralMediaLabel,

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -138,7 +138,7 @@ export const CreateMediaFolderModal = ({
   )
 
   const methods = useForm<MediaFolderCreationInfo>({
-    mode: "onChange",
+    mode: "onTouched",
     resolver: yupResolver(DirectorySettingsSchema(existingTitles)),
     context: {
       type: "mediaDirectoryName",

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -330,7 +330,11 @@ export const CreateMediaFolderModal = ({
                     isDisabled={isWriteDisabled}
                     onClick={methods.handleSubmit((data) => {
                       methods.setValue("selectedPages", [])
-                      onSubmit(data)
+                      const dataWithoutSelectedPages = {
+                        ...data,
+                        selectedPages: [],
+                      }
+                      onSubmit(dataWithoutSelectedPages)
                     })}
                   >
                     Skip, I’ll add {pluralMediaLabel} later

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -250,7 +250,7 @@ export const CreateMediaFolderModal = ({
                     isLoaded={!isListMediaFilesLoading}
                   >
                     {files.length > 0 && (
-                      <Box w="100%" h="25.25rem" overflow="scroll">
+                      <Box w="100%" h="25.25rem" overflow="scroll" p="2px">
                         <SimpleGrid columns={3} spacing="1.5rem" w="100%">
                           {files.map(({ data }) => {
                             return data && mediaType === "images" ? (

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -174,7 +174,7 @@ export const CreateMediaFolderModal = ({
 
   useEffect(() => {
     methods.setValue("selectedPages", originalSelectedMedia)
-  }, [originalSelectedMedia])
+  }, [methods, originalSelectedMedia])
 
   const onModalClose = () => {
     methods.reset()

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -1,0 +1,303 @@
+import {
+  Box,
+  FormControl,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  SimpleGrid,
+  Text,
+} from "@chakra-ui/react"
+import { yupResolver } from "@hookform/resolvers/yup"
+import {
+  Button,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  ModalCloseButton,
+} from "@opengovsg/design-system-react"
+import { AxiosError } from "axios"
+import _ from "lodash"
+import { useEffect } from "react"
+import { FormProvider, useForm } from "react-hook-form"
+import { UseMutateAsyncFunction } from "react-query"
+
+import { DirectorySettingsSchema } from "components/DirectorySettingsModal"
+import { ImagePreviewCard } from "components/ImagePreviewCard"
+
+import { getSelectedMediaDto } from "utils/media"
+
+import { GetMediaSubdirectoriesDto, MediaData } from "types/directory"
+import { MiddlewareError } from "types/error"
+import {
+  MediaFolderCreationInfo,
+  MediaLabels,
+  SelectedMediaDto,
+} from "types/media"
+
+interface CreateMediaFolderModalProps {
+  originalSelectedMedia: SelectedMediaDto[]
+  mediaLabels: MediaLabels
+  subDirectories: GetMediaSubdirectoriesDto | undefined
+  mediaData: (MediaData | undefined)[]
+  isWriteDisabled: boolean | undefined
+  isOpen: boolean
+  isLoading: boolean
+  onClose: () => void
+  onProceed: UseMutateAsyncFunction<
+    void,
+    AxiosError<MiddlewareError>,
+    MediaFolderCreationInfo,
+    unknown
+  >
+}
+
+const getButtonLabel = (
+  originalSelectedMedia: SelectedMediaDto[],
+  selectedMedia: SelectedMediaDto[],
+  mediaLabels: MediaLabels
+) => {
+  const {
+    singularDirectoryLabel,
+    singularMediaLabel,
+    pluralMediaLabel,
+  } = mediaLabels
+
+  if (originalSelectedMedia.length > 0) {
+    return `Create ${singularDirectoryLabel}`
+  }
+
+  if (selectedMedia.length > 1) {
+    return `Add ${selectedMedia.length} ${pluralMediaLabel} to ${singularDirectoryLabel}`
+  }
+
+  if (selectedMedia.length === 1) {
+    return `Add ${singularMediaLabel} to ${singularDirectoryLabel}`
+  }
+
+  return `Add ${pluralMediaLabel} to ${singularDirectoryLabel}`
+}
+
+export const CreateMediaFolderModal = ({
+  originalSelectedMedia,
+  mediaLabels,
+  subDirectories,
+  mediaData,
+  isWriteDisabled,
+  isOpen,
+  isLoading,
+  onClose,
+  onProceed,
+}: CreateMediaFolderModalProps): JSX.Element => {
+  const {
+    singularMediaLabel,
+    pluralMediaLabel,
+    singularDirectoryLabel,
+    pluralDirectoryLabel,
+  } = mediaLabels
+
+  const existingTitles = subDirectories?.directories.map(
+    (directory) => directory.name
+  )
+
+  const methods = useForm<MediaFolderCreationInfo>({
+    mode: "onChange",
+    resolver: yupResolver(DirectorySettingsSchema(existingTitles)),
+    context: {
+      type: "mediaDirectoryName",
+    },
+    defaultValues: {
+      newDirectoryName: "",
+      selectedPages: originalSelectedMedia,
+    },
+  })
+
+  const handleSelect = (fileData: MediaData) => {
+    if (
+      methods
+        .getValues("selectedPages")
+        .some((selectedData) => selectedData.filePath === fileData.mediaPath)
+    ) {
+      methods.setValue(
+        "selectedPages",
+        methods
+          .getValues("selectedPages")
+          .filter(
+            (selectedData) => selectedData.filePath !== fileData.mediaPath
+          )
+      )
+    } else {
+      const selectedData = getSelectedMediaDto(fileData)
+      methods.setValue("selectedPages", [
+        ...methods.getValues("selectedPages"),
+        selectedData,
+      ])
+    }
+  }
+
+  useEffect(() => {
+    methods.setValue("selectedPages", originalSelectedMedia)
+  }, [originalSelectedMedia])
+
+  const onModalClose = () => {
+    methods.reset()
+    onClose()
+  }
+
+  const onSubmit = async (data: MediaFolderCreationInfo) => {
+    await onProceed(data)
+    methods.reset()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onModalClose} size="5xl">
+      <ModalOverlay />
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
+          <ModalContent my="4rem">
+            <ModalCloseButton />
+
+            <ModalHeader pt="2rem" pb={0} px="2rem">
+              Create a new {singularDirectoryLabel}
+              {originalSelectedMedia.length > 0
+                ? ` with ${originalSelectedMedia.length} ${
+                    originalSelectedMedia.length === 1
+                      ? singularMediaLabel
+                      : pluralMediaLabel
+                  }`
+                : ""}
+            </ModalHeader>
+
+            <ModalBody px="2rem" pt="1rem" pb={0}>
+              {originalSelectedMedia.length === 0 && (
+                <Text as="p" textStyle="subhead-2">
+                  Use {pluralDirectoryLabel} to organise your {pluralMediaLabel}
+                  . You can always add {pluralMediaLabel} to your{" "}
+                  {singularDirectoryLabel} later.
+                </Text>
+              )}
+
+              <FormControl
+                isRequired
+                isInvalid={!!methods.formState.errors.newDirectoryName}
+                mt={originalSelectedMedia.length === 0 ? "1.5rem" : "1rem"}
+              >
+                <FormLabel>
+                  {_.upperFirst(singularDirectoryLabel)} name
+                </FormLabel>
+                <Input
+                  type="text"
+                  placeholder={`Give a name for your ${singularDirectoryLabel}`}
+                  {...methods.register("newDirectoryName", { required: true })}
+                />
+                <FormErrorMessage>
+                  {methods.formState.errors.newDirectoryName?.message}
+                </FormErrorMessage>
+              </FormControl>
+
+              {originalSelectedMedia.length === 0 && (
+                <>
+                  <Text as="p" textStyle="subhead-1" mt="2rem">
+                    Add {pluralMediaLabel} to this {singularDirectoryLabel}
+                  </Text>
+
+                  {mediaData.length > 0 && (
+                    <Box
+                      w="100%"
+                      h="25.25rem"
+                      overflow="scroll"
+                      px="2px"
+                      py="1rem"
+                    >
+                      <SimpleGrid columns={3} spacing="1.5rem" w="100%">
+                        {mediaData.map(
+                          (data) =>
+                            data && (
+                              <ImagePreviewCard
+                                key={data.name}
+                                name={data.name}
+                                addedTime={data.addedTime}
+                                mediaUrl={data.mediaUrl}
+                                imageHeight="10.5rem"
+                                isSelected={methods
+                                  .watch("selectedPages")
+                                  .some(
+                                    (selectedData) =>
+                                      selectedData.filePath === data.mediaPath
+                                  )}
+                                isMenuNeeded={false}
+                                onClick={() => handleSelect(data)}
+                                onCheck={() => handleSelect(data)}
+                              />
+                            )
+                        )}
+                      </SimpleGrid>
+                    </Box>
+                  )}
+                </>
+              )}
+            </ModalBody>
+
+            <ModalFooter mt={0} px="2rem" pt="0.5rem" pb="1.5rem">
+              <HStack
+                w="100%"
+                spacing={4}
+                justifyContent="flex-end"
+                mt="0.5rem"
+              >
+                {originalSelectedMedia.length > 0 && (
+                  <Button
+                    variant="clear"
+                    colorScheme="neutral"
+                    onClick={onModalClose}
+                  >
+                    Cancel
+                  </Button>
+                )}
+                {originalSelectedMedia.length === 0 && (
+                  <Button
+                    variant="clear"
+                    colorScheme="neutral"
+                    isLoading={
+                      isLoading && methods.watch("selectedPages").length === 0
+                    }
+                    isDisabled={isWriteDisabled}
+                    onClick={methods.handleSubmit((data) => {
+                      methods.setValue("selectedPages", [])
+                      onSubmit(data)
+                    })}
+                  >
+                    Skip, I&apos;ll add {pluralMediaLabel} later
+                  </Button>
+                )}
+                <Button
+                  type="submit"
+                  colorScheme="main"
+                  isLoading={
+                    isLoading && methods.watch("selectedPages").length > 0
+                  }
+                  isDisabled={
+                    isWriteDisabled ||
+                    !methods.formState.isDirty ||
+                    _.some(methods.formState.errors) ||
+                    (originalSelectedMedia.length === 0 &&
+                      methods.watch("selectedPages").length === 0)
+                  }
+                >
+                  {getButtonLabel(
+                    originalSelectedMedia,
+                    methods.getValues("selectedPages"),
+                    mediaLabels
+                  )}
+                </Button>
+              </HStack>
+            </ModalFooter>
+          </ModalContent>
+        </form>
+      </FormProvider>
+    </Modal>
+  )
+}

--- a/src/components/CreateMediaFolderModal/index.ts
+++ b/src/components/CreateMediaFolderModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./CreateMediaFolderModal"

--- a/src/components/DeleteMediaModal/DeleteMediaModal.tsx
+++ b/src/components/DeleteMediaModal/DeleteMediaModal.tsx
@@ -64,7 +64,7 @@ export const DeleteMediaModal = ({
         {selectedMedia.length === 1 && (
           <>
             <ModalHeader>
-              <Text as="h4" textStyle="h4">
+              <Text as="h4" textStyle="h4" mr="2.5rem">
                 Delete {selectedMedia[0].filePath.split("/").pop()}?
               </Text>
             </ModalHeader>

--- a/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsSchema.jsx
@@ -78,4 +78,5 @@ export const DirectorySettingsSchema = (existingTitlesArray = []) =>
           () => false
         )
       }),
+    selectedPages: Yup.array().ensure(),
   })

--- a/src/components/ImagePreviewCard/ImagePreviewCard.tsx
+++ b/src/components/ImagePreviewCard/ImagePreviewCard.tsx
@@ -11,7 +11,7 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Checkbox } from "@opengovsg/design-system-react"
-import { BiEditAlt, BiTrash } from "react-icons/bi"
+import { BiEditAlt, BiFolder, BiTrash } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
 
 import { ContextMenu } from "components/ContextMenu"
@@ -33,6 +33,7 @@ export interface ImagePreviewCardProps {
   onClick?: () => void
   onCheck?: () => void
   onDelete?: () => void
+  onMove?: () => void
 }
 
 // Note: This is written as a separate component as the current Card API is not
@@ -48,6 +49,7 @@ export const ImagePreviewCard = ({
   onClick,
   onCheck,
   onDelete,
+  onMove,
 }: ImagePreviewCardProps): JSX.Element => {
   const { url } = useRouteMatch()
   const { setRedirectToPage } = useRedirectHook()
@@ -184,6 +186,9 @@ export const ImagePreviewCard = ({
               to={`${url}/editMediaSettings/${encodedName}`}
             >
               <Text>Rename image</Text>
+            </ContextMenu.Item>
+            <ContextMenu.Item icon={<BiFolder />} onClick={onMove}>
+              <Text>Move to</Text>
             </ContextMenu.Item>
             <ContextMenu.Item
               icon={<BiTrash />}

--- a/src/components/ImagePreviewCard/ImagePreviewCard.tsx
+++ b/src/components/ImagePreviewCard/ImagePreviewCard.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   GridItem,
   Image,
+  ImageProps,
   Text,
   useMultiStyleConfig,
   VStack,
@@ -25,9 +26,11 @@ export interface ImagePreviewCardProps {
   name: string
   addedTime: number
   mediaUrl: string
+  imageHeight?: ImageProps["height"]
   isSelected: boolean
   isMenuNeeded?: boolean
   onOpen?: () => void
+  onClick?: () => void
   onCheck?: () => void
   onDelete?: () => void
 }
@@ -38,9 +41,11 @@ export const ImagePreviewCard = ({
   name,
   addedTime,
   mediaUrl,
+  imageHeight = "15rem",
   isSelected,
   isMenuNeeded = true,
   onOpen,
+  onClick,
   onCheck,
   onDelete,
 }: ImagePreviewCardProps): JSX.Element => {
@@ -91,9 +96,18 @@ export const ImagePreviewCard = ({
         // Note: Outline is required to avoid the card from shifting when selected
         outline={isSelected ? "solid 2px" : "solid 1px"}
         outlineColor={isSelected ? "base.divider.brand" : "base.divider.medium"}
-        onClick={() =>
-          setRedirectToPage(`${url}/editMediaSettings/${encodedName}`)
-        }
+        onClick={(e) => {
+          // For some weird reason, the onClick event is treated as a submit event
+          // We can safely disable the default behaviour here since we define the
+          // onClick behaviour ourselves
+          e.preventDefault()
+
+          if (onClick) {
+            onClick()
+          } else {
+            setRedirectToPage(`${url}/editMediaSettings/${encodedName}`)
+          }
+        }}
       >
         <GridItem gridArea="image">
           <Box position="relative" backgroundColor="base.canvas.overlay">
@@ -113,7 +127,7 @@ export const ImagePreviewCard = ({
             <Center>
               <Image
                 align="center"
-                height="15rem"
+                height={imageHeight}
                 src={mediaUrl}
                 fallbackSrc="/placeholder_no_image.png"
                 pointerEvents="all"

--- a/src/components/MediaCreationModal/MediaCreationModal.tsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.tsx
@@ -17,6 +17,7 @@ import {
   Flex,
 } from "@chakra-ui/react"
 import { Button, Infobox } from "@opengovsg/design-system-react"
+import _ from "lodash"
 import { useEffect, useState } from "react"
 import { FileRejection } from "react-dropzone"
 import { BiCheckCircle, BiSolidErrorCircle } from "react-icons/bi"
@@ -25,6 +26,8 @@ import { useParams } from "react-router-dom"
 import { Attachment } from "components/Attachment"
 
 import { useCreateMultipleMedia } from "hooks/mediaHooks/useCreateMultipleMedia"
+
+import { getMediaLabels } from "utils/media"
 
 import { MediaDirectoryParams } from "types/folders"
 import { MediaFolderTypes } from "types/media"
@@ -67,15 +70,16 @@ const MediaDropzone = ({
   mediaType,
 }: MediaDropzoneProps) => {
   const { onClose } = useModalContext()
+  const { singularMediaLabel, pluralMediaLabel } = getMediaLabels(mediaType)
 
   return (
     <>
-      <ModalHeader>Upload files</ModalHeader>
+      <ModalHeader>Upload {pluralMediaLabel}</ModalHeader>
       <ModalBody>
         <Text textStyle="body-1" mb="1.5rem">
-          You can upload more than 1 file at once. Having too many files can
-          slow down the site loading time, so we recommend only uploading
-          necessary files to your site.
+          You can upload more than 1 {singularMediaLabel} at once. Having too
+          many {pluralMediaLabel} can slow down the site loading time, so we
+          recommend only uploading necessary {pluralMediaLabel} to your site.
         </Text>
         <Attachment
           rejected={fileRejections}
@@ -98,12 +102,11 @@ const MediaDropzone = ({
         <Button variant="clear" mr={3} onClick={onClose}>
           Cancel
         </Button>
-        <Button
-          isDisabled={isDisabled}
-          onClick={() => onUpload(uploadedFiles)}
-        >{`Upload ${uploadedFiles.length} ${
-          uploadedFiles.length > 1 ? "files" : "file"
-        }`}</Button>
+        <Button isDisabled={isDisabled} onClick={() => onUpload(uploadedFiles)}>
+          {`Upload ${uploadedFiles.length} ${
+            uploadedFiles.length === 1 ? singularMediaLabel : pluralMediaLabel
+          }`}
+        </Button>
       </ModalFooter>
     </>
   )
@@ -112,17 +115,20 @@ const MediaDropzone = ({
 interface UploadProgressIndicatorProps {
   cur: number
   total: number
+  mediaType: MediaFolderTypes
 }
 
 const UploadProgressIndicator = ({
   cur,
   total,
+  mediaType,
 }: UploadProgressIndicatorProps) => {
   const { onClose } = useModalContext()
+  const { pluralMediaLabel } = getMediaLabels(mediaType)
 
   return (
     <>
-      <ModalHeader>Upload files</ModalHeader>
+      <ModalHeader>Upload {pluralMediaLabel}</ModalHeader>
       <ModalBody>
         <Dropzone>
           <Progress
@@ -133,7 +139,7 @@ const UploadProgressIndicator = ({
           <Text
             textStyle="subhead-1"
             mt="1.25rem"
-          >{`Uploading ${cur} of ${total} files`}</Text>
+          >{`Uploading ${cur} of ${total} ${pluralMediaLabel}`}</Text>
           <Text textStyle="caption-1">
             Do not close this screen or navigate away
           </Text>
@@ -152,16 +158,26 @@ const UploadProgressIndicator = ({
 interface MediaUploadSuccessDropzoneProps {
   numMedia: number
   errorMessages: string[]
+  mediaType: MediaFolderTypes
 }
 const MediaUploadSuccessDropzone = ({
   numMedia,
   errorMessages,
+  mediaType,
 }: MediaUploadSuccessDropzoneProps) => {
   const { onClose } = useModalContext()
+  const {
+    singularMediaLabel,
+    pluralMediaLabel,
+    singularDirectoryLabel,
+  } = getMediaLabels(mediaType)
 
   return (
     <>
-      <ModalHeader>Files uploaded!</ModalHeader>
+      <ModalHeader>
+        {_.upperFirst(numMedia === 1 ? singularMediaLabel : pluralMediaLabel)}{" "}
+        uploaded!
+      </ModalHeader>
       <ModalBody>
         <Dropzone>
           <Icon
@@ -169,10 +185,11 @@ const MediaUploadSuccessDropzone = ({
             as={BiCheckCircle}
             fill="utility.feedback.success"
           />
-          <Text
-            textStyle="subhead-1"
-            mt="1.25rem"
-          >{`Successfully uploaded ${numMedia} files`}</Text>
+          <Text textStyle="subhead-1" mt="1.25rem">
+            {`Successfully uploaded ${numMedia} ${
+              numMedia === 1 ? singularMediaLabel : pluralMediaLabel
+            }`}
+          </Text>
         </Dropzone>
         {errorMessages.length > 0 && (
           <>
@@ -187,7 +204,7 @@ const MediaUploadSuccessDropzone = ({
                 mr="0.5rem"
               />
               <Text textColor="utility.feedback.critical">
-                {`${errorMessages.length} files failed to upload`}
+                {`${errorMessages.length} ${pluralMediaLabel} failed to upload`}
               </Text>
             </Flex>
             <UnorderedList>
@@ -203,7 +220,7 @@ const MediaUploadSuccessDropzone = ({
         )}
       </ModalBody>
       <ModalFooter>
-        <Button onClick={onClose}>Return to album</Button>
+        <Button onClick={onClose}>Return to {singularDirectoryLabel}</Button>
       </ModalFooter>
     </>
   )
@@ -211,11 +228,18 @@ const MediaUploadSuccessDropzone = ({
 
 interface MediaUploadFailedDropzoneProps {
   errorMessages: string[]
+  mediaType: MediaFolderTypes
 }
 const MediaUploadFailedDropzone = ({
   errorMessages,
+  mediaType,
 }: MediaUploadFailedDropzoneProps) => {
   const { onClose } = useModalContext()
+  const {
+    singularMediaLabel,
+    pluralMediaLabel,
+    singularDirectoryLabel,
+  } = getMediaLabels(mediaType)
 
   return (
     <>
@@ -225,7 +249,9 @@ const MediaUploadFailedDropzone = ({
           <VStack alignItems="flex-start" maxW="100%">
             <Text textStyle="body-1">
               {`${errorMessages.length} ${
-                errorMessages.length > 1 ? "files" : "file"
+                errorMessages.length === 1
+                  ? singularMediaLabel
+                  : pluralMediaLabel
               } failed to upload`}
             </Text>
             <UnorderedList maxW="100%">
@@ -247,7 +273,7 @@ const MediaUploadFailedDropzone = ({
         </Infobox>
       </ModalBody>
       <ModalFooter>
-        <Button onClick={onClose}>Return to album</Button>
+        <Button onClick={onClose}>Return to {singularDirectoryLabel}</Button>
       </ModalFooter>
     </>
   )
@@ -334,16 +360,21 @@ export const MediaCreationModal = ({
           <UploadProgressIndicator
             cur={numCreated + numFailed}
             total={uploadedFiles.length}
+            mediaType={variant}
           />
         )}
         {curStep === "success" && (
           <MediaUploadSuccessDropzone
             numMedia={numCreated}
             errorMessages={errorMessages}
+            mediaType={variant}
           />
         )}
         {curStep === "failed" && (
-          <MediaUploadFailedDropzone errorMessages={errorMessages} />
+          <MediaUploadFailedDropzone
+            errorMessages={errorMessages}
+            mediaType={variant}
+          />
         )}
       </ModalContent>
     </Modal>

--- a/src/components/MoveMediaModal/MoveMediaModal.tsx
+++ b/src/components/MoveMediaModal/MoveMediaModal.tsx
@@ -118,7 +118,7 @@ export const MoveMediaModal = ({
         <ModalCloseButton />
 
         <ModalHeader>
-          <Text as="h4" textStyle="h4">
+          <Text as="h4" textStyle="h4" mr="2.5rem">
             Move{" "}
             {selectedMedia.length === 1
               ? getLastChildOfPath(selectedMedia[0].filePath)

--- a/src/hooks/directoryHooks/useCreateDirectoryAndMoveFilesHook.ts
+++ b/src/hooks/directoryHooks/useCreateDirectoryAndMoveFilesHook.ts
@@ -1,0 +1,101 @@
+import { AxiosError } from "axios"
+import {
+  useMutation,
+  UseMutationOptions,
+  UseMutationResult,
+  useQueryClient,
+} from "react-query"
+
+import {
+  LIST_MEDIA_DIRECTORY_FILES_KEY,
+  GET_ALL_MEDIA_FILES_KEY,
+  LIST_MEDIA_FOLDERS_KEY,
+} from "constants/queryKeys"
+
+import { moveMultipleMedia } from "hooks/moveHooks"
+
+import { apiService } from "services/ApiService"
+
+import { DirectoryService } from "services"
+import { MiddlewareError } from "types/error"
+import { MediaDirectoryParams } from "types/folders"
+import { MediaFolderCreationInfo } from "types/media"
+
+const createDirectoryAndMoveFiles = async (
+  params: MediaDirectoryParams,
+  { newDirectoryName, selectedPages }: MediaFolderCreationInfo
+) => {
+  const directoryService = new DirectoryService({ apiClient: apiService })
+  const { siteName, mediaDirectoryName } = params
+
+  const newDirectoryPath = [
+    decodeURIComponent(mediaDirectoryName),
+    newDirectoryName,
+  ].join("/")
+
+  if (selectedPages.length === 0) {
+    return directoryService.create(
+      { siteName, mediaDirectoryName, isCreate: true },
+      { newDirectoryName: newDirectoryPath, items: [] }
+    )
+  }
+
+  return (
+    directoryService
+      .create(
+        { siteName, mediaDirectoryName, isCreate: true },
+        { newDirectoryName: newDirectoryPath, items: [] }
+      )
+      // This wait is necessary to avoid the repo lock
+      .then(() => new Promise((resolve) => setTimeout(resolve, 500)))
+      .then(() => {
+        moveMultipleMedia(params, {
+          target: { directoryName: newDirectoryPath },
+          items: selectedPages,
+        })
+      })
+      // This wait is necessary to allow the backend to catch up
+      .then(() => new Promise((resolve) => setTimeout(resolve, 500)))
+  )
+}
+
+export const useCreateDirectoryAndMoveFilesHook = (
+  params: MediaDirectoryParams,
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      void,
+      AxiosError<MiddlewareError>,
+      MediaFolderCreationInfo
+    >,
+    "mutationFn" | "mutationKey"
+  >
+): UseMutationResult<
+  void,
+  AxiosError<MiddlewareError>,
+  MediaFolderCreationInfo
+> => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    void,
+    AxiosError<MiddlewareError>,
+    MediaFolderCreationInfo
+  >((data) => createDirectoryAndMoveFiles(params, data), {
+    ...mutationOptions,
+    onSettled: (data, error, variables, context) => {
+      queryClient.invalidateQueries([LIST_MEDIA_DIRECTORY_FILES_KEY])
+      queryClient.invalidateQueries([GET_ALL_MEDIA_FILES_KEY])
+      queryClient.invalidateQueries([LIST_MEDIA_FOLDERS_KEY])
+      if (mutationOptions?.onSettled)
+        mutationOptions.onSettled(data, error, variables, context)
+    },
+    onSuccess: (data, variables, context) => {
+      if (mutationOptions?.onSuccess)
+        mutationOptions.onSuccess(data, variables, context)
+    },
+    onError: (err, variables, context) => {
+      if (mutationOptions?.onError)
+        mutationOptions.onError(err, variables, context)
+    },
+  })
+}

--- a/src/hooks/moveHooks/useMoveMultipleMediaHook.tsx
+++ b/src/hooks/moveHooks/useMoveMultipleMediaHook.tsx
@@ -19,7 +19,7 @@ import { MiddlewareError } from "types/error"
 import { MediaDirectoryParams } from "types/folders"
 import { MoveMultipleMediaDto, MoveSelectedMediaDto } from "types/media"
 
-const moveMultipleMedia = async (
+export const moveMultipleMedia = async (
   { siteName }: MediaDirectoryParams,
   { target, items }: MoveSelectedMediaDto
 ) => {

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -359,9 +359,7 @@ export const Media = (): JSX.Element => {
         mediaLabels={getMediaLabels(mediaType)}
         mediaType={mediaType}
         subDirectories={mediaFolderSubdirectories}
-        siteName={siteName}
         mediaDirectoryName={mediaDirectoryName}
-        isWriteDisabled={isWriteDisabled}
         isOpen={isCreateMediaFolderModalOpen}
         isLoading={isCreateDirectoryAndMoveFilesLoading}
         onClose={onCreateMediaFolderModalClose}

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -359,7 +359,8 @@ export const Media = (): JSX.Element => {
         mediaLabels={getMediaLabels(mediaType)}
         mediaType={mediaType}
         subDirectories={mediaFolderSubdirectories}
-        mediaData={files.map(({ data }) => data) || []}
+        siteName={siteName}
+        mediaDirectoryName={mediaDirectoryName}
         isWriteDisabled={isWriteDisabled}
         isOpen={isCreateMediaFolderModalOpen}
         isLoading={isCreateDirectoryAndMoveFilesLoading}

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -19,9 +19,10 @@ import {
 } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { useEffect, useState } from "react"
-import { BiFolderOpen, BiTrash } from "react-icons/bi"
+import { BiFolderOpen, BiFolderPlus, BiTrash } from "react-icons/bi"
 import { Link, Switch, useHistory, useRouteMatch } from "react-router-dom"
 
+import { CreateMediaFolderModal } from "components/CreateMediaFolderModal"
 import { DeleteMediaModal } from "components/DeleteMediaModal"
 import { Greyscale } from "components/Greyscale"
 import { ImagePreviewCard } from "components/ImagePreviewCard"
@@ -29,12 +30,14 @@ import { MoveMediaModal } from "components/MoveMediaModal"
 
 import { MAX_MEDIA_LEVELS, MEDIA_PAGINATION_SIZE } from "constants/media"
 
+import { useCreateDirectoryAndMoveFilesHook } from "hooks/directoryHooks/useCreateDirectoryAndMoveFilesHook"
 import { useGetAllMediaFiles } from "hooks/directoryHooks/useGetAllMediaFiles"
 import { useListMediaFolderFiles } from "hooks/directoryHooks/useListMediaFolderFiles"
 import { useListMediaFolderSubdirectories } from "hooks/directoryHooks/useListMediaFolderSubdirectories"
 import { useDeleteMultipleMediaHook } from "hooks/mediaHooks"
 import { useMoveMultipleMediaHook } from "hooks/moveHooks"
 import { usePaginate } from "hooks/usePaginate"
+import useRedirectHook from "hooks/useRedirectHook"
 
 import { DeleteWarningScreen } from "layouts/screens/DeleteWarningScreen"
 import { DirectoryCreationScreen } from "layouts/screens/DirectoryCreationScreen"
@@ -65,7 +68,7 @@ interface CreateDirectoryButtonProps {
   isWriteDisabled: boolean | undefined
   directoryLevel: number
   singularDirectoryLabel: string
-  url: string
+  onOpen: () => void
 }
 
 // Utility method for getting the text under the page title in the header
@@ -119,12 +122,11 @@ const CreateDirectoryButton = ({
   isWriteDisabled,
   directoryLevel,
   singularDirectoryLabel,
-  url,
+  onOpen,
 }: CreateDirectoryButtonProps) => (
   <Greyscale isActive={isWriteDisabled}>
     <CreateButton
-      as={Link}
-      to={directoryLevel < MAX_MEDIA_LEVELS ? `${url}/createDirectory` : "#"}
+      onClick={onOpen}
       isDisabled={directoryLevel >= MAX_MEDIA_LEVELS}
     >
       {`Create ${singularDirectoryLabel}`}
@@ -140,6 +142,7 @@ export const Media = (): JSX.Element => {
     mediaRoom: MediaFolderTypes
     mediaDirectoryName: string
   }>()
+  const { setRedirectToPage } = useRedirectHook()
   const { siteName, mediaRoom: mediaType, mediaDirectoryName } = params
   const [selectedMedia, setSelectedMedia] = useState<SelectedMediaDto[]>([])
   // Note: We need a separate variable here so that we do not lose the selection
@@ -149,6 +152,12 @@ export const Media = (): JSX.Element => {
     individualMedia,
     setIndividualMedia,
   ] = useState<SelectedMediaDto | null>(null)
+
+  const {
+    isOpen: isCreateMediaFolderModalOpen,
+    onOpen: onCreateMediaFolderModalOpen,
+    onClose: onCreateMediaFolderModalClose,
+  } = useDisclosure()
 
   const {
     isOpen: isMoveModalOpen,
@@ -238,6 +247,43 @@ export const Media = (): JSX.Element => {
   )
 
   const {
+    mutateAsync: createDirectoryAndMoveFiles,
+    isLoading: isCreateDirectoryAndMoveFilesLoading,
+  } = useCreateDirectoryAndMoveFilesHook(params, {
+    onSettled: () => {
+      setSelectedMedia([])
+      onCreateMediaFolderModalClose()
+    },
+    onSuccess: (data, variables, context) => {
+      if (variables.selectedPages.length === 0) {
+        successToast({
+          id: "create-directory-success",
+          description: `Successfully created ${singularDirectoryLabel}!`,
+        })
+      } else {
+        successToast({
+          id: "create-directory-and-move-files-success",
+          description: `Successfully created ${singularDirectoryLabel} and moved ${
+            variables.selectedPages.length === 1
+              ? singularMediaLabel
+              : pluralMediaLabel
+          }!`,
+        })
+      }
+
+      setRedirectToPage(
+        `${url}%2F${encodeURIComponent(variables.newDirectoryName)}`
+      )
+    },
+    onError: (err, variables, context) => {
+      errorToast({
+        id: "create-directory-error",
+        description: `Your ${singularDirectoryLabel} could not be created successfully. ${DEFAULT_RETRY_MSG}`,
+      })
+    },
+  })
+
+  const {
     mutate: moveMultipleMedia,
     isLoading: isMoveMultipleMediaLoading,
   } = useMoveMultipleMediaHook(params, {
@@ -308,6 +354,18 @@ export const Media = (): JSX.Element => {
 
   return (
     <>
+      <CreateMediaFolderModal
+        originalSelectedMedia={selectedMedia}
+        mediaLabels={getMediaLabels(mediaType)}
+        subDirectories={mediaFolderSubdirectories}
+        mediaData={files.map(({ data }) => data) || []}
+        isWriteDisabled={isWriteDisabled}
+        isOpen={isCreateMediaFolderModalOpen}
+        isLoading={isCreateDirectoryAndMoveFilesLoading}
+        onClose={onCreateMediaFolderModalClose}
+        onProceed={createDirectoryAndMoveFiles}
+      />
+
       <MoveMediaModal
         selectedMedia={(individualMedia && [individualMedia]) || selectedMedia}
         mediaType={mediaType}
@@ -411,15 +469,20 @@ export const Media = (): JSX.Element => {
                         <Icon as={BiFolderOpen} mr="1rem" fontSize="1.25rem" />
                         Move images to album
                       </Menu.Item>
-                      {/* FIXME: To add back when flow is available
-                          <Menu.Item>
-                            <Icon
-                              as={BiFolderPlus}
-                              mr="1rem"
-                              fontSize="1.25rem"
-                            />
-                            Create new album with images
-                          </Menu.Item> */}
+
+                      {directoryLevel < MAX_MEDIA_LEVELS && (
+                        <Menu.Item
+                          onClick={() => onCreateMediaFolderModalOpen()}
+                        >
+                          <Icon
+                            as={BiFolderPlus}
+                            mr="1rem"
+                            fontSize="1.25rem"
+                          />
+                          Create new album with images
+                        </Menu.Item>
+                      )}
+
                       <Menu.Item
                         color="interaction.critical.default"
                         onClick={() => onDeleteModalOpen()}
@@ -449,7 +512,7 @@ export const Media = (): JSX.Element => {
                           isWriteDisabled={isWriteDisabled}
                           directoryLevel={directoryLevel}
                           singularDirectoryLabel={singularDirectoryLabel}
-                          url={url}
+                          onOpen={onCreateMediaFolderModalOpen}
                         />
                       </Tooltip>
                     ) : (
@@ -457,7 +520,7 @@ export const Media = (): JSX.Element => {
                         isWriteDisabled={isWriteDisabled}
                         directoryLevel={directoryLevel}
                         singularDirectoryLabel={singularDirectoryLabel}
-                        url={url}
+                        onOpen={onCreateMediaFolderModalOpen}
                       />
                     )}
                   </Box>
@@ -613,11 +676,6 @@ export const Media = (): JSX.Element => {
         <ProtectedRouteWithProps
           path={[`${path}/editMediaSettings/:fileName`]}
           component={MediaSettingsScreen}
-          onClose={() => history.goBack()}
-        />
-        <ProtectedRouteWithProps
-          path={[`${path}/createDirectory`]}
-          component={DirectoryCreationScreen}
           onClose={() => history.goBack()}
         />
         <ProtectedRouteWithProps

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -357,6 +357,7 @@ export const Media = (): JSX.Element => {
       <CreateMediaFolderModal
         originalSelectedMedia={selectedMedia}
         mediaLabels={getMediaLabels(mediaType)}
+        mediaType={mediaType}
         subDirectories={mediaFolderSubdirectories}
         mediaData={files.map(({ data }) => data) || []}
         isWriteDisabled={isWriteDisabled}
@@ -467,7 +468,11 @@ export const Media = (): JSX.Element => {
                     <Menu.List>
                       <Menu.Item onClick={() => onMoveModalOpen()}>
                         <Icon as={BiFolderOpen} mr="1rem" fontSize="1.25rem" />
-                        Move images to album
+                        Move{" "}
+                        {selectedMedia.length === 1
+                          ? singularMediaLabel
+                          : pluralMediaLabel}{" "}
+                        to {singularDirectoryLabel}
                       </Menu.Item>
 
                       {directoryLevel < MAX_MEDIA_LEVELS && (
@@ -479,7 +484,10 @@ export const Media = (): JSX.Element => {
                             mr="1rem"
                             fontSize="1.25rem"
                           />
-                          Create new album with images
+                          Create new {singularDirectoryLabel} with{" "}
+                          {selectedMedia.length === 1
+                            ? singularMediaLabel
+                            : pluralMediaLabel}
                         </Menu.Item>
                       )}
 
@@ -633,14 +641,20 @@ export const Media = (): JSX.Element => {
                             }
                             onCheck={() => handleSelect(data)}
                             onDelete={onDeleteModalOpen}
+                            onMove={onMoveModalOpen}
                           />
                         ) : (
                           data && (
                             <FilePreviewCard
                               name={data.name}
+                              isSelected={selectedMedia.some(
+                                (selectedData) =>
+                                  selectedData.filePath === data.mediaPath
+                              )}
                               onOpen={() =>
                                 setIndividualMedia(getSelectedMediaDto(data))
                               }
+                              onCheck={() => handleSelect(data)}
                               onDelete={onDeleteModalOpen}
                               onMove={onMoveModalOpen}
                             />

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -44,7 +44,7 @@ import { MediaSettingsScreen } from "layouts/screens/MediaSettingsScreen"
 
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 
-import { getMediaLabels } from "utils/media"
+import { getMediaLabels, getSelectedMediaDto } from "utils/media"
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { EmptyAlbumImage, EmptyDirectoryImage } from "assets"
@@ -113,17 +113,6 @@ const getPlaceholderText = (
   results.push("you add will appear here.")
 
   return results.join(" ")
-}
-
-// Utility method to construct a SelectedMediaDto from MediaData
-const getSelectedMediaDto = (fileData: MediaData) => {
-  const selectedData: SelectedMediaDto = {
-    filePath: fileData.mediaPath,
-    sha: fileData.sha,
-    size: fileData.size || 0,
-  }
-
-  return selectedData
 }
 
 const CreateDirectoryButton = ({

--- a/src/layouts/Media/components/FilePreviewCard.tsx
+++ b/src/layouts/Media/components/FilePreviewCard.tsx
@@ -1,81 +1,138 @@
-import {
-  LinkBox,
-  LinkOverlay,
-  Icon,
-  Text,
-  Divider,
-  HStack,
-  Box,
-} from "@chakra-ui/react"
+import { Box, Divider, HStack, Icon, Text } from "@chakra-ui/react"
+import { Checkbox } from "@opengovsg/design-system-react"
 import { BiChevronRight, BiEditAlt, BiFolder, BiTrash } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
 
 import { Card, CardBody } from "components/Card"
 import { ContextMenu } from "components/ContextMenu"
 
+import useRedirectHook from "hooks/useRedirectHook"
+
 import { BxFileArchiveSolid } from "assets"
 
 interface FilePreviewCardProps {
   name: string
+  isSelected: boolean
+  isMenuNeeded?: boolean
   onOpen?: () => void
+  onClick?: () => void
+  onCheck?: () => void
   onDelete?: () => void
   onMove?: () => void
 }
 
 export const FilePreviewCard = ({
   name,
+  isSelected,
+  isMenuNeeded = true,
   onOpen,
+  onClick,
+  onCheck,
   onDelete,
   onMove,
 }: FilePreviewCardProps): JSX.Element => {
   const { url } = useRouteMatch()
+  const { setRedirectToPage } = useRedirectHook()
   const encodedName = encodeURIComponent(name)
 
   return (
-    <Box position="relative" h="100%">
-      <LinkBox position="relative" h="100%">
-        <LinkOverlay
-          as={RouterLink}
-          to={`${url}/editMediaSettings/${encodedName}`}
-        >
-          <Card variant="multi">
-            <CardBody>
-              <Icon as={BxFileArchiveSolid} fontSize="1.5rem" fill="icon.alt" />
-              <Text textStyle="body-1" color="text.label" noOfLines={3}>
-                {name}
-              </Text>
-            </CardBody>
-          </Card>
-        </LinkOverlay>
-      </LinkBox>
-      <ContextMenu onOpen={onOpen}>
-        <ContextMenu.Button />
-        <ContextMenu.List>
-          <ContextMenu.Item
-            icon={<BiEditAlt />}
-            as={RouterLink}
-            to={`${url}/editMediaSettings/${encodedName}`}
-          >
-            <Text>Edit details</Text>
-          </ContextMenu.Item>
-          <ContextMenu.Item icon={<BiFolder />} onClick={onMove}>
-            <HStack spacing="4rem" alignItems="center">
-              <Text>Move to</Text>
-              <Icon as={BiChevronRight} fontSize="1.25rem" />
-            </HStack>
-          </ContextMenu.Item>
-          <>
-            <Divider />
-            <ContextMenu.Item
-              icon={<BiTrash />}
-              color="interaction.critical.default"
-              onClick={onDelete}
+    <Box position="relative" h="100%" data-group>
+      {/* Checkbox overlay */}
+      <Checkbox
+        position="absolute"
+        left="1rem"
+        top="0.5rem"
+        h="3.25rem"
+        w="3.25rem"
+        size="md"
+        p="1rem"
+        variant="transparent"
+        display={isSelected ? "inline-block" : "none"}
+        _groupHover={{
+          bg: "transparent",
+          display: "inline-block",
+        }}
+        _focusWithin={{
+          outline: "none",
+        }}
+        zIndex={1}
+        isChecked={isSelected}
+        onChange={() => {
+          if (onCheck) onCheck()
+        }}
+      />
+
+      <Box
+        position="relative"
+        h="100%"
+        onClick={(e) => {
+          // For some weird reason, the onClick event is treated as a submit event
+          // We can safely disable the default behaviour here since we define the
+          // onClick behaviour ourselves
+          e.preventDefault()
+
+          if (onClick) {
+            onClick()
+          } else {
+            setRedirectToPage(`${url}/editMediaSettings/${encodedName}`)
+          }
+        }}
+      >
+        <Card variant="multi" _hover={{ bg: undefined }}>
+          <CardBody>
+            {!isSelected && (
+              <Icon
+                as={BxFileArchiveSolid}
+                fontSize="1.5rem"
+                fill="icon.alt"
+                _groupHover={{
+                  display: "none",
+                }}
+              />
+            )}
+            <Text
+              textStyle="body-1"
+              color="text.label"
+              noOfLines={3}
+              ml={isSelected ? "2.5rem" : 0}
+              _groupHover={{ marginLeft: "2.5rem" }}
             >
-              Delete file
+              {name}
+            </Text>
+          </CardBody>
+        </Card>
+      </Box>
+
+      {isMenuNeeded && (
+        <ContextMenu onOpen={onOpen}>
+          <ContextMenu.Button />
+          <ContextMenu.List>
+            <ContextMenu.Item
+              icon={<BiEditAlt />}
+              as={RouterLink}
+              to={`${url}/editMediaSettings/${encodedName}`}
+            >
+              <Text>Edit details</Text>
             </ContextMenu.Item>
-          </>
-        </ContextMenu.List>
-      </ContextMenu>
+            <ContextMenu.Item icon={<BiFolder />} onClick={onMove}>
+              <HStack spacing="4rem" alignItems="center">
+                <Text>Move to</Text>
+                <Icon as={BiChevronRight} fontSize="1.25rem" />
+              </HStack>
+            </ContextMenu.Item>
+            <>
+              <Divider />
+              <ContextMenu.Item
+                icon={<BiTrash />}
+                color="interaction.critical.default"
+                onClick={onDelete}
+              >
+                Delete file
+              </ContextMenu.Item>
+            </>
+          </ContextMenu.List>
+        </ContextMenu>
+      )}
     </Box>
   )
 }

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -36,3 +36,8 @@ export interface MoveMultipleMediaDto {
   target: { directoryName: string }
   items: Array<{ name: string; type: "file" }>
 }
+
+export interface MediaFolderCreationInfo {
+  newDirectoryName: string
+  selectedPages: SelectedMediaDto[]
+}

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,4 +1,5 @@
-import { MediaLabels } from "types/media"
+import { MediaData } from "types/directory"
+import { MediaLabels, SelectedMediaDto } from "types/media"
 
 // Utility method to help ease over the various labels associated
 // with the media type so that we can avoid repeated conditionals
@@ -20,4 +21,15 @@ export const getMediaLabels = (mediaType: "files" | "images"): MediaLabels => {
     singularDirectoryLabel: "album",
     pluralDirectoryLabel: "albums",
   }
+}
+
+// Utility method to construct a SelectedMediaDto from MediaData
+export const getSelectedMediaDto = (fileData: MediaData) => {
+  const selectedData: SelectedMediaDto = {
+    filePath: fileData.mediaPath,
+    sha: fileData.sha,
+    size: fileData.size || 0,
+  }
+
+  return selectedData
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-746.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- A new flow to create album with selected media has been introduced.
- The existing create album modal has also been enhanced.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="781" alt="Screenshot 2023-11-10 at 13 01 22" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/e8b90028-58f8-4716-97c0-19183933caff">
<img width="1511" alt="Screenshot 2023-11-10 at 13 01 43" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/3ce732d4-89d4-4673-bcbf-1b5d2eae52c6">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="1063" alt="Screenshot 2023-11-10 at 13 02 03" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/5a16442a-6fbb-4e9e-b712-4d2b17e398a3">
<img width="1053" alt="Screenshot 2023-11-10 at 13 02 25" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/2104ef7c-ac29-443f-bd8f-0e853022d24f">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and go to the Images workspace.
    - [ ] Click on Create album on the top right, enter an existing album name and verify that you cannot continue.
    - [ ] Enter a new album name and skip adding images, verify that the new album has been created.
    - [ ] Go back to the images workspace and click on the Create album again.
    - [ ] Enter a new album name, select a few images and click on skip adding images, verify that the new album is created without the images that you selected earlier.
    - [ ] Go back to the images workspace and click on the Create album again.
    - [ ] Enter a new album name, select a few images, verify that the text of the primary button changes with the selection count.
    - [ ] Continue to create the album with the selected images. Verify that the new album has been created and the images you selected earlier are inside.
    - [ ] On the same sub-directory page, select the images and go to "Edit selected", verify that the "Create new album with images" button is present.
    - [ ] Create a new album with the selected images, verify that the modal only has one input field and the new album can be created with the selected images earlier.
    - [ ] Select any images from various albums, then go to an album that is already 3 levels deep (i.e. Images > Level 2 > Level 3 in the breadcrumb), verify that the "Create new album with images" button is not present under "Edit selected".
    - [ ] Go to another album that is not 3 levels deep and create the album with the selected images. Verify that the album is created successfully with the selected images earlier.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*