### PR TITLE
IS-734 Add delete icon to table control and other minor UI fixes

### DIFF
--- a/src/layouts/components/Editor/components/MenuItem.tsx
+++ b/src/layouts/components/Editor/components/MenuItem.tsx
@@ -1,4 +1,4 @@
-import { Icon, Tooltip } from "@chakra-ui/react"
+import { Icon, Tooltip, Divider } from "@chakra-ui/react"
 import { IconButton } from "@opengovsg/design-system-react"
 import { MouseEventHandler } from "react"
 import { IconType } from "react-icons/lib"
@@ -9,6 +9,8 @@ interface MenuItemProps {
   action?: MouseEventHandler<HTMLButtonElement>
   isActive?: null | (() => boolean)
   isRound?: boolean
+  color?: string
+  type?: string
 }
 
 export const MenuItem = ({
@@ -17,24 +19,51 @@ export const MenuItem = ({
   action,
   isRound,
   isActive = null,
+  color = "",
+  type = "item",
 }: MenuItemProps) => (
-  // NOTE: Delay opening by 500ms
   <Tooltip label={title || "divider"} hasArrow openDelay={500}>
-    <IconButton
-      _hover={{ bg: "gray.100" }}
-      _active={{ bg: "gray.200" }}
-      onClick={action}
-      bgColor={isActive && isActive() ? "gray.200" : "transparent"}
-      border="none"
-      h="1.75rem"
-      w="1.75rem"
-      minH="1.75rem"
-      minW="1.75rem"
-      p="0.25rem"
-      aria-label={title || "divider"}
-      isRound={isRound}
-    >
-      <Icon as={icon} fontSize="1.25rem" color="base.content.medium" />
-    </IconButton>
+    {type === "divider" ? (
+      <IconButton
+        _hover={{ bg: "transparent" }}
+        _active={{ bg: "gray.200" }}
+        bgColor="transparent"
+        border="none"
+        h="1.75rem"
+        w="1rem"
+        minH="1.75rem"
+        minW="1rem"
+        aria-label={title || "divider"}
+        isRound={isRound}
+      >
+        <Divider
+          orientation="vertical"
+          border="px solid"
+          borderColor="base.divider.strong"
+          h="1.25rem"
+        />
+      </IconButton>
+    ) : (
+      <IconButton
+        _hover={{ bg: "gray.100" }}
+        _active={{ bg: "gray.200" }}
+        onClick={action}
+        bgColor={isActive && isActive() ? "gray.200" : "transparent"}
+        border="none"
+        h="1.75rem"
+        w="1.75rem"
+        minH="1.75rem"
+        minW="1.75rem"
+        p="0.25rem"
+        aria-label={title || "divider"}
+        isRound={isRound}
+      >
+        <Icon
+          as={icon}
+          fontSize="1.25rem"
+          color={color || "base.content.medium"}
+        />
+      </IconButton>
+    )}
   </Tooltip>
 )

--- a/src/layouts/components/Editor/components/TableBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/TableBubbleMenu.tsx
@@ -26,7 +26,7 @@ export const TableBubbleMenu = () => {
     >
       <Box
         background="grey.50"
-        borderRadius="2rem"
+        borderRadius="0.25rem"
         p="2px 6px"
         opacity="50%"
         _hover={{
@@ -34,15 +34,15 @@ export const TableBubbleMenu = () => {
         }}
       >
         <MenuItem
-          icon={BxAddColLeft}
-          action={() => editor.chain().focus().addColumnBefore().run()}
-          title="Add column before"
-          isRound
-        />
-        <MenuItem
           icon={BxAddColRight}
           action={() => editor.chain().focus().addColumnAfter().run()}
           title="Add column after"
+          isRound
+        />
+        <MenuItem
+          icon={BxAddColLeft}
+          action={() => editor.chain().focus().addColumnBefore().run()}
+          title="Add column before"
           isRound
         />
         <MenuItem
@@ -69,10 +69,12 @@ export const TableBubbleMenu = () => {
           title="Delete row"
           isRound
         />
+        <MenuItem type="divider" />
         <MenuItem
           icon={BiTrash}
           action={() => editor.chain().focus().deleteTable().run()}
           title="Delete table"
+          color="interaction.critical.default"
           isRound
         />
       </Box>

--- a/src/layouts/components/Editor/components/TableBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/TableBubbleMenu.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react"
 import { BubbleMenu } from "@tiptap/react"
+import { BiTrash } from "react-icons/bi"
 
 import { useEditorContext } from "contexts/EditorContext"
 
@@ -66,6 +67,12 @@ export const TableBubbleMenu = () => {
           icon={BxDelRow}
           action={() => editor.chain().focus().deleteRow().run()}
           title="Delete row"
+          isRound
+        />
+        <MenuItem
+          icon={BiTrash}
+          action={() => editor.chain().focus().deleteTable().run()}
+          title="Delete table"
           isRound
         />
       </Box>

--- a/src/layouts/components/Editor/extensions/Table/styles.scss
+++ b/src/layouts/components/Editor/extensions/Table/styles.scss
@@ -33,6 +33,7 @@
     padding: 0.25rem;
     display: none;
     font-size: 0.75rem;
+    z-index: 1;
   }
 
   .table-block-border {

--- a/src/layouts/components/Editor/extensions/Table/styles.scss
+++ b/src/layouts/components/Editor/extensions/Table/styles.scss
@@ -32,6 +32,7 @@
     color: white;
     padding: 0.25rem;
     display: none;
+    font-size: 0.75rem;
   }
 
   .table-block-border {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [IS-734](https://isomeropengov.atlassian.net/browse/IS-734?atlOrigin=eyJpIjoiYTFiN2I4NTg2YWI0NDJmODg3YjIzZTFmOGRiMzVhYzIiLCJwIjoiaiJ9)
Closes [IS-810](https://isomeropengov.atlassian.net/browse/IS-810?atlOrigin=eyJpIjoiNTM2YzM0MzNkOWFkNDQ1M2EzZWY3MTkzYTdkN2FiZDkiLCJwIjoiaiJ9)
Closes [IS-811](https://isomeropengov.atlassian.net/browse/IS-811?atlOrigin=eyJpIjoiZWQ1ODQwZTgxYTM3NDlmZWJjYWVmNzM3YThjOTI2MWQiLCJwIjoiaiJ9)

- IS-734: the table component in our new RTE does not have a delete icon in the floating menu, and it's quite hard for users to delete the table.
- IS-810: Table block label is visibly larger than the labels of other nodes/components (image, cards, etc.), the font size is inconsistent 
- IS-811: Text in the first cell of table is overlapping with the table label when the label is visible, which is a bad UX. 

## Solution

<!-- How did you solve the problem? -->
- IS-734: Added a delete icon to the floating menu which users can click and delete the entire table. The icon is done according to [this latest design.](https://www.figma.com/file/owgl8SFMKQd2jrCJMVrukR/CMS-%7C-Q42023?node-id=166%3A40664&mode=dev) 
- Is-810: Adjusted  the font size of table label to be the same as other components
- IS-811: Increased the `z-index` of table label to bring it on top of the text

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Added `delete` icon to table floating menu 

**Improvements**:

- Adjusted  the font size of table label to be the same as other components
- Increased the `z-index` of table label to bring it on top of the text
- Swapped the first two options of table floating menu to make it consistent with [the latest design](https://www.figma.com/file/owgl8SFMKQd2jrCJMVrukR/CMS-%7C-Q42023?node-id=166%3A40664&mode=dev)
- Decreased the `radius` of table floating menu to make it consistent with [the latest design ](https://www.figma.com/file/owgl8SFMKQd2jrCJMVrukR/CMS-%7C-Q42023?node-id=166%3A40664&mode=dev)

## Before & After Screenshots

**BEFORE**:

https://github.com/isomerpages/isomercms-frontend/assets/14878879/0510a5aa-0c1f-43b0-8ae5-7b159314c7ae

**AFTER**:

https://github.com/isomerpages/isomercms-frontend/assets/14878879/7bf828fb-31af-422a-8cc2-0265b08dc731

## Tests

<!-- What tests should be run to confirm functionality? -->

UAT tests using [staging CMS](https://staging-cms.isomer.gov.sg/)
- [ ] Use the option in the toolbar to create a table in the RTE
- [ ] Select the table and observe there is a `delete` icon in the floating menu
- [ ] Click the `delete` icon and observe the entire table is deleted 
- [ ] Select the table and observe the `font size` of the label is the same as other nodes
- [ ] Type some text in the first cell of the table, observe the table label is not being covered by the text in the top-left cell
- [ ] In the floating menu, observe the first 2 options are now consistent with [the latest design ](https://www.figma.com/file/owgl8SFMKQd2jrCJMVrukR/CMS-%7C-Q42023?node-id=166%3A40664&mode=dev)
- [ ] Observe the `radius` of the floating menu is consistent with [the latest design ](https://www.figma.com/file/owgl8SFMKQd2jrCJMVrukR/CMS-%7C-Q42023?node-id=166%3A40664&mode=dev)


[IS-734]: https://isomeropengov.atlassian.net/browse/IS-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-810]: https://isomeropengov.atlassian.net/browse/IS-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-811]: https://isomeropengov.atlassian.net/browse/IS-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