### PR TITLE
IS-712 Fixed image resizing issue in RTE

### DIFF
--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ImageBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ImageBubbleMenu.tsx
@@ -117,7 +117,7 @@ const ImageLinkButton = () => {
           )}
         </Popover>
 
-        {/* <Popover placement="bottom">
+        <Popover placement="bottom">
           {({ isOpen, onClose }) => (
             <>
               <PopoverTrigger>
@@ -148,7 +148,7 @@ const ImageLinkButton = () => {
               </PopoverContent>
             </>
           )}
-        </Popover> */}
+        </Popover>
 
         <Tooltip label="Remove image" hasArrow placement="top">
           <IconButton

--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
@@ -56,7 +56,11 @@ export const ResizeImagePopover = ({
       return
     }
 
-    editor.chain().focus().setImageStyle(`width: ${data.value}%;`).run()
+    const style = {
+      width: data.value,
+    }
+
+    editor.chain().focus().setImageStyle(style).run()
 
     onClose()
   }

--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
@@ -68,8 +68,6 @@ export const ResizeImagePopover = ({
       .updateAttributes("image", {
         // use locally scoped style to override width in template scss
         style: `width: ${data.value}%;`,
-        // To display the resized width value in the form
-        // width: `${data.value}%`,
         ...isomerImageAttrs,
       })
       .run()
@@ -82,6 +80,7 @@ export const ResizeImagePopover = ({
       const initialValue: string | number =
         editor.state.selection
           .content()
+          // regex to parse the width value from style tag
           .content.firstChild?.attrs.style?.match(/width: (\d+)%/)?.[1] ?? 100
 
       if (typeof initialValue === "string") {

--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
@@ -65,7 +65,10 @@ export const ResizeImagePopover = ({
     editor
       .chain()
       .focus()
-      .setImage({
+      .updateAttributes("image", {
+        // use locally scoped style to override width in template scss
+        style: `width: ${data.value}%;`,
+        // To display the resized width value in the form
         width: `${data.value}%`,
         ...isomerImageAttrs,
       })
@@ -88,7 +91,7 @@ export const ResizeImagePopover = ({
         methods.setValue("value", initialValue)
       }
     }
-  }, [isOpen])
+  }, [editor.state.selection, isOpen, methods])
 
   return (
     <FormProvider {...methods}>

--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
@@ -56,21 +56,7 @@ export const ResizeImagePopover = ({
       return
     }
 
-    const isomerImageAttrs = {
-      src: node.attrs.src,
-      alt: node.attrs.alt,
-      href: node.attrs.href,
-    }
-
-    editor
-      .chain()
-      .focus()
-      .updateAttributes("image", {
-        // use locally scoped style to override width in template scss
-        style: `width: ${data.value}%;`,
-        ...isomerImageAttrs,
-      })
-      .run()
+    editor.chain().focus().setImageStyle(`width: ${data.value}%;`).run()
 
     onClose()
   }

--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ResizeImagePopover.tsx
@@ -69,7 +69,7 @@ export const ResizeImagePopover = ({
         // use locally scoped style to override width in template scss
         style: `width: ${data.value}%;`,
         // To display the resized width value in the form
-        width: `${data.value}%`,
+        // width: `${data.value}%`,
         ...isomerImageAttrs,
       })
       .run()
@@ -80,12 +80,16 @@ export const ResizeImagePopover = ({
   useEffect(() => {
     if (isOpen) {
       const initialValue: string | number =
-        editor.state.selection.content().content.firstChild?.attrs.width ?? 100
+        editor.state.selection
+          .content()
+          .content.firstChild?.attrs.style?.match(/width: (\d+)%/)?.[1] ?? 100
 
       if (typeof initialValue === "string") {
         methods.setValue(
           "value",
-          initialValue.endsWith("%") ? Number(initialValue.slice(0, -1)) : 100
+          initialValue.endsWith("%")
+            ? Number(initialValue.slice(0, -1))
+            : Number(initialValue)
         )
       } else {
         methods.setValue("value", initialValue)

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -16,7 +16,6 @@ interface IsomerImageOptions {
 
 interface IsomerImageStyle {
   width?: number
-  backgroundColor?: string
 }
 
 declare module "@tiptap/core" {
@@ -104,10 +103,6 @@ export const IsomerImage = Image.extend({
             return false
           }
           style += `width: ${styleOptions.width}%;`
-        }
-
-        if (styleOptions.backgroundColor) {
-          style += `background-color: ${styleOptions.backgroundColor};`
         }
 
         const attrs = { style }

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -40,6 +40,9 @@ export const IsomerImage = Image.extend({
       height: {
         default: "auto",
       },
+      style: {
+        default: null,
+      },
       href: {
         default: null,
         parseHTML: (element) =>

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -14,12 +14,17 @@ interface IsomerImageOptions {
   style?: string
 }
 
+interface IsomerImageStyle {
+  width?: number
+  backgroundColor?: string
+}
+
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     isomerImage: {
       setImage: (options: IsomerImageOptions) => ReturnType
       deleteImage: () => ReturnType
-      setImageStyle: (style: string) => ReturnType
+      setImageStyle: (style: IsomerImageStyle) => ReturnType
     }
   }
 }
@@ -86,8 +91,25 @@ export const IsomerImage = Image.extend({
         return true
       },
 
-      setImageStyle: (style) => ({ tr, dispatch, editor }) => {
+      setImageStyle: (styleOptions) => ({ tr, dispatch, editor }) => {
         const { from, to } = tr.selection
+
+        let style = ""
+
+        if (styleOptions.width) {
+          if (styleOptions.width < 1 || styleOptions.width > 100) {
+            console.error(
+              "Invalid width value. It should be between 1 and 100."
+            )
+            return false
+          }
+          style += `width: ${styleOptions.width}%;`
+        }
+
+        if (styleOptions.backgroundColor) {
+          style += `background-color: ${styleOptions.backgroundColor};`
+        }
+
         const attrs = { style }
 
         tr.doc.nodesBetween(from, to, (node, pos) => {

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -41,7 +41,7 @@ export const IsomerImage = Image.extend({
         default: "auto",
       },
       style: {
-        default: null,
+        default: "width: 100%",
       },
       href: {
         default: null,

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -11,6 +11,7 @@ interface IsomerImageOptions {
   width?: string
   height?: string
   href?: string
+  style?: string
 }
 
 declare module "@tiptap/core" {
@@ -18,6 +19,7 @@ declare module "@tiptap/core" {
     isomerImage: {
       setImage: (options: IsomerImageOptions) => ReturnType
       deleteImage: () => ReturnType
+      setImageStyle: (style: string) => ReturnType
     }
   }
 }
@@ -81,6 +83,23 @@ export const IsomerImage = Image.extend({
 
       deleteImage: () => ({ tr, editor }) => {
         editor.state.selection.replace(tr)
+        return true
+      },
+
+      setImageStyle: (style) => ({ tr, dispatch, editor }) => {
+        const { from, to } = tr.selection
+        const attrs = { style }
+
+        tr.doc.nodesBetween(from, to, (node, pos) => {
+          if (node.type === editor.schema.nodes.image) {
+            tr.setNodeMarkup(pos, null, { ...node.attrs, ...attrs })
+          }
+        })
+
+        if (dispatch) {
+          tr.scrollIntoView()
+        }
+
         return true
       },
     }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->
Closes [IS-712]
The existing (commented out) image resizing feature on the new RTE has 2 major issues:

1. When user enters a new percentage value and clicks save in the form, it creates an additional resized image node instead of resizing the original image node 
2. To make the feature work, the `width` property in `.content img` in the template scss file has to be removed, which affects the old non-RTE page and is not backward compatible 

## Solution

<!-- How did you solve the problem? -->

1. To avoid duplicating image node, `updateAttributes` is called on the image editor instead of `setImage`, which will update the attribute of the selected image node. 
2. To avoid removing the `width` property in `.content img` css, a locally scoped `style` tag is used to update the `width` of each image node which overrides the pre-defined css property. 
3. To make 2nd point possible, A modification is needed in `image` extension to accept `style` as incoming attribute. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Fixed issues on image resizing feature in the new RTE 

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

https://github.com/isomerpages/isomercms-frontend/assets/14878879/5bbea17d-00bd-4bc7-b186-1307fccf788d


**AFTER**:

<!-- [insert screenshot here] -->
https://github.com/isomerpages/isomercms-frontend/assets/14878879/a3d5aee5-0a64-4467-a035-9d55fef87524

## Tests

<!-- What tests should be run to confirm functionality? -->
Go to staging site and replicate the action in the screen recording under `AFTER` section. 






[IS-712]: https://isomeropengov.atlassian.net/browse/IS-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