### PR TITLE
swap order of github and email login

### DIFF
--- a/src/layouts/Login/LoginPage.tsx
+++ b/src/layouts/Login/LoginPage.tsx
@@ -163,25 +163,10 @@ const LoginContent = (): JSX.Element => {
       </Infobox>
       <Tabs width="100%">
         <TabList>
-          <Tab>Github Login</Tab>
           <Tab>Email Login</Tab>
+          <Tab>Github Login</Tab>
         </TabList>
         <TabPanels pt="2rem" minHeight="16.5rem">
-          <TabPanel>
-            <Button
-              as={Link}
-              rel="noopener noreferrer"
-              textDecoration="none"
-              w="full"
-              _hover={{
-                textDecoration: "none",
-                bgColor: "primary.600",
-              }}
-              href={`${process.env.REACT_APP_BACKEND_URL_V2}/auth/github-redirect`}
-            >
-              <Text color="white">Log in with GitHub</Text>
-            </Button>
-          </TabPanel>
           <TabPanel>
             <Button
               onClick={() => getSgidAuth()}
@@ -226,6 +211,21 @@ const LoginContent = (): JSX.Element => {
                 errorMessage={getAxiosErrorMessage(loginError)}
               />
             )}
+          </TabPanel>
+          <TabPanel>
+            <Button
+              as={Link}
+              rel="noopener noreferrer"
+              textDecoration="none"
+              w="full"
+              _hover={{
+                textDecoration: "none",
+                bgColor: "primary.600",
+              }}
+              href={`${process.env.REACT_APP_BACKEND_URL_V2}/auth/github-redirect`}
+            >
+              <Text color="white">Log in with GitHub</Text>
+            </Button>
           </TabPanel>
           <Text color="text.helper" fontSize="0.625rem" pt="2rem">
             {


### PR DESCRIPTION
## Problem

github login is the default tab option and most users are logging in via email
@shazlithebestie's request

Closes [insert issue #]

## Solution

swap order of logins

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

- verify that on login screen, the email login option is displayed first

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [ ] Smoke tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
