### PR TITLE
fix/prevent logout in login pages

### DIFF
--- a/src/contexts/LoginContext.tsx
+++ b/src/contexts/LoginContext.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useState,
 } from "react"
+import { useLocation } from "react-router-dom"
 
 import { LOCAL_STORAGE_KEYS } from "constants/localStorage"
 
@@ -15,6 +16,7 @@ import { useLocalStorage } from "hooks/useLocalStorage"
 import { LoggedInUser, UserType, UserTypes } from "types/user"
 
 const { REACT_APP_BACKEND_URL_V2: BACKEND_URL } = process.env
+const LOGIN_PATHS = ["/", "/sgid-callback"]
 
 interface LoginContextProps extends LoggedInUser {
   isLoading: boolean
@@ -36,6 +38,7 @@ const useLoginContext = (): LoginContextProps => {
 const LoginProvider = ({
   children,
 }: PropsWithChildren<Record<string, never>>): JSX.Element => {
+  const { pathname } = useLocation()
   const [, , removeSites] = useLocalStorage(
     LOCAL_STORAGE_KEYS.SitesIsPrivate,
     false
@@ -69,7 +72,11 @@ const LoginProvider = ({
       return response
     },
     async (error) => {
-      if (error.response && error.response.status === 401) {
+      if (
+        error.response &&
+        error.response.status === 401 &&
+        !LOGIN_PATHS.includes(pathname)
+      ) {
         await logout()
       }
       setIsLoading(false)


### PR DESCRIPTION
## Problem

Possible fix to https://linear.app/ogp/issue/ISOM-1009/sgid-logins-are-failing-silently - cannot verify as issue is hard to reproduce

This PR prevents the calling of the `logout` endpoints on our login pages, i.e. `/` and `/sgid-redirect` - as their interaction could possibly be the source of failed sgid logins. As these pages are also inaccessible if the user is logged in, since they will be redirected to `/sites`, there is no reason to call `/logout` from these pages regardless.

## Tests

- [ ] Login with sgid
- [ ] Login with email
