### PR TITLE
fix(media): use encoded params for mediaDirectoryName

### DIFF
--- a/src/layouts/screens/MediaSettingsScreen.jsx
+++ b/src/layouts/screens/MediaSettingsScreen.jsx
@@ -5,7 +5,7 @@ import { MediaSettingsModal } from "components/MediaSettingsModal"
 import { useGetMediaHook, useUpdateMediaHook } from "hooks/mediaHooks"
 
 export const MediaSettingsScreen = ({ match, onClose }) => {
-  const { params, decodedParams } = match
+  const { params } = match
   const { data: mediaData } = useGetMediaHook(params)
   const { mutateAsync: updateHandler } = useUpdateMediaHook(params, {
     onSuccess: onClose,
@@ -13,7 +13,7 @@ export const MediaSettingsScreen = ({ match, onClose }) => {
 
   return (
     <MediaSettingsModal
-      params={decodedParams}
+      params={params}
       onClose={onClose}
       mediaData={mediaData}
       onProceed={updateHandler}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The use of the decodedParams causes the call to `useListMediaFolderFiles` to be incorrect.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Use the encoded params instead. There is no need to use the decoded version here.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to any site and go to the images tab
    - [ ] Go into an album with images inside
    - [ ] Attempt to rename the image. Verify that you are able to rename and not receive any errors.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

This fix needs to go in before backend.