### PR TITLE
fix: missing style for nps modal

### DIFF
--- a/src/theme/components/Rating.ts
+++ b/src/theme/components/Rating.ts
@@ -1,0 +1,45 @@
+import { createMultiStyleConfigHelpers } from "@chakra-ui/react"
+import { anatomy } from "@chakra-ui/theme-tools"
+
+import { textStyles } from "theme/textStyles"
+
+const parts = anatomy("rating").parts("button", "container")
+
+const {
+  definePartsStyle,
+  defineMultiStyleConfig,
+} = createMultiStyleConfigHelpers(parts.keys)
+
+const baseStyle = definePartsStyle({
+  container: {
+    display: "flex",
+    flexFlow: "row nowrap",
+    listStyleType: "none",
+    alignItems: "flex-start",
+    gap: "1.5rem",
+    w: "full",
+    alignSelf: "center",
+    px: "1.16rem",
+    py: "0.5rem",
+  },
+  button: {
+    ...textStyles["subhead-2"],
+    minH: "auto",
+    minW: "auto",
+    _active: {
+      bg: "interaction.support.selected",
+      color: "base.content.inverse",
+      _hover: {
+        bg: "interaction.support.selected",
+      },
+      _disabled: {
+        bg: "interaction.support.disabled",
+        color: "interaction.support.disabled-content",
+      },
+    },
+  },
+})
+
+export const Rating = defineMultiStyleConfig({
+  baseStyle,
+})

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -4,6 +4,7 @@ import { Card, CARD_THEME_KEY } from "./Card"
 import { Checkbox } from "./Checkbox"
 import { DISPLAY_CARD_THEME_KEY, DisplayCard } from "./DisplayCard"
 import { Infobox } from "./Infobox"
+import { Rating } from "./Rating"
 
 // eslint-disable-next-line import/prefer-default-export
 export const components = {
@@ -13,4 +14,5 @@ export const components = {
   Breadcrumb,
   Infobox,
   Attachment,
+  Rating,
 }


### PR DESCRIPTION
## Problem

Current NPS modal has no styles applied. Seems like we accidentally deleted it.

Closes IS-843

## Solution

Reinstate styles from https://github.com/isomerpages/isomercms-frontend/pull/1370/files#diff-96215533909ccc4efb20eaff62065495f61ce94f83d218f11b7d28882f8b5544

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

### Test
- Enable NPS modal for staging on GB
- Go to a staging site
- Navigate to page and then press back
- Ensure NPS modal pops up with expected styles (e.g. is given below)

![Screenshot 2023-12-19 at 3 07 32 PM](https://github.com/isomerpages/isomercms-frontend/assets/5507822/654f3557-c1c0-4d86-8f73-51639b5595aa)
