### PR TITLE
fix: upgrade axios to 1.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@tiptap/pm": "^2.1.12",
         "@tiptap/react": "^2.1.12",
         "@tiptap/starter-kit": "^2.1.12",
-        "axios": "^1.7.2",
+        "axios": "^1.8.3",
         "bluebird": "^3.7.1",
         "bootstrap": "^4.6.0",
         "cheerio": "^1.0.0-rc.10",
@@ -14138,9 +14138,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@tiptap/pm": "^2.1.12",
     "@tiptap/react": "^2.1.12",
     "@tiptap/starter-kit": "^2.1.12",
-    "axios": "^1.7.2",
+    "axios": "^1.8.3",
     "bluebird": "^3.7.1",
     "bootstrap": "^4.6.0",
     "cheerio": "^1.0.0-rc.10",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ const queryClient = new QueryClient({
 const API_BASE_URL_V2 = `${process.env.REACT_APP_BACKEND_URL_V2}`
 const apiClient = axios.create({
   baseURL: API_BASE_URL_V2,
+  allowAbsoluteUrls: false,
   timeout: 100000, // 100 secs
 })
 

--- a/src/layouts/Workspace/Workspace.stories.tsx
+++ b/src/layouts/Workspace/Workspace.stories.tsx
@@ -13,6 +13,7 @@ import { Workspace } from "./Workspace"
 
 const apiClient = axios.create({
   baseURL: process.env.REACT_APP_BACKEND_URL_V2,
+  allowAbsoluteUrls: false,
   timeout: 100000,
 })
 

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -4,6 +4,7 @@ import axios from "axios"
 const API_BASE_URL_V2 = `${process.env.REACT_APP_BACKEND_URL_V2}`
 export const apiService = axios.create({
   baseURL: API_BASE_URL_V2,
+  allowAbsoluteUrls: false,
   // 100 secs
   timeout: 100000,
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We need to upgrade axios to 1.8.3.

Reference: https://opengovproducts.slack.com/archives/CK9GGK6EP/p1741763549869339

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Upgrade axios to 1.8.3.