### PR TITLE
fix(editpage): remove all trailing empty p tags if present

### DIFF
--- a/src/hooks/pageHooks/useUpdatePageHook.jsx
+++ b/src/hooks/pageHooks/useUpdatePageHook.jsx
@@ -26,11 +26,17 @@ export function useUpdatePageHook(params, queryParams) {
     (body) => {
       const { newFileName, sha, frontMatter, pageBody } = extractPageInfo(body)
 
+      let updatedPageBody = pageBody
+
+      while (updatedPageBody.endsWith("<p></p>")) {
+        updatedPageBody = updatedPageBody.slice(0, -7)
+      }
+
       return pageService.update(params, {
         newFileName,
         sha,
         frontMatter,
-        pageBody,
+        pageBody: updatedPageBody,
       })
     },
     {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

In the Tiptap editor, trailing empty &lt;p> tags are being rendered as text, which negatively affects the rendering of the page when the last node by the user is something other than a paragraph.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Remove any trailing empty &lt;p> tags just before sending to the backend to save.
    - Note: This does not affect the trailing node added by Tiptap, as it is always added automatically when the user loads the page.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="669" alt="Screenshot 2024-01-09 at 17 44 48" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/488fdf8b-3c9b-4d83-a933-423f0bed0f37">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="684" alt="Screenshot 2024-01-09 at 17 45 16" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/fd8e493c-68d0-4f86-bd99-72c0f6ba0da2">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit using the Tiptap editor.
    - [ ] Add an image at the end of the page and save.
    - [ ] Verify that on the staging site, there is no text that appears after the image.
    - [ ] After the image, add multiple empty paragraphs and save.
    - [ ] Verify that on the staging site, there is no text that appears after the image.
    - [ ] Edit a page using the old Markdown editor and add `Blahblah<p></p>` to the end of the page.
    - [ ] Verify that on the staging site, only "Blahblah" appears without `<p></p>` being rendered.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*