### PR TITLE
feat(app): add link between traces + rum

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,6 +50,8 @@ const {
   REACT_APP_DATADOG_CLIENT_TOKEN,
   REACT_APP_VERSION,
   REACT_APP_ENV,
+  REACT_APP_BACKEND_URL_V2,
+  REACT_APP_BACKEND_URL,
 } = process.env
 
 if (REACT_APP_ENV === "staging" || REACT_APP_ENV === "production") {
@@ -61,6 +63,7 @@ if (REACT_APP_ENV === "staging" || REACT_APP_ENV === "production") {
     env: REACT_APP_ENV,
     // Specify a version number to identify the deployed version of your application in Datadog
     version: REACT_APP_VERSION,
+    allowedTracingUrls: [REACT_APP_BACKEND_URL_V2, REACT_APP_BACKEND_URL],
     ...DATADOG_RUM_SETTINGS,
   })
 


### PR DESCRIPTION
## Problem
currently our backend trace isn't tied to our frontend RUM replay. this PR adds an allow list of backend urls, which will then allow DD to tie the traces to the specific rum session. 

Closes [insert issue #]

## Solution
- add `allowedTracingUrls` - see [here](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum)
    - we can add in regex, functions or strings.
    - strings match by initial section, so any url that starts with the given string will be matched. in our case, we use the env vrs `REACT_APP_BACKEND_URL`
