### PR TITLE
fix: submitting state for react-hook-form

### DIFF
--- a/src/components/Header/ContactModal/ContactVerificationModal.tsx
+++ b/src/components/Header/ContactModal/ContactVerificationModal.tsx
@@ -43,7 +43,12 @@ export const ContactVerificationModal = ({
   const [mobile, setMobile] = useState<string>("")
 
   const handleSendOtp = async ({ mobile: mobileInput }: ContactProps) => {
-    await sendContactOtp({ mobile: mobileInput }) // Non-2xx responses will be caught by axios and thrown as error
+    try {
+      await sendContactOtp({ mobile: mobileInput }) // Non-2xx responses will be caught by axios and thrown as error
+    } catch (e) {
+      // Needed for react-hook-form to reset isSubmitting
+      return
+    }
     successToast({
       id: "send-otp-success",
       description: `OTP sent to ${mobileInput}`,
@@ -52,7 +57,12 @@ export const ContactVerificationModal = ({
   }
 
   const handleVerifyOtp = async ({ otp }: ContactOtpProps) => {
-    await verifyContactOtp({ mobile, otp })
+    try {
+      await verifyContactOtp({ mobile, otp })
+    } catch (e) {
+      // Needed for react-hook-form to reset isSubmitting
+      return
+    }
     onClose()
     successToast({
       id: "verify-otp-success",

--- a/src/layouts/Login/LoginPage.tsx
+++ b/src/layouts/Login/LoginPage.tsx
@@ -105,7 +105,12 @@ const LoginContent = (): JSX.Element => {
 
   const handleSendOtp = async ({ email: emailInput }: LoginProps) => {
     const trimmedEmail = emailInput.trim()
-    await sendLoginOtp({ email: trimmedEmail }) // Non-2xx responses will be caught by axios and thrown as error
+    try {
+      await sendLoginOtp({ email: trimmedEmail }) // Non-2xx responses will be caught by axios and thrown as error
+    } catch (e) {
+      // Needed for react-hook-form to reset isSubmitting
+      return
+    }
     successToast({
       id: "send-otp-success",
       description: `OTP sent to ${trimmedEmail}`,
@@ -114,7 +119,12 @@ const LoginContent = (): JSX.Element => {
   }
 
   const handleVerifyOtp = async ({ otp }: OtpProps) => {
-    await verifyLoginOtp({ email, otp })
+    try {
+      await verifyLoginOtp({ email, otp })
+    } catch (e) {
+      // Needed for react-hook-form to reset isSubmitting
+      return
+    }
     history.replace("/sites")
   }
 

--- a/src/layouts/ReviewRequest/components/Comments/SendCommentForm.tsx
+++ b/src/layouts/ReviewRequest/components/Comments/SendCommentForm.tsx
@@ -39,17 +39,13 @@ export const SendCommentForm = ({
   const {
     mutateAsync: updateNotifications,
     error: updateNotificationsError,
+    isLoading: isUpddatingComments,
   } = useUpdateComments()
 
   const queryClient = useQueryClient()
 
   const handleUpdateNotifications = async ({ comment }: CommentFormProps) => {
-    try {
-      await updateNotifications({ siteName, requestId, message: comment })
-    } catch (e) {
-      // Needed for react-hook-form to reset isSubmitting
-      return
-    }
+    await updateNotifications({ siteName, requestId, message: comment })
     resetField("comment")
     queryClient.invalidateQueries([COMMENTS_KEY, siteName])
   }
@@ -67,7 +63,7 @@ export const SendCommentForm = ({
     <form onSubmit={handleSubmit(handleUpdateNotifications)}>
       <FormControl
         isInvalid={!!formState.errors.comment}
-        isReadOnly={formState.isSubmitting}
+        isReadOnly={isUpddatingComments}
         pb="1.5rem"
       >
         <HStack>
@@ -85,7 +81,7 @@ export const SendCommentForm = ({
             variant="clear"
             aria-label="link to send comment"
             type="submit"
-            isLoading={formState.isSubmitting}
+            isLoading={isUpddatingComments}
             isDisabled={!formState.isValid}
           />
         </HStack>

--- a/src/layouts/ReviewRequest/components/Comments/SendCommentForm.tsx
+++ b/src/layouts/ReviewRequest/components/Comments/SendCommentForm.tsx
@@ -44,7 +44,12 @@ export const SendCommentForm = ({
   const queryClient = useQueryClient()
 
   const handleUpdateNotifications = async ({ comment }: CommentFormProps) => {
-    await updateNotifications({ siteName, requestId, message: comment })
+    try {
+      await updateNotifications({ siteName, requestId, message: comment })
+    } catch (e) {
+      // Needed for react-hook-form to reset isSubmitting
+      return
+    }
     resetField("comment")
     queryClient.invalidateQueries([COMMENTS_KEY, siteName])
   }


### PR DESCRIPTION
## Problem

Resolves IS-777.

This PR fixes an issue introduced by a change to the behaviour of `react-hook-form` - it no longer returns `isSubmitting` to false when an error is thrown (see [link](https://github.com/orgs/react-hook-form/discussions/9879)). As we make use of react-query, which handles promises rejection (and requires promises to throw on failure), we need to add an additional catch statement for each of the places where we make use of `isSubmitting` to determine whether the submit button is disabled. Note that error handling is already tackled in each of these places, hence the catch without doing anything else - this is purely to ensure that react-hook-form returns to the correct state.

Affected components:

- [ ] Email Login (both send otp and verify otp)
- [ ] Verification of contact number
- [ ] Comment submission