### PR TITLE
chore: reset staging url when privatising site

### DIFF
--- a/src/hooks/settingsHooks/useUpdateSettings.ts
+++ b/src/hooks/settingsHooks/useUpdateSettings.ts
@@ -2,7 +2,7 @@ import { AxiosError } from "axios"
 import _ from "lodash"
 import { useMutation, UseMutationResult, useQueryClient } from "react-query"
 
-import { SETTINGS_CONTENT_KEY } from "constants/queryKeys"
+import { SETTINGS_CONTENT_KEY, STAGING_URL_KEY } from "constants/queryKeys"
 
 import * as SettingsService from "services/SettingsService"
 
@@ -58,6 +58,7 @@ export const useUpdateSettings = (
     {
       onSettled: () => {
         queryClient.invalidateQueries([SETTINGS_CONTENT_KEY, siteName])
+        queryClient.invalidateQueries([STAGING_URL_KEY, siteName])
       },
       onSuccess,
       onError,


### PR DESCRIPTION
This PR resets the staging url when a quickied site is converted to private (and vice-versa). To be reviewed in conjunction with PR [#1094](https://github.com/isomerpages/isomercms-backend/pull/1094) on the backend repo.

Tests:

- Privatise a quickied site
  - Staging url should change from `staging-lite` to `staging`
- Unprivatise a quickied site
  - Staging url should change from `staging` to `staging-lite`