### PR TITLE
Fix/is724-apply-styles

### DIFF
--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -70,7 +70,7 @@ export const EditPage = () => {
         pluginKey: "tableBubble",
       }),
       Table.configure({
-        resizable: true,
+        resizable: false,
       }),
       TableRow,
       TableHeader,

--- a/src/layouts/components/Editor/Editor.tsx
+++ b/src/layouts/components/Editor/Editor.tsx
@@ -11,7 +11,7 @@ export const Editor = (props: BoxProps) => {
   const { editor } = useEditorContext()
 
   return (
-    <Box p="1.25rem" h="100%" maxW="50%" {...props}>
+    <Box p="1.25rem" h="100%" maxW="50%" minW="40%" {...props}>
       <Flex
         bg="white"
         border="1px solid"

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -2,11 +2,6 @@
   outline: none;
 }
 
-.tableWrapper {
-  padding: 1rem 0;
-  overflow-x: auto;
-}
-
 .resize-cursor {
   cursor: ew-resize;
   cursor: col-resize;
@@ -37,10 +32,10 @@
 
     td,
     th {
-      border: 2px solid #ced4da;
+      border: 1px solid #d6d6d6;
       box-sizing: border-box;
       min-width: 1em;
-      padding: 3px 5px;
+      padding: 0.5em 0.75em;
       position: relative;
       vertical-align: top;
 
@@ -50,35 +45,9 @@
     }
 
     th {
-      background-color: #f1f3f5;
+      color: #323232;
       font-weight: bold;
       text-align: left;
-    }
-
-    .selectedCell:after {
-      background: rgba(200, 200, 255, 0.4);
-      content: "";
-      left: 0;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      pointer-events: none;
-      position: absolute;
-      z-index: 2;
-    }
-
-    .column-resize-handle {
-      background-color: #adf;
-      bottom: -2px;
-      position: absolute;
-      right: -2px;
-      pointer-events: none;
-      top: 0;
-      width: 4px;
-    }
-
-    p {
-      margin: 0;
     }
   }
 

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -75,14 +75,6 @@
     margin-bottom: 0.75rem; // taken from .content in blueprint.scss
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5 {
-    color: var(--site-secondary-color);
-  }
-
   code {
     background-color: rgba(#616161, 0.1);
     color: #616161;

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -66,47 +66,13 @@
   }
 
   h1,
-  h1 center {
-    font-family: "Lato", sans-serif;
-    font-size: 3.375rem;
-    line-height: 3.75rem;
-    letter-spacing: -1.5px;
-    word-wrap: normal;
-  }
-
   h2,
-  h2 center {
-    font-family: "Lato", sans-serif;
-    font-size: 2.75rem;
-    line-height: 3.75rem;
-  }
-
   h3,
-  h3 center {
-    font-family: "Lato", sans-serif;
-    font-size: 2rem;
-    line-height: 2.8125rem;
-  }
-
   h4,
-  h4 center {
-    font-family: "Lato", sans-serif;
-    font-size: 1.625rem;
-    line-height: 1.875rem;
-  }
-
   h5,
-  h5 center {
-    font-family: "Lato", sans-serif;
-    font-size: 1.375rem;
-    line-height: 1.875rem;
-  }
-
-  h6,
-  h6 center {
-    font-family: "Lato", sans-serif;
-    font-size: 1rem;
-    line-height: 1.25rem;
+  h6 {
+    margin-top: 3.75rem; // taken from .content in blueprint.scss
+    margin-bottom: 0.75rem; // taken from .content in blueprint.scss
   }
 
   h1,
@@ -114,8 +80,6 @@
   h3,
   h4,
   h5 {
-    margin-top: 3.75rem; // taken from .content in blueprint.scss
-    margin-bottom: 0.75rem; // taken from .content in blueprint.scss
     color: var(--site-secondary-color);
   }
 

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -74,26 +74,49 @@
     word-wrap: normal;
   }
 
-  @media screen and (max-width: 1023px) {
-    h1,
-    h1 center {
-      font-size: 3rem;
-    }
+  h2,
+  h2 center {
+    font-family: "Lato", sans-serif;
+    font-size: 2.75rem;
+    line-height: 3.75rem;
   }
-  @media screen and (max-width: 768px) {
-    h1,
-    h1 center {
-      font-size: 2.75rem;
-    }
+
+  h3,
+  h3 center {
+    font-family: "Lato", sans-serif;
+    font-size: 2rem;
+    line-height: 2.8125rem;
+  }
+
+  h4,
+  h4 center {
+    font-family: "Lato", sans-serif;
+    font-size: 1.625rem;
+    line-height: 1.875rem;
+  }
+
+  h5,
+  h5 center {
+    font-family: "Lato", sans-serif;
+    font-size: 1.375rem;
+    line-height: 1.875rem;
+  }
+
+  h6,
+  h6 center {
+    font-family: "Lato", sans-serif;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 
   h1,
   h2,
   h3,
   h4,
-  h5,
-  h6 {
-    color: #4372d6;
+  h5 {
+    margin-top: 3.75rem; // taken from .content in blueprint.scss
+    margin-bottom: 0.75rem; // taken from .content in blueprint.scss
+    color: var(--site-secondary-color);
   }
 
   code {

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -66,6 +66,28 @@
   }
 
   h1,
+  h1 center {
+    font-family: "Lato", sans-serif;
+    font-size: 3.375rem;
+    line-height: 3.75rem;
+    letter-spacing: -1.5px;
+    word-wrap: normal;
+  }
+
+  @media screen and (max-width: 1023px) {
+    h1,
+    h1 center {
+      font-size: 3rem;
+    }
+  }
+  @media screen and (max-width: 768px) {
+    h1,
+    h1 center {
+      font-size: 2.75rem;
+    }
+  }
+
+  h1,
   h2,
   h3,
   h4,

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -65,16 +65,6 @@
     padding: 0 1rem;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    margin-top: 3.75rem; // taken from .content in blueprint.scss
-    margin-bottom: 0.75rem; // taken from .content in blueprint.scss
-  }
-
   code {
     background-color: rgba(#616161, 0.1);
     color: #616161;

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -1,3 +1,5 @@
+@use "styles/isomer-cms/pages/Editor.module.scss";
+
 .tiptap:focus {
   outline: none;
 }
@@ -9,6 +11,8 @@
 
 /* Basic editor styles */
 .tiptap {
+  @extend .previewTextStyles;
+
   > * + * {
     margin-top: 0.75em;
   }
@@ -67,7 +71,7 @@
   h4,
   h5,
   h6 {
-    line-height: 1.1;
+    color: #4372d6;
   }
 
   code {

--- a/src/styles/isomer-cms/elements/base.scss
+++ b/src/styles/isomer-cms/elements/base.scss
@@ -60,7 +60,7 @@ h4,
 h5,
 h6 {
   font-family: "Inter", sans-serif;
-  font-weight: 700 !important;
+  font-weight: 700;
   margin: 0;
   padding: 0;
   letter-spacing: 0 !important;

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -47,42 +47,42 @@
   h1 {
     font-size: 3.375rem;
     line-height: 4.5rem;
-    font-weight: 400;
+    font-weight: 400 !important;
     letter-spacing: -0.022em;
   }
 
   h2 {
     font-size: 2.75rem;
     line-height: 4rem;
-    font-weight: 400;
+    font-weight: 400 !important;
     letter-spacing: -0.022em;
   }
 
   h3 {
     font-size: 2rem;
     line-height: 3rem;
-    font-weight: 400;
+    font-weight: 400 !important;
     letter-spacing: -0.022em;
   }
 
   h4 {
     font-size: 1.625rem;
     line-height: 2.5rem;
-    font-weight: 400;
+    font-weight: 400 !important;
     letter-spacing: -0.02em;
   }
 
   h5 {
     font-size: 1.375rem;
     line-height: 2rem;
-    font-weight: 400;
+    font-weight: 400 !important;
     letter-spacing: -0.018em;
   }
 
   h6 {
     font-size: 1rem;
     line-height: 1.5rem;
-    font-weight: 400;
+    font-weight: 400 !important;
     letter-spacing: -0.011em;
   }
 }

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -47,42 +47,42 @@
   h1 {
     font-size: 3.375rem;
     line-height: 4.5rem;
-    font-weight: 400 !important;
+    font-weight: 400;
     letter-spacing: -0.022em;
   }
 
   h2 {
     font-size: 2.75rem;
     line-height: 4rem;
-    font-weight: 400 !important;
+    font-weight: 400;
     letter-spacing: -0.022em;
   }
 
   h3 {
     font-size: 2rem;
     line-height: 3rem;
-    font-weight: 400 !important;
+    font-weight: 400;
     letter-spacing: -0.022em;
   }
 
   h4 {
     font-size: 1.625rem;
     line-height: 2.5rem;
-    font-weight: 400 !important;
+    font-weight: 400;
     letter-spacing: -0.02em;
   }
 
   h5 {
     font-size: 1.375rem;
     line-height: 2rem;
-    font-weight: 400 !important;
+    font-weight: 400;
     letter-spacing: -0.018em;
   }
 
   h6 {
     font-size: 1rem;
     line-height: 1.5rem;
-    font-weight: 400 !important;
+    font-weight: 400;
     letter-spacing: -0.011em;
   }
 }


### PR DESCRIPTION
Headings + table borders now match 
<img width="1442" alt="Screenshot 2023-11-16 at 8 57 00 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/9e690689-8129-4140-aa1c-c47f5afa8942">

opting to show the vertical lines cuz I feel its easier for our user? lmk if we dont agree on this 
<img width="1328" alt="Screenshot 2023-11-16 at 8 57 41 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/25889ed6-886a-4133-93dd-c452f67a3382">
