### PR TITLE
feat(cards): make the card link optional

### DIFF
--- a/src/components/EditorCardsDrawer/EditorCardItem.tsx
+++ b/src/components/EditorCardsDrawer/EditorCardItem.tsx
@@ -196,12 +196,15 @@ export const EditorCardItem = ({
           </FormControl>
 
           {/* Card link URL */}
-          <FormControl isRequired isInvalid={!!errors.cards?.[index]?.linkUrl}>
+          <FormControl isInvalid={!!errors.cards?.[index]?.linkUrl}>
             <FormLabel mb="0.75rem">Link URL</FormLabel>
             <Input
               type="text"
               placeholder="Insert /page-url or https://"
-              {...methods.register(`cards.${index}.linkUrl`, { onChange })}
+              {...methods.register(`cards.${index}.linkUrl`, {
+                onChange,
+                onBlur: () => methods.trigger(),
+              })}
             />
             <FormErrorMessage>
               {errors.cards?.[index]?.linkUrl?.message}
@@ -209,12 +212,18 @@ export const EditorCardItem = ({
           </FormControl>
 
           {/* Card link text */}
-          <FormControl isRequired isInvalid={!!errors.cards?.[index]?.linkText}>
+          <FormControl
+            isRequired={methods.watch(`cards.${index}.linkUrl`)?.length > 0}
+            isInvalid={!!errors.cards?.[index]?.linkText}
+          >
             <FormLabel mb="0.75rem">Link text</FormLabel>
             <Input
               type="text"
               placeholder="Enter text to be displayed for the link"
-              {...methods.register(`cards.${index}.linkText`, { onChange })}
+              {...methods.register(`cards.${index}.linkText`, {
+                onChange,
+                onBlur: () => methods.trigger(),
+              })}
             />
             <FormErrorMessage>
               {errors.cards?.[index]?.linkText?.message}

--- a/src/components/EditorCardsDrawer/EditorCardsDrawer.tsx
+++ b/src/components/EditorCardsDrawer/EditorCardsDrawer.tsx
@@ -34,6 +34,25 @@ import { LINK_URL_REGEX } from "utils"
 
 import { EditorCardItem } from "./EditorCardItem"
 
+const editorCardsInfoBasicShape = {
+  title: Yup.string().required("Title is required"),
+  description: Yup.string().max(
+    TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT,
+    `Description cannot exceed ${TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT} characters`
+  ),
+  linkUrl: Yup.string().matches(
+    new RegExp(LINK_URL_REGEX),
+    "Please enter a valid link URL"
+  ),
+  linkText: Yup.string().when("linkUrl", {
+    is: (value: string) => value.length > 0,
+    then: Yup.string().required(
+      "Link text is required when link URL is present"
+    ),
+    otherwise: Yup.string(),
+  }),
+}
+
 const editorCardsInfoSchema = Yup.object().shape({
   isDisplayImage: Yup.boolean(),
   cards: Yup.array()
@@ -43,34 +62,12 @@ const editorCardsInfoSchema = Yup.object().shape({
         Yup.object().shape({
           image: Yup.string().required("An image is required"),
           altText: Yup.string().required("Alt text is required"),
-          title: Yup.string().required("Title is required"),
-          description: Yup.string().max(
-            TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT,
-            `Description cannot exceed ${TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT} characters`
-          ),
-          linkUrl: Yup.string()
-            .required("Link URL is required")
-            .matches(
-              new RegExp(LINK_URL_REGEX),
-              "Please enter a valid link URL"
-            ),
-          linkText: Yup.string().required("Link text is required"),
+          ...editorCardsInfoBasicShape,
         })
       ),
       otherwise: Yup.array().of(
         Yup.object().shape({
-          title: Yup.string().required("Title is required"),
-          description: Yup.string().max(
-            TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT,
-            `Description cannot exceed ${TIPTAP_CARDS_DESCRIPTION_CHAR_LIMIT} characters`
-          ),
-          linkUrl: Yup.string()
-            .required("Link URL is required")
-            .matches(
-              new RegExp(LINK_URL_REGEX),
-              "Please enter a valid link URL"
-            ),
-          linkText: Yup.string().required("Link text is required"),
+          ...editorCardsInfoBasicShape,
         })
       ),
     })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Users have been requesting that the card block do not need to contain a link. Let's make their wishes come true.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Updated the validation schema for the card grid block to make links optional, unless a link URL has been provided.
    - If the link URL is not present, but the link text is provided, it is still treated as a card without a link and the link text does not appear on the card
- Made the validation happen on blur, so that the error message can appear to prompt the user to add the link text as soon as they have added the link URL.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="1107" alt="Screenshot 2024-02-05 at 13 32 41" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/24fd9904-1426-49ce-9885-fccae4af53c2">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="1110" alt="Screenshot 2024-02-05 at 13 33 29" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/8f5462a2-ef0c-4c1b-a529-18257d13f1ce">
<img width="1113" alt="Screenshot 2024-02-05 at 13 33 47" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/794379c2-f248-4b7e-8f68-760ce935fa5d">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and edit a page using the new Tiptap editor
    - [ ] Add a card grid block
    - [ ] Create a card without putting any link URL or link text, then save the changes to the card grid. Verify that you should be able to save.
    - [ ] Create another card in the same card grid block and put in only the link URL. Verify that you should not be able to save the changes to the card grid.
    - [ ] Use the same card and add in the link text, then save the changes to the card grid. Verify that you should be able to save.
    - [ ] Create another card in the same card grid block and put in only the link text, then save the changes to the card grid. Verify that you should be able to save, but the link text does not appear in the editor preview.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*