### PR TITLE
fix(markdown): update styling to remove overflow

### DIFF
--- a/src/components/pages/MarkdownEditor.jsx
+++ b/src/components/pages/MarkdownEditor.jsx
@@ -7,6 +7,7 @@ import EditorModals from "components/pages/EditorModals"
 import { useMarkdown } from "hooks/useMarkdown"
 
 import editorStyles from "styles/isomer-cms/pages/Editor.module.scss"
+import "./editor.scss"
 
 import {
   boldButton,
@@ -137,6 +138,7 @@ const MarkdownEditor = ({ siteName, onChange, value, isLoading }) => {
       >
         <StatusIcon />
         <SimpleMDE
+          className={editorStyles.cm}
           id="simplemde-editor"
           onChange={onChange}
           value={value}

--- a/src/components/pages/editor.scss
+++ b/src/components/pages/editor.scss
@@ -1,0 +1,5 @@
+.CodeMirror {
+  height: calc(100% - 6rem) !important;
+
+  overflow-y: scroll;
+}

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -130,6 +130,7 @@
   box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
   position: relative;
+  height: calc(100vh - #{$header-height} - #{$footer-height} - 1rem);
 }
 
 .pageEditorSidebarLoading {

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -13073,11 +13073,6 @@ a.navbar-item {
   max-width: 100%;
 }
 
-.CodeMirror {
-  height: calc(100% - 6rem) !important;
-  overflow-y: scroll;
-}
-
 .page-header-container {
   padding-left: 3.125rem;
   margin: 0 0 !important;

--- a/src/styles/isomer-template.scss
+++ b/src/styles/isomer-template.scss
@@ -12654,7 +12654,7 @@ html.has-navbar-fixed-top-widescreen {
 }
 
 .remove-after:after {
-  content: "" !important
+  content: "" !important;
 }
 
 .bg-primary {
@@ -13074,7 +13074,7 @@ a.navbar-item {
 }
 
 .CodeMirror {
-  height: 100% !important;
+  height: calc(100% - 6rem) !important;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
## Problem
Overflow on editor leads to the editor overflowing, which leads to a less than ideal experience for our users

## Solution
1. Fix css styling for `pageEditorSidebar` to have a fixed height
2. shift editor styling to own file instead of residing in `isomertemplate.scss` -> this is to avoid obscuring as it's not a part of the preview per se. also we cannot use css modules cos this needs to target the raw class (`.CodeMirror`) and not the mangled version

## Screenshots
<img width="1481" alt="Screenshot 2023-11-10 at 3 33 03 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/44049504/9543974f-56a6-463a-82ff-c690b83fbf7d">

## Tests
- go to the old editor
- paste some content in until it overflows
- editor should be scrollable
