### PR TITLE
fix: add referrer policy for iframe required by YouTube

### DIFF
--- a/src/layouts/components/Editor/extensions/Iframe/Iframe.ts
+++ b/src/layouts/components/Editor/extensions/Iframe/Iframe.ts
@@ -62,6 +62,9 @@ export const Iframe = Node.create<IframeOptions>({
       style: {
         default: null,
       },
+      referrerpolicy: {
+        default: "strict-origin-when-cross-origin",
+      },
     }
   },
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

YouTube embeds broke suddenly because they start to enforce the need to add the `referrer-policy` when loading inside the CMS.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Add `referrer-policy` attribute to the iframe.
    - NOTE: Existing live sites are not affected, since we add the CSP header to allow.