### PR TITLE
fix(updateLinkModal): update link + proper default

### DIFF
--- a/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
@@ -11,6 +11,7 @@ import {
 } from "@chakra-ui/react"
 import { Button, FormErrorMessage, Input } from "@opengovsg/design-system-react"
 import { BubbleMenu } from "@tiptap/react"
+import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 
 import { useEditorContext } from "contexts/EditorContext"
@@ -20,28 +21,36 @@ const LinkButton = () => {
   const { editor } = useEditorContext()
   const { onClose, onOpen, isOpen } = useDisclosure()
   const { showModal } = useEditorModal()
-
   const {
     register,
     watch,
     formState: { errors, isValid },
+    setValue,
   } = useForm({
     mode: "onTouched",
     defaultValues: {
-      href: (editor.getAttributes("link").href as string) || "",
+      href: "", // we don't set default values here since this does not change on component re-open
     },
   })
+
+  useEffect(() => {
+    // set default values here instead
+    const { href } = editor.getAttributes("link")
+    setValue("href", href)
+    // only done once per every time the modal is opened
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
   const href = watch("href")
+
   const onSubmit = () => {
     if (href) {
       editor
         .chain()
-        .focus()
+        .extendMarkRange("link")
         // NOTE: Force `https` by default
         .setLink({ href })
         .run()
-    } else {
-      editor.chain().focus().unsetLink().run()
     }
     onClose()
   }


### PR DESCRIPTION
## Problem

Update link modal not updating + does not have proper defaults



## Solution

Use `.extendMarkRange("link")` instead, this is a direct copy paste from their [demo](https://tiptap.dev/api/marks/link). 
For default values, re-update every time the modal is opened. 


## Tests

https://github.com/isomerpages/isomercms-frontend/assets/42832651/5a80f0fe-d63a-46a6-a792-8cf5c6c1ed3c


<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new link1 + `text1` 
- [ ] Create a new link2 + `text2` 
- [ ] modify the first link's test to be `text1-1` 
- [ ] modify the second link's text to be `text-2-2`
- [ ] modifiy the first link's text to be `text1-1-1`
- [ ] note that all the changes are as reflected in the dom of the preview (ie the links have the correct alt texts) 

