### PR TITLE
fix(media): fix logic for disabling button in create media folder modal

### DIFF
--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -355,6 +355,7 @@ export const CreateMediaFolderModal = ({
                     !methods.formState.isDirty ||
                     _.some(methods.formState.errors) ||
                     (originalSelectedMedia.length === 0 &&
+                      files.length !== 0 &&
                       methods.watch("selectedPages").length === 0)
                   }
                 >


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The button remains disabled even when adding content, when the folder does not have any images/files.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Fix the logic to also check if there are even images/files for users to select from.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*