### PR TITLE
refactor(tiptap-editor): update width

### DIFF
--- a/src/layouts/EditPage/TiptapEditPage.tsx
+++ b/src/layouts/EditPage/TiptapEditPage.tsx
@@ -58,10 +58,11 @@ export const TiptapEditPage = ({
       variant="tiptap"
     >
       {/* Editor */}
-      <Editor h="80vh" />
+      <Editor h="80vh" w="45vw" />
       {/* Preview */}
       <PagePreview
         h="calc(100vh - 160px - 1rem)"
+        w="100%"
         chunk={editor.getHTML()}
         title={initialPageData?.content?.frontMatter?.title || ""}
       />


### PR DESCRIPTION
## Problem
Editor width should be `45vw` instead of `50%`; changing it on `TiptapEditPage` first to avoid potential design regression on the markdown editor 

Closes IS-718
## Solution
update props
