### PR TITLE
fix(rum): change service tag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,7 @@ if (REACT_APP_ENV === "staging" || REACT_APP_ENV === "production") {
     applicationId: REACT_APP_DATADOG_APP_ID,
     clientToken: REACT_APP_DATADOG_CLIENT_TOKEN,
     site: "datadoghq.com",
-    service: "isomercms-frontend",
+    service: "isomer-infra",
     env: REACT_APP_ENV,
     // Specify a version number to identify the deployed version of your application in Datadog
     version: REACT_APP_VERSION,


### PR DESCRIPTION
## Problem
our frontend tags the service as `isomercms-frontend`; however, with pulumi, we tag all of our resources as `isomer-infra`. in order to standardise our tagging, will instead use `isomer-infra` as the converse is more painful.

Part of [ISOM-771]

## Solution
update rum tag