### PR TITLE
feat(tiptap): rm redundant logos

### DIFF
--- a/src/layouts/components/Editor/components/MenuBar.tsx
+++ b/src/layouts/components/Editor/components/MenuBar.tsx
@@ -10,39 +10,6 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
 
   const items = [
     {
-      icon: "bold",
-      title: "Bold",
-      action: () => editor.chain().focus().toggleBold().run(),
-      isActive: () => editor.isActive("bold"),
-    },
-    {
-      icon: "italic",
-      title: "Italic",
-      action: () => editor.chain().focus().toggleItalic().run(),
-      isActive: () => editor.isActive("italic"),
-    },
-    {
-      icon: "strikethrough",
-      title: "Strike",
-      action: () => editor.chain().focus().toggleStrike().run(),
-      isActive: () => editor.isActive("strike"),
-    },
-    {
-      icon: "code-view",
-      title: "Code",
-      action: () => editor.chain().focus().toggleCode().run(),
-      isActive: () => editor.isActive("code"),
-    },
-    {
-      icon: "mark-pen-line",
-      title: "Highlight",
-      action: () => editor.chain().focus().toggleHighlight().run(),
-      isActive: () => editor.isActive("highlight"),
-    },
-    {
-      type: "divider",
-    },
-    {
       icon: "h-1",
       title: "Heading 1",
       action: () => editor.chain().focus().toggleHeading({ level: 1 }).run(),
@@ -61,11 +28,37 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       isActive: () => editor.isActive("heading", { level: 3 }),
     },
     {
-      icon: "paragraph",
-      title: "Paragraph",
-      action: () => editor.chain().focus().setParagraph().run(),
-      isActive: () => editor.isActive("paragraph"),
+      type: "divider",
     },
+    {
+      icon: "bold",
+      title: "Bold",
+      action: () => editor.chain().focus().toggleBold().run(),
+      isActive: () => editor.isActive("bold"),
+    },
+    {
+      icon: "italic",
+      title: "Italic",
+      action: () => editor.chain().focus().toggleItalic().run(),
+      isActive: () => editor.isActive("italic"),
+    },
+    {
+      icon: "strikethrough",
+      title: "Strike",
+      action: () => editor.chain().focus().toggleStrike().run(),
+      isActive: () => editor.isActive("strike"),
+    },
+    {
+      icon: "double-quotes-l",
+      title: "Blockquote",
+      action: () => editor.chain().focus().toggleBlockquote().run(),
+      isActive: () => editor.isActive("blockquote"),
+    },
+
+    {
+      type: "divider",
+    },
+
     {
       icon: "list-unordered",
       title: "Bullet List",
@@ -85,50 +78,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       isActive: () => editor.isActive("taskList"),
     },
     {
-      icon: "code-box-line",
-      title: "Code Block",
-      action: () => editor.chain().focus().toggleCodeBlock().run(),
-      isActive: () => editor.isActive("codeBlock"),
-    },
-    {
       type: "divider",
-    },
-    {
-      icon: "double-quotes-l",
-      title: "Blockquote",
-      action: () => editor.chain().focus().toggleBlockquote().run(),
-      isActive: () => editor.isActive("blockquote"),
-    },
-    {
-      icon: "separator",
-      title: "Horizontal Rule",
-      action: () => editor.chain().focus().setHorizontalRule().run(),
-    },
-    {
-      type: "divider",
-    },
-    {
-      icon: "text-wrap",
-      title: "Hard Break",
-      action: () => editor.chain().focus().setHardBreak().run(),
-    },
-    {
-      icon: "format-clear",
-      title: "Clear Format",
-      action: () => editor.chain().focus().clearNodes().unsetAllMarks().run(),
-    },
-    {
-      type: "divider",
-    },
-    {
-      icon: "arrow-go-back-line",
-      title: "Undo",
-      action: () => editor.chain().focus().undo().run(),
-    },
-    {
-      icon: "arrow-go-forward-line",
-      title: "Redo",
-      action: () => editor.chain().focus().redo().run(),
     },
     {
       icon: "file-image-line",
@@ -151,6 +101,9 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       action: () => editor.chain().focus().unsetLink().run(),
     },
     {
+      type: "divider",
+    },
+    {
       icon: "table-line",
       title: "Add table",
       action: () =>
@@ -160,6 +113,24 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
           // NOTE: Default to smallest multi table
           .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
           .run(),
+    },
+    {
+      icon: "separator",
+      title: "Horizontal Rule",
+      action: () => editor.chain().focus().setHorizontalRule().run(),
+    },
+    {
+      type: "divider",
+    },
+    {
+      icon: "arrow-go-back-line",
+      title: "Undo",
+      action: () => editor.chain().focus().undo().run(),
+    },
+    {
+      icon: "arrow-go-forward-line",
+      title: "Redo",
+      action: () => editor.chain().focus().redo().run(),
     },
   ]
 

--- a/src/layouts/components/Editor/components/MenuBar.tsx
+++ b/src/layouts/components/Editor/components/MenuBar.tsx
@@ -58,6 +58,12 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
     {
       type: "divider",
     },
+    {
+      icon: "list-ordered",
+      title: "Ordered List",
+      action: () => editor.chain().focus().toggleOrderedList().run(),
+      isActive: () => editor.isActive("orderedList"),
+    },
 
     {
       icon: "list-unordered",
@@ -65,18 +71,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       action: () => editor.chain().focus().toggleBulletList().run(),
       isActive: () => editor.isActive("bulletList"),
     },
-    {
-      icon: "list-ordered",
-      title: "Ordered List",
-      action: () => editor.chain().focus().toggleOrderedList().run(),
-      isActive: () => editor.isActive("orderedList"),
-    },
-    {
-      icon: "list-check-2",
-      title: "Task List",
-      action: () => editor.chain().focus().toggleTaskList().run(),
-      isActive: () => editor.isActive("taskList"),
-    },
+
     {
       type: "divider",
     },


### PR DESCRIPTION
## Problem 
had a lot of stuff we dont use, remove them 

NOTE: we should not remove the nodes from starter kit, cuz that means that every <code> will crash the editor 

Which actually suggests that compat with different html elements is a non-trivial tasks for pages that are already populated with HTML. I dont have an exhaustive list with me at the moment, will put it as part of QA. 

<img width="475" alt="Screenshot 2023-11-16 at 4 49 31 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/014fb142-59c4-4de1-bd92-e631a83c793d">

