### PR TITLE
build(package-lock): bump pm to 2.0.8 to avoid legal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7852,34 +7852,6 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
       "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
     },
-    "node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "dev": true,
@@ -12504,16 +12476,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/object.omit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/object.omit/-/object.omit-3.0.2.tgz",
-      "integrity": "sha512-BxWU36cMP+FKD3OLFluQaj2cBev2sx2LJaHELuphHwnleq+xnEhTmuYYYx4pOT/1U/ZoR6B+RdvxWh2FD6lGGA=="
-    },
-    "node_modules/@types/object.pick": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/object.pick/-/object.pick-1.3.3.tgz",
-      "integrity": "sha512-qZqHmdGEALeSATMB1djT1S5szv6Wtpb7DKpHrt2XG4iyKlV7C2Xk8GmDXr1KXakOqUfX6ohw7ceruYt4NVmB1Q=="
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "license": "MIT"
@@ -12752,11 +12714,6 @@
       "dependencies": {
         "@types/jest": "*"
       }
-    },
-    "node_modules/@types/throttle-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
-      "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ=="
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -15382,17 +15339,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "dev": true,
@@ -17245,11 +17191,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/dash-get": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dash-get/-/dash-get-1.0.2.tgz",
-      "integrity": "sha512-4FbVrHDwfOASx7uQVxeiCTo7ggSdYZbqs8lH+WU6ViypPlDbe9y6IP5VVUDQBv9DcnyaiPT5XT0UWHgJ64zLeQ=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -22757,6 +22698,7 @@
     },
     "node_modules/is-extendable": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -22767,6 +22709,7 @@
     },
     "node_modules/is-extendable/node_modules/is-plain-object": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -29882,19 +29825,9 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.omit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
-      "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
-      "dependencies": {
-        "is-extendable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object.pick": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -32249,12 +32182,11 @@
       }
     },
     "node_modules/prosemirror-trailing-node": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.7.tgz",
-      "integrity": "sha512-8zcZORYj/8WEwsGo6yVCRXFMOfBo0Ub3hCUvmoWIZYfMP26WqENU0mpEP27w7mt8buZWuGrydBewr0tOArPb1Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.8.tgz",
+      "integrity": "sha512-ujRYhSuhQb1Jsarh1IHqb2KoSnRiD7wAMDGucP35DN7j5af6X7B18PfdPIrbwsPTqIAj0fyOvxbuPsWhNvylmA==",
       "dependencies": {
         "@remirror/core-constants": "^2.0.2",
-        "@remirror/core-helpers": "^3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
@@ -38540,14 +38472,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/throttleit": {
       "version": "1.0.0",
       "dev": true,
@@ -39133,6 +39057,7 @@
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"


### PR DESCRIPTION
## Problem
prosemirror has potential legal issues, see [here](https://opengovproducts.slack.com/archives/CK9GGK6EP/p1709632812521449)

## Solution
bump version to `2.0.8`