### PR TITLE
fix(resourceModal): sane default permalink

### DIFF
--- a/src/components/PageSettingsModal/PageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/PageSettingsModal.tsx
@@ -37,6 +37,7 @@ import FormFieldMedia from "components/FormFieldMedia"
 import { LoadingButton } from "components/LoadingButton"
 import { Modal } from "components/Modal"
 
+import { getDefaultPermalink } from "utils/permalink"
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { PageVariant } from "types/pages"
@@ -145,15 +146,6 @@ export const PageSettingsModal = ({
       pageData,
       data,
     })
-  }
-
-  const getDefaultPermalink = (title: string) => {
-    if (!title) return ""
-    const titleSlug = title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-    return `/${titleSlug}/`
   }
 
   const currTitle = watch("title")

--- a/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
+++ b/src/components/PageSettingsModal/ResourcePageSettingsModal.tsx
@@ -43,6 +43,7 @@ import FormFieldMedia from "components/FormFieldMedia"
 import { LoadingButton } from "components/LoadingButton"
 import { Modal } from "components/Modal"
 
+import { getDefaultPermalink } from "utils/permalink"
 import { isWriteActionsDisabled } from "utils/reviewRequests"
 
 import { PageVariant } from "types/pages"
@@ -228,6 +229,19 @@ export const ResourcePageSettingsModal = ({
     })
   }
 
+  const isResourcePageCreated = !fileName
+
+  const currTitle = watch("title")
+  const currPermalink = watch("permalink")
+  useEffect(() => {
+    if (
+      isResourcePageCreated &&
+      currPermalink !== getDefaultPermalink(currTitle)
+    ) {
+      setValue("permalink", getDefaultPermalink(currTitle))
+    }
+  }, [isResourcePageCreated, setValue, currTitle, currPermalink])
+
   return (
     <Modal isOpen onClose={onClose}>
       <ModalOverlay />
@@ -235,7 +249,9 @@ export const ResourcePageSettingsModal = ({
         <ModalCloseButton id="settings-CLOSE" />
         <ModalHeader>
           <Text as="h1">
-            {fileName ? "Resource page settings" : "Create new resource"}
+            {isResourcePageCreated
+              ? "Create new resource"
+              : "Resource page settings"}
           </Text>
         </ModalHeader>
         <ModalBody>
@@ -297,14 +313,24 @@ export const ResourcePageSettingsModal = ({
                     <Box mb="0.75rem">
                       <FormLabel mb={0}>Page URL</FormLabel>
                       <FormLabel.Description color="text.description">
-                        {`${siteUrl}${watch("permalink")}`}
+                        {isResourcePageCreated
+                          ? `You can change this later in Resource Page Settings.`
+                          : `${siteUrl}${watch("permalink")}`}
                       </FormLabel.Description>
                     </Box>
                     <Input
                       {...register("permalink", { required: true })}
                       id="permalink"
                       placeholder="Insert /page-url or https://"
+                      isDisabled={isResourcePageCreated}
                     />
+                    {isResourcePageCreated && (
+                      <Box my="0.5rem">
+                        <Text textStyle="body-2">
+                          {`${siteUrl}${watch("permalink")}`}
+                        </Text>
+                      </Box>
+                    )}
                     <FormErrorMessage>
                       {errors.permalink?.message}
                     </FormErrorMessage>

--- a/src/utils/permalink.ts
+++ b/src/utils/permalink.ts
@@ -1,0 +1,8 @@
+export const getDefaultPermalink = (title: string) => {
+  if (!title) return ""
+  const titleSlug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return `/${titleSlug}/`
+}


### PR DESCRIPTION
## Problem

same as #1843 but for resource pages 


## Tests
follow video


https://github.com/isomerpages/isomercms-frontend/assets/42832651/f545f927-90ba-4daf-a555-62f5b1a834f7

- [ ] create a resource page, note that you should be unable to modify the permalink 
- [ ] edit resource page modal's functionality remains the same, we dont still allow them to change to whatever.

