### PR TITLE
fix(media): bring the user back to the select media modal screen after upload

### DIFF
--- a/src/components/MediaCreationModal/MediaCreationModal.tsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.tsx
@@ -159,13 +159,14 @@ interface MediaUploadSuccessDropzoneProps {
   numMedia: number
   errorMessages: string[]
   mediaType: MediaFolderTypes
+  onProceed: () => void
 }
 const MediaUploadSuccessDropzone = ({
   numMedia,
   errorMessages,
   mediaType,
+  onProceed,
 }: MediaUploadSuccessDropzoneProps) => {
-  const { onClose } = useModalContext()
   const {
     singularMediaLabel,
     pluralMediaLabel,
@@ -220,7 +221,7 @@ const MediaUploadSuccessDropzone = ({
         )}
       </ModalBody>
       <ModalFooter>
-        <Button onClick={onClose}>Return to {singularDirectoryLabel}</Button>
+        <Button onClick={onProceed}>Return to {singularDirectoryLabel}</Button>
       </ModalFooter>
     </>
   )
@@ -281,6 +282,7 @@ const MediaUploadFailedDropzone = ({
 
 interface MediaCreationModalProps {
   onClose: () => void
+  onProceed: () => void
   variant: MediaFolderTypes
 }
 
@@ -295,6 +297,7 @@ interface MediaCreationRouteParams
 
 export const MediaCreationModal = ({
   onClose,
+  onProceed,
   variant,
 }: MediaCreationModalProps) => {
   const { onClose: onModalClose } = useDisclosure()
@@ -368,6 +371,7 @@ export const MediaCreationModal = ({
             numMedia={numCreated}
             errorMessages={errorMessages}
             mediaType={variant}
+            onProceed={onProceed}
           />
         )}
         {curStep === "failed" && (

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -9,8 +9,6 @@ import { MediaAltText } from "components/media/MediaAltText"
 import MediasSelectModal from "components/media/MediasSelectModal"
 import { MediaCreationModal } from "components/MediaCreationModal/MediaCreationModal"
 
-import { useCreateMediaHook } from "hooks/mediaHooks/useCreateMediaHook"
-
 import { getMediaDirectoryName } from "utils"
 
 const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
@@ -35,8 +33,6 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
     mediaRoom: type,
     mediaDirectoryName: type,
   })
-
-  const { mutateAsync: createHandler } = useCreateMediaHook(queryParams)
 
   const retrieveMediaDirectoryParams = () =>
     `/${getMediaDirectoryName(queryParams.mediaDirectoryName, {
@@ -64,18 +60,8 @@ const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
         <MediaCreationModal
           params={queryParams}
           variant={queryParams.mediaRoom}
-          onProceed={async ({ data }) => {
-            await createHandler({ data })
-            onMediaSelect({ ...data, mediaUrl: data.content })
-            if (showAltTextModal) setMediaMode("details")
-            else
-              onProceed({
-                selectedMediaPath: `${retrieveMediaDirectoryParams()}/${
-                  data.name
-                }`,
-              })
-          }}
-          onClose={onClose}
+          onProceed={() => setMediaMode("select")}
+          onClose={() => setMediaMode("select")}
         />
       )
     }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-763.
Closes IS-779.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The user is now brought back to the select media modal after uploading files.
- Any closure of the upload files modal also brings the user back to the select media modal.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit any page.
    - [ ] Click on the insert image modal, upload a new image.
    - [ ] When you click "Return to album", verify that you are brought back to the select media modal screen.
    - [ ] Click on the "Upload new images" button again.
    - [ ] Click on "Cancel". Verify that you are brought back to the select media modal screen.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*