### PR TITLE
fix(media): should not have files that begin with underscore

### DIFF
--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -29,9 +29,9 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
       )
       .test(
         "File not supported",
-        "File names cannot begin with an underscore",
+        "File names must begin with a letter or number",
         (value) => {
-          return !value.startsWith("_")
+          return /^[a-zA-Z0-9]/.test(value)
         }
       )
       .min(

--- a/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
+++ b/src/components/MediaSettingsModal/MediaSettingsSchema.jsx
@@ -27,6 +27,13 @@ export const MediaSettingsSchema = (existingTitlesArray = []) =>
           return (value.match(/\./g) || []).length <= 1
         }
       )
+      .test(
+        "File not supported",
+        "File names cannot begin with an underscore",
+        (value) => {
+          return !value.startsWith("_")
+        }
+      )
       .min(
         MEDIA_SETTINGS_TITLE_MIN_LENGTH,
         `Title must be longer than ${MEDIA_SETTINGS_TITLE_MIN_LENGTH} characters`

--- a/src/hooks/mediaHooks/useCreateMultipleMedia.ts
+++ b/src/hooks/mediaHooks/useCreateMultipleMedia.ts
@@ -48,6 +48,8 @@ export const useCreateMultipleMedia = (
           // with a safe replacement character
           newFileName: `${getFileName(file.name)
             .replaceAll(/[\W\s]/g, "_")
+            // Remove any leading underscores
+            .replace(/^_+/g, "")
             .trim()}.${getFileExt(file.name)}`,
         }))
       )


### PR DESCRIPTION
## Problem

currently files that start with _ are ignored. this means that in the final output, the site does not have the broken link.

this issue is quite existent in our sites (eg. https://www.cdc.gov.sg/our-programmes/gallery/2021/) 

when i did a string search, this lead to quite a number of sites with these types of images. this is not ideal, and as such this edge case will be coded out as part of the link checker for user to fix

Tests 
- [ ] enter into a repo and try to rename an image into something with an leading underscore.
- [ ] asset that you get the error message as shown below
![Screenshot 2024-03-05 at 2 03 20 PM](https://github.com/isomerpages/isomercms-frontend/assets/42832651/95fbccc9-aa7e-4fae-831c-2ccbb236c8c7)
- [ ] upload an image named '_name.png' into the images folder. assert that the leading underscore gets stripped off


https://github.com/isomerpages/isomercms-frontend/assets/42832651/1ce91503-04b0-442e-8fef-10ae99e3129c

