### PR TITLE
fix(dompurify): further limit src

### DIFF
--- a/src/layouts/EditPage/utils.ts
+++ b/src/layouts/EditPage/utils.ts
@@ -38,15 +38,19 @@ DOMPurify.setConfig({
 })
 DOMPurify.addHook("uponSanitizeElement", (node, data) => {
   // Allow script tags if it has a src attribute
-  // Script sources are handled by our CSP sanitiser
-  if (
+  const hasUnallowedSrcValue =
     data.tagName === "script" &&
     !(
       node.hasAttribute("src") &&
       node.innerHTML === "" &&
       ALLOWED_SRC.includes(node.getAttribute("src") ?? "")
     )
-  ) {
+
+  const hasUnallowedScriptAttribute =
+    data.tagName === "script" &&
+    (node.hasAttribute("href") || node.hasAttribute("xlink:href"))
+
+  if (hasUnallowedSrcValue || hasUnallowedScriptAttribute) {
     // Adapted from https://github.com/cure53/DOMPurify/blob/e0970d88053c1c564b6ccd633b4af7e7d9a10375/src/purify.js#L719-L736
     DOMPurify.removed.push({ element: node })
     try {

--- a/src/layouts/EditPage/utils.ts
+++ b/src/layouts/EditPage/utils.ts
@@ -13,11 +13,9 @@ import { adjustImageSrcs } from "utils"
  */
 const ALLOWED_SRC = [
   "//www.instagram.com/embed.js",
-  "https://www.evvochannel.tv/jwplayer7/jwplayer.js",
   "/jquery/resize-tables.js",
   "/jquery/jquery.min.js",
   "/jquery/bp-menu-new-tab.js",
-  "//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js",
 ]
 
 DOMPurify.setConfig({

--- a/src/layouts/EditPage/utils.ts
+++ b/src/layouts/EditPage/utils.ts
@@ -6,6 +6,20 @@ import checkCSP from "utils/cspUtils"
 import { MediaData } from "types/directory"
 import { adjustImageSrcs } from "utils"
 
+/**
+ * While we do have a CSP in place, we want to further restrict the content that
+ * that the user can input.
+ * NOTE: Any changes to this list should also be updated in backend code
+ */
+const ALLOWED_SRC = [
+  "//www.instagram.com/embed.js",
+  "https://www.evvochannel.tv/jwplayer7/jwplayer.js",
+  "/jquery/resize-tables.js",
+  "/jquery/jquery.min.js",
+  "/jquery/bp-menu-new-tab.js",
+  "//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js",
+]
+
 DOMPurify.setConfig({
   ADD_TAGS: ["iframe", "#comment", "script"],
   ADD_ATTR: [
@@ -29,7 +43,11 @@ DOMPurify.addHook("uponSanitizeElement", (node, data) => {
   // Script sources are handled by our CSP sanitiser
   if (
     data.tagName === "script" &&
-    !(node.hasAttribute("src") && node.innerHTML === "")
+    !(
+      node.hasAttribute("src") &&
+      node.innerHTML === "" &&
+      ALLOWED_SRC.includes(node.getAttribute("src") ?? "")
+    )
   ) {
     // Adapted from https://github.com/cure53/DOMPurify/blob/e0970d88053c1c564b6ccd633b4af7e7d9a10375/src/purify.js#L719-L736
     DOMPurify.removed.push({ element: node })


### PR DESCRIPTION
## Problem

our csp headers are too permissive for a wholistic block of allowed lists. 

## Solution

while we should be limiting csp headers, a quick fix here is to limit the allowed src. 

This is a breaking change for our users who have been using the `script` tag, to ease in this change, have looked at all the script tags that our agency users have currently been using in their md files, and whitelisted them to achieve parity 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [X] Yes - this PR contains breaking changes
  - Moving forward, ops would need to inform eng if any agency would like to use a script tag with a different source. this change already breaks some agencies code, will be following up with ops to see if they are willing to change this on their end. 
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests

<!-- What tests should be run to confirm functionality? -->

https://github.com/isomerpages/isomercms-frontend/assets/42832651/0400a94f-8439-40ef-81dc-262f19418144


- [X] Smoke tests
- [ ] put in the following content into the markdown files
```
Allowed script 

<script src="//www.instagram.com/embed.js" async="true"></script>

Disallowed in csp

<script src="//www.evil.com/embed.js" async="true"></script>

Allowed in csp but should also be controlled

<script src="//www.blah.cloudfront.net/embed.js" async="true"></script>


Attributes not allowed 

<svg><script src="/jquery/jquery.min.js" href="THISFILEWILLBELOADED"></script></svg>
<svg><script src="/jquery/jquery.min.js" xlink:href="THISFILEWILLBELOADED"></script></svg>

```
- [ ] press save 
- [ ] accept the disclaimer if it pops up
- [ ] post save, only one of the 3 script tags should persist 

note, this same code will be used in the backend as well


