### PR TITLE
feat(cards): introduce drawer to support sub-editing

### DIFF
--- a/src/components/EditorCardsDrawer/EditorCardsDrawer.tsx
+++ b/src/components/EditorCardsDrawer/EditorCardsDrawer.tsx
@@ -1,0 +1,37 @@
+import { Text } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import { Editor } from "@tiptap/core"
+
+import { EditorDrawer } from "components/EditorDrawer"
+
+interface EditorCardsDrawerProps {
+  editor: Editor
+  isOpen: boolean
+  onClose: () => void
+  onProceed: () => void
+}
+
+export const EditorCardsDrawer = ({
+  editor,
+  isOpen,
+  onClose,
+  onProceed,
+}: EditorCardsDrawerProps): JSX.Element => {
+  return (
+    <EditorDrawer isOpen={isOpen}>
+      <EditorDrawer.Header onClose={onClose}>
+        <Text as="h5" textStyle="h5">
+          Editing card grid
+        </Text>
+      </EditorDrawer.Header>
+
+      <EditorDrawer.Content>
+        <Text>Placeholder content</Text>
+      </EditorDrawer.Content>
+
+      <EditorDrawer.Footer>
+        <Button>Save card grid</Button>
+      </EditorDrawer.Footer>
+    </EditorDrawer>
+  )
+}

--- a/src/components/EditorCardsDrawer/index.ts
+++ b/src/components/EditorCardsDrawer/index.ts
@@ -1,0 +1,2 @@
+export * from "./EditorCardsDrawer"
+export * from "./EditorCardItem"

--- a/src/components/EditorDrawer/EditorDrawer.tsx
+++ b/src/components/EditorDrawer/EditorDrawer.tsx
@@ -1,0 +1,96 @@
+import { Grid, GridItem, HStack, Icon, Spacer } from "@chakra-ui/react"
+import { IconButton } from "@opengovsg/design-system-react"
+import React, { PropsWithChildren } from "react"
+import { BiX } from "react-icons/bi"
+
+import { MiniDrawer } from "components/MiniDrawer"
+
+interface EditorDrawerProps {
+  isOpen: boolean
+}
+
+interface EditorDrawerHeaderProps {
+  onClose: () => void
+  children: React.ReactNode
+}
+
+interface EditorDrawerContentProps {
+  children: React.ReactNode
+}
+
+interface EditorDrawerFooterProps {
+  children: React.ReactNode
+}
+
+export const EditorDrawer = ({
+  isOpen,
+  children,
+}: PropsWithChildren<EditorDrawerProps>): JSX.Element => {
+  return (
+    <MiniDrawer isOpen={isOpen} width="45vw">
+      <Grid
+        bgColor="base.canvas.default"
+        w="100%"
+        h="100%"
+        gridTemplateRows="3.25rem 1fr 4rem"
+        gridTemplateAreas="'header' 'content' 'footer'"
+        borderRight="1px solid"
+        borderRightColor="base.divider.medium"
+      >
+        {children}
+      </Grid>
+    </MiniDrawer>
+  )
+}
+
+export const EditorDrawerHeader = ({
+  onClose,
+  children,
+}: EditorDrawerHeaderProps): JSX.Element => {
+  return (
+    <GridItem gridArea="header" pt="1.5rem" pl="1.5rem" pr="0.875rem">
+      <HStack h="1.75rem">
+        {children}
+        <Spacer />
+        <IconButton
+          variant="clear"
+          onClick={onClose}
+          aria-label="close editor drawer"
+        >
+          <Icon as={BiX} fontSize="1.5rem" color="base.content.strong" />
+        </IconButton>
+      </HStack>
+    </GridItem>
+  )
+}
+
+export const EditorDrawerContent = ({
+  children,
+}: EditorDrawerContentProps): JSX.Element => {
+  return (
+    <GridItem gridArea="content" p="1.5rem" overflowY="scroll">
+      {children}
+    </GridItem>
+  )
+}
+
+export const EditorDrawerFooter = ({
+  children,
+}: EditorDrawerFooterProps): JSX.Element => {
+  return (
+    <GridItem
+      gridArea="footer"
+      borderTop="1px solid"
+      borderTopColor="base.divider.medium"
+    >
+      <HStack my="0.625rem" px="2rem">
+        <Spacer />
+        {children}
+      </HStack>
+    </GridItem>
+  )
+}
+
+EditorDrawer.Header = EditorDrawerHeader
+EditorDrawer.Content = EditorDrawerContent
+EditorDrawer.Footer = EditorDrawerFooter

