### PR TITLE
fix(editor): change inner prosemirror stuff to have 100% height

### DIFF
--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -18,6 +18,8 @@
     margin-top: 0.75em;
   }
 
+  height: 100%;
+
   p.is-empty::before {
     color: #adb5bd;
     content: attr(data-placeholder);


### PR DESCRIPTION
## Problem
Currently, our editor height is shorter than what is shown. This leads to confusion when users click out of the editor (perhaps at whitespace at the bottom) but are unable to edit.

Closes IS-715

## Solution
change `tiptap` height to `100%`

## Test
- [ ] create a new page
- [ ] clicking anywhere shuold have cursor show and allow you to edit