### PR TITLE
fix: add tiptap pro env var

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,8 @@ jobs:
       with:
         node-version: 18
     - name: Install dependencies
+      env:
+        TIPTAP_PRO_TOKEN: ${{secrets.TIPTAP_PRO_TOKEN}}
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

CI fails for playwright cos of missing auth token.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Add token to CI