### PR TITLE
fix(routeselector/resourceroom): remove accidental comments + fix typo

### DIFF
--- a/src/__tests__/RouteSelector.spec.jsx
+++ b/src/__tests__/RouteSelector.spec.jsx
@@ -384,7 +384,7 @@ describe("Tests for RouteSelector", () => {
       render(
         <MemoryRouter
           initialEntries={[
-            "/sites/site-name/resourceRoom/my-resource/resourceCategory/my-category/editPage/my-file",
+            "/sites/site-name/resourceRoom/my-resource/resourceCategory/my-category/editPage/my-file.md",
           ]}
         >
           <LoggedInContextProvider>
@@ -518,7 +518,7 @@ describe("Tests for RouteSelector", () => {
     test("Should render EditPage page for site site-name if logged in", () => {
       // Act
       render(
-        <MemoryRouter initialEntries={["/sites/site-name/editPage/my-file"]}>
+        <MemoryRouter initialEntries={["/sites/site-name/editPage/my-file.md"]}>
           <LoggedInContextProvider>
             <RouteSelector />
           </LoggedInContextProvider>
@@ -656,7 +656,7 @@ describe("Tests for RouteSelector", () => {
       render(
         <MemoryRouter
           initialEntries={[
-            "/sites/site-name/folders/my-folder/editPage/my-file",
+            "/sites/site-name/folders/my-folder/editPage/my-file.md",
           ]}
         >
           <LoggedInContextProvider>
@@ -693,7 +693,7 @@ describe("Tests for RouteSelector", () => {
       render(
         <MemoryRouter
           initialEntries={[
-            "/sites/site-name/folders/my-folder/subfolders/my%20subfolder/editPage/my-file",
+            "/sites/site-name/folders/my-folder/subfolders/my%20subfolder/editPage/my-file.md",
           ]}
         >
           <LoggedInContextProvider>

--- a/src/layouts/ResourceRoom/ResourceRoom.tsx
+++ b/src/layouts/ResourceRoom/ResourceRoom.tsx
@@ -386,7 +386,7 @@ const ResourceRoomContent = ({
               >
                 <FormLabel>Resource room title</FormLabel>
                 <Input
-                  placeholder="New resource oom name"
+                  placeholder="New resource room name"
                   {...register("newDirectoryName", {
                     required:
                       "Please ensure that you have entered a resource room name!",

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -69,19 +69,6 @@ export const RouteSelector = () => {
           exact
           path={[
             "/sites/:siteName([a-zA-Z0-9-]+)/resourceRoom/:resourceRoomName([a-zA-Z0-9-]+)/resourceCategory/:resourceCategoryName([a-zA-Z0-9-]+)/editPage/:fileName",
-          ]}
-          component={injectApprovalRedirect(EditPage)}
-          validate={{
-            fileName: (value) => {
-              const encodedName = value.split(".").slice(0, -1).join(".")
-              return !specialCharactersRegexTest.test(encodedName)
-            },
-          }}
-        />
-
-        <ProtectedRouteWithProps
-          exact
-          path={[
             "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName([a-zA-Z0-9-]+)/subfolders/:subCollectionName/editPage/:fileName",
             "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName([a-zA-Z0-9-]+)/editPage/:fileName",
             "/sites/:siteName([a-zA-Z0-9-]+)/editPage/:fileName",
@@ -90,10 +77,14 @@ export const RouteSelector = () => {
           validate={{
             fileName: (value) => {
               const encodedName = value.split(".").slice(0, -1).join(".")
-              return !specialCharactersRegexTest.test(encodedName)
+              const decodedName = decodeURIComponent(encodedName)
+              return (
+                value === "terms-of-use.md" ||
+                !specialCharactersRegexTest.test(decodedName)
+              )
             },
             subCollectionName: (value) => {
-              return !specialCharactersRegexTest.test(value)
+              return !specialCharactersRegexTest.test(decodeURIComponent(value))
             },
           }}
         />
@@ -105,7 +96,7 @@ export const RouteSelector = () => {
           ]}
           validate={{
             subCollectionName: (value) => {
-              return !specialCharactersRegexTest.test(value)
+              return !specialCharactersRegexTest.test(decodeURIComponent(value))
             },
           }}
         >

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -78,10 +78,7 @@ export const RouteSelector = () => {
             fileName: (value) => {
               const encodedName = value.split(".").slice(0, -1).join(".")
               const decodedName = decodeURIComponent(encodedName)
-              return (
-                value === "terms-of-use.md" ||
-                ALLOWED_CHARACTERS_REGEX.test(decodedName)
-              )
+              return ALLOWED_CHARACTERS_REGEX.test(decodedName)
             },
             subCollectionName: (value) => {
               return ALLOWED_CHARACTERS_REGEX.test(decodeURIComponent(value))

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -35,7 +35,7 @@ import { Workspace } from "layouts/Workspace"
 import { ProtectedRouteWithProps } from "routing/ProtectedRouteWithProps"
 import RedirectIfLoggedInRoute from "routing/RedirectIfLoggedInRoute"
 
-import { specialCharactersRegexTest } from "utils"
+import { ALLOWED_CHARACTERS_REGEX } from "utils"
 
 import {
   ApprovedReviewRedirect,
@@ -80,11 +80,11 @@ export const RouteSelector = () => {
               const decodedName = decodeURIComponent(encodedName)
               return (
                 value === "terms-of-use.md" ||
-                !specialCharactersRegexTest.test(decodedName)
+                ALLOWED_CHARACTERS_REGEX.test(decodedName)
               )
             },
             subCollectionName: (value) => {
-              return !specialCharactersRegexTest.test(decodeURIComponent(value))
+              return ALLOWED_CHARACTERS_REGEX.test(decodeURIComponent(value))
             },
           }}
         />
@@ -96,7 +96,7 @@ export const RouteSelector = () => {
           ]}
           validate={{
             subCollectionName: (value) => {
-              return !specialCharactersRegexTest.test(decodeURIComponent(value))
+              return ALLOWED_CHARACTERS_REGEX.test(decodeURIComponent(value))
             },
           }}
         >
@@ -120,8 +120,8 @@ export const RouteSelector = () => {
               // NOTE: This value is prepended with either `files|images`
               // and nested directories are separated by `/` as well.
               const decodedValues = decodeURIComponent(value).split("/")
-              return decodedValues.every(
-                (val) => !specialCharactersRegexTest.test(val)
+              return decodedValues.every((val) =>
+                ALLOWED_CHARACTERS_REGEX.test(val)
               )
             },
           }}

--- a/src/routing/RouteSelector.jsx
+++ b/src/routing/RouteSelector.jsx
@@ -82,8 +82,6 @@ export const RouteSelector = () => {
         <ProtectedRouteWithProps
           exact
           path={[
-            // Collection is correct
-            // Subcollection disallows a few special characters
             "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName([a-zA-Z0-9-]+)/subfolders/:subCollectionName/editPage/:fileName",
             "/sites/:siteName([a-zA-Z0-9-]+)/folders/:collectionName([a-zA-Z0-9-]+)/editPage/:fileName",
             "/sites/:siteName([a-zA-Z0-9-]+)/editPage/:fileName",

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -63,6 +63,11 @@ export const fileNameExtensionRegexTest = /^[a-zA-z]{3,4}$/
 export const RESOURCE_CATEGORY_REGEX = "^([a-zA-Z0-9]*[- ]?)+$"
 export const slugifyLowerFalseRegexTest = /^([a-zA-Z0-9]+-)*[a-zA-Z0-9]+$/
 export const resourceCategoryRegexTest = RegExp(RESOURCE_CATEGORY_REGEX)
+// NOTE: This is a negation of the specialCharactersRegex
+// and also allows for `-`.
+// This is because of migration of pre-cms sites from github
+// over to cms allows for dashes in the file/folder name.
+export const ALLOWED_CHARACTERS_REGEX = /[^~%^*_+./\\`;~{}[\]"<>]/
 export const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 export const jekyllFirstCharacterRegexTest = /^[._#~]/
 export const mediaSpecialCharactersRegexTest = /[~%^?*+#./\\`;~{}[\]"<>]/


### PR DESCRIPTION
## Problem
merged previous PR too early, had a commit that was unpushed to upstream that removes extra comments and fixes a typo.

## Solution
1. fix typo
2. remove extra comment
3. validate on `terms-of-use` 
4. use decoded params instead
