### PR TITLE
fix: allow adding multiple collaborators consecutively

### DIFF
--- a/src/hooks/collaboratorHooks/useAddCollaboratorHook.ts
+++ b/src/hooks/collaboratorHooks/useAddCollaboratorHook.ts
@@ -1,5 +1,10 @@
 import { AxiosError } from "axios"
-import { UseMutationResult, useQueryClient, useMutation } from "react-query"
+import {
+  UseMutationResult,
+  useQueryClient,
+  useMutation,
+  UseMutationOptions,
+} from "react-query"
 
 import {
   LIST_COLLABORATORS_KEY,
@@ -7,17 +12,31 @@ import {
 } from "constants/queryKeys"
 
 import { CollaboratorService } from "services"
+import { AddCollaboratorDto } from "types/collaborators"
 import { MiddlewareError } from "types/error"
 
 export const useAddCollaboratorHook = (
-  siteName: string
+  siteName: string,
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      void,
+      AxiosError<{ error: MiddlewareError }>,
+      AddCollaboratorDto
+    >,
+    "mutationFn" | "mutationKey"
+  >
 ): UseMutationResult<
   void,
   AxiosError<{ error: MiddlewareError }>,
-  { newCollaboratorEmail: string; isAcknowledged: boolean }
+  AddCollaboratorDto
 > => {
   const queryClient = useQueryClient()
-  return useMutation(
+
+  return useMutation<
+    void,
+    AxiosError<{ error: MiddlewareError }>,
+    AddCollaboratorDto
+  >(
     ({ newCollaboratorEmail, isAcknowledged }) =>
       CollaboratorService.addCollaborator(
         siteName,
@@ -25,12 +44,22 @@ export const useAddCollaboratorHook = (
         isAcknowledged
       ),
     {
-      onSuccess: () => {
+      ...mutationOptions,
+      onSuccess: (data, variables, context) => {
         queryClient.invalidateQueries([LIST_COLLABORATORS_KEY, siteName])
         queryClient.invalidateQueries([
           SITE_DASHBOARD_COLLABORATORS_KEY,
           siteName,
         ])
+
+        if (mutationOptions?.onSuccess) {
+          mutationOptions.onSuccess(data, variables, context)
+        }
+      },
+      onError: (err, variables, context) => {
+        if (mutationOptions?.onError) {
+          mutationOptions.onError(err, variables, context)
+        }
       },
     }
   )

--- a/src/types/collaborators.ts
+++ b/src/types/collaborators.ts
@@ -20,3 +20,8 @@ export type CollaboratorData = {
 export type CollaboratorRole = {
   role: SiteMemberRole
 }
+
+export type AddCollaboratorDto = {
+  newCollaboratorEmail: string
+  isAcknowledged: boolean
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

It is not possible to add multiple collaborators consecutively, due to an issue with the way the `useEffect` hook is being called.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Removed the need for a `useEffect` hook by handling the finished states via react-query directly.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site using email login.
    - [ ] Open the collaborators modal and add multiple collaborators consecutively (without closing the modal or doing anything else). Verify that you can add multiple collaborators consecutively.
    - [ ] Add an invalid email address, verify that the error message says "That doesn't look like a valid email. Try a gov.sg or other whitelisted email."
    - [ ] Add a valid email address that is unlikely to be whitelisted (i.e. `test@example.com`), verify that the error message says "This collaborator couldn't be added. Visit our guide for more assistance."

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*