### PR TITLE
fix: use menlo security for gsib

### DIFF
--- a/src/components/ViewStagingSiteModal/ViewStagingSiteModal.tsx
+++ b/src/components/ViewStagingSiteModal/ViewStagingSiteModal.tsx
@@ -17,6 +17,8 @@ import { useEffect, useState } from "react"
 import { ButtonLink } from "components/ButtonLink"
 import { Modal } from "components/Modal"
 
+import { useStagingLink } from "hooks/useStagingLink"
+
 export interface ViewStagingSiteModalProps {
   isOpen: boolean
   onClose: () => void
@@ -57,6 +59,8 @@ export function ViewStagingSiteModal({
   stagingUrl,
   editMode,
 }: ViewStagingSiteModalProps) {
+  const stagingLink = useStagingLink(stagingUrl)
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -78,7 +82,7 @@ export function ViewStagingSiteModal({
               what your site may look like on smaller devices:
             </Text>
 
-            <GenerateQr text={stagingUrl || ""} />
+            <GenerateQr text={stagingLink || ""} />
           </VStack>
         </ModalBody>
         <ModalFooter>
@@ -87,7 +91,7 @@ export function ViewStagingSiteModal({
               Close
             </Button>
             <Skeleton isLoaded={!isLoading}>
-              <ButtonLink href={stagingUrl}>
+              <ButtonLink href={stagingLink}>
                 <Text color="white">Open staging site in a new tab</Text>
               </ButtonLink>
             </Skeleton>

--- a/src/hooks/useStagingLink.ts
+++ b/src/hooks/useStagingLink.ts
@@ -1,0 +1,12 @@
+const GSIB_INDICATOR = "menlo-view.menlosecurity.com"
+
+export const useStagingLink = (link?: string): string | undefined => {
+  // NOTE: Prepend the menlo link if this is on GSIB because
+  // GSIBs do a security scan that will fail otherwise with a TOO_MANY_REDIRECTS
+  // error when we access the raw link directly.
+  if (window.name.includes(GSIB_INDICATOR)) {
+    return `https://safe.menlosecurity.com/${link}`
+  }
+
+  return link
+}

--- a/src/layouts/SiteDashboard/SiteDashboard.tsx
+++ b/src/layouts/SiteDashboard/SiteDashboard.tsx
@@ -47,6 +47,7 @@ import {
 import { useGetBrokenLinks } from "hooks/siteDashboardHooks/useGetLinkChecker"
 import { useRefreshLinkChecker } from "hooks/siteDashboardHooks/useRefreshLinkChecker"
 import useRedirectHook from "hooks/useRedirectHook"
+import { useStagingLink } from "hooks/useStagingLink"
 
 import { getDateTimeFromUnixTime } from "utils/date"
 import { isSiteLaunchEnabled } from "utils/siteLaunchUtils"
@@ -96,6 +97,7 @@ export const SiteDashboard = (): JSX.Element => {
   const {
     mutateAsync: updateViewedReviewRequests,
   } = useUpdateViewedReviewRequests()
+  const stagingLink = useStagingLink(siteInfo?.stagingUrl)
 
   const isBrokenLinksReporterEnabled = useFeatureIsOn(
     "is_broken_links_report_enabled"
@@ -143,11 +145,11 @@ export const SiteDashboard = (): JSX.Element => {
               mainButtonText="Open staging"
               isDisabled={isSiteInfoLoading || isSiteInfoError}
               as={ButtonLink}
-              href={siteInfo?.stagingUrl}
+              href={stagingLink}
             >
               <MenuDropdownItem
                 as={ButtonLink}
-                href={siteInfo?.stagingUrl}
+                href={stagingLink}
                 isDisabled={isSiteInfoLoading || isSiteInfoError}
               >
                 <Text textStyle="body-1" fill="text.body">


### PR DESCRIPTION
# problem
1. gsib access to staging site fails as gsib uses a security scan which. leasd to too many redirects

# solution
1. use `menlosecurity` and prepend if gsib is detected
