### PR TITLE
fix(media): allow creating folders in empty folder

### DIFF
--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -71,6 +71,7 @@ interface CreateMediaFolderModalProps {
 
 const getButtonLabel = (
   originalSelectedMedia: SelectedMediaDto[],
+  filesCount: number,
   selectedMedia: SelectedMediaDto[],
   mediaLabels: MediaLabels
 ) => {
@@ -80,7 +81,7 @@ const getButtonLabel = (
     pluralMediaLabel,
   } = mediaLabels
 
-  if (originalSelectedMedia.length > 0) {
+  if (originalSelectedMedia.length > 0 || filesCount === 0) {
     return `Create ${singularDirectoryLabel}`
   }
 
@@ -229,7 +230,7 @@ export const CreateMediaFolderModal = ({
                 </FormErrorMessage>
               </FormControl>
 
-              {originalSelectedMedia.length === 0 && (
+              {originalSelectedMedia.length === 0 && files.length !== 0 && (
                 <>
                   <Text as="h5" textStyle="h5" mt="2rem">
                     Select {pluralMediaLabel} to add to this{" "}
@@ -314,7 +315,7 @@ export const CreateMediaFolderModal = ({
                 justifyContent="flex-end"
                 mt="0.5rem"
               >
-                {originalSelectedMedia.length > 0 && (
+                {(originalSelectedMedia.length > 0 || files.length === 0) && (
                   <Button
                     variant="clear"
                     colorScheme="neutral"
@@ -323,7 +324,7 @@ export const CreateMediaFolderModal = ({
                     Cancel
                   </Button>
                 )}
-                {originalSelectedMedia.length === 0 && (
+                {originalSelectedMedia.length === 0 && files.length !== 0 && (
                   <Button
                     variant="clear"
                     colorScheme="neutral"
@@ -359,6 +360,7 @@ export const CreateMediaFolderModal = ({
                 >
                   {getButtonLabel(
                     originalSelectedMedia,
+                    files.length,
                     methods.getValues("selectedPages"),
                     mediaLabels
                   )}

--- a/src/layouts/Media/Media.tsx
+++ b/src/layouts/Media/Media.tsx
@@ -632,8 +632,7 @@ export const Media = (): JSX.Element => {
                   {directoryLevel < MAX_MEDIA_LEVELS && (
                     <Greyscale isActive={isWriteDisabled}>
                       <Button
-                        as={Link}
-                        to={`${url}/createDirectory`}
+                        onClick={onCreateMediaFolderModalOpen}
                         mt="1rem"
                         variant="clear"
                       >


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Users are not able to create folders when the folder is empty.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The link to create a new folder when inside an empty folder is now fixed and correctly points to opening the create media folder modal.
- The media folder modal has also been fixed to not show the select images/files portion if there are no files to begin with.

## Before & After Screenshots

**BEFORE**:

<img width="1047" alt="Screenshot 2023-11-24 at 11 01 27" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/6c9e74cd-9390-42c7-8d8f-e415da2db4ce">

**AFTER**:

<img width="1055" alt="Screenshot 2023-11-24 at 11 01 43" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/4e1c636f-a405-4547-86e6-2559bf454476">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and access the images/files workspace
    - [ ] Go into an empty folder or create one if there isn't any.
    - [ ] Click on the "Or, create an album/directory" button. Verify that the create media folder modal opens.
    - [ ] Verify that the create media folder modal does not show any information about getting users to select images/files to add to this new folder.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*