### PR TITLE
Fix/rm-.NpmRc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 .vscode
 .idea
 .cache_ggshield
+.npmrc
 
 npm-debug.log*
 yarn-debug.log*

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true


### PR DESCRIPTION
## Problem

our tiptap editor uses a private registory, and involves committing a token to .npmrc

add .npmrc into gitignore + rm cache

