### PR TITLE
Fix/buildStatusBadgeAPI

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -133,7 +133,13 @@ const Header = ({
           </Flex>
         ) : null}
         <HStack flex={1} justifyContent="flex-end">
-          ({isShowStagingBuildStatusEnabled && <StatusBadge />})
+          (
+          {isShowStagingBuildStatusEnabled && (
+            <Box mr="-0.25rem">
+              <StatusBadge />
+            </Box>
+          )}
+          )
           <NotificationMenu />
           <Button
             onClick={onOpen}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,5 @@
-import {
-  Box,
-  Flex,
-  Icon,
-  Text,
-  HStack,
-  useDisclosure,
-  Skeleton,
-} from "@chakra-ui/react"
+import { Box, Flex, Icon, Text, HStack, useDisclosure } from "@chakra-ui/react"
+import { useFeatureIsOn } from "@growthbook/growthbook-react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import axios from "axios"
 import PropTypes from "prop-types"
@@ -19,13 +12,14 @@ import { StatusBadge } from "components/Header/StatusBadge"
 import { ViewStagingSiteModal } from "components/ViewStagingSiteModal"
 import { WarningModal } from "components/WarningModal"
 
+import { FEATURE_FLAGS } from "constants/featureFlags"
+
 import { useLoginContext } from "contexts/LoginContext"
 
 import {
   useGetReviewRequests,
   useGetStagingUrl,
 } from "hooks/siteDashboardHooks"
