### PR TITLE
fix(editpagelayout): shift context call elsewhere

### DIFF
--- a/src/layouts/EditPage/EditPageLayout.tsx
+++ b/src/layouts/EditPage/EditPageLayout.tsx
@@ -20,8 +20,6 @@ import Header from "components/Header"
 import { OverwriteChangesModal } from "components/OverwriteChangesModal"
 import { WarningModal } from "components/WarningModal"
 
-import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
-
 import { useGetMultipleMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook, useUpdatePageHook } from "hooks/pageHooks"
 import { useCspHook, useGetSiteColorsHook } from "hooks/settingsHooks"
@@ -37,6 +35,7 @@ import { sanitiseRawHtml, updateHtmlWithMediaData } from "./utils"
 interface EditPageLayoutProps {
   getEditorContent: () => string
   setEditorContent: (content: string) => void
+  shouldDisableSave?: boolean
   variant: PageVariant
 }
 
@@ -44,9 +43,9 @@ export const EditPageLayout = ({
   getEditorContent,
   setEditorContent,
   variant = "markdown",
+  shouldDisableSave = false,
   children,
 }: PropsWithChildren<EditPageLayoutProps>) => {
-  const { isAnyDrawerOpen } = useEditorDrawerContext()
   const params = useParams<{ siteName: string }>()
   const decodedParams = getDecodedParams(params)
   const [mediaSrcs, setMediaSrcs] = useState(new Set(""))
@@ -223,7 +222,7 @@ export const EditPageLayout = ({
               // TODO: Add an alert/modal
               // to warn the user when they violate our csp
               // so they know why + can take action to remedy
-              isDisabled={isContentViolation || isAnyDrawerOpen}
+              isDisabled={isContentViolation || shouldDisableSave}
               isLoading={isSavingPage}
             >
               Save

--- a/src/layouts/EditPage/MarkdownEditPage.tsx
+++ b/src/layouts/EditPage/MarkdownEditPage.tsx
@@ -24,6 +24,7 @@ import MarkdownEditor from "components/pages/MarkdownEditor"
 import PagePreview from "components/pages/PagePreview"
 
 import { useEditorContext } from "contexts/EditorContext"
+import { useEditorDrawerContext } from "contexts/EditorDrawerContext"
 
 import { useGetMultipleMediaHook } from "hooks/mediaHooks"
 import { useGetPageHook } from "hooks/pageHooks"
@@ -119,11 +120,14 @@ export const MarkdownEditPage = ({ togglePreview }: MarkdownPageProps) => {
     updateHtmlWithMediaData()
   }, [mediaData, editorValue, updateHtmlWithMediaData])
 
+  const { isAnyDrawerOpen } = useEditorDrawerContext()
+
   return (
     <EditPageLayout
       variant="markdown"
       getEditorContent={() => editorValue}
       setEditorContent={(content: string) => setEditorValue(content)}
+      shouldDisableSave={isAnyDrawerOpen}
     >
       <Box w="100%" p="1.25rem">
         <Flex flexDir="row" bg="gray.100" p="1.38rem" mb="1.38rem">

--- a/src/layouts/EditPage/TiptapEditPage.tsx
+++ b/src/layouts/EditPage/TiptapEditPage.tsx
@@ -98,12 +98,15 @@ export const TiptapEditPage = ({
     setHtmlChunk(processedChunk)
   }, [mediaData, editorHtmlValue, csp, mediaSrcs])
 
+  const { isAnyDrawerOpen } = useEditorDrawerContext()
+
   return (
     <EditPageLayout
       setEditorContent={(content) => {
         editor.commands.setContent(content)
       }}
       getEditorContent={() => editor.getHTML()}
+      shouldDisableSave={isAnyDrawerOpen}
       variant="tiptap"
     >
       {/* Editor drawers */}


### PR DESCRIPTION
## Problem
we were crashign previously due to the context call in `EditPageLayout`. This was because `EditPageLayout` is a layout component that was shared between both legacy/current sites. 

## Solution
1. separate the call out as a prop
2. for `LegacyEditPage`, there's a default argument of `false` on `EditPageLayout` so no changes needed (callers should set **if required**) 
3. for the other two, just inlined the `isAnyDrawerOpen` functionality. (i'm not sure if `MarkdownEditPage` requires because technically it should not but who knows)
4. Take note that `useEditorDrawerContext` is only called for cards/details, which means that no existing functionality in `LegacyEditPage` requires this.

misc - style fix cos i noticed got some whitespace. set the editor to grow instead of giving fixed width. this means that when resizing, we take away the width of editor first if not enough. if there's extra space, the editor will grow to fit extra space.

## Test
- [ ] Go to a legacy site (or just off the flag for the env) 
- [ ] editor shud not crash
- [ ] turn on flag
- [ ] same site should work