--- a/src/components/EditorDrawer/index.ts
+++ b/src/components/EditorDrawer/index.ts
@@ -1,0 +1,1 @@
+export * from "./EditorDrawer"

--- a/src/components/MiniDrawer/MiniDrawer.tsx
+++ b/src/components/MiniDrawer/MiniDrawer.tsx
@@ -1,0 +1,30 @@
+import { BoxProps, Slide, SlideProps } from "@chakra-ui/react"
+
+type MiniDrawerProps = SlideProps & {
+  isOpen: boolean
+  width?: BoxProps["width"]
+}
+
+export const MiniDrawer = ({
+  isOpen,
+  width,
+  children,
+  ...rest
+}: MiniDrawerProps): JSX.Element => {
+  return (
+    <Slide
+      direction="left"
+      in={isOpen}
+      style={{
+        zIndex: 10,
+        position: "absolute",
+        top: "0",
+        left: "0",
+        width: (width as string) || "100%",
+      }}
+      {...rest}
+    >
+      {children}
+    </Slide>
+  )
+}

--- a/src/components/MiniDrawer/index.ts
+++ b/src/components/MiniDrawer/index.ts
@@ -1,0 +1,1 @@
+export * from "./MiniDrawer"

--- a/src/contexts/EditorDrawerContext.tsx
+++ b/src/contexts/EditorDrawerContext.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren, createContext, useContext } from "react"
+
+import { DrawerVariant } from "types/editPage"
+
+interface EditorDrawerContextProps {
+  isAnyDrawerOpen: boolean
+  isDrawerOpen: (drawerVariant: DrawerVariant) => boolean
+  onDrawerOpen: (drawerVariant: DrawerVariant) => () => void
+  onDrawerClose: (drawerVariant: DrawerVariant) => () => void
+  onDrawerProceed: (drawerVariant: DrawerVariant) => () => void
+}
+
+const EditorDrawerContext = createContext<null | EditorDrawerContextProps>(null)
+
+export const useEditorDrawerContext = (): EditorDrawerContextProps => {
+  const editorDrawerContext = useContext(EditorDrawerContext)
+
+  if (!editorDrawerContext) {
+    throw new Error(
+      "useEditorDrawer must be used within an EditorDrawerContextProvider"
+    )
+  }
+
+  return editorDrawerContext
+}
+
+export const EditorDrawerContextProvider = ({
+  isAnyDrawerOpen,
+  isDrawerOpen,
+  onDrawerOpen,
+  onDrawerClose,
+  onDrawerProceed,
+  ...rest
+}: PropsWithChildren<EditorDrawerContextProps>): JSX.Element => {
+  return (
+    <EditorDrawerContext.Provider
+      value={{
+        isAnyDrawerOpen,
+        isDrawerOpen,
+        onDrawerOpen,
+        onDrawerClose,
+        onDrawerProceed,
+      }}
+      {...rest}
+    />
+  )
+}

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -34,15 +34,15 @@ import {
   FormSGIframe,
   Iframe,
   Instagram,
-  IsomerImage,
-  IsomerCards,
   IsomerCard,
-  IsomerClickableCard,
-  IsomerCardImage,
   IsomerCardBody,
-  IsomerCardTitle,
   IsomerCardDescription,
+  IsomerCardImage,
   IsomerCardLink,
+  IsomerCards,
+  IsomerCardTitle,
+  IsomerClickableCard,
+  IsomerImage,
 } from "layouts/components/Editor/extensions"
 
 import { isEmbedCodeValid } from "utils/allowedHTML"

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -34,15 +34,15 @@ import {
   FormSGIframe,
   Iframe,
   Instagram,
-  IsomerCard,
-  IsomerCardBody,
-  IsomerCardDescription,
-  IsomerCardImage,
-  IsomerCardLink,
-  IsomerCards,
-  IsomerCardTitle,
-  IsomerClickableCard,
   IsomerImage,
+  IsomerCards,
+  IsomerCard,
+  IsomerClickableCard,
+  IsomerCardImage,
+  IsomerCardBody,
+  IsomerCardTitle,
+  IsomerCardDescription,
+  IsomerCardLink,
 } from "layouts/components/Editor/extensions"
 
 import { isEmbedCodeValid } from "utils/allowedHTML"

