### PR TITLE
Fix/is 778 creating media in subfolder in select modal

### DIFF
--- a/src/components/DirectorySettingsModal/DirectorySettingsModal.jsx
+++ b/src/components/DirectorySettingsModal/DirectorySettingsModal.jsx
@@ -14,13 +14,10 @@ import { LoadingButton } from "components/LoadingButton"
 import elementStyles from "styles/isomer-cms/Elements.module.scss"
 
 import { getDirectorySettingsType } from "utils/directoryUtils"
+import { getMediaDirectoryName } from "utils/media"
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
-import {
-  deslugifyDirectory,
-  getLastItemType,
-  getMediaDirectoryName,
-} from "utils"
+import { deslugifyDirectory, getLastItemType } from "utils"
 
 import { DirectorySettingsSchema } from "./DirectorySettingsSchema"
 

--- a/src/components/MediaCreationModal/MediaCreationModal.tsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.tsx
@@ -21,13 +21,12 @@ import _ from "lodash"
 import { useEffect, useState } from "react"
 import { FileRejection } from "react-dropzone"
 import { BiCheckCircle, BiSolidErrorCircle } from "react-icons/bi"
-import { useParams } from "react-router-dom"
 
 import { Attachment } from "components/Attachment"
 
 import { useCreateMultipleMedia } from "hooks/mediaHooks/useCreateMultipleMedia"
 
-import { getMediaLabels } from "utils/media"
+import { getMediaDirectoryName, getMediaLabels } from "utils/media"
 
 import { MediaDirectoryParams } from "types/folders"
 import { MediaFolderTypes } from "types/media"
@@ -280,12 +279,6 @@ const MediaUploadFailedDropzone = ({
   )
 }
 
-interface MediaCreationModalProps {
-  onClose: () => void
-  onProceed: () => void
-  variant: MediaFolderTypes
-}
-
 interface MediaCreationRouteParams
   extends Omit<
     MediaDirectoryParams,
@@ -295,14 +288,25 @@ interface MediaCreationRouteParams
   mediaDirectoryName?: string
 }
 
