### PR TITLE
fix(no broken link): not reporting duplicate permalink

### DIFF
--- a/src/layouts/LinkReport/LinksReport.tsx
+++ b/src/layouts/LinkReport/LinksReport.tsx
@@ -398,6 +398,14 @@ const LinkBody = () => {
       return <NoBrokenLinks />
     }
 
+    // todo: remove this once design is ready with showing duplicate permalinks
+    const onlyDuplicatePermalinks = brokenLinks.errors.every(
+      (error) => error.type === "duplicate-permalink"
+    )
+    if (onlyDuplicatePermalinks) {
+      return <NoBrokenLinks />
+    }
+
     return <LinkContent brokenLinks={brokenLinks.errors} />
   }
 


### PR DESCRIPTION
## Problem

currently we only have designs for broken links and not duplicate permalinks. 
add a less confusing state when the site only has duplicate permalinks. note that design is currently working on the iterations for duplicate permalinks, this is just a temp measure


## Before & After Screenshots

**BEFORE**:

![Screenshot 2024-03-12 at 8.49.44 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/4JosFH65rhzwIvkZw2J6/62564a76-7e5c-452a-8c5d-ecb7e7a28a56.png)

<!-- [insert screenshot here] -->

**AFTER**:

![Screenshot 2024-03-12 at 8.54.11 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/4JosFH65rhzwIvkZw2J6/f2af7d8b-023a-46af-8261-2245e0e301d1.png)

<!-- [insert screenshot here] -->

