### PR TITLE
fix(tiptap): correctly parse linked image node if it is first

### DIFF
--- a/src/layouts/components/Editor/extensions/Image/Image.ts
+++ b/src/layouts/components/Editor/extensions/Image/Image.ts
@@ -146,7 +146,7 @@ export const IsomerImage = Image.extend({
         tag: 'img[src]:not([src^="data:"])',
       },
       {
-        tag: 'a[href].isomer-image-wrapper > img[src]:not([src^="data:"])',
+        tag: "a[href].isomer-image-wrapper:has(> img)",
       },
     ]
   },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The image node is not correctly parsed by Tiptap when it contains a link and it is the first node in the page.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Make `parseHTML` parse the parent `<a>` tag directly instead of the `<img>` tag.
    - I have no idea why, it just seems to work

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Go to any site and edit a page using the Tiptap editor.
    - [ ] Insert an image at the top of the page and save. Refresh the page and verify that the image appears in the preview.
    - [ ] Add a link to that image and save. Refresh the page and verify that the image appears in the preview, and the link works on the preview.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*