### PR TITLE
fix: prevent path traversal for API endpoint URL

### DIFF
--- a/src/services/PageService.jsx
+++ b/src/services/PageService.jsx
@@ -1,3 +1,5 @@
+const { isSafePath } = require("../utils/misc")
+
 export class PageService {
   constructor({ apiClient }) {
     this.apiClient = apiClient
@@ -12,6 +14,22 @@ export class PageService {
     resourceCategoryName,
     fileName,
   }) {
+    // Check the input parameters to ensure the paths are safe
+    const paramsToCheck = [
+      siteName,
+      collectionName,
+      subCollectionName,
+      resourceRoomName,
+      resourceCategoryName,
+      fileName,
+    ]
+
+    paramsToCheck.forEach((param) => {
+      if (param && !isSafePath(param)) {
+        throw new Error(`Unsafe path detected in parameter: ${param}`)
+      }
+    })
+
     let endpoint = `/sites/${siteName}`
     if (collectionName) {
       endpoint += `/collections/${collectionName}`

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -7,3 +7,10 @@ export const isLinkInternal = (url: string) => {
   tempLink.href = url
   return tempLink.hostname === window.location.hostname
 }
+
+// Util method to check if a URL path is safe (i.e. does not contain any
+// directory traversal patterns like '..\' or '\..', etc).
+export const isSafePath = (path: string): boolean => {
+  const unsafePattern = /(\\\.\.|\.\.\\)/
+  return !unsafePattern.test(path)
+}

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -8,9 +8,11 @@ export const isLinkInternal = (url: string) => {
   return tempLink.hostname === window.location.hostname
 }
 
-// Util method to check if a URL path is safe (i.e. does not contain any
-// directory traversal patterns like '..\' or '\..', etc).
+// Util method to check if a URL path is safe
 export const isSafePath = (path: string): boolean => {
-  const unsafePattern = /(\\\.\.|\.\.\\)/
-  return !unsafePattern.test(path)
+  if (path.indexOf("\\") !== -1) {
+    return false
+  }
+
+  return true
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-2132.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Adds a check on the input parameters to prevent any potential path traversals before crafting the final API endpoint.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

<img width="1687" height="175" alt="image" src="https://github.com/user-attachments/assets/da5265d2-5ffa-48e4-b3f2-1c2ee61bfea6" />

**AFTER**:

<!-- [insert screenshot here] -->

<img width="490" height="78" alt="image" src="https://github.com/user-attachments/assets/a0a0b72e-0d8d-4b8d-842b-daaf0f858c46" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Log in to the CMS, then try this URL: `https://staging-cms.isomer.gov.sg/sites/isomer-vapt2025one/folders/example-folder/subfolders/example-subfolder/editPageSettings/x%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5Cfoo`
    - [ ] Verify in the Console tab that there is an error message that starts with "Error: Unsafe path detected in parameter"
    - [ ] Verify in the Network tab that there is no requests with a 403 response to a URL that ends with `foo`.