### PR TITLE
IS-807 Fixed duplicating issue when setting hyperlink & alt text for image in RTE

### DIFF
--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ImageAltTextPopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ImageAltTextPopover.tsx
@@ -53,7 +53,7 @@ export const ImageAltTextPopover = ({
     editor
       .chain()
       .focus()
-      .setImage({
+      .setImageMeta({
         alt: data.value,
         ...isomerImageAttrs,
       })

--- a/src/layouts/components/Editor/components/ImageBubbleMenu/ImageHyperlinkPopover.tsx
+++ b/src/layouts/components/Editor/components/ImageBubbleMenu/ImageHyperlinkPopover.tsx
@@ -57,7 +57,7 @@ export const ImageHyperlinkPopover = ({
     editor
       .chain()
       .focus()
-      .setImage({
+      .setImageMeta({
         href: data.value,
         ...isomerImageAttrs,
       })

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -22,6 +22,7 @@ declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     isomerImage: {
       setImage: (options: IsomerImageOptions) => ReturnType
+      setImageMeta: (options: IsomerImageOptions) => ReturnType
       deleteImage: () => ReturnType
       setImageStyle: (style: IsomerImageStyle) => ReturnType
     }
@@ -60,6 +61,32 @@ export const IsomerImage = Image.extend({
   addCommands() {
     return {
       setImage: (options) => ({ tr, dispatch, editor }) => {
+        if (!options.src) {
+          return false
+        }
+
+        if (dispatch) {
+          const node = editor.schema.nodes.image.create(options)
+
+          if (tr.selection.empty) {
+            const offset = tr.selection.to
+
+            tr.insert(offset, node)
+              .scrollIntoView()
+              .setSelection(Selection.near(tr.doc.resolve(offset)))
+          } else {
+            const offset = tr.selection.to + 1
+
+            tr.insert(offset, node)
+              .scrollIntoView()
+              .setSelection(Selection.near(tr.doc.resolve(offset)))
+          }
+        }
+
+        return true
+      },
+
+      setImageMeta: (options) => ({ tr, dispatch, editor }) => {
         if (!options.src) {
           return false
         }

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -11,7 +11,6 @@ interface IsomerImageOptions {
   width?: string
   height?: string
   href?: string
-  style?: string
 }
 
 interface IsomerImageStyle {
@@ -22,7 +21,9 @@ declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     isomerImage: {
       setImage: (options: IsomerImageOptions) => ReturnType
-      setImageMeta: (options: IsomerImageOptions) => ReturnType
+      setImageMeta: (
+        options: Pick<IsomerImageOptions, "alt" | "href">
+      ) => ReturnType
       deleteImage: () => ReturnType
       setImageStyle: (style: IsomerImageStyle) => ReturnType
     }
@@ -87,10 +88,6 @@ export const IsomerImage = Image.extend({
       },
 
       setImageMeta: (options) => ({ tr, dispatch, editor }) => {
-        if (!options.src) {
-          return false
-        }
-
         const { from, to } = tr.selection
 
         tr.doc.nodesBetween(from, to, (node, pos) => {

--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -64,22 +64,16 @@ export const IsomerImage = Image.extend({
           return false
         }
 
-        if (dispatch) {
-          const node = editor.schema.nodes.image.create(options)
+        const { from, to } = tr.selection
 
-          if (tr.selection.empty) {
-            const offset = tr.selection.to
-
-            tr.insert(offset, node)
-              .scrollIntoView()
-              .setSelection(Selection.near(tr.doc.resolve(offset)))
-          } else {
-            const offset = tr.selection.to + 1
-
-            tr.insert(offset, node)
-              .scrollIntoView()
-              .setSelection(Selection.near(tr.doc.resolve(offset)))
+        tr.doc.nodesBetween(from, to, (node, pos) => {
+          if (node.type === editor.schema.nodes.image) {
+            tr.setNodeMarkup(pos, null, { ...node.attrs, ...options })
           }
+        })
+
+        if (dispatch) {
+          tr.scrollIntoView()
         }
 
         return true


### PR DESCRIPTION
## Problem
Closes IS-807

The Hyperlink and AltText options of the image node in our new RTE has user-impacting bugs. Everytime users add or change the values through the handler, the RTE creates a duplicated image and applies the changes to the newly duplicated image, resulting in user confusion and very bad user experience. 

## Solution

The bug resides in the `setImage` method of the `image` extension. The logic of selecting the current node and updating its attributes is incorrect. This PR fixes the logic therefore fixes the bug for both options. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The image duplicating issue is fixed for both `Hyperlink` and `AltText` options of image node in the new RTE

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

https://github.com/isomerpages/isomercms-frontend/assets/14878879/4a7c8213-f157-46df-bb13-c93070bbc888

**AFTER**:

<!-- [insert screenshot here] -->

https://github.com/isomerpages/isomercms-frontend/assets/14878879/9cb08ff5-fd9d-4fd2-84c2-df1968782e84


## Tests

<!-- What tests should be run to confirm functionality? -->

- UAT test in staging environment using the following steps:
- [ ] Go to staging CMS and click the repo `qilu-site-test`
- [ ] Go to rte test page 
- [ ] There are 3 existing images, try to modify the `hyperlink` and `altText` of them, notice that no duplicate image is created and the properties are modified successfully 
- [ ] Try to create a new image by clicking the icon in the toolbar 
- [ ] Observe the image creation is successful 
- [ ] Try to delete those images and observe the deletions are successful
