### PR TITLE
update referrer policy for hyperlinks

### DIFF
--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -180,7 +180,7 @@ export const EditPage = () => {
                   .chain()
                   .focus()
                   .insertContent(
-                    `<a target="_blank" rel="noopener nofollow" referrerpolicy="origin-when-cross-origin" href="${href}">${text}</a>`
+                    `<a target="_blank" rel="noopener nofollow" href="${href}">${text}</a>`
                   )
                   .run()
                 onHyperlinkModalClose()

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -180,7 +180,7 @@ export const EditPage = () => {
                   .chain()
                   .focus()
                   .insertContent(
-                    `<a target="_blank" rel="noopener nofollow" referrerpolicy="strict-origin-when-cross-origin" href="${href}">${text}</a>`
+                    `<a target="_blank" rel="noopener nofollow" referrerpolicy="origin-when-cross-origin" href="${href}">${text}</a>`
                   )
                   .run()
                 onHyperlinkModalClose()

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -180,7 +180,7 @@ export const EditPage = () => {
                   .chain()
                   .focus()
                   .insertContent(
-                    `<a target="_blank" rel="noopener noreferrer nofollow" href="${href}">${text}</a>`
+                    `<a target="_blank" rel="noopener nofollow" referrerpolicy="strict-origin-when-cross-origin" href="${href}">${text}</a>`
                   )
                   .run()
                 onHyperlinkModalClose()

--- a/src/layouts/EditPage/EditPage.tsx
+++ b/src/layouts/EditPage/EditPage.tsx
@@ -210,7 +210,7 @@ export const EditPage = () => {
                     .chain()
                     .focus()
                     .insertContent(
-                      `<a target="_blank" rel="noopener noreferrer nofollow" href="${selectedMediaPath}">${
+                      `<a target="_blank" rel="noopener nofollow" href="${selectedMediaPath}">${
                         altText || "file"
                       }</a>`
                     )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->
Current referrer policy for external links does not allow the receiving site to have any analytics of their site traffic.

## Solution

<!-- How did you solve the problem? -->
Update referrer policy from "noreferrer" to "strict-origin-when-cross-origin"

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

## Tests
- [ ] Insert hyperlink via new editor
- [ ] Ensure output site's <a> tag has the new referrer policy when you inspect it