+interface MediaCreationModalProps {
+  params: MediaCreationRouteParams
+  onClose: () => void
+  onProceed: () => void
+  variant: MediaFolderTypes
+}
+
 export const MediaCreationModal = ({
+  params,
   onClose,
   onProceed,
   variant,
 }: MediaCreationModalProps) => {
   const { onClose: onModalClose } = useDisclosure()
-  const params = useParams<MediaCreationRouteParams>()
-  const { siteName, mediaDirectoryName } = params
+  const { siteName, mediaDirectoryName: rawMediaDirectoryName } = params
+  const mediaDirectoryName = `${getMediaDirectoryName(
+    rawMediaDirectoryName || "",
+    { splitOn: "/" }
+  )}`
 
   const {
     mutateAsync: uploadFiles,

--- a/src/components/media/MediaModal.jsx
+++ b/src/components/media/MediaModal.jsx
@@ -9,7 +9,7 @@ import { MediaAltText } from "components/media/MediaAltText"
 import MediasSelectModal from "components/media/MediasSelectModal"
 import { MediaCreationModal } from "components/MediaCreationModal/MediaCreationModal"
 
-import { getMediaDirectoryName } from "utils"
+import { getMediaDirectoryName } from "utils/media"
 
 const MediaModal = ({ onClose, onProceed, type, showAltTextModal = false }) => {
   const {

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -41,9 +41,9 @@ import { FilePreviewCard, MediaDirectoryCard } from "layouts/Media/components"
 
 import mediaStyles from "styles/isomer-cms/pages/Media.module.scss"
 
-import { getMediaLabels } from "utils/media"
+import { getMediaDirectoryName, getMediaLabels } from "utils/media"
 
-import { deslugifyDirectory, getMediaDirectoryName } from "utils"
+import { deslugifyDirectory } from "utils"
 
 const filterMediaByFileName = (medias, filterTerm) =>
   medias.filter((media) =>

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -135,9 +135,10 @@ const MediasSelectModal = ({
       size="6xl"
       scrollBehavior="inside"
       closeOnOverlayClick={false}
+      isCentered
     >
       <ModalOverlay />
-      <ModalContent padding="0.5rem" paddingTop="1rem">
+      <ModalContent padding="0.5rem" paddingTop="1rem" maxHeight="90%">
         <ModalHeader>
           <VStack alignItems="right" gap="1rem">
             <HStack justifyContent="space-between">

--- a/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useDeleteDirectoryHook.jsx
@@ -11,9 +11,10 @@ import {
 
 import { ServicesContext } from "contexts/ServicesContext"
 
+import { getMediaDirectoryName } from "utils/media"
 import { useSuccessToast, useErrorToast } from "utils/toasts"
 
-import { DEFAULT_RETRY_MSG, getMediaDirectoryName } from "utils"
+import { DEFAULT_RETRY_MSG } from "utils"
 
 // eslint-disable-next-line import/prefer-default-export
 export function useDeleteDirectoryHook(params, queryParams) {

--- a/src/hooks/directoryHooks/useUpdateDirectoryHook.jsx
+++ b/src/hooks/directoryHooks/useUpdateDirectoryHook.jsx
@@ -10,9 +10,10 @@ import {
 
 import { ServicesContext } from "contexts/ServicesContext"
 
+import { getMediaDirectoryName } from "utils/media"
 import { useSuccessToast, useErrorToast } from "utils/toasts"
 
-import { DEFAULT_RETRY_MSG, getMediaDirectoryName } from "utils"
+import { DEFAULT_RETRY_MSG } from "utils"
 
 import { extractUpdateDirectoryInfo } from "./utils"
 

--- a/src/hooks/directoryHooks/utils.ts
+++ b/src/hooks/directoryHooks/utils.ts
@@ -1,5 +1,6 @@
+import { getMediaDirectoryName } from "utils/media"
+
 import { DirectoryInfoProps, DirectoryInfoReturn } from "types/directory"
-import { getMediaDirectoryName } from "utils"
 
 export function extractCreateDirectoryInfo({
   data,

--- a/src/layouts/screens/DeleteWarningScreen.jsx
+++ b/src/layouts/screens/DeleteWarningScreen.jsx
@@ -10,13 +10,10 @@ import { useDeleteDirectoryHook } from "hooks/directoryHooks"
 import { useGetMediaHook, useDeleteMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook, useDeletePageHook } from "hooks/pageHooks"
 
+import { getMediaDirectoryName } from "utils/media"
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
-import {
-  getLastItemType,
-  getMediaDirectoryName,
-  pageFileNameToTitle,
-} from "utils"
+import { getLastItemType, pageFileNameToTitle } from "utils"
 
 export const DeleteWarningScreen = ({ match, onClose }) => {
   const [isDeleteChecked, setIsDeleteChecked] = useState(false)

--- a/src/layouts/screens/DirectorySettingsScreen.jsx
+++ b/src/layouts/screens/DirectorySettingsScreen.jsx
@@ -9,7 +9,9 @@ import {
   useUpdateDirectoryHook,
 } from "hooks/directoryHooks"
 
-import { getLastItemType, getMediaDirectoryName } from "utils"
+import { getMediaDirectoryName } from "utils/media"
+
+import { getLastItemType } from "utils"
 
 // axios settings
 axios.defaults.withCredentials = true

--- a/src/layouts/screens/MediaCreationScreen.jsx
+++ b/src/layouts/screens/MediaCreationScreen.jsx
@@ -2,21 +2,15 @@ import PropTypes from "prop-types"
 
 import { MediaCreationModal } from "components/MediaCreationModal"
 
-import { useCreateMediaHook } from "hooks/mediaHooks"
-
 export const MediaCreationScreen = ({ match, onClose }) => {
-  const { params, decodedParams } = match
-
-  const { mutateAsync: createHandler } = useCreateMediaHook(params, {
-    onSuccess: () => onClose(),
-  })
+  const { decodedParams } = match
 
   return (
     <MediaCreationModal
       params={decodedParams}
       variant={decodedParams.mediaRoom}
       onClose={onClose}
-      onProceed={createHandler}
+      onProceed={onClose}
     />
   )
 }

--- a/src/services/DirectoryService.jsx
+++ b/src/services/DirectoryService.jsx
@@ -1,4 +1,6 @@
-import { getLastItemType, getMediaDirectoryName } from "../utils"
+import { getMediaDirectoryName } from "utils/media"
+
+import { getLastItemType } from "../utils"
 
 export class DirectoryService {
   constructor({ apiClient }) {

--- a/src/utils/legacy.js
+++ b/src/utils/legacy.js
@@ -289,21 +289,6 @@ export const getLastItemType = (params) => {
   return lastItemType
 }
 
-export const getMediaDirectoryName = (
-  mediaDirectoryName,
-  { start = 0, end, splitOn = "%2F", joinOn = "%2F", decode = false }
-) => {
-  const mediaDirectoryArray = mediaDirectoryName.split(splitOn)
-  const selectedMediaDirectoryArray = mediaDirectoryArray.slice(start, end)
-  if (decode) {
-    const decodedSelectedMediaDirectoryArray = selectedMediaDirectoryArray.map(
-      (v) => decodeURIComponent(v)
-    )
-    return decodedSelectedMediaDirectoryArray.join(joinOn)
-  }
-  return selectedMediaDirectoryArray.join(joinOn)
-}
-
 export const getNextItemType = (params) => {
   const lastItemType = getLastItemType(params)
   if (lastItemType === "siteName") {

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -33,3 +33,32 @@ export const getSelectedMediaDto = (fileData: MediaData) => {
 
   return selectedData
 }
+
+interface GetMediaDirectoryNameSplitProps {
+  start?: number
+  end?: number
+  splitOn?: string
+  joinOn?: string
+  decode?: boolean
+}
+
+export const getMediaDirectoryName = (
+  mediaDirectoryName: string,
+  {
+    start = 0,
+    end,
+    splitOn = "%2F",
+    joinOn = "%2F",
+    decode = false,
+  }: GetMediaDirectoryNameSplitProps
+) => {
+  const mediaDirectoryArray = mediaDirectoryName.split(splitOn)
+  const selectedMediaDirectoryArray = mediaDirectoryArray.slice(start, end)
+  if (decode) {
+    const decodedSelectedMediaDirectoryArray = selectedMediaDirectoryArray.map(
+      (v) => decodeURIComponent(v)
+    )
+    return decodedSelectedMediaDirectoryArray.join(joinOn)
+  }
+  return selectedMediaDirectoryArray.join(joinOn)
+}


### PR DESCRIPTION
## Problem

This PR fixes an issue with uploading images within subfolders in the select modal, which would upload the result to the root.  This issue was caused by the create modal taking url params instead of the params which were passed to the modal - it has been reconfigured to make use of the passed params.

It also refactors `getMediaDirectoryName` into typescript, and fixes an issue with modal closing after uploading an image on the media tab.

Also resolves IS-765 (makes the select modal taller).

## Tests

<!-- What tests should be run to confirm functionality? -->
Check that uploading functionality works for
- [ ] Media tab, root
- [ ] Media tab, nested directory
- [ ] Select media modal (edit page/page settings), root
- [ ] Select media modal (edit page/page settings), nested directory

