### PR TITLE
feat(tiptap): add Instagram embed proper node handler

### DIFF
--- a/src/components/EditorEmbedModal/EditorEmbedModal.tsx
+++ b/src/components/EditorEmbedModal/EditorEmbedModal.tsx
@@ -18,7 +18,6 @@ import {
   Link,
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
-import * as Cheerio from "cheerio"
 import { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import * as Yup from "yup"
@@ -45,18 +44,7 @@ export const EditorEmbedModal = ({
   const { data: csp } = useCspHook()
 
   const handleSubmit = (embedCode: EditorEmbedContents) => {
-    const { value } = embedCode
-    const $ = Cheerio.load(value)
-
-    if ($("blockquote").hasClass("instagram-media")) {
-      const postUrl = $(".instagram-media").attr("data-instgrm-permalink")
-      const url = document.createElement("a")
-      url.href = postUrl || ""
-      const code = `<iframe src="https://${url.host}${url.pathname}embed/" frameborder="0" allowfullscreen="true" width="320" height="440"></iframe>`
-      onProceed({ value: code })
-    } else {
-      onProceed(embedCode)
-    }
+    onProceed(embedCode)
   }
 
   const methods = useForm<EditorEmbedContents>({
@@ -92,6 +80,7 @@ export const EditorEmbedModal = ({
         cursorValue
           .replace('<div class="iframe-wrapper">', "")
           .replace('<div class="formsg-wrapper">', "")
+          .replace('<div class="instagram-wrapper">', "")
           // Remove the closing div tag
           .slice(0, -6)
       )

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -35,6 +35,7 @@ import {
   FormSGIframe,
   Iframe,
   IsomerImage,
+  Instagram,
 } from "layouts/components/Editor/extensions"
 
 import { isEmbedCodeValid } from "utils/allowedHTML"
@@ -78,6 +79,7 @@ export const EditPage = () => {
       FormSG,
       FormSGDiv,
       FormSGIframe,
+      Instagram,
       Markdown,
       BubbleMenu.configure({
         pluginKey: "linkBubble",

--- a/src/layouts/components/Editor/extensions/Instagram/Instagram.ts
+++ b/src/layouts/components/Editor/extensions/Instagram/Instagram.ts
@@ -1,0 +1,308 @@
+import { Node } from "@tiptap/core"
+import { ReactNodeViewRenderer } from "@tiptap/react"
+
+import { InstagramView } from "./InstagramView"
+
+export interface InstagramOption {
+  HTMLAttributes: {
+    class: string
+  }
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    instagram: {
+      /**
+       * Add an Instagram embed
+       */
+      setInstagram: (options: {
+        postUrl: string
+        caption: string
+      }) => ReturnType
+    }
+  }
+}
+
+export const Instagram = Node.create<InstagramOption>({
+  name: "instagram",
+  group: "block",
+  atom: true,
+  draggable: true,
+  defining: true,
+  priority: 300,
+
+  addAttributes() {
+    return {
+      class: {
+        default: "instagram-media",
+      },
+      "data-instgrm-captioned": {
+        default: null,
+      },
+      "data-instgrm-permalink": {
+        default: null,
+      },
+      "data-instgrm-version": {
+        default: "14",
+      },
+      style: {
+        default: null,
+      },
+      caption: {
+        default: "",
+        parseHTML: (element) =>
+          element.querySelector('p > a[href^="https://www.instagram.com/"]')
+            ?.textContent ?? "",
+      },
+      permalink: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-instgrm-permalink"),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "blockquote[data-instgrm-permalink]",
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { caption, permalink, src, ...rest } = HTMLAttributes
+
+    return [
+      "div",
+      { class: "instagram-wrapper" },
+      [
+        "blockquote",
+        rest,
+        [
+          "div",
+          { style: "padding: 16px;" },
+          [
+            "a",
+            {
+              href: permalink,
+              style:
+                "background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;",
+            },
+            [
+              "div",
+              {
+                style:
+                  "display: flex; flex-direction: row; align-items: center;",
+              },
+              [
+                "div",
+                {
+                  style:
+                    "background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;",
+                },
+              ],
+              [
+                "div",
+                {
+                  style:
+                    "display: flex; flex-direction: column; flex-grow: 1; justify-content: center;",
+                },
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;",
+                  },
+                ],
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;",
+                  },
+                ],
+              ],
+            ],
+            ["div", { style: "padding: 19% 0;" }],
+            [
+              "div",
+              {
+                style:
+                  "display:block; height:50px; margin:0 auto 12px; width:50px;",
+              },
+              [
+                "svg",
+                {
+                  width: "50px",
+                  height: "50px",
+                  viewBox: "0 0 60 60",
+                  version: "1.1",
+                  xmlns: "https://www.w3.org/2000/svg",
+                  "xmlns:xlink": "https://www.w3.org/1999/xlink",
+                },
+                [
+                  "g",
+                  {
+                    stroke: "none",
+                    "stroke-width": "1",
+                    fill: "none",
+                    "fill-rule": "evenodd",
+                  },
+                  [
+                    "g",
+                    {
+                      transform: "translate(-511.000000, -20.000000)",
+                      fill: "#000000",
+                    },
+                    [
+                      "g",
+                      {},
+                      [
+                        "path",
+                        {
+                          d:
+                            "M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631",
+                        },
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+            [
+              "div",
+              { style: "padding-top: 8px;" },
+              [
+                "div",
+                {
+                  style:
+                    "color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;",
+                },
+                "View this post on Instagram",
+              ],
+            ],
+            ["div", { style: "padding: 12.5% 0;" }],
+            [
+              "div",
+              {
+                style:
+                  "display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;",
+              },
+              [
+                "div",
+                {},
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);",
+                  },
+                ],
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;",
+                  },
+                ],
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);",
+                  },
+                ],
+              ],
+              [
+                "div",
+                { style: "margin-left: 8px;" },
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;",
+                  },
+                ],
+                [
+                  "div",
+                  {
+                    style:
+                      "width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)",
+                  },
+                ],
+              ],
+              [
+                "div",
+                { style: "margin-left: auto;" },
+                [
+                  "div",
+                  {
+                    style:
+                      "width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);",
+                  },
+                ],
+                [
+                  "div",
+                  {
+                    style:
+                      "background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);",
+                  },
+                ],
+                [
+                  "div",
+                  {
+                    style:
+                      "width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);",
+                  },
+                ],
+              ],
+            ],
+            [
+              "div",
+              {
+                style:
+                  "display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;",
+              },
+              [
+                "div",
+                {
+                  style:
+                    "background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;",
+                },
+              ],
+              [
+                "div",
+                {
+                  style:
+                    "background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;",
+                },
+              ],
+            ],
+          ],
+          [
+            "p",
+            {
+              style:
+                "color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;",
+            },
+            [
+              "a",
+              {
+                href: permalink,
+                style:
+                  "color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;",
+                target: "_blank",
+              },
+              caption,
+            ],
+          ],
+        ],
+      ],
+      ["script", { async: true, src: "//www.instagram.com/embed.js" }],
+    ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(InstagramView)
+  },
+})

--- a/src/layouts/components/Editor/extensions/Instagram/InstagramView.tsx
+++ b/src/layouts/components/Editor/extensions/Instagram/InstagramView.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from "@chakra-ui/react"
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react"
+
+export const InstagramView = ({ node }: NodeViewProps) => {
+  return (
+    <Box
+      as={NodeViewWrapper}
+      bg="#FAF594"
+      border="3px solid #0d0d0d"
+      borderRadius="0.5rem"
+      margin="1rem 0"
+      position="relative"
+      data-drag-handle
+    >
+      <Text
+        ml="1rem"
+        bgColor="#0d0d0d"
+        textStyle="caption-1"
+        fontWeight="bold"
+        color="#fff"
+        position="absolute"
+        top="0"
+        padding="0.25rem 0.75rem"
+        borderRadius="0 0 0.5rem 0.5rem"
+      >
+        Instagram Post
+      </Text>
+      <Box mt="1.5rem" p="1rem">
+        {node.attrs.permalink}
+      </Box>
+    </Box>
+  )
+}

--- a/src/layouts/components/Editor/extensions/Instagram/index.ts
+++ b/src/layouts/components/Editor/extensions/Instagram/index.ts
@@ -1,0 +1,1 @@
+export * from "./Instagram"

--- a/src/layouts/components/Editor/extensions/index.ts
+++ b/src/layouts/components/Editor/extensions/index.ts
@@ -1,3 +1,4 @@
 export * from "./Iframe"
 export * from "./FormSG"
 export * from "./Image"
+export * from "./Instagram"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Instagram embed is done in a hacky manner whereby we replace it with our own custom iframe, which we cannot guarantee to support.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The Instagram embed is now a full Tiptap Node.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to a site that has the Tiptap editor enabled and edit a page with the new Tiptap editor.
    - [ ] Insert an Instagram embed (both captioned and non-captioned) using the embed modal.
    - [ ] Verify that the Instagram post can be inserted correctly and loads in the final staging site.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*