### PR TITLE
fix(styles): fix overlapping page title issue

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -129,13 +129,15 @@ const Header = ({
         </HStack>
         {/* <Spacer /> */}
         {title ? (
-          <Flex 
-            minWidth="-webkit-min-content" 
+          <Flex
+            minWidth="-webkit-min-content"
             alignItems="center"
             flex={1}
             justifyContent="center"
-            >
-            <Text textStyle="h5" noOfLines={1}>{title}</Text>
+          >
+            <Text textStyle="h5" noOfLines={1}>
+              {title}
+            </Text>
           </Flex>
         ) : null}
         <HStack flex="0 1 content" justifyContent="flex-end" w="fit-content">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -97,8 +97,9 @@ const Header = ({
         bg="white"
         h="4rem"
         w="100%"
+        spacing="0.5rem"
       >
-        <HStack spacing="1.25rem" flex={1}>
+        <HStack spacing="1.25rem" flex="1 1 content">
           {!showButton ? (
             <Box w="180px">
               <img
@@ -128,11 +129,16 @@ const Header = ({
         </HStack>
         {/* <Spacer /> */}
         {title ? (
-          <Flex minWidth="-webkit-min-content" alignItems="center">
-            <Text textStyle="h5">{title}</Text>
+          <Flex 
+            minWidth="-webkit-min-content" 
+            alignItems="center"
+            flex={1}
+            justifyContent="center"
+            >
+            <Text textStyle="h5" noOfLines={1}>{title}</Text>
           </Flex>
         ) : null}
-        <HStack flex={1} justifyContent="flex-end">
+        <HStack flex="0 1 content" justifyContent="flex-end" w="fit-content">
           (
           {isShowStagingBuildStatusEnabled && (
             <Box mr="-0.25rem">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -99,7 +99,7 @@ const Header = ({
         w="100%"
         spacing="0.5rem"
       >
-        <HStack spacing="1.25rem" flex="1 1 content">
+        <HStack spacing="1.25rem" flex="0 1 content">
           {!showButton ? (
             <Box w="180px">
               <img
@@ -121,7 +121,7 @@ const Header = ({
                 }
                 onClick={handleBackNav}
               />
-              <Text color="text.label" textStyle="body-1">
+              <Text color="text.label" textStyle="body-1" noOfLines={1}>
                 {backButtonTextFromParams || backButtonText}
               </Text>
             </>
@@ -140,7 +140,7 @@ const Header = ({
             </Text>
           </Flex>
         ) : null}
-        <HStack flex="0 1 content" justifyContent="flex-end" w="fit-content">
+        <HStack flex="0 0 content" justifyContent="flex-end" w="fit-content">
           (
           {isShowStagingBuildStatusEnabled && (
             <Box mr="-0.25rem">


### PR DESCRIPTION
## Problem

On normal pages, the staging build indicator overlaps the page title if the title is too long.

![image](https://github.com/isomerpages/isomercms-frontend/assets/139780851/23a3b631-cda0-4387-87dd-e5f9bf003b15)

## Solution

Done as a part of Design team learning thanks @seaerchin for demoing the solution and explaining concepts! 🙇 

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Open / create a normal page with a long title (100 chars)
2. Check that status indicator doesn't overlap page title (title should truncate)
3. Change folder name to something long (30 chars)
4. Check that no elements on header overlap each other

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
