### PR TITLE
fix: remove date validation in announcements

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -216,13 +216,6 @@ const validateNonFutureResourceDate = (dateStr) => {
   const daysDiff = today - chosenDate
   return daysDiff >= 0
 }
-
-const validateNonFutureAnnouncementDate = (dateStr) => {
-  const today = moment().tz("Asia/Singapore")
-  const isoDateStr = moment(dateStr, "DD MMMM YYYY", true)
-  return isoDateStr.isAfter(today)
-}
-
 // Homepage Editor
 // ==========
 // Returns new errors.highlights[index] object
@@ -289,8 +282,6 @@ const validateAnnouncementItems = (announcementError, field, value) => {
     case "date": {
       if (!moment(value, "DD MMMM YYYY", true).isValid()) {
         errorMessage = `Date is invalid`
-      } else if (validateNonFutureAnnouncementDate(value)) {
-        errorMessage = `Date cannot be in the future`
       }
 
       break


### PR DESCRIPTION
## Problem

Some agencies was to show upcoming events etc in announcements. but current validation disallows future dates

Closes IS-842

## Solution

Removed validation on future dates

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

### Tests

- Go to staging site
- Click on Homepage
- Add announcement block
- Put a future date
- Ensure there are no validation errors
- Ensure you're able to save page properly