### PR TITLE
fix(image): search pagination

### DIFF
--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -68,6 +68,7 @@ const MediasSelectModal = ({
     { initialData: { directories: [] } }
   )
 
+  const [searchValue, setSearchedValue] = useState("")
   const {
     data: { files: mediaFolderFiles, total },
     isLoading: isListMediaFilesLoading,
@@ -78,6 +79,7 @@ const MediasSelectModal = ({
       // returns an index with 1 offset
       curPage: curPage - 1,
       limit: MEDIA_PAGINATION_SIZE,
+      search: searchValue,
     },
     { initialData: { files: [] } }
   )
@@ -88,7 +90,6 @@ const MediasSelectModal = ({
     mediaDirectoryName
   )
 
-  const [searchValue, setSearchedValue] = useState("")
   const filteredDirectories = filterMediaByFileName(
     mediaFolderSubdirectories,
     searchValue

--- a/src/services/DirectoryService/DirectoryService.ts
+++ b/src/services/DirectoryService/DirectoryService.ts
@@ -101,11 +101,12 @@ export const getMediaFolderFiles = ({
   mediaDirectoryName,
   curPage = 0,
   limit = 1000,
+  search = "",
 }: MediaDirectoryParams): Promise<GetMediaFilesDto> => {
   const endpoint = `/sites/${siteName}/media/${mediaDirectoryName}/files`
   return apiService
     .get<GetMediaFilesDto>(endpoint, {
-      params: { page: curPage, limit },
+      params: { page: curPage, limit, search },
     })
     .then(({ data }) => data)
 }

--- a/src/types/folders.ts
+++ b/src/types/folders.ts
@@ -11,6 +11,7 @@ export interface MediaDirectoryParams {
   mediaDirectoryName: string
   curPage?: number
   limit?: number
+  search?: string
 }
 
 export type DirectoryParams = Omit<FolderUrlParams, "subCollectionName">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->


Our images modal in FE is broken when search is used due to pagination. 
Review this tgt with [ee](https://github.com/isomerpages/isomercms-backend/pull/1026) 
Also our sort by didnt work particaulry well due to casing, that has been modified as well

Screenshots 

## Before 
![image (5)](https://github.com/isomerpages/isomercms-backend/assets/42832651/28439ce7-9dc1-4151-a0c6-2b3360899957)


## After 
![Screenshot 2023-11-10 at 1 44 30 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/9e515c9d-35b7-475a-9bae-0448a5838364)


## Tests 
[ ] Go into a repo with lots of images (at least > 15 since thats what we paginate by)
[ ] Search for any image that would be > 15th index when alphabeticaly ordered. (eg. seach for an image that start with z) 
[ ] ensure that you can see the image in the modal 