### PR TITLE
chore: add frustration signal tracking

### DIFF
--- a/src/constants/datadog.ts
+++ b/src/constants/datadog.ts
@@ -1,4 +1,9 @@
-export const DATADOG_RUM_SETTINGS = {
+import { RumInitConfiguration } from "@datadog/browser-rum"
+
+export const DATADOG_RUM_SETTINGS: Omit<
+  RumInitConfiguration,
+  "applicationId" | "clientToken"
+> = {
   sessionSampleRate: 100,
   sessionReplaySampleRate: 100,
   trackUserInteractions: true,
@@ -6,4 +11,4 @@ export const DATADOG_RUM_SETTINGS = {
   trackLongTasks: true,
   defaultPrivacyLevel: "mask-user-input",
   enableExperimentalFeatures: ["clickmap"],
-} as const
+}


### PR DESCRIPTION
## Problem
No frustration signal tracking in dd meant that we weren't getting important dd points

Closes [ISOM-1309]

## Solution
Add frustration signal trackign in + remove `as const` cast. the cast had to be removed as the library type doesn't allow readonly assignment to a mutable property...