### PR TITLE
chore: fix broken edit link button

### DIFF
--- a/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
+++ b/src/layouts/components/Editor/components/LinkBubbleMenu.tsx
@@ -73,7 +73,9 @@ const LinkButton = () => {
           const { href: _linkHref } = editor.getAttributes("link")
           const linkHref = _linkHref as string
           const isLinkRelativeFilePath =
-            linkHref.startsWith("/") && linkHref.split("/").at(1) === "files"
+            linkHref &&
+            linkHref.startsWith("/") &&
+            linkHref.split("/").at(1) === "files"
           if (isLinkRelativeFilePath) {
             showModal("files")
           } else {


### PR DESCRIPTION
This PR fixes an issue where attempting to modify a link would not work if no `link` attribute exists in the editor.