### PR TITLE
fix(editor): refactor to use `tooltip` 

### DIFF
--- a/src/layouts/EditPage/TiptapEditPage.tsx
+++ b/src/layouts/EditPage/TiptapEditPage.tsx
@@ -61,8 +61,9 @@ export const TiptapEditPage = ({
       <Editor h="80vh" w="45vw" />
       {/* Preview */}
       <PagePreview
+        // NOTE: Reserve 45vw for editor
+        w="calc(100% - 45vw)"
         h="calc(100vh - 160px - 1rem)"
-        w="100%"
         chunk={editor.getHTML()}
         title={initialPageData?.content?.frontMatter?.title || ""}
       />

--- a/src/layouts/components/Editor/components/MenuBar.tsx
+++ b/src/layouts/components/Editor/components/MenuBar.tsx
@@ -1,7 +1,5 @@
 import { Divider, HStack } from "@chakra-ui/react"
 import { Editor } from "@tiptap/react"
-import { Fragment } from "react"
-import { v4 as uuid } from "uuid"
 
 import { useEditorModal } from "contexts/EditorModalContext"
 

--- a/src/layouts/components/Editor/components/MenuItem.tsx
+++ b/src/layouts/components/Editor/components/MenuItem.tsx
@@ -19,7 +19,7 @@ export const MenuItem = ({
   isActive = null,
 }: MenuItemProps) => (
   // NOTE: Delay opening by 500ms
-  <Tooltip label={title || "divider"} openDelay={500}>
+  <Tooltip label={title || "divider"} hasArrow openDelay={500}>
     <IconButton
       _hover={{ bg: "gray.100" }}
       _active={{ bg: "gray.200" }}

--- a/src/layouts/components/Editor/components/MenuItem.tsx
+++ b/src/layouts/components/Editor/components/MenuItem.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@chakra-ui/react"
 import { IconButton } from "@opengovsg/design-system-react"
 import { MouseEventHandler } from "react"
 import remixiconUrl from "remixicon/fonts/remixicon.symbol.svg"
@@ -17,21 +18,23 @@ export const MenuItem = ({
   isRound,
   isActive = null,
 }: MenuItemProps) => (
-  <IconButton
-    _hover={{ bg: "gray.100" }}
-    _active={{ bg: "gray.200" }}
-    onClick={action}
-    title={title}
-    bgColor={isActive && isActive() ? "gray.200" : "transparent"}
-    border="none"
-    h="1.75rem"
-    w="1.75rem"
-    p="0.25rem"
-    aria-label={title || "divider"}
-    isRound={isRound}
-  >
-    <svg className="remix" height="1.25rem" width="1.25rem">
-      <use xlinkHref={`${remixiconUrl}#ri-${icon}`} />
-    </svg>
-  </IconButton>
+  // NOTE: Delay opening by 500ms
+  <Tooltip label={title || "divider"} openDelay={500}>
+    <IconButton
+      _hover={{ bg: "gray.100" }}
+      _active={{ bg: "gray.200" }}
+      onClick={action}
+      bgColor={isActive && isActive() ? "gray.200" : "transparent"}
+      border="none"
+      h="1.75rem"
+      w="1.75rem"
+      p="0.25rem"
+      aria-label={title || "divider"}
+      isRound={isRound}
+    >
+      <svg className="remix" height="1.25rem" width="1.25rem">
+        <use xlinkHref={`${remixiconUrl}#ri-${icon}`} />
+      </svg>
+    </IconButton>
+  </Tooltip>
 )


### PR DESCRIPTION
## Problem
Previously, we were relying on the `title` prop to show the tooltip (this is HTML spec). However, this led to a significant delay before the tooltip showed.

Closes IS-743

## Solution
Change to use chakra tooltip. Design system tooltip **does not work** (see [here](https://github.com/opengovsg/design-system/issues/546))

## Test
- [ ] go to new editor
- [ ] hover over tooltip
- [ ] should appear after 0.5s