### PR TITLE
fix(media): enhance bulk delete for media files

### DIFF
--- a/src/services/MediaService.jsx
+++ b/src/services/MediaService.jsx
@@ -46,4 +46,14 @@ export class MediaService {
       .delete(this.getMediaEndpoint(apiParams), { data: body })
       .then((res) => res.data)
   }
+
+  async deleteMultiple(apiParams, { items }) {
+    const { siteName } = apiParams
+    const body = {
+      items,
+    }
+    return this.apiClient
+      .delete(`/sites/${siteName}/media`, { data: body })
+      .then((res) => res.data)
+  }
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The mass deletion of media files often encounters the repo lock, which causes only half of the media files to be deleted.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Make use of the new backend endpoint to bulk delete all the media files, so that the repo lock is only performed once. This will also allow the deletes to happen much quicker.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site as an email-login user
    - [ ] Select multiple images/files across multiple directories and delete all
    - [ ] Verify that all the images/files are deleted
    - [ ] Navigate to any site as a GitHub-login user
    - [ ] Select multiple images/files across multiple directories and delete all
    - [ ] Verify that all the images/files are deleted

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

> [!WARNING]
> The backend needs to be fully deployed first.
> Backend PR: https://github.com/isomerpages/isomercms-backend/pull/1065