### PR TITLE
fix: limit for get media

### DIFF
--- a/src/services/DirectoryService/DirectoryService.ts
+++ b/src/services/DirectoryService/DirectoryService.ts
@@ -65,6 +65,7 @@ export const getWorkspacePages = (siteName: string): Promise<PageData[]> => {
   return apiService.get<PageData[]>(endpoint).then(({ data }) => data)
 }
 
+// 0 references, legacy method currently unused
 export const getMediaData = ({
   siteName,
   mediaDirectoryName,
@@ -100,7 +101,7 @@ export const getMediaFolderFiles = ({
   siteName,
   mediaDirectoryName,
   curPage = 0,
-  limit = 1000,
+  limit = 15, // NOTE: limit only affects repos on GGS. For GitHub will still load the max items allowed (1000)
   search = "",
 }: MediaDirectoryParams): Promise<GetMediaFilesDto> => {
   const endpoint = `/sites/${siteName}/media/${mediaDirectoryName}/files`


### PR DESCRIPTION
current limit value of 1000 affects ggs repos as all files are being fetched. changed it to be 15. For github repos, they are not affected as we do not pass the limit value to the read call

src/services/db/RepoService.ts
```
const contents = await super.readDirectory(sessionData, {
        directoryName,
      })
```