### PR TITLE
fix p1 accordion issues

### DIFF
--- a/src/layouts/components/Editor/components/BlockWrapper/BlockWrapper.tsx
+++ b/src/layouts/components/Editor/components/BlockWrapper/BlockWrapper.tsx
@@ -7,16 +7,19 @@ import "./styles.scss"
 interface BlockWrapperProps {
   name: string
   isSelected: boolean
+  otherButtons?: JSX.Element
 }
 
 export const BlockWrapper = ({
   name,
   isSelected,
+  otherButtons,
   children,
 }: PropsWithChildren<BlockWrapperProps>): JSX.Element => {
   return (
     <Box as={NodeViewWrapper}>
       <Box position="relative" maxW="36.5rem" data-group>
+        {isSelected && <>{otherButtons}</>}
         <Box
           _groupHover={{
             display: "block",
@@ -29,7 +32,9 @@ export const BlockWrapper = ({
           textColor="white"
           p="0.25rem"
         >
-          <Text textStyle="caption-1">{name}</Text>
+          <Text textStyle="caption-1" contentEditable="false">
+            {name}
+          </Text>
         </Box>
         <Box
           className="drag-handle"

--- a/src/layouts/components/Editor/components/BlockWrapper/BlockWrapper.tsx
+++ b/src/layouts/components/Editor/components/BlockWrapper/BlockWrapper.tsx
@@ -7,19 +7,19 @@ import "./styles.scss"
 interface BlockWrapperProps {
   name: string
   isSelected: boolean
-  otherButtons?: JSX.Element
+  childButtons?: JSX.Element
 }
 
 export const BlockWrapper = ({
   name,
   isSelected,
-  otherButtons,
+  childButtons,
   children,
 }: PropsWithChildren<BlockWrapperProps>): JSX.Element => {
   return (
     <Box as={NodeViewWrapper}>
       <Box position="relative" maxW="36.5rem" data-group>
-        {isSelected && <>{otherButtons}</>}
+        {isSelected && <>{childButtons}</>}
         <Box
           _groupHover={{
             display: "block",

--- a/src/layouts/components/Editor/components/MenuBar.tsx
+++ b/src/layouts/components/Editor/components/MenuBar.tsx
@@ -292,7 +292,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
           name: "Accordion",
           description: "Let users hide or show content.",
           icon: EditorAccordionImage,
-          action: () => editor.chain().focus().setHorizontalRule().run(),
+          action: () => editor.chain().focus().setDetailsGroup().run(),
           isHidden: !rteEnabledBlocks.includes(RTE_BLOCKS.ACCORDION),
         },
         {

--- a/src/layouts/components/Editor/extensions/Details/IsomerDetailGroupView.tsx
+++ b/src/layouts/components/Editor/extensions/Details/IsomerDetailGroupView.tsx
@@ -29,7 +29,12 @@ export const IsomerDetailGroupView = ({
           display="flex"
           justifyContent="flex-end"
         >
-          <Box backgroundColor={selected ? "white" : "transparent"}>
+          <Box
+            backgroundColor={selected ? "white" : "transparent"}
+            marginTop="-0.25rem"
+            boxShadow="0px 0px 4px 0px rgba(0, 0, 0, 0.8)"
+            borderRadius="4px"
+          >
             <Tooltip label="Edit accordion grid" hasArrow placement="top">
               <IconButton
                 _hover={{ bg: "gray.100" }}
@@ -109,13 +114,14 @@ export const IsomerDetailGroupView = ({
     <BlockWrapper
       name="Accordion grid"
       isSelected={selected}
-      otherButtons={otherButtons}
+      childButtons={otherButtons}
       padding-top="0.5rem"
       padding-bottom="0.5rem"
     >
       <Box
         borderColor="base.divider.strong"
         borderWidth="1px"
+        mt="1rem"
         h="100%"
         w="100%"
       >

--- a/src/layouts/components/Editor/extensions/Details/IsomerDetailGroupView.tsx
+++ b/src/layouts/components/Editor/extensions/Details/IsomerDetailGroupView.tsx
@@ -1,8 +1,10 @@
-import { Box, Icon, IconButton, Text } from "@chakra-ui/react"
-import { NodeViewContent, NodeViewProps, NodeViewWrapper } from "@tiptap/react"
-import { BiPencil, BiPlus } from "react-icons/bi"
+import { Box, HStack, Icon, IconButton, Tooltip } from "@chakra-ui/react"
+import { NodeViewContent, NodeViewProps } from "@tiptap/react"
+import { BiPencil, BiPlus, BiTrash } from "react-icons/bi"
 
 import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
+
+import { BlockWrapper } from "../../components/BlockWrapper"
 
 export const IsomerDetailGroupView = ({
   node,
@@ -13,94 +15,112 @@ export const IsomerDetailGroupView = ({
   const endPos = startPos + node.nodeSize
   const activePos = editor.state.selection.anchor
   const selected = activePos >= startPos && activePos <= endPos
+
   const { onDrawerOpen } = useEditorDrawerContext()
-  return (
-    <NodeViewWrapper data-drag-handle>
-      <Box position="relative">
-        {selected && (
-          <Box
-            position="absolute"
-            top="calc(-1.5rem - 2px)"
-            left="-2px"
-            zIndex="1"
-            backgroundColor="#055AFF"
-            textColor="white"
-            p="0.25rem"
-          >
-            <Text textStyle="caption-1">Accordion</Text>
-          </Box>
-        )}
-        <Box
-          outline={selected ? "2px solid #055AFF" : undefined}
-          py="0.75rem"
-          w="calc(100% - 20px)"
+  const otherButtons = (
+    <>
+      <Box
+        display={selected ? "block" : "none"}
+        position="absolute"
+        width="100%"
+      >
+        <HStack
+          borderColor="base.divider.medium"
+          display="flex"
+          justifyContent="flex-end"
         >
-          <NodeViewContent />
-          {selected && (
-            <>
-              <Box
-                position="absolute"
-                bottom="0"
-                left="50%"
-                transform="translateX(-50%)"
-                mb="-1.5rem"
-                zIndex={1}
-                background="white"
-                h="2.75rem"
-                w="2.75rem"
-              >
-                <IconButton
-                  variant="outline"
-                  aria-label="Add accordion"
-                  icon={<Icon as={BiPlus} w="1.5rem" h="1.5rem" />}
-                  onClick={() => {
-                    editor.chain().appendDetail(startPos, endPos).run()
-                  }}
-                  position="absolute"
-                  bottom="0"
-                  left="50%"
-                  transform="translateX(-50%)"
-                  zIndex={2}
-                  background="white"
-                />
-              </Box>
-              <Box
-                background="white"
-                zIndex={1}
-                right={0}
-                top={0}
-                mt="-1rem"
-                mr="0.5rem"
-                position="absolute"
-                minH="1.75rem"
+          <Box backgroundColor={selected ? "white" : "transparent"}>
+            <Tooltip label="Edit accordion grid" hasArrow placement="top">
+              <IconButton
+                _hover={{ bg: "gray.100" }}
+                _active={{ bg: "gray.200" }}
+                onClick={onDrawerOpen("accordion")}
+                bgColor="transparent"
+                border="none"
                 h="1.75rem"
+                w="1.75rem"
+                minH="1.75rem"
                 minW="1.75rem"
-                color="base.content.medium"
-                borderColor="base.content.medium"
+                p="0.25rem"
+                aria-label="edit accordion block"
               >
-                <IconButton
-                  variant="outline"
-                  aria-label="Edit accordion"
-                  icon={<Icon as={BiPencil} w="1.25rem" h="1.25rem" />}
-                  onClick={() => {
-                    onDrawerOpen("accordion")()
-                  }}
-                  right={0}
-                  top={0}
-                  position="absolute"
-                  zIndex={2}
-                  background="white"
-                  minH="1.75rem"
-                  h="1.75rem"
-                  minW="1.75rem"
+                <Icon
+                  as={BiPencil}
+                  fontSize="1.25rem"
                   color="base.content.medium"
-                  borderColor="base.content.medium"
                 />
-              </Box>
-            </>
-          )}
-        </Box>
+              </IconButton>
+            </Tooltip>
+            <Tooltip label="Delete accordion " hasArrow placement="top">
+              <IconButton
+                _hover={{ bg: "gray.100" }}
+                _active={{ bg: "gray.200" }}
+                onClick={() => {
+                  editor.chain().focus().unsetDetailsGroup().run()
+                }}
+                bgColor="transparent"
+                border="none"
+                h="1.75rem"
+                w="1.75rem"
+                minH="1.75rem"
+                minW="1.75rem"
+                p="0.25rem"
+                aria-label="delete accordion block"
+              >
+                <Icon
+                  as={BiTrash}
+                  fontSize="1.25rem"
+                  color="interaction.critical.default"
+                />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </HStack>
       </Box>
-    </NodeViewWrapper>
+      <Box
+        position="absolute"
+        bottom="0"
+        left="50%"
+        transform="translateX(-50%)"
+        mb="-1.5rem"
+        zIndex={1}
+        background="white"
+        h="2.75rem"
+        w="2.75rem"
+      >
+        <IconButton
+          variant="outline"
+          aria-label="Add accordion"
+          icon={<Icon as={BiPlus} w="1.5rem" h="1.5rem" />}
+          onClick={() => {
+            editor.chain().appendDetail(startPos, endPos).run()
+          }}
+          position="absolute"
+          bottom="0"
+          left="50%"
+          transform="translateX(-50%)"
+          zIndex={2}
+          background="white"
+        />
+      </Box>
+    </>
+  )
+  return (
+    <BlockWrapper
+      name="Accordion grid"
+      isSelected={selected}
+      otherButtons={otherButtons}
+      padding-top="0.5rem"
+      padding-bottom="0.5rem"
+    >
+      <Box
+        borderColor="base.divider.strong"
+        borderWidth="1px"
+        h="100%"
+        w="100%"
+      >
+        <NodeViewContent />
+      </Box>
+    </BlockWrapper>
   )
 }

--- a/src/layouts/components/Editor/extensions/Details/IsomerDetails.ts
+++ b/src/layouts/components/Editor/extensions/Details/IsomerDetails.ts
@@ -68,4 +68,27 @@ export const IsomerDetails = Details.extend({
       )
     }
   },
+
+  addKeyboardShortcuts() {
+    return {
+      Backspace: () => {
+        const { schema, selection } = this.editor.state
+        const { empty, $anchor } = selection
+
+        if (!empty || $anchor.parent.type !== schema.nodes.detailsSummary) {
+          return false
+        }
+
+        if ($anchor.parentOffset !== 0) {
+          return this.editor.commands.command(({ tr }) => {
+            const start = $anchor.pos - 1
+            const end = $anchor.pos
+            tr.delete(start, end)
+            return true
+          })
+        }
+        return this.editor.commands.removeDetail()
+      },
+    }
+  },
 })

--- a/src/layouts/components/Editor/styles.scss
+++ b/src/layouts/components/Editor/styles.scss
@@ -142,7 +142,10 @@
   }
 
   .node-detailGroup * [data-type="details"]:first-child {
-    border-top: 1px solid #d4d4d4;
+    border-top: 0;
+  }
+  .node-detailGroup * [data-type="details"]:last-child {
+    border-bottom: 0;
   }
 
   summary {

--- a/src/styles/isomer-cms/pages/Editor.module.scss
+++ b/src/styles/isomer-cms/pages/Editor.module.scss
@@ -178,6 +178,9 @@ details.isomer-details summary {
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
+  &:empty {
+    justify-content: flex-end;
+  }
 }
 
 details.isomer-details summary::marker {


### PR DESCRIPTION
## Problem

This PR attempts to fix the functional issues wrt to Accordions. 
Will leave paddings as separate since those will be easier to fix + don't really need much context to be worked on. 

Fix bunch of stuff [here](https://www.notion.so/opengov/Accordion-1de9bd79bfa540daacfdc5b703a80b00?pvs=4)

To test template stuff, need to make changes to [kishore-test](https://staging-cms.isomer.gov.sg/sites/kishore-test/editPage/accordion%20page.md)

Corresponding template pr: https://github.com/isomerpages/isomerpages-template/pull/361 (doesnt block this pr since complex blocks are behind feature flag anyway)

deprior padding related fix as design is not 100% sure about it yet + padding are easier to fix so no biggie

![Screenshot 2023-12-06 at 4 15 20 PM](https://github.com/isomerpages/isomercms-frontend/assets/42832651/e3bbcc01-4c48-4043-a05d-23b945e990d5)


## Reviewer notes

The approach for this PR would look weird considering the buttons are not bubble-menued. 
I did try it but it kept popping up on every individual cell (similar behaviour to our table stuff). I somehow couldnt get it to work since (note that there were 2 levels of abstraction here [bubbleMenu in react/src](https://github.com/ueberdosis/tiptap/blob/main/packages/react/src/BubbleMenu.tsx) -> [bubblemenu in the extensions](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bubble-menu/src/bubble-menu.ts)). As of now, the API is not extensible enough to allow for this to happen, and this wasnt just a trivial as a `.extend` that we do for our other extensions like `table` .There might be a way, please let me know if that is the case, but i time boxed this effort and just wrapped it around `NodeViewWrapper` to at least land something in main line first. 

This is still feature flagged and thus safe to merge to production for now, but hopefully p1 issues are all fixed and the pending stuff are just padding css stuff 
