### PR TITLE
Fix/is 689 reuse image/album tiles

### DIFF
--- a/src/components/ImagePreviewCard/ImagePreviewCard.tsx
+++ b/src/components/ImagePreviewCard/ImagePreviewCard.tsx
@@ -60,29 +60,29 @@ export const ImagePreviewCard = ({
   return (
     <Box position="relative" h="100%" data-group>
       {/* Checkbox overlay over image */}
-      <Checkbox
-        position="absolute"
-        left="0"
-        top="0"
-        h="3.25rem"
-        w="3.25rem"
-        size="md"
-        p="1rem"
-        variant="transparent"
-        display={isSelected ? "inline-block" : "none"}
-        _groupHover={{
-          bg: "transparent",
-          display: "inline-block",
-        }}
-        _focusWithin={{
-          outline: "none",
-        }}
-        zIndex={1}
-        isChecked={isSelected}
-        onChange={() => {
-          if (onCheck) onCheck()
-        }}
-      />
+      {onCheck && (
+        <Checkbox
+          position="absolute"
+          left="0"
+          top="0"
+          h="3.25rem"
+          w="3.25rem"
+          size="md"
+          p="1rem"
+          variant="transparent"
+          display={isSelected ? "inline-block" : "none"}
+          _groupHover={{
+            bg: "transparent",
+            display: "inline-block",
+          }}
+          _focusWithin={{
+            outline: "none",
+          }}
+          zIndex={1}
+          isChecked={isSelected}
+          onChange={onCheck}
+        />
+      )}
 
       <Grid
         as={chakra.button}

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -91,6 +91,7 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
           }
           onMediaSelect={onMediaSelect}
           onClose={onClose}
+          mediaType={type}
         />
       )
     }

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -217,14 +217,15 @@ const MediasSelectModal = ({
                 {filteredDirectories.map((dir) => (
                   <MediaDirectoryCard
                     title={dir.name}
-                    onClick={() =>
+                    onClick={() => {
+                      onMediaSelect("")
                       setQueryParams((prevState) => {
                         return {
                           ...prevState,
                           mediaDirectoryName: `${prevState.mediaDirectoryName}%2F${dir.name}`,
                         }
                       })
-                    }
+                    }}
                     isMenuNeeded={false}
                   />
                 ))}

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -27,9 +27,8 @@ import { useState, useEffect } from "react"
 import { useFormContext } from "react-hook-form"
 import { useRouteMatch } from "react-router-dom"
 
-import { FolderCard } from "components/FolderCard"
+import { ImagePreviewCard } from "components/ImagePreviewCard"
 import { LoadingButton } from "components/LoadingButton"
-import MediaCard from "components/media/MediaCard"
 
 import { MEDIA_PAGINATION_SIZE } from "constants/media"
 
@@ -38,8 +37,11 @@ import { useListMediaFolderFiles } from "hooks/directoryHooks/useListMediaFolder
 import { useListMediaFolderSubdirectories } from "hooks/directoryHooks/useListMediaFolderSubdirectories"
 import { usePaginate } from "hooks/usePaginate"
 
-import contentStyles from "styles/isomer-cms/pages/Content.module.scss"
+import { FilePreviewCard, MediaDirectoryCard } from "layouts/Media/components"
+
 import mediaStyles from "styles/isomer-cms/pages/Media.module.scss"
+
+import { getMediaLabels } from "utils/media"
 
 import { deslugifyDirectory, getMediaDirectoryName } from "utils"
 
@@ -48,6 +50,10 @@ const filterMediaByFileName = (medias, filterTerm) =>
     media.name.toLowerCase().includes(filterTerm.toLowerCase())
   )
 
+const titleCase = (str) => {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
+}
+
 const MediasSelectModal = ({
   onProceed,
   onClose,
@@ -55,9 +61,12 @@ const MediasSelectModal = ({
   onUpload,
   queryParams,
   setQueryParams,
+  mediaType,
 }) => {
   const { params } = useRouteMatch()
-  const { siteName, fileName } = params
+  const { fileName } = params
+
+  const { singularMediaLabel, pluralMediaLabel } = getMediaLabels(mediaType)
 
   const { mediaRoom, mediaDirectoryName } = queryParams
 
@@ -138,8 +147,9 @@ const MediasSelectModal = ({
               <ModalCloseButton onClick={onClose} position="static" />
             </HStack>
             <Text textStyle="body-1">
-              Choose from your images or upload a new image. You can organise
-              your images in Workspace &gt; Images.
+              Choose from your {pluralMediaLabel} or upload a new{" "}
+              {singularMediaLabel}. You can organise your {pluralMediaLabel} in
+              Workspace &gt; {titleCase(pluralMediaLabel)}.
             </Text>
             <Flex w="100%" justifyContent="space-between">
               {/* Search medias */}
@@ -156,7 +166,7 @@ const MediasSelectModal = ({
                 color="interaction.main.default"
                 onClick={onUpload}
               >
-                Upload new image
+                Upload new {singularMediaLabel}
               </Button>
             </Flex>
           </VStack>
@@ -200,28 +210,25 @@ const MediasSelectModal = ({
                   : "fit-content"
               }
               isLoaded={!isListMediaFolderSubdirectoriesLoading}
+              pb="2.25rem"
             >
-              <div className={contentStyles.folderContainerBoxes}>
-                <div className={contentStyles.boxesContainer}>
-                  {/* Directories */}
-                  {filteredDirectories.map((dir) => (
-                    <FolderCard
-                      displayText={dir.name}
-                      siteName={siteName}
-                      onClick={() =>
-                        setQueryParams((prevState) => {
-                          return {
-                            ...prevState,
-                            mediaDirectoryName: `${prevState.mediaDirectoryName}%2F${dir.name}`,
-                          }
-                        })
-                      }
-                      key={dir.path}
-                      hideSettings
-                    />
-                  ))}
-                </div>
-              </div>
+              <SimpleGrid w="100%" columns={3} spacing="1.5rem">
+                {/* Directories */}
+                {filteredDirectories.map((dir) => (
+                  <MediaDirectoryCard
+                    title={dir.name}
+                    onClick={() =>
+                      setQueryParams((prevState) => {
+                        return {
+                          ...prevState,
+                          mediaDirectoryName: `${prevState.mediaDirectoryName}%2F${dir.name}`,
+                        }
+                      })
+                    }
+                    isMenuNeeded={false}
+                  />
+                ))}
+              </SimpleGrid>
             </Skeleton>
 
             <Skeleton
@@ -233,23 +240,36 @@ const MediasSelectModal = ({
                 {files &&
                   files
                     .filter(({ data }) => filteredMedias.includes(data?.name))
-                    .map(({ data, isLoading }, mediaItemIndex) => (
+                    .map(({ data, isLoading }) => (
                       <Skeleton
                         w="100%"
                         h={isLoading ? "4.5rem" : "fit-content"}
                         isLoaded={!isLoading}
                         key={data.name}
                       >
-                        <MediaCard
-                          type={mediaRoom}
-                          media={data}
-                          mediaItemIndex={mediaItemIndex}
-                          onClick={() => onMediaSelect(data)}
-                          isSelected={
-                            data.name === watch("selectedMedia")?.name
-                          }
-                          showSettings={false}
-                        />
+                        {pluralMediaLabel === "images" ? (
+                          <ImagePreviewCard
+                            name={data.name}
+                            addedTime={data.addedTime}
+                            mediaUrl={data.mediaUrl}
+                            isSelected={
+                              data.name === watch("selectedMedia")?.name
+                            }
+                            onClick={() => onMediaSelect(data)}
+                            isMenuNeeded={false}
+                          />
+                        ) : (
+                          <FilePreviewCard
+                            name={data.name}
+                            addedTime={data.addedTime}
+                            mediaUrl={data.mediaUrl}
+                            isSelected={
+                              data.name === watch("selectedMedia")?.name
+                            }
+                            onClick={() => onMediaSelect(data)}
+                            isMenuNeeded={false}
+                          />
+                        )}
                       </Skeleton>
                     ))}
               </SimpleGrid>

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -247,7 +247,7 @@ const MediasSelectModal = ({
                         isLoaded={!isLoading}
                         key={data.name}
                       >
-                        {pluralMediaLabel === "images" ? (
+                        {mediaType === "images" ? (
                           <ImagePreviewCard
                             name={data.name}
                             addedTime={data.addedTime}

--- a/src/layouts/Media/components/FilePreviewCard.tsx
+++ b/src/layouts/Media/components/FilePreviewCard.tsx
@@ -36,31 +36,40 @@ export const FilePreviewCard = ({
   const encodedName = encodeURIComponent(name)
 
   return (
-    <Box position="relative" h="100%" data-group>
+    <Box
+      position="relative"
+      h="100%"
+      borderRadius="0.25rem"
+      borderWidth="0px"
+      // Note: Outline is required to avoid the card from shifting when selected
+      outline={isSelected ? "solid 2px" : "solid 1px"}
+      outlineColor={isSelected ? "base.divider.brand" : "base.divider.medium"}
+      data-group
+    >
       {/* Checkbox overlay */}
-      <Checkbox
-        position="absolute"
-        left="1rem"
-        top="0.5rem"
-        h="3.25rem"
-        w="3.25rem"
-        size="md"
-        p="1rem"
-        variant="transparent"
-        display={isSelected ? "inline-block" : "none"}
-        _groupHover={{
-          bg: "transparent",
-          display: "inline-block",
-        }}
-        _focusWithin={{
-          outline: "none",
-        }}
-        zIndex={1}
-        isChecked={isSelected}
-        onChange={() => {
-          if (onCheck) onCheck()
-        }}
-      />
+      {onCheck && (
+        <Checkbox
+          position="absolute"
+          left="1rem"
+          top="0.5rem"
+          h="3.25rem"
+          w="3.25rem"
+          size="md"
+          p="1rem"
+          variant="transparent"
+          display={isSelected ? "inline-block" : "none"}
+          _groupHover={{
+            bg: "transparent",
+            display: "inline-block",
+          }}
+          _focusWithin={{
+            outline: "none",
+          }}
+          zIndex={1}
+          isChecked={isSelected}
+          onChange={onCheck}
+        />
+      )}
 
       <Box
         position="relative"
@@ -80,13 +89,14 @@ export const FilePreviewCard = ({
       >
         <Card variant="multi" _hover={{ bg: undefined }}>
           <CardBody>
-            {!isSelected && (
+            {!(isSelected && onCheck) && (
+              // Icon is hidden only if checkbox exists
               <Icon
                 as={BxFileArchiveSolid}
                 fontSize="1.5rem"
                 fill="icon.alt"
                 _groupHover={{
-                  display: "none",
+                  display: `${onCheck && "none"}`,
                 }}
               />
             )}
@@ -94,8 +104,8 @@ export const FilePreviewCard = ({
               textStyle="body-1"
               color="text.label"
               noOfLines={3}
-              ml={isSelected ? "2.5rem" : 0}
-              _groupHover={{ marginLeft: "2.5rem" }}
+              ml={isSelected && onCheck ? "2.5rem" : 0}
+              _groupHover={{ marginLeft: `${onCheck && "2.5rem"}` }}
             >
               {name}
             </Text>

--- a/src/layouts/Media/components/MediaDirectoryCard.tsx
+++ b/src/layouts/Media/components/MediaDirectoryCard.tsx
@@ -1,9 +1,11 @@
-import { LinkOverlay, LinkBox, Divider, Text, Icon } from "@chakra-ui/react"
-import { BiEdit, BiFolder, BiTrash, BiWrench } from "react-icons/bi"
+import { LinkOverlay, LinkBox, Text, Icon } from "@chakra-ui/react"
+import { BiEdit, BiFolder, BiTrash } from "react-icons/bi"
 import { Link as RouterLink, useRouteMatch } from "react-router-dom"
 
 import { Card, CardBody } from "components/Card"
 import { ContextMenu } from "components/ContextMenu"
+
+import { getMediaLabels } from "utils/media"
 
 import { prettifyPageFileName } from "utils"
 
@@ -29,6 +31,7 @@ export const MediaDirectoryCard = ({
   const encodedDirectoryPath = `${mediaDirectoryName}%2F${encodeURIComponent(
     title
   )}`
+  const { singularDirectoryLabel } = getMediaLabels(mediaType)
 
   return (
     <Card
@@ -71,7 +74,7 @@ export const MediaDirectoryCard = ({
               as={RouterLink}
               to={`${url}/editDirectorySettings/${encodedDirectoryPath}`}
             >
-              Rename {mediaType === "images" ? "album" : "directory"}
+              Rename {singularDirectoryLabel}
             </ContextMenu.Item>
             <>
               <ContextMenu.Item
@@ -80,7 +83,7 @@ export const MediaDirectoryCard = ({
                 to={`${url}/deleteDirectory/${encodedDirectoryPath}`}
                 color="text.danger"
               >
-                Delete {mediaType === "images" ? "album" : "directory"}
+                Delete {singularDirectoryLabel}
               </ContextMenu.Item>
             </>
           </ContextMenu.List>

--- a/src/layouts/Media/components/MediaDirectoryCard.tsx
+++ b/src/layouts/Media/components/MediaDirectoryCard.tsx
@@ -9,10 +9,14 @@ import { prettifyPageFileName } from "utils"
 
 interface MediaDirectoryCardProps {
   title: string
+  onClick?: () => void
+  isMenuNeeded?: boolean
 }
 
 export const MediaDirectoryCard = ({
   title,
+  onClick,
+  isMenuNeeded = true,
 }: MediaDirectoryCardProps): JSX.Element => {
   const {
     params: { siteName, mediaRoom: mediaType, mediaDirectoryName },
@@ -27,42 +31,61 @@ export const MediaDirectoryCard = ({
   )}`
 
   return (
-    <Card variant="single">
-      <LinkBox position="relative">
-        <LinkOverlay
-          as={RouterLink}
-          to={`/sites/${siteName}/media/${mediaType}/mediaDirectory/${encodedDirectoryPath}`}
-        >
-          <CardBody>
-            <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
-            <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
-              {prettifyPageFileName(title)}
-            </Text>
-          </CardBody>
-        </LinkOverlay>
-      </LinkBox>
-      <ContextMenu>
-        <ContextMenu.Button pos="absolute" />
-        <ContextMenu.List>
-          <ContextMenu.Item
-            icon={<BiEdit />}
+    <Card
+      variant="single"
+      onClick={(e) => {
+        if (onClick) {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+    >
+      {onClick ? (
+        <CardBody>
+          <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
+          <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+            {prettifyPageFileName(title)}
+          </Text>
+        </CardBody>
+      ) : (
+        <LinkBox position="relative">
+          <LinkOverlay
             as={RouterLink}
-            to={`${url}/editDirectorySettings/${encodedDirectoryPath}`}
+            to={`/sites/${siteName}/media/${mediaType}/mediaDirectory/${encodedDirectoryPath}`}
           >
-            Rename {mediaType === "images" ? "album" : "directory"}
-          </ContextMenu.Item>
-          <>
+            <CardBody>
+              <Icon as={BiFolder} fontSize="1.5rem" fill="icon.alt" />
+              <Text textStyle="subhead-1" color="text.label" noOfLines={1}>
+                {prettifyPageFileName(title)}
+              </Text>
+            </CardBody>
+          </LinkOverlay>
+        </LinkBox>
+      )}
+      {isMenuNeeded && (
+        <ContextMenu>
+          <ContextMenu.Button pos="absolute" />
+          <ContextMenu.List>
             <ContextMenu.Item
-              icon={<BiTrash />}
+              icon={<BiEdit />}
               as={RouterLink}
-              to={`${url}/deleteDirectory/${encodedDirectoryPath}`}
-              color="text.danger"
+              to={`${url}/editDirectorySettings/${encodedDirectoryPath}`}
             >
-              Delete {mediaType === "images" ? "album" : "directory"}
+              Rename {mediaType === "images" ? "album" : "directory"}
             </ContextMenu.Item>
-          </>
-        </ContextMenu.List>
-      </ContextMenu>
+            <>
+              <ContextMenu.Item
+                icon={<BiTrash />}
+                as={RouterLink}
+                to={`${url}/deleteDirectory/${encodedDirectoryPath}`}
+                color="text.danger"
+              >
+                Delete {mediaType === "images" ? "album" : "directory"}
+              </ContextMenu.Item>
+            </>
+          </ContextMenu.List>
+        </ContextMenu>
+      )}
     </Card>
   )
 }


### PR DESCRIPTION
## Problem

This PR modifies the existing image select modals (present in edit page and fields which involve selecting a media item, e.g. resource page creation and settings) to reuse the same media components present in the general media layout.

To support this, the specific components (`MediaDirectoryCard`, `ImagePreviewCard` and `FilePreviewCard`) have also been modified to allows variants which do not contain the checkbox/menu.

The file preview card has also been fixed to display a highlight border when selected/checked. (Resolves IS-773)

Before:
<img width="1546" alt="Screenshot 2023-11-16 at 9 50 27 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/22111124/86bf2e5b-6461-4834-96c9-4173cf89637b">

After:
<img width="1539" alt="Screenshot 2023-11-16 at 9 53 11 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/22111124/95a64676-7b42-4836-af0e-709bc5f822c6">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Image/file layout should still be working correctly (checkboxes work as intended)
- [ ] Insert image/file in edit page works properly
- [ ] Insert images/file in select media button (page/resource page creation, settings) works properly

