### PR TITLE
fix(editor): improve embed functionality

### DIFF
--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -48,6 +48,7 @@ import {
 } from "layouts/components/Editor/extensions"
 
 import { isEmbedCodeValid } from "utils/allowedHTML"
+import { isEmbedActive } from "utils/tiptap"
 
 import { MediaService } from "services"
 import { DrawerVariant, EditorEmbedContents } from "types/editPage"
@@ -296,7 +297,7 @@ export const EditPage = () => {
               onClose={onEmbedModalClose}
               onProceed={handleEmbedInsert}
               cursorValue={
-                editor.state.selection.empty
+                editor.state.selection.empty || !isEmbedActive(editor)
                   ? ""
                   : getHTMLFromFragment(
                       editor.state.selection.content().content,

--- a/src/layouts/EditPage/utils.ts
+++ b/src/layouts/EditPage/utils.ts
@@ -19,6 +19,7 @@ DOMPurify.setConfig({
     "async",
     "mozallowfullscreen",
     "webkitallowfullscreen",
+    "referrerpolicy",
   ],
   // required in case <script> tag appears as the first line of the markdown
   FORCE_BODY: true,

--- a/src/layouts/components/Editor/Editor.tsx
+++ b/src/layouts/components/Editor/Editor.tsx
@@ -7,6 +7,7 @@ import { useEditorContext } from "contexts/EditorContext"
 
 import { LinkBubbleMenu, MenuBar, TableBubbleMenu } from "./components"
 import { CardsBubbleMenu } from "./components/CardsBubbleMenu"
+import { EmbedBubbleMenu } from "./components/EmbedBubbleMenu"
 import { ImageBubbleMenu } from "./components/ImageBubbleMenu"
 
 export const Editor = (props: BoxProps) => {
@@ -27,6 +28,7 @@ export const Editor = (props: BoxProps) => {
         <ImageBubbleMenu />
         <TableBubbleMenu />
         <CardsBubbleMenu />
+        <EmbedBubbleMenu />
         <Box
           as={EditorContent}
           editor={editor}

--- a/src/layouts/components/Editor/components/EmbedBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/EmbedBubbleMenu.tsx
@@ -1,17 +1,52 @@
-import { HStack, Icon } from "@chakra-ui/react"
+import { HStack, Icon, useDisclosure } from "@chakra-ui/react"
 import { IconButton, Tooltip } from "@opengovsg/design-system-react"
-import { BubbleMenu } from "@tiptap/react"
+import { BubbleMenu, getHTMLFromFragment } from "@tiptap/react"
 import { BiPencil, BiTrash } from "react-icons/bi"
 
-import { useEditorContext } from "contexts/EditorContext"
-import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
+import { EditorEmbedModal } from "components/EditorEmbedModal"
 
-const CardsButton = () => {
-  const { onDrawerOpen } = useEditorDrawerContext()
+import { useEditorContext } from "contexts/EditorContext"
+
+import { useCspHook } from "hooks/settingsHooks"
+
+import { isEmbedCodeValid } from "utils/allowedHTML"
+import { isEmbedActive } from "utils/tiptap"
+
+import { EditorEmbedContents } from "types/editPage"
+
+const EmbedButton = () => {
+  const {
+    isOpen: isEmbedModalOpen,
+    onOpen: onEmbedModalOpen,
+    onClose: onEmbedModalClose,
+  } = useDisclosure()
   const { editor } = useEditorContext()
+  const { data: csp } = useCspHook()
+
+  const handleEmbedInsert = ({ value }: EditorEmbedContents) => {
+    if (isEmbedCodeValid(csp, value)) {
+      editor.chain().focus().insertContent(value.replaceAll("\n", "")).run()
+    }
+
+    onEmbedModalClose()
+  }
 
   return (
     <>
+      <EditorEmbedModal
+        isOpen={isEmbedModalOpen}
+        onClose={onEmbedModalClose}
+        onProceed={handleEmbedInsert}
+        cursorValue={
+          editor.state.selection.empty
+            ? ""
+            : getHTMLFromFragment(
+                editor.state.selection.content().content,
+                editor.schema
+              )
+        }
+      />
+
       <HStack
         bgColor="#fafafa"
         borderRadius="0.25rem"
@@ -21,11 +56,11 @@ const CardsButton = () => {
         px="0.5rem"
         py="0.25rem"
       >
-        <Tooltip label="Edit card grid" hasArrow placement="top">
+        <Tooltip label="Edit embed" hasArrow placement="top">
           <IconButton
             _hover={{ bg: "gray.100" }}
             _active={{ bg: "gray.200" }}
-            onClick={onDrawerOpen("cards")}
+            onClick={onEmbedModalOpen}
             bgColor="transparent"
             border="none"
             h="1.75rem"
@@ -33,7 +68,7 @@ const CardsButton = () => {
             minH="1.75rem"
             minW="1.75rem"
             p="0.25rem"
-            aria-label="edit cards block"
+            aria-label="edit embed code"
           >
             <Icon
               as={BiPencil}
@@ -42,11 +77,11 @@ const CardsButton = () => {
             />
           </IconButton>
         </Tooltip>
-        <Tooltip label="Delete card grid" hasArrow placement="top">
+        <Tooltip label="Delete embed" hasArrow placement="top">
           <IconButton
             _hover={{ bg: "gray.100" }}
             _active={{ bg: "gray.200" }}
-            onClick={() => editor.chain().focus().deleteCards().run()}
+            onClick={() => editor.chain().focus().deleteIframe().run()}
             bgColor="transparent"
             border="none"
             h="1.75rem"
@@ -54,7 +89,7 @@ const CardsButton = () => {
             minH="1.75rem"
             minW="1.75rem"
             p="0.25rem"
-            aria-label="delete cards block"
+            aria-label="delete embed content"
           >
             <Icon
               as={BiTrash}
@@ -68,21 +103,21 @@ const CardsButton = () => {
   )
 }
 
-export const CardsBubbleMenu = () => {
+export const EmbedBubbleMenu = () => {
   const { editor } = useEditorContext()
 
   return (
     <BubbleMenu
-      shouldShow={() => editor.isActive("isomercards")}
+      shouldShow={() => isEmbedActive(editor)}
       editor={editor}
       tippyOptions={{
         duration: 100,
         placement: "top-start",
-        offset: [511, -16],
+        offset: [493, -16],
         zIndex: 0,
       }}
     >
-      <CardsButton />
+      <EmbedButton />
     </BubbleMenu>
   )
 }

--- a/src/layouts/components/Editor/extensions/Iframe/Iframe.ts
+++ b/src/layouts/components/Editor/extensions/Iframe/Iframe.ts
@@ -14,10 +14,10 @@ export interface IframeOptions {
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     iframe: {
-      /**
-       * Add an iframe
-       */
+      // Set the current node as an iframe
       setIframe: (options: { src: string }) => ReturnType
+      // Delete the current node
+      deleteIframe: () => ReturnType
     }
   }
 }
@@ -87,6 +87,10 @@ export const Iframe = Node.create<IframeOptions>({
           tr.replaceRangeWith(selection.from, selection.to, node)
         }
 
+        return true
+      },
+      deleteIframe: () => ({ tr, editor }) => {
+        editor.state.selection.replace(tr)
         return true
       },
     }

--- a/src/utils/tiptap.ts
+++ b/src/utils/tiptap.ts
@@ -1,0 +1,10 @@
+import { Editor } from "@tiptap/core"
+
+// Utility method to check if the currently active node is a supported embed
+export const isEmbedActive = (editor: Editor) => {
+  return (
+    editor.isActive("iframe") ||
+    editor.isActive("instagram") ||
+    editor.isActive("formsg")
+  )
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The embed code functionality is not perfect.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- A bubble menu has been added for all supported embed blocks, which allows the user to edit and delete the selected embed block.
- The DOMPurify configuration has been expanded to allow `referrerpolicy` attribute to support Google Maps embedding.
- A tooltip has been added for the cards bubble menu (also added to the embed bubble menu).
- Ensure that the embed code modal is only used for embed blocks, so that users cannot secretly edit the underlying HTML of other blocks.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to a site and edit a page using the new Tiptap editor.
    - [ ] Insert a Google Maps embed code using the insert embed modal, verify that it can be added.
    - [ ] Click on the inserted embed block, verify that the bubble menu appears on the top right of the block.
    - [ ] Verify that a tooltip appears when hovering over each of the action button icons on the bubble menu.
    - [ ] Insert an Instagram embed block, verify that the bubble menu appears on the top right of the inserted block.
    - [ ] Insert a FormSG embed block, verify that the bubble menu appears on the top right of the inserted block.
    - [ ] Insert a card grid block and select that block, verify that a tooltip appears when hovering over each of the action button icons on the bubble menu.
    - [ ] Click on the Insert embed code modal while the card grid block is selected, verify that the insert embed code modal's textarea is empty.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*