### PR TITLE
feat(cards): support undo/redo of cards editing

### DIFF
--- a/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.stories.tsx
+++ b/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.stories.tsx
@@ -1,0 +1,47 @@
+import { useDisclosure } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import type { Meta, StoryFn } from "@storybook/react"
+
+import { useSuccessToast } from "utils"
+
+import { EditorDrawerCloseWarningModal } from "./EditorDrawerCloseWarningModal"
+
+const editorDrawerCloseWarningModalMeta = {
+  title: "Components/Editor/Drawer Close Warning Modal",
+  component: EditorDrawerCloseWarningModal,
+} as Meta<typeof EditorDrawerCloseWarningModal>
+
+interface EditorDrawerCloseWarningModalTemplateArgs {
+  name: string
+}
+
+const editorDrawerCloseWarningModalTemplate: StoryFn<
+  typeof EditorDrawerCloseWarningModal
+> = ({ name }: EditorDrawerCloseWarningModalTemplateArgs) => {
+  const { isOpen, onOpen, onClose } = useDisclosure({ defaultIsOpen: true })
+  const successToast = useSuccessToast()
+  const onProceed = () => {
+    successToast({
+      id: "storybook-editor-drawer-close-warning-success",
+      description: "STORYBOOK: Successfully exited from editor drawer",
+    })
+    onClose()
+  }
+
+  return (
+    <>
+      <Button onClick={onOpen}>Open editor drawer close warning modal</Button>
+      <EditorDrawerCloseWarningModal
+        name={name}
+        isOpen={isOpen}
+        onClose={onClose}
+        onProceed={onProceed}
+      />
+    </>
+  )
+}
+
+export const Default = editorDrawerCloseWarningModalTemplate.bind({})
+Default.args = {}
+
+export default editorDrawerCloseWarningModalMeta

--- a/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.tsx
+++ b/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.tsx
@@ -1,0 +1,54 @@
+import {
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+interface EditorDrawerCloseWarningModalProps {
+  name: string
+  isOpen: boolean
+  onClose: () => void
+  onProceed: () => void
+}
+
+export const EditorDrawerCloseWarningModal = ({
+  name,
+  isOpen,
+  onClose,
+  onProceed,
+}: EditorDrawerCloseWarningModalProps): JSX.Element => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Are you sure you want to exit {name} editing?</ModalHeader>
+
+        <ModalCloseButton />
+
+        <ModalBody>
+          <Text>
+            You haven’t saved your edits to the {name}. If you exit edit mode,
+            you will lose all your unsaved changes.
+          </Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <HStack w="100%" spacing="1rem" justifyContent="flex-end">
+            <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+              Go back to {name}
+            </Button>
+            <Button colorScheme="critical" onClick={onProceed}>
+              Exit {name} editing
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/EditorDrawerCloseWarningModal/index.ts
+++ b/src/components/EditorDrawerCloseWarningModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./EditorDrawerCloseWarningModal"

--- a/src/layouts/components/Editor/extensions/Cards/Cards.ts
+++ b/src/layouts/components/Editor/extensions/Cards/Cards.ts
@@ -22,6 +22,8 @@ declare module "@tiptap/core" {
       deleteCards: () => ReturnType
       // Set the content of the current card grid block
       setCardsContent: (cardContent: EditorCard[]) => ReturnType
+      // Set the content of the current card grid block without updating history
+      setCardsContentWithoutHistory: (cardContent: EditorCard[]) => ReturnType
     }
   }
 }
@@ -177,6 +179,26 @@ export const IsomerCards = Node.create<CardOptions>({
             )
         }
 
+        return true
+      },
+      setCardsContentWithoutHistory: (content) => ({
+        tr,
+        dispatch,
+        editor,
+      }) => {
+        if (dispatch) {
+          const offset = tr.selection.anchor
+          const node = createCardGridWithContent(editor.schema, content)
+
+          tr.setMeta("addToHistory", false)
+            .replaceSelectionWith(node)
+            .scrollIntoView()
+            .setSelection(
+              Selection.near(
+                tr.doc.resolve(tr.doc.resolve(offset).parentOffset)
+              )
+            )
+        }
         return true
       },
     }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Card grid block

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Undo/redo is supported with all editing of the card grid block treated as a single transaction. Closing the editor is without saving will reset the editor state correctly.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*