### PR TITLE
fix: mediasselectmodal breadcrumb

### DIFF
--- a/src/components/media/MediasSelectModal.jsx
+++ b/src/components/media/MediasSelectModal.jsx
@@ -600,6 +600,7 @@ const MediasSelectModal = ({
                 </Text>
                 <FolderBreadcrumb
                   mediaDirectoryName={queryParams.mediaDirectoryName}
+                  setQueryParams={setQueryParams}
                 />
               </VStack>
             </ModalHeader>


### PR DESCRIPTION
This PR fixes a bug where the breadcrumb for images when inserting it via a field (e.g. on the settings page) was not working.

Tests

- [ ] Navigate to any field which allows for insertion of image (e.g. on settings page)
- [ ] Within the image select modal, navigate to any subfolder
- [ ] The breadcrumb to navigate back to a parent folder should work