### PR TITLE
feat: enhance Telegram URL regex

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -16,7 +16,7 @@ const PERMALINK_REGEX = "^((/([a-zA-Z0-9]+-)*[a-zA-Z0-9]+)+)/?$"
 export const URL_REGEX_PREFIX = "^(https://)?(www.)?("
 export const URL_REGEX_SUFFIX = ".com/)([a-zA-Z0-9_-]+([/.])?)+$"
 export const YOUTUBE_REGEX = ".com/(@)?)([a-zA-Z0-9_-]+([/.])?)+$"
-export const TELEGRAM_REGEX = "telegram|t).me/([a-zA-Z0-9_-]+([/.])?)+$"
+export const TELEGRAM_REGEX = "telegram|t).me/\\+?([a-zA-Z0-9_-]+([/.])?)+$"
 export const TIKTOK_REGEX = ".com/@)([a-zA-Z0-9_-]+([/.])?)+$"
 // Linkedin doesn't seem to restrict special characters
 export const LINKEDIN_REGEX = ".com/).+$"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

It appears that Telegram invite links to private groups are created in the format `t.me/+...`, which does not match the existing regex we have.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Enhance the Telegram URL regex to allow for an optional `+` at the start of the path.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="1169" alt="Screenshot 2024-07-05 at 15 09 30" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/e3b6529b-f30f-4999-9a2b-493467206cf9">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="1152" alt="Screenshot 2024-07-05 at 15 09 41" src="https://github.com/isomerpages/isomercms-frontend/assets/27919917/92d4f9aa-b082-4eab-94ad-df5dd9c455bb">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Go to any site and visit the site settings page.
    - [ ] Attempt to add a Telegram invite link under the social media settings: `https://t.me/+Ird7tka7i7U3N2l1/`. No validation errors should appear.
    - [ ] Save the page, the changes should persist.
    - [ ] Attempt to add a normal Telegram group link: `https://t.me/group_name`. No validation errors should appear.
    - [ ] Attempt to add an invalid link: `https://t.me/++Ird7tka7i7U3N2l1/`. An error message should appear on blur.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

_None_