### PR TITLE
refactor(legacy/markdown-editpage): update width

### DIFF
--- a/src/layouts/EditPage/MarkdownEditPage.tsx
+++ b/src/layouts/EditPage/MarkdownEditPage.tsx
@@ -129,7 +129,7 @@ export const MarkdownEditPage = ({ togglePreview }: MarkdownPageProps) => {
       setEditorContent={(content: string) => setEditorValue(content)}
       shouldDisableSave={isAnyDrawerOpen}
     >
-      <Box w="100%" p="1.25rem">
+      <Box flex="0 0 45vw" p="1.25rem">
         <Flex flexDir="row" bg="gray.100" p="1.38rem" mb="1.38rem">
           <Flex flexDir="column" alignContent="flex-start" mr="1rem">
             <Text textStyle="subhead-1" mb="0.62rem">
@@ -164,8 +164,7 @@ export const MarkdownEditPage = ({ togglePreview }: MarkdownPageProps) => {
       {/* Preview */}
       <PagePreview
         h="calc(100vh - 0.5rem)"
-        w="62.5rem"
-        minW="62.5rem"
+        flex="1 0"
         title={initialPageData?.content?.frontMatter?.title || ""}
         chunk={htmlChunk}
       />

--- a/src/layouts/LegacyEditPage.jsx
+++ b/src/layouts/LegacyEditPage.jsx
@@ -97,7 +97,13 @@ const EditPage = ({ match }) => {
       setEditorContent={setEditorValue}
     >
       {/* Editor */}
-      <Box minW="50%" flexGrow={1} p="1.25rem" maxH="100%" overflowY="scroll">
+      <Box
+        flexGrow={1}
+        p="1.25rem"
+        maxH="100%"
+        overflowY="scroll"
+        flex="0 0 45vw"
+      >
         <MarkdownEditor
           siteName={siteName}
           onChange={(value) => setEditorValue(value)}
@@ -109,7 +115,7 @@ const EditPage = ({ match }) => {
       {/* Preview */}
       <PagePreview
         h="calc(100vh - 160px - 1.25rem)"
-        flex="0 0 62.5rem"
+        flex="1 0"
         pageParams={decodedParams}
         title={pageData?.content?.frontMatter?.title || ""}
         chunk={htmlChunk}


### PR DESCRIPTION
## Problem
Previously, we set both editpages to a fixed `62.5rem` width. This appears ok on big screens (1920+) but squashes the editor on smaller screens. 

## Solution
- set editor to `45vw` 
- let the preview fill teh remaining space.
- this was done using the `flex` [syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/flex); concretely, what this means is that we always use `45vw` as the basis for the editor and let any remaining space go to the preview. (see videos below)

## Videos

https://github.com/isomerpages/isomercms-frontend/assets/44049504/fca9d7c5-eda6-46bc-8824-0c7dbc57202d