--- a/src/layouts/EditPage/EditPageLayout.tsx
+++ b/src/layouts/EditPage/EditPageLayout.tsx
@@ -20,6 +20,8 @@ import Header from "components/Header"
 import { OverwriteChangesModal } from "components/OverwriteChangesModal"
 import { WarningModal } from "components/WarningModal"
 
+import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
+
 import { useGetMultipleMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook, useUpdatePageHook } from "hooks/pageHooks"
 import { useCspHook, useGetSiteColorsHook } from "hooks/settingsHooks"
@@ -44,6 +46,7 @@ export const EditPageLayout = ({
   variant = "markdown",
   children,
 }: PropsWithChildren<EditPageLayoutProps>) => {
+  const { isAnyDrawerOpen } = useEditorDrawerContext()
   const params = useParams<{ siteName: string }>()
   const decodedParams = getDecodedParams(params)
   const [mediaSrcs, setMediaSrcs] = useState(new Set(""))
@@ -200,7 +203,13 @@ export const EditPageLayout = ({
             isEditPage
             params={decodedParams}
           />
-          <Flex flexDir="row" w="100%" h="100%" alignItems="flex-start">
+          <Flex
+            flexDir="row"
+            w="100%"
+            h="100%"
+            alignItems="flex-start"
+            position="relative"
+          >
             {/* Editor */}
             {children}
           </Flex>
@@ -214,7 +223,7 @@ export const EditPageLayout = ({
               // TODO: Add an alert/modal
               // to warn the user when they violate our csp
               // so they know why + can take action to remedy
-              isDisabled={isContentViolation}
+              isDisabled={isContentViolation || isAnyDrawerOpen}
               isLoading={isSavingPage}
             >
               Save

--- a/src/layouts/EditPage/TiptapEditPage.tsx
+++ b/src/layouts/EditPage/TiptapEditPage.tsx
@@ -5,9 +5,11 @@ import { marked } from "marked"
 import { useCallback, useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
+import { EditorCardsDrawer } from "components/EditorCardsDrawer"
 import PagePreview from "components/pages/PagePreview"
 
 import { useEditorContext } from "contexts/EditorContext"
+import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
 
 import { useGetMultipleMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook } from "hooks/pageHooks"
@@ -31,6 +33,11 @@ interface TiptapEditPageProps {
 export const TiptapEditPage = ({
   shouldUseFetchedData,
 }: TiptapEditPageProps) => {
+  const {
+    isDrawerOpen,
+    onDrawerClose,
+    onDrawerProceed,
+  } = useEditorDrawerContext()
   const params = useParams<{ siteName: string }>()
   const { data: initialPageData, isLoading: isLoadingPage } = useGetPageHook(
     params
@@ -101,8 +108,17 @@ export const TiptapEditPage = ({
       getEditorContent={() => editor.getHTML()}
       variant="tiptap"
     >
+      {/* Editor drawers */}
+      <EditorCardsDrawer
+        editor={editor}
+        isOpen={isDrawerOpen("cards")}
+        onClose={onDrawerClose("cards")}
+        onProceed={onDrawerProceed("cards")}
+      />
+
       {/* Editor */}
       <Editor h="80vh" w="45vw" />
+
       {/* Preview */}
       <PagePreview
         // NOTE: Reserve 45vw for editor

--- a/src/layouts/components/Editor/components/CardsBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/CardsBubbleMenu.tsx
@@ -1,4 +1,4 @@
-import { HStack, Icon } from "@chakra-ui/react"
+import { HStack, Icon, useDisclosure } from "@chakra-ui/react"
 import { IconButton } from "@opengovsg/design-system-react"
 import { BubbleMenu } from "@tiptap/react"
 import { BiPencil, BiTrash } from "react-icons/bi"

--- a/src/layouts/components/Editor/components/CardsBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/CardsBubbleMenu.tsx
@@ -4,9 +4,10 @@ import { BubbleMenu } from "@tiptap/react"
 import { BiPencil, BiTrash } from "react-icons/bi"
 
 import { useEditorContext } from "contexts/EditorContext"
+import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
 
 const CardsButton = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { onDrawerOpen } = useEditorDrawerContext()
   const { editor } = useEditorContext()
 
   return (
@@ -16,13 +17,14 @@ const CardsButton = () => {
         borderRadius="0.25rem"
         border="1px solid"
         borderColor="base.divider.medium"
+        boxShadow="0px 8px 12px 0px rgba(187, 187, 187, 0.50)"
         px="0.5rem"
         py="0.25rem"
       >
         <IconButton
           _hover={{ bg: "gray.100" }}
           _active={{ bg: "gray.200" }}
-          onClick={onOpen}
+          onClick={onDrawerOpen("cards")}
           bgColor="transparent"
           border="none"
           h="1.75rem"

--- a/src/layouts/components/Editor/extensions/TrailingNode.ts
+++ b/src/layouts/components/Editor/extensions/TrailingNode.ts
@@ -1,0 +1,72 @@
+import { Extension } from "@tiptap/core"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
+
+// @ts-ignore
+function nodeEqualsType({ types, node }) {
+  return (
+    (Array.isArray(types) && types.includes(node.type)) || node.type === types
+  )
+}
+
+/**
+ * Extension based on:
+ * - https://github.com/ueberdosis/tiptap/blob/v1/packages/tiptap-extensions/src/extensions/TrailingNode.js
+ * - https://github.com/remirror/remirror/blob/e0f1bec4a1e8073ce8f5500d62193e52321155b9/packages/prosemirror-trailing-node/src/trailing-node-plugin.ts
+ */
+
+export interface TrailingNodeOptions {
+  node: string
+  notAfter: string[]
+}
+
+export const TrailingNode = Extension.create<TrailingNodeOptions>({
+  name: "trailingNode",
+
+  addOptions() {
+    return {
+      node: "paragraph",
+      notAfter: ["paragraph"],
+    }
+  },
+
+  addProseMirrorPlugins() {
+    const plugin = new PluginKey(this.name)
+    const disabledNodes = Object.entries(this.editor.schema.nodes)
+      .map(([, value]) => value)
+      .filter((node) => this.options.notAfter.includes(node.name))
+
+    return [
+      new Plugin({
+        key: plugin,
+        appendTransaction: (_, __, state) => {
+          const { doc, tr, schema } = state
+          const shouldInsertNodeAtEnd = plugin.getState(state)
+          const endPosition = doc.content.size
+          const type = schema.nodes[this.options.node]
+
+          if (shouldInsertNodeAtEnd) {
+            return tr.insert(endPosition, type.create())
+          }
+
+          return null
+        },
+        state: {
+          init: (_, state) => {
+            const lastNode = state.tr.doc.lastChild
+
+            return !nodeEqualsType({ node: lastNode, types: disabledNodes })
+          },
+          apply: (tr, value) => {
+            if (!tr.docChanged) {
+              return value
+            }
+
+            const lastNode = tr.doc.lastChild
+
+            return !nodeEqualsType({ node: lastNode, types: disabledNodes })
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/src/types/editPage.ts
+++ b/src/types/editPage.ts
@@ -2,6 +2,8 @@ export interface EditorEmbedContents {
   value: string
 }
 
+export type DrawerVariant = "cards"
+
 export interface EditorCard {
   image: string
   altText: string


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Card grid block

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Adds a new mini drawer component to support editing within a form outside of the Tiptap editor.

**Note: This PR is part of a stack of changes, refer to #1707 for the complete write-up:**
1. #1701 
2. #1704 **<--- YOU ARE HERE**
3. #1705 
4. #1706
5. #1707

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*