-import { useGetStagingStatus } from "hooks/useGetStagingStatus"
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
@@ -88,10 +82,9 @@ const Header = ({
     if (isEditPage && !shouldAllowEditPageBackNav) onWarningModalOpen()
     else toggleBackNav()
   }
-  const {
-    data: getStagingStatusData,
-    isLoading: isGetStagingStatusLoading,
-  } = useGetStagingStatus(siteName)
+  const isShowStagingBuildStatusEnabled = useFeatureIsOn(
+    FEATURE_FLAGS.IS_SHOW_STAGING_BUILD_STATUS_ENABLED
+  )
 
   return (
     <>
@@ -139,9 +132,7 @@ const Header = ({
           </Flex>
         ) : null}
         <HStack flex={1} justifyContent="flex-end">
-          <Skeleton isLoaded={!isGetStagingStatusLoading} mr="0.75rem">
-            {getStagingStatusData && <StatusBadge {...getStagingStatusData} />}
-          </Skeleton>
+          ({isShowStagingBuildStatusEnabled && <StatusBadge />})
           <NotificationMenu />
           <Button
             onClick={onOpen}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Icon, Text, HStack, useDisclosure } from "@chakra-ui/react"
-import { useFeatureIsOn } from "@growthbook/growthbook-react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import axios from "axios"
 import PropTypes from "prop-types"
@@ -23,6 +22,8 @@ import {
 import useRedirectHook from "hooks/useRedirectHook"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
+
+import { useIsIsomerFeatureOn } from "utils/growthbook"
 
 import { getBackButton } from "utils"
 
@@ -82,7 +83,7 @@ const Header = ({
     if (isEditPage && !shouldAllowEditPageBackNav) onWarningModalOpen()
     else toggleBackNav()
   }
-  const isShowStagingBuildStatusEnabled = useFeatureIsOn(
+  const isShowStagingBuildStatusEnabled = useIsIsomerFeatureOn(
     FEATURE_FLAGS.IS_SHOW_STAGING_BUILD_STATUS_ENABLED
   )
 

--- a/src/components/Header/StatusBadge.tsx
+++ b/src/components/Header/StatusBadge.tsx
@@ -32,7 +32,7 @@ const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
   switch (status) {
     case "READY":
       headingText = `All saved edits are on staging`
-      bodyText = "Click on 'Open staging' to take a look."
+      bodyText = "Click 'Open staging' to see a preview of your site."
 
       biLoaderIcon = (props: IconBaseProps) => (
         <BiCheckCircle {...props} color="#0F796F" />
@@ -40,18 +40,16 @@ const StagingPopoverContent = ({ status }: StagingPopoverContentProps) => {
 
       break
     case "PENDING":
-      headingText = `Staging site is building`
-      bodyText =
-        "We detected a change in your site. We'll let you know when the staging site is ready."
+      headingText = `Your staging site is being built`
+      bodyText = "This status indicator will change once it's ready."
       biLoaderIcon = (props: IconBaseProps) => (
         <BiLoader {...props} style={{ animation: "spin 2s linear infinite" }} />
       )
       break
     case "ERROR":
-      headingText =
-        "We had some trouble updating the staging site since the latest save. "
+      headingText = "Your staging site may not show the latest changes"
       bodyText =
-        "Don't worry, your production site isn't affected. Try saving your page again. If the issue persists, please contact support@isomer.gov.sg."
+        "Your live site isn't affected. Please save the page again before clicking 'Open Staging'. If changes still don't show, email support@isomer.gov.sg"
 
       biLoaderIcon = (props: IconBaseProps) => <BiError {...props} />
       break
@@ -110,7 +108,7 @@ export const StatusBadgeComponent = ({
   return (
     <Popover placement="bottom-start" trigger="hover">
       <PopoverTrigger>
-        <Box mr="1rem">
+        <Box>
           <Badge
             colorScheme={colourScheme}
             variant="subtle"

--- a/src/components/Header/StatusBadge.tsx
+++ b/src/components/Header/StatusBadge.tsx
@@ -9,7 +9,6 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { Badge } from "@opengovsg/design-system-react"
-import { useMemo } from "react"
 import { BiCheckCircle, BiError, BiLoader } from "react-icons/bi"
 import { GoDotFill } from "react-icons/go"
 import { IconBaseProps } from "react-icons/lib"

--- a/src/components/Header/StatusBadge.tsx
+++ b/src/components/Header/StatusBadge.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chakra-ui/react"
 import { Badge } from "@opengovsg/design-system-react"
 import { BiCheckCircle, BiError, BiLoader } from "react-icons/bi"
+import { BsFillQuestionCircleFill } from "react-icons/bs"
 import { GoDotFill } from "react-icons/go"
 import { IconBaseProps } from "react-icons/lib"
 import { useParams } from "react-router-dom"
@@ -121,6 +122,10 @@ export const StatusBadgeComponent = ({
             <Text ml="0.25rem" mr="0.5rem">
               {displayText}
             </Text>
+            <Icon
+              as={BsFillQuestionCircleFill}
+              color="interaction.neutral.active"
+            />
           </Badge>
         </Box>
       </PopoverTrigger>

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -7,6 +7,7 @@ export const FEATURE_FLAGS = {
   IS_SHOW_STAGING_BUILD_STATUS_ENABLED: "is_show_staging_build_status_enabled",
 } as const
 
+export type FeatureFlagsType = typeof FEATURE_FLAGS[keyof typeof FEATURE_FLAGS]
 // NOTE: Only have 4 default blocks:
 // hero/infobar/infopic/resources
 export const NUM_DEFAULT_HOMEPAGE_BLOCKS = 4

--- a/src/hooks/useGetStagingStatus.ts
+++ b/src/hooks/useGetStagingStatus.ts
@@ -1,7 +1,5 @@
-import { useFeatureIsOn } from "@growthbook/growthbook-react"
 import { useQuery, UseQueryResult } from "react-query"
 
-import { FEATURE_FLAGS } from "constants/featureFlags"
 import { GET_STAGING_BUILD_STATUS_KEY } from "constants/queryKeys"
 
 import { getStagingBuildStatus } from "services/StagingBuildService"

--- a/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
+++ b/src/layouts/layouts/SiteEditLayout/SiteEditHeader.tsx
@@ -6,7 +6,6 @@ import {
   HStack,
   useDisclosure,
 } from "@chakra-ui/react"
-import { useFeatureIsOn } from "@growthbook/growthbook-react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { BiArrowBack, BiCheckCircle } from "react-icons/bi"
 import { useParams, useHistory } from "react-router-dom"
@@ -26,9 +25,8 @@ import { useGetStagingUrl } from "hooks/siteDashboardHooks"
 
 import { ReviewRequestModal } from "layouts/ReviewRequest"
 
+import { useIsIsomerFeatureOn } from "utils/growthbook"
 import { doesOpenReviewRequestExist } from "utils/reviewRequests"
-
-import { FeatureFlags } from "types/featureFlags"
 
 export const SiteEditHeader = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -45,7 +43,7 @@ export const SiteEditHeader = (): JSX.Element => {
   } = useDisclosure()
   const { siteName } = useParams<{ siteName: string }>()
   const { data: stagingUrl, isLoading } = useGetStagingUrl(siteName)
-  const isShowStagingBuildStatusEnabled = useFeatureIsOn<FeatureFlags>(
+  const isShowStagingBuildStatusEnabled = useIsIsomerFeatureOn(
     FEATURE_FLAGS.IS_SHOW_STAGING_BUILD_STATUS_ENABLED
   )
 

--- a/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
+++ b/src/layouts/layouts/SiteViewLayout/SiteViewHeader.tsx
@@ -22,14 +22,14 @@ import { FEATURE_FLAGS } from "constants/featureFlags"
 
 import { useLoginContext } from "contexts/LoginContext"
 
-import { FeatureFlags } from "types/featureFlags"
+import { useIsIsomerFeatureOn } from "utils/growthbook"
 
 export const SiteViewHeader = (): JSX.Element => {
   const { displayedName } = useLoginContext()
   const { pathname } = useLocation()
   const isAtSiteDashboard = pathname.endsWith("dashboard")
   const { siteName } = useParams<{ siteName: string }>()
-  const isShowStagingBuildStatusEnabled = useFeatureIsOn<FeatureFlags>(
+  const isShowStagingBuildStatusEnabled = useIsIsomerFeatureOn(
     FEATURE_FLAGS.IS_SHOW_STAGING_BUILD_STATUS_ENABLED
   )
 

--- a/src/utils/growthbook.ts
+++ b/src/utils/growthbook.ts
@@ -1,4 +1,9 @@
-import { GrowthBook } from "@growthbook/growthbook-react"
+import { GrowthBook, useFeatureIsOn } from "@growthbook/growthbook-react"
+import { useParams } from "react-router-dom"
+
+import { FeatureFlagsType } from "constants/featureFlags"
+
+import { FeatureFlags } from "types/featureFlags"
 
 const GROWTHBOOK_API_HOST = "https://cdn.growthbook.io"
 
@@ -19,4 +24,14 @@ export const getSiteNameAttributeFromPath = (path: string) => {
     return pathnames[2]
   }
   return ""
+}
+
+export const useIsIsomerFeatureOn = (
+  featureName: FeatureFlagsType
+): boolean => {
+  const { siteName } = useParams<{ siteName: string }>()
+  if (siteName === "storybook") return true
+
+  const isFeatureEnabled = useFeatureIsOn<FeatureFlags>(featureName)
+  return isFeatureEnabled
 }


### PR DESCRIPTION
## Problem

Forgot to remove one last place where api calls were made. Functionally, api to be should only be made iif whitelisted.


Verified that the only other place that `useGetStagingStatus` gets called is in the component `StatusBadge` which only gets rendered conditionally based on feature flag
![Screenshot 2023-11-11 at 4 42 18 PM](https://github.com/isomerpages/isomercms-frontend/assets/42832651/c673a4c3-7fbe-4f16-9f23-5a86cead6993)


Storybooks no longer worked post adding feature flag to fe, modified the code to allow for this.
![Screenshot 2023-11-11 at 4 36 56 PM](https://github.com/isomerpages/isomercms-frontend/assets/42832651/a522204b-fbfa-4246-8698-bdb0cced607f)


