### PR TITLE
fix(modals): set motion preset to none

### DIFF
--- a/src/components/CollaboratorModal/components/MainSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/MainSubmodal.tsx
@@ -8,7 +8,6 @@ import {
   Divider,
   FormControl,
   Input,
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalProps,
@@ -28,6 +27,8 @@ import { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { BiTrash } from "react-icons/bi"
 import { useParams } from "react-router-dom"
+
+import { Modal } from "components/Modal"
 
 import { useLoginContext } from "contexts/LoginContext"
 
@@ -189,7 +190,6 @@ export const MainSubmodal = ({
   return (
     <Modal
       {...props}
-      motionPreset="none"
       onCloseComplete={() => {
         reset()
         collaboratorFormMethods.resetField("isAcknowledged")

--- a/src/components/CollaboratorModal/components/MainSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/MainSubmodal.tsx
@@ -189,6 +189,7 @@ export const MainSubmodal = ({
   return (
     <Modal
       {...props}
+      motionPreset="none"
       onCloseComplete={() => {
         reset()
         collaboratorFormMethods.resetField("isAcknowledged")

--- a/src/components/CollaboratorModal/components/RemoveCollaboratorSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/RemoveCollaboratorSubmodal.tsx
@@ -5,11 +5,12 @@ import {
   Stack,
   ModalProps,
   ModalOverlay,
-  Modal,
   ModalContent,
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 import { useParams } from "react-router-dom"
+
+import { Modal } from "components/Modal"
 
 import { useLoginContext } from "contexts/LoginContext"
 
@@ -40,7 +41,7 @@ export const RemoveCollaboratorSubmodal = ({
   } = useDeleteCollaboratorHook(siteName)
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Remove collaborator?</ModalHeader>

--- a/src/components/CollaboratorModal/components/RemoveCollaboratorSubmodal.tsx
+++ b/src/components/CollaboratorModal/components/RemoveCollaboratorSubmodal.tsx
@@ -40,7 +40,7 @@ export const RemoveCollaboratorSubmodal = ({
   } = useDeleteCollaboratorHook(siteName)
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Remove collaborator?</ModalHeader>

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -3,7 +3,6 @@ import {
   Center,
   FormControl,
   HStack,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -31,6 +30,7 @@ import { useRouteMatch } from "react-router-dom"
 
 import { DirectorySettingsSchema } from "components/DirectorySettingsModal"
 import { ImagePreviewCard } from "components/ImagePreviewCard"
+import { Modal } from "components/Modal"
 
 import { MEDIA_PAGINATION_SIZE } from "constants/media"
 
@@ -191,12 +191,7 @@ export const CreateMediaFolderModal = ({
   }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onModalClose}
-      size="5xl"
-      motionPreset="none"
-    >
+    <Modal isOpen={isOpen} onClose={onModalClose} size="5xl">
       <ModalOverlay />
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onSubmit)}>

--- a/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
+++ b/src/components/CreateMediaFolderModal/CreateMediaFolderModal.tsx
@@ -191,7 +191,12 @@ export const CreateMediaFolderModal = ({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onModalClose} size="5xl">
+    <Modal
+      isOpen={isOpen}
+      onClose={onModalClose}
+      size="5xl"
+      motionPreset="none"
+    >
       <ModalOverlay />
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onSubmit)}>

--- a/src/components/DeleteMediaModal/DeleteMediaModal.tsx
+++ b/src/components/DeleteMediaModal/DeleteMediaModal.tsx
@@ -56,7 +56,7 @@ export const DeleteMediaModal = ({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onModalClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onModalClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/DeleteMediaModal/DeleteMediaModal.tsx
+++ b/src/components/DeleteMediaModal/DeleteMediaModal.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   HStack,
   Icon,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -24,6 +23,8 @@ import {
 } from "@opengovsg/design-system-react"
 import { useState } from "react"
 import { BiImage } from "react-icons/bi"
+
+import { Modal } from "components/Modal"
 
 import { MediaLabels, SelectedMediaDto } from "types/media"
 import { getReadableFileSize } from "utils"
@@ -56,7 +57,7 @@ export const DeleteMediaModal = ({
   }
 
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onModalClose}>
+    <Modal isOpen={isOpen} onClose={onModalClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/EditorCardsDrawer/EditorCardItem.tsx
+++ b/src/components/EditorCardsDrawer/EditorCardItem.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   FormControl,
   HStack,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -27,6 +26,7 @@ import { UseFormReturn } from "react-hook-form"
 import { Editable } from "components/Editable"
 import { FormContext } from "components/Form"
 import FormFieldMedia from "components/FormFieldMedia"
+import { Modal } from "components/Modal"
 
 import { TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT } from "constants/tiptap"
 
@@ -54,7 +54,6 @@ export const EditorCardItem = ({
   return (
     <>
       <Modal
-        motionPreset="none"
         isOpen={isDeleteWarningModalOpen}
         onClose={onDeleteWarningModalClose}
       >

--- a/src/components/EditorCardsDrawer/EditorCardItem.tsx
+++ b/src/components/EditorCardsDrawer/EditorCardItem.tsx
@@ -54,6 +54,7 @@ export const EditorCardItem = ({
   return (
     <>
       <Modal
+        motionPreset="none"
         isOpen={isDeleteWarningModalOpen}
         onClose={onDeleteWarningModalClose}
       >

--- a/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.tsx
+++ b/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.tsx
@@ -1,6 +1,5 @@
 import {
   HStack,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -9,6 +8,8 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+import { Modal } from "components/Modal"
 
 interface EditorDrawerCloseWarningModalProps {
   name: string
@@ -24,7 +25,7 @@ export const EditorDrawerCloseWarningModal = ({
   onProceed,
 }: EditorDrawerCloseWarningModalProps): JSX.Element => {
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Are you sure you want to exit {name} editing?</ModalHeader>

--- a/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.tsx
+++ b/src/components/EditorDrawerCloseWarningModal/EditorDrawerCloseWarningModal.tsx
@@ -24,7 +24,7 @@ export const EditorDrawerCloseWarningModal = ({
   onProceed,
 }: EditorDrawerCloseWarningModalProps): JSX.Element => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Are you sure you want to exit {name} editing?</ModalHeader>

--- a/src/components/EditorEmbedModal/EditorEmbedModal.tsx
+++ b/src/components/EditorEmbedModal/EditorEmbedModal.tsx
@@ -90,7 +90,7 @@ export const EditorEmbedModal = ({
   }, [cursorValue, isOpen, methods])
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
 
       <FormProvider {...methods}>

--- a/src/components/EditorEmbedModal/EditorEmbedModal.tsx
+++ b/src/components/EditorEmbedModal/EditorEmbedModal.tsx
@@ -1,7 +1,6 @@
 import {
   FormControl,
   HStack,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -21,6 +20,8 @@ import {
 import { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import * as Yup from "yup"
+
+import { Modal } from "components/Modal"
 
 import { useCspHook } from "hooks/settingsHooks"
 
@@ -90,7 +91,7 @@ export const EditorEmbedModal = ({
   }, [cursorValue, isOpen, methods])
 
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
 
       <FormProvider {...methods}>

--- a/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.tsx
@@ -40,7 +40,7 @@ export const FeedbackModal = ({
   const { mutateAsync: submitFeedback, isLoading } = useSubmitFeedback()
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <form

--- a/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -19,6 +18,7 @@ import {
 import { useState } from "react"
 import { useForm } from "react-hook-form"
 
+import { Modal } from "components/Modal"
 import { Rating } from "components/Rating/Rating"
 
 import { useLoginContext } from "contexts/LoginContext"
@@ -40,7 +40,7 @@ export const FeedbackModal = ({
   const { mutateAsync: submitFeedback, isLoading } = useSubmitFeedback()
 
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <form

--- a/src/components/Header/ContactModal/ContactVerificationModal.tsx
+++ b/src/components/Header/ContactModal/ContactVerificationModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalBody,
   ModalContent,
   ModalHeader,
@@ -8,6 +7,8 @@ import {
 } from "@chakra-ui/react"
 import { ModalCloseButton } from "@opengovsg/design-system-react"
 import { useState } from "react"
+
+import { Modal } from "components/Modal"
 
 import { useLoginContext } from "contexts/LoginContext"
 
@@ -72,7 +73,7 @@ export const ContactVerificationModal = ({
   }
 
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/Header/ContactModal/ContactVerificationModal.tsx
+++ b/src/components/Header/ContactModal/ContactVerificationModal.tsx
@@ -72,7 +72,7 @@ export const ContactVerificationModal = ({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/HyperlinkModal.jsx
+++ b/src/components/HyperlinkModal.jsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -16,6 +15,7 @@ import PropTypes from "prop-types"
 import { useState } from "react"
 
 import FormField from "components/FormField"
+import { Modal } from "components/Modal"
 
 import FormContext from "./Form/FormContext"
 import FormTitle from "./Form/FormTitle"
@@ -28,7 +28,7 @@ const HyperlinkModal = ({ onSave, initialText, onClose }) => {
   const [link, setLink] = useState("")
 
   return (
-    <Modal isOpen onClose={onClose} motionPreset="none">
+    <Modal isOpen onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/components/HyperlinkModal.jsx
+++ b/src/components/HyperlinkModal.jsx
@@ -28,7 +28,7 @@ const HyperlinkModal = ({ onSave, initialText, onClose }) => {
   const [link, setLink] = useState("")
 
   return (
-    <Modal isOpen onClose={onClose}>
+    <Modal isOpen onClose={onClose} motionPreset="none">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/components/MediaCreationModal/MediaCreationModal.tsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.tsx
@@ -343,6 +343,7 @@ export const MediaCreationModal = ({
         onClose()
         onModalClose()
       }}
+      motionPreset="none"
     >
       <ModalOverlay />
       <ModalContent>

--- a/src/components/MediaCreationModal/MediaCreationModal.tsx
+++ b/src/components/MediaCreationModal/MediaCreationModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -23,6 +22,7 @@ import { FileRejection } from "react-dropzone"
 import { BiCheckCircle, BiSolidErrorCircle } from "react-icons/bi"
 
 import { Attachment } from "components/Attachment"
+import { Modal } from "components/Modal"
 
 import { useCreateMultipleMedia } from "hooks/mediaHooks/useCreateMultipleMedia"
 
@@ -343,7 +343,6 @@ export const MediaCreationModal = ({
         onClose()
         onModalClose()
       }}
-      motionPreset="none"
     >
       <ModalOverlay />
       <ModalContent>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,5 @@
+import type { ModalProps } from "@chakra-ui/react"
+
+export const Modal = ({ motionPreset, ...rest }: ModalProps) => {
+  return <Modal motionPreset={motionPreset || "none"} {...rest} />
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,5 +1,10 @@
 import { Modal as ChakraModal, ModalProps } from "@chakra-ui/react"
 
+/**
+ * NOTE: We are wrapping the Modal component from Chakra UI by enforcing the
+ * motion preset to be "none" by default. This is because having animations
+ * makes the CMS appear very slow on GSIBs.
+ */
 export const Modal = ({ motionPreset, ...rest }: ModalProps) => {
   return <ChakraModal motionPreset={motionPreset || "none"} {...rest} />
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
-import type { ModalProps } from "@chakra-ui/react"
+import { Modal as ChakraModal, ModalProps } from "@chakra-ui/react"
 
 export const Modal = ({ motionPreset, ...rest }: ModalProps) => {
-  return <Modal motionPreset={motionPreset || "none"} {...rest} />
+  return <ChakraModal motionPreset={motionPreset || "none"} {...rest} />
 }

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./Modal"

--- a/src/components/MoveMediaModal/MoveMediaModal.tsx
+++ b/src/components/MoveMediaModal/MoveMediaModal.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   HStack,
   Icon,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -25,6 +24,7 @@ import { UseMutateFunction } from "react-query"
 import { useParams } from "react-router-dom"
 
 import { Breadcrumbs } from "components/Breadcrumbs"
+import { Modal } from "components/Modal"
 import { DirMenuItem, FileMenuItem } from "components/move/MoveMenuItem"
 
 import {
@@ -112,7 +112,7 @@ export const MoveMediaModal = ({
   }, [mediaType, isOpen])
 
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onModalClose}>
+    <Modal isOpen={isOpen} onClose={onModalClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/MoveMediaModal/MoveMediaModal.tsx
+++ b/src/components/MoveMediaModal/MoveMediaModal.tsx
@@ -112,7 +112,7 @@ export const MoveMediaModal = ({
   }, [mediaType, isOpen])
 
   return (
-    <Modal isOpen={isOpen} onClose={onModalClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onModalClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/PageSettingsModal/PageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.tsx
@@ -1,6 +1,5 @@
 import {
   Input,
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -36,6 +35,7 @@ import {
 } from "components/Form"
 import FormFieldMedia from "components/FormFieldMedia"
 import { LoadingButton } from "components/LoadingButton"
+import { Modal } from "components/Modal"
 
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
@@ -147,7 +147,7 @@ export const PageSettingsModal = ({
   }
 
   return (
-    <Modal motionPreset="none" isOpen onClose={onClose}>
+    <Modal isOpen onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton id="settings-CLOSE" />

--- a/src/components/PageSettingsModal/PageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.tsx
@@ -147,7 +147,7 @@ export const PageSettingsModal = ({
   }
 
   return (
-    <Modal isOpen onClose={onClose}>
+    <Modal motionPreset="none" isOpen onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton id="settings-CLOSE" />

--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -229,7 +229,7 @@ export const ResourcePageSettingsModal = ({
   }
 
   return (
-    <Modal isOpen onClose={onClose}>
+    <Modal motionPreset="none" isOpen onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton id="settings-CLOSE" />

--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -1,6 +1,5 @@
 import {
   Input,
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -42,6 +41,7 @@ import {
 } from "components/Form"
 import FormFieldMedia from "components/FormFieldMedia"
 import { LoadingButton } from "components/LoadingButton"
+import { Modal } from "components/Modal"
 
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
@@ -229,7 +229,7 @@ export const ResourcePageSettingsModal = ({
   }
 
   return (
-    <Modal motionPreset="none" isOpen onClose={onClose}>
+    <Modal isOpen onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton id="settings-CLOSE" />

--- a/src/components/ViewStagingSiteModal/ViewStagingSiteModal.tsx
+++ b/src/components/ViewStagingSiteModal/ViewStagingSiteModal.tsx
@@ -1,6 +1,5 @@
 import {
   HStack,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -15,7 +14,8 @@ import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 import QRCode from "qrcode"
 import { useEffect, useState } from "react"
 
-import { ButtonLink } from "../ButtonLink"
+import { ButtonLink } from "components/ButtonLink"
+import { Modal } from "components/Modal"
 
 export interface ViewStagingSiteModalProps {
   isOpen: boolean
@@ -58,7 +58,7 @@ export function ViewStagingSiteModal({
   editMode,
 }: ViewStagingSiteModalProps) {
   return (
-    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader mb="0.5rem"> Open staging site</ModalHeader>

--- a/src/components/ViewStagingSiteModal/ViewStagingSiteModal.tsx
+++ b/src/components/ViewStagingSiteModal/ViewStagingSiteModal.tsx
@@ -58,7 +58,7 @@ export function ViewStagingSiteModal({
   editMode,
 }: ViewStagingSiteModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader mb="0.5rem"> Open staging site</ModalHeader>

--- a/src/components/WarningModal/WarningModal.tsx
+++ b/src/components/WarningModal/WarningModal.tsx
@@ -23,7 +23,7 @@ export const WarningModal = ({
   children,
   ...rest
 }: PropsWithChildren<WarningModalProps>): JSX.Element => (
-  <Modal {...rest}>
+  <Modal motionPreset="none" {...rest}>
     <ModalOverlay />
     <ModalContent>
       <ModalHeader>

--- a/src/components/WarningModal/WarningModal.tsx
+++ b/src/components/WarningModal/WarningModal.tsx
@@ -1,7 +1,6 @@
 import {
   Text,
   HStack,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
@@ -11,6 +10,8 @@ import {
 } from "@chakra-ui/react"
 import { ModalCloseButton } from "@opengovsg/design-system-react"
 import { PropsWithChildren } from "react"
+
+import { Modal } from "components/Modal"
 
 interface WarningModalProps extends ModalProps {
   displayTitle: string
@@ -23,7 +24,7 @@ export const WarningModal = ({
   children,
   ...rest
 }: PropsWithChildren<WarningModalProps>): JSX.Element => (
-  <Modal motionPreset="none" {...rest}>
+  <Modal {...rest}>
     <ModalOverlay />
     <ModalContent>
       <ModalHeader>

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -6,7 +6,6 @@ import {
   Center,
   SimpleGrid,
   Text,
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -46,6 +45,7 @@ import { useRouteMatch } from "react-router-dom"
 
 import { ImagePreviewCard } from "components/ImagePreviewCard"
 import { LoadingButton } from "components/LoadingButton"
+import { Modal } from "components/Modal"
 
 import { MEDIA_PAGINATION_SIZE } from "constants/media"
 
@@ -383,7 +383,6 @@ const MediasSelectModal = ({
       closeOnOverlayClick={false}
       isCentered
       overflowY="hidden"
-      motionPreset="none"
     >
       <ModalOverlay />
       <ModalContent

--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -383,6 +383,7 @@ const MediasSelectModal = ({
       closeOnOverlayClick={false}
       isCentered
       overflowY="hidden"
+      motionPreset="none"
     >
       <ModalOverlay />
       <ModalContent

--- a/src/features/AnnouncementModal/AnnouncementModal.tsx
+++ b/src/features/AnnouncementModal/AnnouncementModal.tsx
@@ -1,7 +1,6 @@
 import {
   Flex,
   Image,
-  Modal,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
@@ -17,6 +16,7 @@ import { Button } from "@opengovsg/design-system-react"
 import { useMemo, useState } from "react"
 import { BiRightArrowAlt } from "react-icons/bi"
 
+import { Modal } from "components/Modal"
 import { ProgressIndicator } from "components/ProgressIndicator"
 
 import { useAnnouncements } from "hooks/useAnnouncement"
@@ -79,7 +79,6 @@ export const AnnouncementModal = ({
         onClose()
       }}
       size="md"
-      motionPreset="none"
     >
       <ModalOverlay />
       <ModalContent>

--- a/src/features/AnnouncementModal/AnnouncementModal.tsx
+++ b/src/features/AnnouncementModal/AnnouncementModal.tsx
@@ -79,6 +79,7 @@ export const AnnouncementModal = ({
         onClose()
       }}
       size="md"
+      motionPreset="none"
     >
       <ModalOverlay />
       <ModalContent>

--- a/src/layouts/EditPage/MarkdownEditPage.tsx
+++ b/src/layouts/EditPage/MarkdownEditPage.tsx
@@ -2,7 +2,6 @@ import {
   useDisclosure,
   Text,
   Box,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -21,6 +20,7 @@ import { useCallback, useEffect, useState } from "react"
 import { BiLinkExternal } from "react-icons/bi"
 import { useParams } from "react-router-dom"
 
+import { Modal } from "components/Modal"
 import MarkdownEditor from "components/pages/MarkdownEditor"
 import PagePreview from "components/pages/PagePreview"
 
@@ -204,13 +204,7 @@ const PreviewModal = ({
   togglePreview,
 }: PreviewModalProps) => {
   return (
-    <Modal
-      motionPreset="none"
-      isOpen={isOpen}
-      onClose={onClose}
-      size="4xl"
-      scrollBehavior="inside"
-    >
+    <Modal isOpen={isOpen} onClose={onClose} size="4xl" scrollBehavior="inside">
       <ModalOverlay />
       <ModalContent p="1rem">
         <ModalHeader>

--- a/src/layouts/EditPage/MarkdownEditPage.tsx
+++ b/src/layouts/EditPage/MarkdownEditPage.tsx
@@ -204,7 +204,13 @@ const PreviewModal = ({
   togglePreview,
 }: PreviewModalProps) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="4xl" scrollBehavior="inside">
+    <Modal
+      motionPreset="none"
+      isOpen={isOpen}
+      onClose={onClose}
+      size="4xl"
+      scrollBehavior="inside"
+    >
       <ModalOverlay />
       <ModalContent p="1rem">
         <ModalHeader>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -4,7 +4,6 @@ import {
   FormControl,
   FormErrorMessage,
   Icon,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -35,6 +34,7 @@ import {
 import { ContextMenu } from "components/ContextMenu"
 import { EmptyArea } from "components/EmptyArea"
 import { Greyscale } from "components/Greyscale"
+import { Modal } from "components/Modal"
 
 import {
   useCreateResourceDirectory,
@@ -125,7 +125,7 @@ const EmptyResourceRoom = () => {
           />
         </Center>
       </SiteEditLayout>
-      <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Create resource room</ModalHeader>
@@ -355,7 +355,7 @@ const ResourceRoomContent = ({
         </Section>
       </SiteEditLayout>
 
-      <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <form

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -125,7 +125,7 @@ const EmptyResourceRoom = () => {
           />
         </Center>
       </SiteEditLayout>
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Create resource room</ModalHeader>
@@ -355,7 +355,7 @@ const ResourceRoomContent = ({
         </Section>
       </SiteEditLayout>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal motionPreset="none" isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <form

--- a/src/layouts/ReviewRequest/components/ApprovedModal/ApprovedModal.tsx
+++ b/src/layouts/ReviewRequest/components/ApprovedModal/ApprovedModal.tsx
@@ -27,7 +27,7 @@ export const ApprovedModal = ({
   const { onClose } = props
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader bg="primary.100" p={0}>

--- a/src/layouts/ReviewRequest/components/ApprovedModal/ApprovedModal.tsx
+++ b/src/layouts/ReviewRequest/components/ApprovedModal/ApprovedModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -11,6 +10,8 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+import { Modal } from "components/Modal"
 
 import { ToastImage } from "assets"
 
@@ -27,7 +28,7 @@ export const ApprovedModal = ({
   const { onClose } = props
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader bg="primary.100" p={0}>

--- a/src/layouts/ReviewRequest/components/CancelRequestModal/CancelRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/CancelRequestModal/CancelRequestModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -11,6 +10,8 @@ import {
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 import { useEffect } from "react"
 import { useParams } from "react-router-dom"
+
+import { Modal } from "components/Modal"
 
 import { useCancelReviewRequest } from "hooks/reviewHooks/useCancelReviewRequest"
 
@@ -45,7 +46,7 @@ export const CancelRequestModal = (
   }, [error, errorToast, isError])
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/CancelRequestModal/CancelRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/CancelRequestModal/CancelRequestModal.tsx
@@ -45,7 +45,7 @@ export const CancelRequestModal = (
   }, [error, errorToast, isError])
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/EditingBlockedModal/EditingBlockedModal.tsx
+++ b/src/layouts/ReviewRequest/components/EditingBlockedModal/EditingBlockedModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -10,13 +9,15 @@ import {
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 
+import { Modal } from "components/Modal"
+
 export const EditingBlockedModal = (
   props: Omit<ModalProps, "children">
 ): JSX.Element => {
   const { onClose } = props
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/EditingBlockedModal/EditingBlockedModal.tsx
+++ b/src/layouts/ReviewRequest/components/EditingBlockedModal/EditingBlockedModal.tsx
@@ -16,7 +16,7 @@ export const EditingBlockedModal = (
   const { onClose } = props
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
+++ b/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
@@ -79,7 +79,7 @@ export const ManageReviewerModal = ({
   }, [errorToast, isUpdateReviewRequestError, updateReviewRequestError])
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
+++ b/src/layouts/ReviewRequest/components/ManageReviewerModal/ManageReviewerModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -15,6 +14,8 @@ import { useEffect } from "react"
 import { Controller, FormProvider, useForm } from "react-hook-form"
 import { useParams } from "react-router-dom"
 import Select from "react-select"
+
+import { Modal } from "components/Modal"
 
 import { useReviewRequestRoleContext } from "contexts/ReviewRequestRoleContext"
 
@@ -79,7 +80,7 @@ export const ManageReviewerModal = ({
   }, [errorToast, isUpdateReviewRequestError, updateReviewRequestError])
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/PendingApprovalModal/PendingApprovalModal.tsx
+++ b/src/layouts/ReviewRequest/components/PendingApprovalModal/PendingApprovalModal.tsx
@@ -16,7 +16,7 @@ export const PendingApprovalModal = (
   const { onClose } = props
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/PendingApprovalModal/PendingApprovalModal.tsx
+++ b/src/layouts/ReviewRequest/components/PendingApprovalModal/PendingApprovalModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -10,13 +9,15 @@ import {
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 
+import { Modal } from "components/Modal"
+
 export const PendingApprovalModal = (
   props: Omit<ModalProps, "children">
 ): JSX.Element => {
   const { onClose } = props
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/PublishedModal/PublishedModal.tsx
+++ b/src/layouts/ReviewRequest/components/PublishedModal/PublishedModal.tsx
@@ -33,6 +33,7 @@ export const PublishedModal = (
   return (
     <Modal
       {...props}
+      motionPreset="none"
       onCloseComplete={() => {
         invalidateMergeRelatedQueries(
           queryClient,

--- a/src/layouts/ReviewRequest/components/PublishedModal/PublishedModal.tsx
+++ b/src/layouts/ReviewRequest/components/PublishedModal/PublishedModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -13,6 +12,8 @@ import {
 import { Button, ModalCloseButton, Link } from "@opengovsg/design-system-react"
 import { useQueryClient } from "react-query"
 import { useParams } from "react-router-dom"
+
+import { Modal } from "components/Modal"
 
 import { invalidateMergeRelatedQueries } from "hooks/reviewHooks"
 import { useGetSiteUrl } from "hooks/siteDashboardHooks"
@@ -33,7 +34,6 @@ export const PublishedModal = (
   return (
     <Modal
       {...props}
-      motionPreset="none"
       onCloseComplete={() => {
         invalidateMergeRelatedQueries(
           queryClient,

--- a/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.stories.tsx
+++ b/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.stories.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -19,6 +18,8 @@ import { ModalCloseButton, Button, Tab } from "@opengovsg/design-system-react"
 import { Story, ComponentMeta } from "@storybook/react"
 import _ from "lodash"
 
+import { Modal } from "components/Modal"
+
 import { MOCK_ITEMS } from "mocks/constants"
 
 import { RequestOverview, RequestOverviewProps } from "./RequestOverview"
@@ -31,7 +32,7 @@ const overviewMeta = {
 const Template: Story<RequestOverviewProps> = ({ items }) => {
   const props = useDisclosure({ defaultIsOpen: true })
   return (
-    <Modal {...props} size="full" motionPreset="none">
+    <Modal {...props} size="full">
       <ModalOverlay />
       <ModalContent>
         {/*

--- a/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.stories.tsx
+++ b/src/layouts/ReviewRequest/components/RequestOverview/RequestOverview.stories.tsx
@@ -31,10 +31,10 @@ const overviewMeta = {
 const Template: Story<RequestOverviewProps> = ({ items }) => {
   const props = useDisclosure({ defaultIsOpen: true })
   return (
-    <Modal {...props} size="full">
+    <Modal {...props} size="full" motionPreset="none">
       <ModalOverlay />
       <ModalContent>
-        {/* 
+        {/*
             NOTE: padding has to be used as the base component from Chakra uses it to set padding.
             Not using it (and using pt etc) would result in the property being overwritten to the default.
             The format is top, left + right, bottom.
@@ -54,10 +54,10 @@ const Template: Story<RequestOverviewProps> = ({ items }) => {
         <ModalBody px="16.5rem" pt="1.5rem" pb="2.5rem">
           <Tabs defaultIndex={1}>
             <TabList>
-              {/* 
+              {/*
                   NOTE: The design system tab has inbuilt left-margin.
                   However, the figma design requires that the tabs be aligned with the content.
-                  Hence, margin is set to 0 here 
+                  Hence, margin is set to 0 here
                   */}
               <Tab ml={0}>Add Details</Tab>
               <Tab>Edited Items</Tab>

--- a/src/layouts/ReviewRequest/components/ReviewRequestForm/ReviewRequestForm.stories.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestForm/ReviewRequestForm.stories.tsx
@@ -36,10 +36,10 @@ const Template: Story<ReviewRequestFormProps> = ({ admins }) => {
   })
   const props = useDisclosure({ defaultIsOpen: true })
   return (
-    <Modal {...props} size="full">
+    <Modal {...props} size="full" motionPreset="none">
       <ModalOverlay />
       <ModalContent>
-        {/* 
+        {/*
           NOTE: padding has to be used as the base component from Chakra uses it to set padding.
           Not using it (and using pt etc) would result in the property being overwritten to the default.
           The format is top, left + right, bottom.
@@ -59,10 +59,10 @@ const Template: Story<ReviewRequestFormProps> = ({ admins }) => {
         <ModalBody px="16.5rem" pt="1.5rem" pb="2.5rem">
           <Tabs>
             <TabList>
-              {/* 
+              {/*
                 NOTE: The design system tab has inbuilt left-margin.
                 However, the figma design requires that the tabs be aligned with the content.
-                Hence, margin is set to 0 here 
+                Hence, margin is set to 0 here
                 */}
               <Tab ml={0}>Add Details</Tab>
               <Tab>Edited Items</Tab>

--- a/src/layouts/ReviewRequest/components/ReviewRequestForm/ReviewRequestForm.stories.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestForm/ReviewRequestForm.stories.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -20,6 +19,8 @@ import { Story, ComponentMeta } from "@storybook/react"
 import _ from "lodash"
 import { useForm, FormProvider } from "react-hook-form"
 
+import { Modal } from "components/Modal"
+
 import { MOCK_ADMINS } from "mocks/constants"
 import { ReviewRequestInfo } from "types/reviewRequest"
 
@@ -36,7 +37,7 @@ const Template: Story<ReviewRequestFormProps> = ({ admins }) => {
   })
   const props = useDisclosure({ defaultIsOpen: true })
   return (
-    <Modal {...props} size="full" motionPreset="none">
+    <Modal {...props} size="full">
       <ModalOverlay />
       <ModalContent>
         {/*

--- a/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
@@ -90,11 +90,11 @@ export const ReviewRequestModal = (
   const selectedReviewers = methods.watch("reviewers")
 
   return (
-    <Modal {...props} size="full">
+    <Modal {...props} size="full" motionPreset="none">
       <ModalOverlay />
       <ModalContent>
         <form onSubmit={onSubmit}>
-          {/* 
+          {/*
           NOTE: padding has to be used as the base component from Chakra uses it to set padding.
           Not using it (and using pt etc) would result in the property being overwritten to the default.
           The format is top, left + right, bottom.
@@ -114,10 +114,10 @@ export const ReviewRequestModal = (
           <ModalBody px="16.5rem" pt="1.5rem" pb="2.5rem">
             <Tabs>
               <TabList>
-                {/* 
+                {/*
                 NOTE: The design system tab has inbuilt left-margin.
                 However, the figma design requires that the tabs be aligned with the content.
-                Hence, margin is set to 0 here 
+                Hence, margin is set to 0 here
                 */}
                 <Tab ml={0}>Add Details</Tab>
                 <Tab>Edited Items</Tab>

--- a/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/ReviewRequestModal/ReviewRequestModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -19,6 +18,8 @@ import { Button, ModalCloseButton, Tab } from "@opengovsg/design-system-react"
 import { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { useParams } from "react-router-dom"
+
+import { Modal } from "components/Modal"
 
 import { useLoginContext } from "contexts/LoginContext"
 
@@ -90,7 +91,7 @@ export const ReviewRequestModal = (
   const selectedReviewers = methods.watch("reviewers")
 
   return (
-    <Modal {...props} size="full" motionPreset="none">
+    <Modal {...props} size="full">
       <ModalOverlay />
       <ModalContent>
         <form onSubmit={onSubmit}>

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -22,6 +21,7 @@ import { BiCopy, BiMailSend } from "react-icons/bi"
 import Select from "react-select"
 
 import { ButtonLink } from "components/ButtonLink"
+import { Modal } from "components/Modal"
 
 import { User } from "types/reviewRequest"
 
@@ -71,7 +71,7 @@ export const SendRequestModal = ({
   const remainingAdmins = sortedAdmins.slice(2)
 
   return (
-    <Modal motionPreset="none" {...props}>
+    <Modal {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
+++ b/src/layouts/ReviewRequest/components/SendRequestModal/SendRequestModal.tsx
@@ -71,7 +71,7 @@ export const SendRequestModal = ({
   const remainingAdmins = sortedAdmins.slice(2)
 
   return (
-    <Modal {...props}>
+    <Modal motionPreset="none" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/Settings/ColourSettings.tsx
+++ b/src/layouts/Settings/ColourSettings.tsx
@@ -5,7 +5,6 @@ import {
   forwardRef,
   Flex,
   FormControl,
-  Modal,
   ModalContent,
 } from "@chakra-ui/react"
 import {
@@ -18,6 +17,8 @@ import { upperFirst } from "lodash"
 import { useState } from "react"
 import { SketchPicker } from "react-color"
 import { useFormContext, Controller } from "react-hook-form"
+
+import { Modal } from "components/Modal"
 
 import { Section, SectionHeader } from "layouts/components"
 
@@ -150,7 +151,6 @@ const FormColourPickerBase = forwardRef<FormColourPickerProps, "input">(
           </Flex>
         </HStack>
         <Modal
-          motionPreset="none"
           onClose={onClose}
           isOpen={isOpen}
           isCentered

--- a/src/layouts/Settings/ColourSettings.tsx
+++ b/src/layouts/Settings/ColourSettings.tsx
@@ -150,6 +150,7 @@ const FormColourPickerBase = forwardRef<FormColourPickerProps, "input">(
           </Flex>
         </HStack>
         <Modal
+          motionPreset="none"
           onClose={onClose}
           isOpen={isOpen}
           isCentered

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalFooter,
@@ -18,6 +17,8 @@ import {
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { Redirect, useParams } from "react-router-dom"
+
+import { Modal } from "components/Modal"
 
 import { useSiteLaunchContext } from "contexts/SiteLaunchContext"
 
@@ -67,11 +68,7 @@ const RiskAcceptanceModal = ({
   const isRiskAccepted = watch("isRiskAccepted")
   const { increasePageNumber, decreasePageNumber } = useSiteLaunchContext()
   return (
-    <Modal
-      motionPreset="none"
-      isOpen={isOpen}
-      onClose={() => decreasePageNumber()}
-    >
+    <Modal isOpen={isOpen} onClose={() => decreasePageNumber()}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
+++ b/src/layouts/SiteLaunchPad/SiteLaunchPad.tsx
@@ -67,7 +67,11 @@ const RiskAcceptanceModal = ({
   const isRiskAccepted = watch("isRiskAccepted")
   const { increasePageNumber, decreasePageNumber } = useSiteLaunchContext()
   return (
-    <Modal isOpen={isOpen} onClose={() => decreasePageNumber()}>
+    <Modal
+      motionPreset="none"
+      isOpen={isOpen}
+      onClose={() => decreasePageNumber()}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
@@ -1,6 +1,5 @@
 import {
   useDisclosure,
-  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
@@ -13,6 +12,8 @@ import { Button, FormErrorMessage, Input } from "@opengovsg/design-system-react"
 import { BubbleMenu } from "@tiptap/react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
+
+import { Modal } from "components/Modal"
 
 import { useEditorContext } from "contexts/EditorContext"
 import { useEditorModal } from "contexts/EditorModalContext"
@@ -83,7 +84,7 @@ const LinkButton = () => {
         Change link
       </button>
       <FormControl isRequired isInvalid={!!errors.href?.message}>
-        <Modal motionPreset="none" isOpen={isOpen} onClose={onClose} size="sm">
+        <Modal isOpen={isOpen} onClose={onClose} size="sm">
           <ModalOverlay />
           <ModalContent>
             <ModalHeader>Update link</ModalHeader>

--- a/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
@@ -83,7 +83,7 @@ const LinkButton = () => {
         Change link
       </button>
       <FormControl isRequired isInvalid={!!errors.href?.message}>
-        <Modal isOpen={isOpen} onClose={onClose} size="sm">
+        <Modal motionPreset="none" isOpen={isOpen} onClose={onClose} size="sm">
           <ModalOverlay />
           <ModalContent>
             <ModalHeader>Update link</ModalHeader>


### PR DESCRIPTION
> [!IMPORTANT]
> Requires testing on multiple devices + GSIB

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The opening and closing of modals in a GSIB is extremely slow in the default rendering mode.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Set the `motionPreset` for all modals to be `none`, so the modal will appear immediately instead of having an animation in which the modal slowly appears.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Go to any site.
    - [ ] Click on every possible action, verify that modals that are opened and closed appear and disappear immediately without any animation.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*