### PR TITLE
Fix: colours stylesheet

### DIFF
--- a/src/utils/siteColorUtils.js
+++ b/src/utils/siteColorUtils.js
@@ -27,7 +27,14 @@ const getStyleSheet = (uniqueTitle) => {
 
 const createPageStyleSheet = (repoName, primaryColor, secondaryColor) => {
   const styleElement = document.createElement("style")
-  const styleTitle = `${repoName}-style`
+  const styleTitle = `custom-style`
+  const existingStyleElement = document.getElementById(styleTitle)
+
+  // Remove existing stylesheet if it exists
+  if (existingStyleElement) {
+    existingStyleElement.parentNode.removeChild(existingStyleElement)
+  }
+
   styleElement.setAttribute("id", styleTitle)
   styleElement.setAttribute("title", styleTitle)
   document.head.appendChild(styleElement)


### PR DESCRIPTION
Resolves IS-762. This PR fixes an issue where colours were not being updated properly on the preview in 2 cases:

- User navigates to one site, loads a page, then visits a different site and loads a page - still uses original colour scheme
- User loads a page, then navigates to settings and changes colours - upon returning to any page the colours are still old

This issue was caused because any changes only added on a new stylesheet, but this had lower priority than the original stylesheet, meaning that colours would stay the same until refreshed.

To fix this, the custom inserted stylesheet is explicitly deleted at the start of the insertion if it exists prior - this allows the site colours to remain updated.

Tests:

- [ ] Go to a site, load a page, go to a different site (with different colour scheme), load a page - colours should be different
- [ ] Load a page, go to settings, change colour, load another page - colours should reflect changed colour