### PR TITLE
fix(embed-views): add a max width

### DIFF
--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ImageBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ImageBubbleMenu.tsx
@@ -117,7 +117,7 @@ const ImageLinkButton = () => {
           )}
         </Popover>
 
-        <Popover placement="bottom">
+        {/* <Popover placement="bottom">
           {({ isOpen, onClose }) => (
             <>
               <PopoverTrigger>
@@ -148,7 +148,7 @@ const ImageLinkButton = () => {
               </PopoverContent>
             </>
           )}
-        </Popover>
+        </Popover> */}
 
         <Tooltip label="Remove image" hasArrow placement="top">
           <IconButton

--- a/src/layouts/components/Editor/extensions/FormSG/FormSGView.tsx
+++ b/src/layouts/components/Editor/extensions/FormSG/FormSGView.tsx
@@ -8,7 +8,9 @@ export const FormSGView = ({ node, selected }: NodeViewProps) => {
 
   return (
     <BlockWrapper name="Embed" isSelected={selected}>
-      <Code paddingInline="0.75rem">{formSrc}</Code>
+      <Code paddingInline="0.75rem" maxW="100%">
+        {formSrc}
+      </Code>
     </BlockWrapper>
   )
 }

--- a/src/layouts/components/Editor/extensions/Iframe/IframeView.tsx
+++ b/src/layouts/components/Editor/extensions/Iframe/IframeView.tsx
@@ -6,7 +6,9 @@ import { BlockWrapper } from "../../components/BlockWrapper"
 export const IframeView = ({ node, selected }: NodeViewProps) => {
   return (
     <BlockWrapper name="Embed" isSelected={selected}>
-      <Code paddingInline="0.75rem"> {node.attrs.src}</Code>
+      <Code paddingInline="0.75rem" maxW="100%">
+        {node.attrs.src}
+      </Code>
     </BlockWrapper>
   )
 }

--- a/src/layouts/components/Editor/extensions/Instagram/InstagramView.tsx
+++ b/src/layouts/components/Editor/extensions/Instagram/InstagramView.tsx
@@ -6,7 +6,9 @@ import { BlockWrapper } from "../../components/BlockWrapper"
 export const InstagramView = ({ node, selected }: NodeViewProps) => {
   return (
     <BlockWrapper name="Embed" isSelected={selected}>
-      <Code paddingInline="0.75rem"> {node.attrs.permalink}</Code>
+      <Code paddingInline="0.75rem" maxW="100%">
+        {node.attrs.permalink}
+      </Code>
     </BlockWrapper>
   )
 }


### PR DESCRIPTION
## Problem
1. if embed source too long, it overflows 
2. image resizing doesn't work _yet_

## Solution
1. add `maxW` prop so it knows when overflow.
2. comment out image resizing for now 

## Screenshots
**before**
![Screenshot 2023-12-06 at 12 17 16 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/6f65f65c-8eff-4bd8-bc6b-b497defc0a60)

**after**
![Screenshot 2023-12-06 at 12 17 39 PM](https://github.com/isomerpages/isomercms-frontend/assets/44049504/81e7c4fb-e860-49a2-940e-e1d43296bb4e)
