### PR TITLE
fix(path-traversal): add regex to prevent path traversal attack

### DIFF
--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -66,18 +66,18 @@ export const RouteSelector = () => {
         <ProtectedRouteWithProps
           exact
           path={[
-            "/sites/:siteName/resourceRoom/:resourceRoomName/resourceCategory/:resourceCategoryName/editPage/:fileName",
-            "/sites/:siteName/folders/:collectionName/subfolders/:subCollectionName/editPage/:fileName",
-            "/sites/:siteName/folders/:collectionName/editPage/:fileName",
-            "/sites/:siteName/editPage/:fileName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/resourceRoom/:resourceRoomName/resourceCategory/:resourceCategoryName/editPage/:fileName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName/subfolders/:subCollectionName/editPage/:fileName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName/editPage/:fileName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/editPage/:fileName",
           ]}
           component={injectApprovalRedirect(EditPage)}
         />
 
         <ProtectedRouteWithProps
           path={[
-            "/sites/:siteName/folders/:collectionName/subfolders/:subCollectionName",
-            "/sites/:siteName/folders/:collectionName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName/subfolders/:subCollectionName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName",
           ]}
         >
           <ApprovedReviewRedirect>
@@ -87,13 +87,13 @@ export const RouteSelector = () => {
 
         <ProtectedRouteWithProps
           exact
-          path="/sites/:siteName/navbar"
+          path="/sites/:siteName([a-zA-Z0-9-]+)/navbar"
           component={injectApprovalRedirect(EditNavBar)}
         />
 
         <ProtectedRouteWithProps
           path={[
-            "/sites/:siteName/media/:mediaRoom/mediaDirectory/:mediaDirectoryName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/media/:mediaRoom/mediaDirectory/:mediaDirectoryName",
           ]}
         >
           <ApprovedReviewRedirect>
@@ -101,47 +101,47 @@ export const RouteSelector = () => {
           </ApprovedReviewRedirect>
         </ProtectedRouteWithProps>
 
-        <ProtectedRouteWithProps path="/sites/:siteName/dashboard">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/dashboard">
           <SiteLaunchProvider>
             <SiteDashboard />
           </SiteLaunchProvider>
         </ProtectedRouteWithProps>
 
-        <ProtectedRouteWithProps path="/sites/:siteName/linkCheckerReport">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/linkCheckerReport">
           <SiteLaunchProvider>
             <LinksReport />
           </SiteLaunchProvider>
         </ProtectedRouteWithProps>
 
-        <ProtectedRouteWithProps path="/sites/:siteName/siteLaunchPad">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/siteLaunchPad">
           <SiteLaunchProvider>
             <SiteLaunchPadPage />
           </SiteLaunchProvider>
         </ProtectedRouteWithProps>
 
-        <ProtectedRouteWithProps path="/sites/:siteName/review/:reviewId">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/review/:reviewId">
           <ReviewRequestRoleProvider>
             <ReviewRequestDashboard />
           </ReviewRequestRoleProvider>
         </ProtectedRouteWithProps>
 
-        <ProtectedRouteWithProps path="/sites/:siteName/workspace">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/workspace">
           <ApprovedReviewRedirect>
             <Workspace />
           </ApprovedReviewRedirect>
         </ProtectedRouteWithProps>
 
         <ProtectedRouteWithProps
-          path="/sites/:siteName/homepage"
+          path="/sites/:siteName([a-zA-Z0-9-]+)/homepage"
           component={injectApprovalRedirect(EditHomepage)}
         />
 
         <ProtectedRouteWithProps
-          path="/sites/:siteName/contact-us"
+          path="/sites/:siteName([a-zA-Z0-9-]+)/contact-us"
           component={injectApprovalRedirect(EditContactUs)}
         />
 
-        <ProtectedRouteWithProps path="/sites/:siteName/resourceRoom/:resourceRoomName/resourceCategory/:resourceCategoryName">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/resourceRoom/:resourceRoomName/resourceCategory/:resourceCategoryName">
           <ApprovedReviewRedirect>
             <ResourceCategory />
           </ApprovedReviewRedirect>
@@ -149,8 +149,8 @@ export const RouteSelector = () => {
 
         <ProtectedRouteWithProps
           path={[
-            "/sites/:siteName/resourceRoom/:resourceRoomName",
-            "/sites/:siteName/resourceRoom",
+            "/sites/:siteName([a-zA-Z0-9-]+)/resourceRoom/:resourceRoomName",
+            "/sites/:siteName([a-zA-Z0-9-]+)/resourceRoom",
           ]}
         >
           <ApprovedReviewRedirect>
@@ -158,7 +158,7 @@ export const RouteSelector = () => {
           </ApprovedReviewRedirect>
         </ProtectedRouteWithProps>
 
-        <ProtectedRouteWithProps path="/sites/:siteName/settings">
+        <ProtectedRouteWithProps path="/sites/:siteName([a-zA-Z0-9-]+)/settings">
           <ApprovedReviewRedirect>
             <Settings />
           </ApprovedReviewRedirect>


### PR DESCRIPTION
## Problem
Currently, our frontend is vulnerable to path traversal attacks due to non-sanitisation of path parameters. 

## Solution
Validate site name according to teh regex in the picture below. sanitization is **not** done for other stuff like resource room name because **these allow spaces in the name.**


<img width="607" alt="Screenshot 2024-03-08 at 1 37 08 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/44049504/ae4b5b19-c4c4-4a26-b790-4680b9444802">

Attempting to use `%20` in the regex will lead to erroneous validation (as seen in the ss). We also cannot allow `%` because this will lead to allowing url encoded characters (`%5c`).
<img width="1149" alt="Screenshot 2024-03-08 at 1 38 41 PM" src="https://github.com/isomerpages/isomercms-frontend/assets/44049504/923e53b0-595c-4582-9ebe-a0ba0a468264">