### PR TITLE
feat(rte): use proper node for FormSG embed

### DIFF
--- a/src/components/EditorEmbedModal/EditorEmbedModal.tsx
+++ b/src/components/EditorEmbedModal/EditorEmbedModal.tsx
@@ -54,9 +54,6 @@ export const EditorEmbedModal = ({
       url.href = postUrl || ""
       const code = `<iframe src="https://${url.host}${url.pathname}embed/" frameborder="0" allowfullscreen="true" width="320" height="440"></iframe>`
       onProceed({ value: code })
-    } else if ($('iframe[src^="https://form.gov.sg"]').length > 0) {
-      // We only want to keep the <iframe> part, the rest is filled in by Tiptap
-      onProceed({ value: $('iframe[src^="https://form.gov.sg"]').toString() })
     } else {
       onProceed(embedCode)
     }
@@ -94,6 +91,7 @@ export const EditorEmbedModal = ({
         "value",
         cursorValue
           .replace('<div class="iframe-wrapper">', "")
+          .replace('<div class="formsg-wrapper">', "")
           // Remove the closing div tag
           .slice(0, -6)
       )

--- a/src/constants/tiptap.ts
+++ b/src/constants/tiptap.ts
@@ -1,0 +1,1 @@
+export const TIPTAP_FORMSG_NODE_PRIORITY = 300

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -28,12 +28,12 @@ import { ServicesContext } from "contexts/ServicesContext"
 import { useGetPageHook } from "hooks/pageHooks"
 import { useCspHook } from "hooks/settingsHooks"
 
-import { Iframe } from "layouts/components/Editor/extensions"
 import {
   FormSG,
   FormSGDiv,
   FormSGIframe,
-} from "layouts/components/Editor/extensions/FormSG"
+  Iframe,
+} from "layouts/components/Editor/extensions"
 
 import { isEmbedCodeValid } from "utils/allowedHTML"
 

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -29,6 +29,11 @@ import { useGetPageHook } from "hooks/pageHooks"
 import { useCspHook } from "hooks/settingsHooks"
 
 import { Iframe } from "layouts/components/Editor/extensions"
+import {
+  FormSG,
+  FormSGDiv,
+  FormSGIframe,
+} from "layouts/components/Editor/extensions/FormSG"
 
 import { isEmbedCodeValid } from "utils/allowedHTML"
 
@@ -68,6 +73,9 @@ export const EditPage = () => {
       Image.configure({ allowBase64: true }),
       Link.configure({ openOnClick: false, protocols: ["mailto"] }),
       Iframe,
+      FormSG,
+      FormSGDiv,
+      FormSGIframe,
       Markdown,
       BubbleMenu.configure({
         pluginKey: "linkBubble",

--- a/src/layouts/components/Editor/extensions/FormSG/FormSG.ts
+++ b/src/layouts/components/Editor/extensions/FormSG/FormSG.ts
@@ -2,6 +2,8 @@ import { Node } from "@tiptap/core"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import _ from "lodash"
 
+import { TIPTAP_FORMSG_NODE_PRIORITY } from "constants/tiptap"
+
 import { FormSGView } from "./FormSGView"
 
 export interface FormSGOptions {
@@ -88,7 +90,7 @@ export const FormSGIframe = Node.create({
 
 export const FormSG = Node.create<FormSGOptions>({
   name: "formsg",
-  priority: 300,
+  priority: TIPTAP_FORMSG_NODE_PRIORITY,
   group: "block",
   content: "formsgdiv formsgiframe formsgdiv",
   atom: true,

--- a/src/layouts/components/Editor/extensions/FormSG/FormSG.ts
+++ b/src/layouts/components/Editor/extensions/FormSG/FormSG.ts
@@ -1,4 +1,4 @@
-import { Node, nodePasteRule } from "@tiptap/core"
+import { Node } from "@tiptap/core"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import _ from "lodash"
 

--- a/src/layouts/components/Editor/extensions/FormSG/FormSG.ts
+++ b/src/layouts/components/Editor/extensions/FormSG/FormSG.ts
@@ -1,0 +1,121 @@
+import { Node, nodePasteRule } from "@tiptap/core"
+import { ReactNodeViewRenderer } from "@tiptap/react"
+import _ from "lodash"
+
+import { FormSGView } from "./FormSGView"
+
+export interface FormSGOptions {
+  HTMLAttributes: {
+    [key: string]: string
+  }
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    formsg: {
+      setFormsg: (options: { src: string }) => ReturnType
+    }
+  }
+}
+
+export const FormSGDiv = Node.create({
+  name: "formsgdiv",
+  group: "formsg",
+  content: "inline*",
+  draggable: false,
+  defining: true,
+
+  addAttributes() {
+    return {
+      style: {
+        default: null,
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[style]:has(> a[href^="https://form.gov.sg"])',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      {
+        style: HTMLAttributes.style,
+      },
+      0,
+    ]
+  },
+})
+
+export const FormSGIframe = Node.create({
+  name: "formsgiframe",
+  group: "formsg",
+  atom: true,
+  draggable: true,
+  defining: true,
+
+  addAttributes() {
+    return {
+      id: {
+        default: "iframe",
+      },
+      src: {
+        default: null,
+      },
+      style: {
+        default: "width: 100%; height: 500px",
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'iframe[src^="https://form.gov.sg/"]',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["iframe", HTMLAttributes]
+  },
+})
+
+export const FormSG = Node.create<FormSGOptions>({
+  name: "formsg",
+  priority: 300,
+  group: "block",
+  content: "formsgdiv formsgiframe formsgdiv",
+  atom: true,
+  draggable: true,
+  defining: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: "formsg-wrapper",
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[class="formsg-wrapper"]',
+      },
+    ]
+  },
+
+  renderHTML() {
+    return ["div", { class: "formsg-wrapper" }, 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FormSGView)
+  },
+})

--- a/src/layouts/components/Editor/extensions/FormSG/FormSGView.tsx
+++ b/src/layouts/components/Editor/extensions/FormSG/FormSGView.tsx
@@ -1,0 +1,36 @@
+import { Box, Text } from "@chakra-ui/react"
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react"
+
+export const FormSGView = ({ node }: NodeViewProps) => {
+  const formSrc = node.content.child(1).attrs.src
+
+  return (
+    <Box
+      as={NodeViewWrapper}
+      bg="#FAF594"
+      border="3px solid #0d0d0d"
+      borderRadius="0.5rem"
+      margin="1rem 0"
+      position="relative"
+      data-drag-handle
+      contentEditable={false}
+    >
+      <Text
+        ml="1rem"
+        bgColor="#0d0d0d"
+        textStyle="caption-1"
+        fontWeight="bold"
+        color="#fff"
+        position="absolute"
+        top="0"
+        padding="0.25rem 0.75rem"
+        borderRadius="0 0 0.5rem 0.5rem"
+      >
+        FormSG Embed
+      </Text>
+      <Box mt="1.5rem" p="1rem">
+        {formSrc}
+      </Box>
+    </Box>
+  )
+}

--- a/src/layouts/components/Editor/extensions/FormSG/index.ts
+++ b/src/layouts/components/Editor/extensions/FormSG/index.ts
@@ -1,0 +1,2 @@
+export * from "./FormSG"
+export * from "./FormSGView"

--- a/src/layouts/components/Editor/extensions/Iframe/Iframe.ts
+++ b/src/layouts/components/Editor/extensions/Iframe/Iframe.ts
@@ -68,7 +68,7 @@ export const Iframe = Node.create<IframeOptions>({
   parseHTML() {
     return [
       {
-        tag: "iframe",
+        tag: 'iframe:not([src^="https://form.gov.sg/"])',
       },
     ]
   },

--- a/src/layouts/components/Editor/extensions/index.ts
+++ b/src/layouts/components/Editor/extensions/index.ts
@@ -1,1 +1,2 @@
 export * from "./Iframe"
+export * from "./FormSG"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The FormSG embed does not use a proper Tiptap node to display, causing the attribution to be removed as part of the hacky workaround.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The FormSG embed now uses a proper Tiptap node to represent the content.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Edit a page using the new RTE
    - [ ] Test the FormSG embed using the embed modal, verify that it can be added and saved.
    - [ ] Refresh the page, verify that the FormSG embed still stays the same.
    - [ ] Save the page, verify that there are no changes to the contents of the file.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*