### PR TITLE
Fix/review request files title overflow

### DIFF
--- a/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
+++ b/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.tsx
@@ -113,7 +113,12 @@ const ItemName = ({ name, path }: Pick<EditedItemProps, "name" | "path">) => {
   const theme = useTheme()
   return (
     <VStack align="flex-start">
-      <Text textStyle="subhead-2" textColor="text.label" noOfLines={1}>
+      <Text
+        textStyle="subhead-2"
+        textColor="text.label"
+        noOfLines={1}
+        width="100%"
+      >
         {name}
       </Text>
       <Breadcrumb
@@ -526,13 +531,11 @@ const RequestOverviewTable = ({
             const row: Row<EditedItemProps> = table.getRowModel().rows[index]
             // NOTE: This is guaranteed to exist because the table will filter
             // so that the index we're referencing is within the filtered items.
-            return row
-              .getVisibleCells()
-              .map((cell) => (
-                <Td key={cell.id}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Td>
-              ))
+            return row.getVisibleCells().map((cell) => (
+              <Td key={cell.id} maxW="40vw">
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </Td>
+            ))
           }}
         />
       </Box>


### PR DESCRIPTION
Fixes an issue on the review request screen where overly long titles would cause the table to constantly flicker.

See video for issue:

https://github.com/isomerpages/isomercms-frontend/assets/22111124/36debffb-3a58-462e-91ab-c8c8c5933cfb


This PR introduces a max width to prevent the page from constantly attempting to adjust to the larger cell size.